### PR TITLE
pref(build): no lock in child thread, 1.2x improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,8 @@
 
 [![codecov](https://codecov.io/gh/umijs/mako/branch/master/graph/badge.svg?token=ptCnNedFGf)](https://codecov.io/gh/umijs/mako)
 
-WIP.
+Mako is a bundler written in Rust.
+
+## CONTRIBUTING
+
+Read [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -1,13 +1,14 @@
+use std::fmt::{Debug, Formatter};
 use swc_common::{sync::Lrc, SourceMap};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Dependency {
     pub source: String,
     pub resolve_type: ResolveType,
     pub order: usize,
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ResolveType {
     Import,
     ExportNamed,
@@ -64,5 +65,11 @@ impl Module {
     #[allow(dead_code)]
     pub fn add_info(&mut self, info: Option<ModuleInfo>) {
         self.info = info;
+    }
+}
+
+impl Debug for Module {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Module id={}", self.id.id)
     }
 }


### PR DESCRIPTION
```bash
❯ hyperfine --runs 10 "./target/release/mako examples/with-antd" "./target/release-origin/mako examples/with-antd"
Benchmark 1: ./target/release/mako examples/with-antd
  Time (mean ± σ):     575.7 ms ±  10.8 ms    [User: 1523.4 ms, System: 726.0 ms]
  Range (min … max):   563.1 ms … 599.0 ms    10 runs

Benchmark 2: ./target/release-origin/mako examples/with-antd
  Time (mean ± σ):     690.8 ms ±   5.8 ms    [User: 2001.2 ms, System: 839.2 ms]
  Range (min … max):   683.0 ms … 699.9 ms    10 runs

Summary
  './target/release/mako examples/with-antd' ran
    1.20 ± 0.02 times faster than './target/release-origin/mako examples/with-antd'
```