### PR TITLE
fix: 修复 sourcemap 文件缺失 sourceContents 字段

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /examples/*/node_modules
 /node_modules
 /flamegraph.svg
+.DS_Store

--- a/crates/mako/src/generate_chunks.rs
+++ b/crates/mako/src/generate_chunks.rs
@@ -91,12 +91,7 @@ impl Compiler {
                 }
 
                 let filename = chunk.filename();
-                let (js_code, js_sourcemap) = js_ast_to_code(
-                    &js_ast,
-                    &self.context.meta.script.cm,
-                    &self.context,
-                    &filename,
-                );
+                let (js_code, js_sourcemap) = js_ast_to_code(&js_ast, &self.context, &filename);
                 OutputFile {
                     path: filename,
                     content: js_code,

--- a/crates/mako/src/main.rs
+++ b/crates/mako/src/main.rs
@@ -24,6 +24,7 @@ mod module;
 mod module_graph;
 mod parse;
 mod resolve;
+mod sourcemap;
 mod transform;
 mod transform_css_handler;
 mod transform_dep_replacer;

--- a/crates/mako/src/sourcemap.rs
+++ b/crates/mako/src/sourcemap.rs
@@ -1,0 +1,28 @@
+use swc_common::{
+    source_map::SourceMapGenConfig, sync::Lrc, BytePos, FileName, LineCol, SourceMap,
+};
+
+pub struct SwcSourceMapGenConfig;
+
+impl SourceMapGenConfig for SwcSourceMapGenConfig {
+    fn file_name_to_source(&self, f: &swc_common::FileName) -> String {
+        f.to_string()
+    }
+
+    /// 生成 sourceContents
+    fn inline_sources_content(&self, _f: &FileName) -> bool {
+        true
+    }
+}
+
+pub fn build_source_map(mappings: &[(BytePos, LineCol)], cm: Lrc<SourceMap>) -> Vec<u8> {
+    let config = SwcSourceMapGenConfig;
+
+    let mut src_buf = vec![];
+
+    cm.build_source_map_with_config(mappings, None, config)
+        .to_writer(&mut src_buf)
+        .unwrap();
+
+    src_buf
+}

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -210,8 +210,7 @@ var _react = _interop_require_default._(require("react"));
         });
         let mut ast = build_js_ast(path, origin, &context);
         transform_js(&mut ast, &context);
-        let (code, _sourcemap) =
-            js_ast_to_code(&ast, &context.meta.script.cm, &context, "index.js");
+        let (code, _sourcemap) = js_ast_to_code(&ast, &context, "index.js");
         let code = code.replace("\"use strict\";", "");
         let code = code.trim().to_string();
         (code, _sourcemap)

--- a/crates/mako/src/transform_in_generate.rs
+++ b/crates/mako/src/transform_in_generate.rs
@@ -52,7 +52,7 @@ fn transform_modules(module_ids: Vec<ModuleId>, context: &Arc<Context>) {
         let ast = &mut info.ast;
         match ast {
             ModuleAst::Script(ast) => {
-                transform_js(ast, &module.id.id, &path, dep_map, env_map.clone(), context);
+                transform_js(ast, &module.id.id, dep_map, env_map.clone(), context);
             }
             ModuleAst::Css(ast) => {
                 let ast = transform_css(ast, &module.id.id, &path, dep_map, context);
@@ -103,7 +103,7 @@ fn transform_css(
     let mut ast = build_js_ast(path, content.as_str(), context);
 
     // wrap js module
-    wrap_js_module(&mut ast, id, path, context);
+    wrap_js_module(&mut ast, id, context);
 
     ast
 }
@@ -126,7 +126,6 @@ fn build_env_map(env_map: HashMap<String, String>) -> AHashMap<JsWord, Expr> {
 fn transform_js(
     ast: &mut swc_ecma_ast::Module,
     id: &str,
-    path: &str,
     dep_map: HashMap<String, String>,
     env_map: AHashMap<JsWord, Expr>,
     context: &Arc<Context>,
@@ -140,10 +139,10 @@ fn transform_js(
         ast.visit_mut_with(&mut env_replacer);
     });
 
-    wrap_js_module(ast, id, path, context);
+    wrap_js_module(ast, id, context);
 }
 
-fn wrap_js_module(ast: &mut Module, id: &str, path: &str, context: &Arc<Context>) {
+fn wrap_js_module(ast: &mut Module, id: &str, context: &Arc<Context>) {
     // 找到 call_expr 的第二个 fn 参数，将原来的 stmts 加入到新的 fn 的 body 中
     // 用字符串生成 ast 的方式是为了容易维护，因为走 ast 拼接的方式不易懂，同时前期修改可能比较频繁
     let origin_stmts: Vec<Stmt> = ast
@@ -152,7 +151,8 @@ fn wrap_js_module(ast: &mut Module, id: &str, path: &str, context: &Arc<Context>
         .map(|stmt| stmt.as_stmt().unwrap().clone())
         .collect();
     let content = include_str!("runtime/runtime_module.ts").replace("__ID__", id);
-    let mut new_ast = build_js_ast(path, content.as_str(), context);
+    // 不能使用 path, 因为会覆盖 cm 中记录的对应 path 的源码内容
+    let mut new_ast = build_js_ast("mako_internal_wrapper", content.as_str(), context);
     for stmt in &mut new_ast.body {
         if let ModuleItem::Stmt(Stmt::Expr(expr)) = stmt {
             if let ExprStmt {
@@ -369,9 +369,8 @@ g_define('test.css', function(module, exports, require) {
         });
         let mut ast = build_js_ast(path, origin, &context);
         let env_map = build_env_map(env_map);
-        super::transform_js(&mut ast, "test", path, dep_map, env_map, &context);
-        let (code, _sourcemap) =
-            js_ast_to_code(&ast, &context.meta.script.cm, &context, "index.js");
+        super::transform_js(&mut ast, "test", dep_map, env_map, &context);
+        let (code, _sourcemap) = js_ast_to_code(&ast, &context, "index.js");
         // let code = code.replace("\"use strict\";", "");
         let code = code.trim().to_string();
         (code, _sourcemap)
@@ -398,8 +397,7 @@ g_define('test.css', function(module, exports, require) {
         });
         let mut ast = build_css_ast(path, content, &context);
         let ast = transform_css(&mut ast, "test.css", path, dep_map, &context);
-        let (code, _sourcemap) =
-            js_ast_to_code(&ast, &context.meta.script.cm, &context, "index.js");
+        let (code, _sourcemap) = js_ast_to_code(&ast, &context, "index.js");
         let code = code.trim().to_string();
         (code, _sourcemap)
     }

--- a/examples/normal/mako.config.json
+++ b/examples/normal/mako.config.json
@@ -1,1 +1,3 @@
-{}
+{
+  "sourcemap": true
+}


### PR DESCRIPTION
修复生成的 sourcemap 文件中缺失 `sourceContents` 字段导致源码内容无法被查看问题。