### PR TITLE
feat: support to replace import.meta.env

### DIFF
--- a/crates/mako_bundler/src/generate/transform/env_replacer.rs
+++ b/crates/mako_bundler/src/generate/transform/env_replacer.rs
@@ -3,19 +3,50 @@ use swc_common::{
     collections::{AHashMap, AHashSet},
     sync::Lrc,
 };
-use swc_ecma_ast::{ComputedPropName, Expr, Id, Ident, Lit, MemberExpr, MemberProp, Module, Str};
+use swc_ecma_ast::{
+    ComputedPropName, Expr, Id, Ident, Lit, MemberExpr, MemberProp, MetaPropExpr, MetaPropKind,
+    Module, Str,
+};
 use swc_ecma_utils::collect_decls;
 use swc_ecma_visit::{VisitMut, VisitMutWith};
+
+enum EnvsType {
+    Node(Lrc<AHashMap<JsWord, Expr>>),
+    Browser(Lrc<AHashMap<String, Expr>>),
+}
 
 pub struct EnvReplacer {
     bindings: Lrc<AHashSet<Id>>,
     envs: Lrc<AHashMap<JsWord, Expr>>,
+    meta_envs: Lrc<AHashMap<String, Expr>>,
 }
 impl EnvReplacer {
     pub fn new(envs: Lrc<AHashMap<JsWord, Expr>>) -> Self {
+        let mut meta_env_map = AHashMap::default();
+
+        // generate meta_envs from envs
+        for (k, v) in envs.iter() {
+            // convert NODE_ENV to MODE
+            let key = if k.eq(&js_word!("NODE_ENV")) {
+                "MODE".into()
+            } else {
+                k.to_string()
+            };
+
+            meta_env_map.insert(key, v.clone());
+        }
+
         Self {
             bindings: Default::default(),
             envs,
+            meta_envs: Lrc::new(meta_env_map),
+        }
+    }
+
+    fn get_env(envs: &EnvsType, sym: &JsWord) -> Option<Expr> {
+        match envs {
+            EnvsType::Node(envs) => envs.get(sym).cloned(),
+            EnvsType::Browser(envs) => envs.get(&sym.to_string()).cloned(),
         }
     }
 }
@@ -46,23 +77,34 @@ impl VisitMut for EnvReplacer {
                 ..
             }) = &**obj
             {
-                if let Expr::Ident(Ident {
-                    sym: js_word!("process"),
-                    ..
-                }) = &**first_obj
-                {
+                let mut envs = EnvsType::Node(self.envs.clone());
+
+                if match &**first_obj {
+                    Expr::Ident(Ident {
+                        sym: js_word!("process"),
+                        ..
+                    }) => true,
+                    Expr::MetaProp(MetaPropExpr {
+                        kind: MetaPropKind::ImportMeta,
+                        ..
+                    }) => {
+                        envs = EnvsType::Browser(self.meta_envs.clone());
+                        true
+                    }
+                    _ => false,
+                } {
                     match prop {
                         MemberProp::Computed(ComputedPropName { expr: c, .. }) => {
                             if let Expr::Lit(Lit::Str(Str { value: sym, .. })) = &**c {
-                                if let Some(env) = self.envs.get(sym) {
-                                    *expr = env.clone();
+                                if let Some(env) = EnvReplacer::get_env(&envs, sym) {
+                                    *expr = env;
                                 }
                             }
                         }
 
                         MemberProp::Ident(Ident { sym, .. }) => {
-                            if let Some(env) = self.envs.get(sym) {
-                                *expr = env.clone();
+                            if let Some(env) = EnvReplacer::get_env(&envs, sym) {
+                                *expr = env;
                             }
                         }
                         _ => {}


### PR DESCRIPTION
支持替换 `import.meta.env.XX` 为具体值，默认包含 `MODE` 环境变量（值与 `NODE_ENV` 一致）

备注：没有查到 `import.meta.env.MODE` 的相关规范，从 [Vite 文档](https://cn.vitejs.dev/guide/env-and-mode.html) 以及 [@import-meta-env](https://iendeavor.github.io/import-meta-env/guide/framework-specific-notes/vite.html) 的文档来看，似乎是 Vite 特有实现但已经演变成社区不成文的约定？