### PR TITLE
perf: speed increase 360% from @stormslowly

### DIFF
--- a/crates/mako_bundler/src/build/build.rs
+++ b/crates/mako_bundler/src/build/build.rs
@@ -1,4 +1,7 @@
+use maplit::hashset;
+use nodejs_resolver::{Options, Resolver};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::{
     compiler::Compiler,
@@ -43,6 +46,26 @@ impl Compiler {
             parent_module_id: None,
             parent_dependecy: None,
         }];
+
+        let resolver: Resolver = Resolver::new(Options {
+            extensions: vec![
+                ".js".to_string(),
+                ".jsx".to_string(),
+                ".ts".to_string(),
+                ".tsx".to_string(),
+                ".mjs".to_string(),
+                ".cjs".to_string(),
+            ],
+            condition_names: hashset! {
+                "node".to_string(),
+                "require".to_string(),
+                "import".to_string(),
+                "browser".to_string(),
+                "default".to_string()
+            },
+            external_cache: Some(Arc::new(Default::default())),
+            ..Default::default()
+        });
 
         while !queue.is_empty() {
             let task = queue.pop().unwrap();
@@ -108,7 +131,7 @@ impl Compiler {
                     dependency: &d.source,
                     files: build_param.files.as_ref(),
                 };
-                let resolve_result = resolve(&resolve_param, &self.context);
+                let resolve_result = resolve(&resolve_param, &self.context, &resolver);
                 println!(
                     "> resolve {} from {} -> {}",
                     &d.source, path_str, resolve_result.path

--- a/crates/mako_bundler/src/build/resolve.rs
+++ b/crates/mako_bundler/src/build/resolve.rs
@@ -1,6 +1,5 @@
-use maplit::hashset;
-use nodejs_resolver::{Options, Resolver};
-use std::{collections::HashMap, path::PathBuf, vec};
+use nodejs_resolver::Resolver;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::context::Context;
 
@@ -40,7 +39,11 @@ fn dispatch_request_type(request: &ResolveParam) -> RequestType {
     }
 }
 
-pub fn resolve(resolve_param: &ResolveParam, context: &Context) -> ResolveResult {
+pub fn resolve(
+    resolve_param: &ResolveParam,
+    context: &Context,
+    resolver: &Resolver,
+) -> ResolveResult {
     let to_resolve = resolve_param.dependency.to_string();
 
     // support external
@@ -60,24 +63,6 @@ pub fn resolve(resolve_param: &ResolveParam, context: &Context) -> ResolveResult
     // - ...
     // ref: https://github.com/webpack/enhanced-resolve
 
-    let resolver = Resolver::new(Options {
-        extensions: vec![
-            ".js".to_string(),
-            ".jsx".to_string(),
-            ".ts".to_string(),
-            ".tsx".to_string(),
-            ".mjs".to_string(),
-            ".cjs".to_string(),
-        ],
-        condition_names: hashset! {
-            "node".to_string(),
-            "require".to_string(),
-            "import".to_string(),
-            "browser".to_string(),
-            "default".to_string()
-        },
-        ..Default::default()
-    });
     match dispatch_request_type(resolve_param) {
         RequestType::Local { request, context } => {
             match resolver.resolve(context.as_path(), request.to_str().unwrap()) {

--- a/examples/with-antd/src/home.tsx
+++ b/examples/with-antd/src/home.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import Button from 'antd/es/button';
+// import Button from 'antd/es/button';
+import { Button } from 'antd';
 import lodash from 'lodash';
 import axios from 'axios';
 


### PR DESCRIPTION
Before.

```bash
$ hyperfine --runs 10 "./target/release/mako examples/with-antd"
Benchmark 1: ./target/release/mako examples/with-antd
  Time (mean ± σ):      4.757 s ±  0.121 s    [User: 2.914 s, System: 1.836 s]
  Range (min … max):    4.597 s …  5.063 s    10 runs
```

After.

```bash
$ hyperfine --runs 10 "./target/release/mako examples/with-antd"
Benchmark 1: ./target/release/mako examples/with-antd
  Time (mean ± σ):      1.180 s ±  0.189 s    [User: 0.830 s, System: 0.333 s]
  Range (min … max):    1.110 s …  1.718 s    10 runs
```

代码来自 @stormslowly 