### PR TITLE
feat: use tracing logging system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,8 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -734,6 +736,8 @@ version = "0.0.0"
 dependencies = [
  "mako_bundler",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2335,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ members = [
 
 [workspace.dependencies]
 tokio = { version = "1" }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"

--- a/crates/mako_bundler/Cargo.toml
+++ b/crates/mako_bundler/Cargo.toml
@@ -37,6 +37,8 @@ swc_css_codegen = "0.146.6"
 swc_css_parser = "0.145.6"
 swc_css_visit = "0.135.6"
 rayon = "1.7.0"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 insta = { version = "1.29.0", features = ["yaml"] }

--- a/crates/mako_bundler/src/build/analyze_deps.rs
+++ b/crates/mako_bundler/src/build/analyze_deps.rs
@@ -4,6 +4,7 @@ use swc_css_visit::{Visit as CssVisit, VisitWith as CssVisitWith};
 use swc_ecma_ast::*;
 use swc_ecma_visit::noop_visit_type;
 use swc_ecma_visit::{Visit, VisitWith};
+use tracing::debug;
 
 use crate::{
     context::Context,
@@ -35,9 +36,9 @@ pub fn analyze_deps(
             // TODO: only analyze top level require to improve performance
             transform_ast.visit_with(&mut collector);
 
-            println!("> analyze deps: {}", analyze_deps_param.path);
+            debug!(analyze_deps_param.path, "analyze deps");
             for d in &collector.dependencies {
-                println!("  - {} ({:?})", d.source, d.resolve_type);
+                debug!("  - {} ({:?})", d.source, d.resolve_type);
             }
         }
     } else if let ModuleAst::Css(stylesheet) = analyze_deps_param.ast {

--- a/crates/mako_bundler/src/build/build.rs
+++ b/crates/mako_bundler/src/build/build.rs
@@ -1,5 +1,6 @@
 use maplit::hashset;
 use nodejs_resolver::{Options, Resolver};
+use tracing::debug;
 
 use std::collections::{HashMap, VecDeque};
 use std::ops::ControlFlow;
@@ -202,8 +203,8 @@ impl Compiler {
                 files: None,
             };
             let resolve_result = resolve(&resolve_param, &context, &resolver);
-            println!(
-                "> resolve {} from {} -> {}",
+            debug!(
+                "resolve {} from {} -> {}",
                 &d.source, path_str, resolve_result.path
             );
             if resolve_result.is_external {

--- a/crates/mako_bundler/src/build/load.rs
+++ b/crates/mako_bundler/src/build/load.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use regex::Regex;
+use tracing::debug;
 
 use crate::{
     context::Context,
@@ -30,7 +31,7 @@ lazy_static! {
 }
 
 pub fn load(load_param: &LoadParam, _context: &Arc<Context>) -> LoadResult {
-    println!("> load {}", load_param.path);
+    debug!(load_param.path, "load");
     let ext_name = ext_name(load_param.path);
     match ext_name {
         "js" | "jsx" | "ts" | "tsx" => load_js(load_param, _context),

--- a/crates/mako_bundler/src/generate/generate.rs
+++ b/crates/mako_bundler/src/generate/generate.rs
@@ -4,10 +4,11 @@ use crate::chunk::{Chunk, ChunkType};
 use crate::module_graph::ModuleGraph;
 use crate::{compiler::Compiler, module::ModuleId};
 use rayon::prelude::*;
+use tracing::debug;
 
 fn wrap_module(id: &ModuleId, code: &str) -> String {
     let id = id.id.clone();
-    println!("> wrap_module: {}", id);
+    debug!(id, "wrap_module");
     format!(
         "g_define(\"{}\", function(module, exports, require) {{\n{}}});",
         id, code
@@ -46,7 +47,7 @@ impl Compiler {
         {
             let chunk_graph = self.context.chunk_graph.read().unwrap();
             let module_graph = self.context.module_graph.read().unwrap();
-            println!("chunks {}", &chunk_graph);
+            debug!("chunks {}", &chunk_graph);
             // generate codes
             chunk_graph
                 .get_chunks()
@@ -67,7 +68,7 @@ impl Compiler {
         output_files.par_iter().for_each(|file| {
             if generate_param.write {
                 let output = &output_dir.join(&file.path);
-                println!(
+                debug!(
                     "output {} {} {}",
                     output.to_string_lossy(),
                     output_dir.to_string_lossy(),

--- a/crates/mako_bundler/src/lib.rs
+++ b/crates/mako_bundler/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(box_patterns)]
 
 use compiler::Compiler;
+use tracing::info;
 
 use crate::plugins::node_polyfill::get_node_builtins;
 
@@ -56,5 +57,5 @@ pub fn run() {
     let mut compiler = Compiler::new(config);
     compiler.run();
 
-    println!("✅ DONE");
+    info!("✅ DONE");
 }

--- a/crates/mako_bundler/tests/bundler_test.rs
+++ b/crates/mako_bundler/tests/bundler_test.rs
@@ -1,6 +1,7 @@
 use mako_bundler::{
     build::build::BuildParam, compiler::Compiler, config::Config, generate::generate::GenerateParam,
 };
+use tracing::debug;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn normal() {
@@ -29,7 +30,7 @@ async fn chunk() {
     let (output, compiler, ..) = test_files("chunks".into());
     assert_debug_snapshot!(output);
     let chunk_graph = compiler.context.chunk_graph.read().unwrap();
-    println!("{}", &chunk_graph);
+    debug!("{}", &chunk_graph);
     assert_display_snapshot!(chunk_graph);
 }
 

--- a/crates/mako_cli/Cargo.toml
+++ b/crates/mako_cli/Cargo.toml
@@ -12,3 +12,5 @@ path = "src/main.rs"
 [dependencies]
 tokio = { workspace = true, features = ["full"] }
 mako_bundler = { path = "../mako_bundler" }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/mako_cli/src/main.rs
+++ b/crates/mako_cli/src/main.rs
@@ -1,4 +1,18 @@
+use tracing::Level;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
 #[tokio::main]
 async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("mako_bundler=debug")),
+        )
+        .without_time()
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to set subscriber");
+
     mako_bundler::run();
 }


### PR DESCRIPTION
`tracing` 配置如下：
```rs
let subscriber = FmtSubscriber::builder()
    .with_max_level(Level::INFO)
    .with_env_filter(
        EnvFilter::try_from_default_env()
            .unwrap_or_else(|_| EnvFilter::new("mako_bundler=debug")),
    )
    .without_time()
    .finish();
```

运行如下命令会输出最高为 `debug` 级别的日志：
```bash
cargo run --bin mako examples/normal
```

可以通过 `RUST_LOG` 环境变量来指定日志级别：
```bash
RUST_LOG=info cargo run --bin mako examples/normal
```