### PR TITLE
fix: add browser to main fields

### DIFF
--- a/crates/mako/src/resolve.rs
+++ b/crates/mako/src/resolve.rs
@@ -87,7 +87,11 @@ pub fn get_resolver(alias: Option<HashMap<String, String>>) -> Resolver {
             "browser".to_string(),
             "default".to_string(),
         ]),
-        main_fields: vec!["module".to_string(), "main".to_string()],
+        main_fields: vec![
+            "browser".to_string(),
+            "module".to_string(),
+            "main".to_string(),
+        ],
         ..Default::default()
     })
 }

--- a/packages/bundler-okam/index.js
+++ b/packages/bundler-okam/index.js
@@ -48,11 +48,14 @@ exports.build = async function (opts) {
   const { build } = require('@alipay/okam');
   build(cwd, config);
 
+  const stats = {
+    compilation: { assets: { 'umi.js': 'umi.js' } },
+    hasErrors: () => false,
+  };
   onBuildComplete({
     err: null,
+    stats,
   });
-
-  const stats = { compilation: { assets: { 'umi.js': 'umi.js' } } };
   return stats;
 };
 


### PR DESCRIPTION
1、添加 browser 到 main_fields，参考 webpack 的默认配置
2、为 onBuildComplete 添加 stats，兼容 umi 和 bigfish 的插件写法
