### PR TITLE
feat: enable concurrent features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "rayon",
 ]
 
 [[package]]
@@ -2936,6 +2937,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "radix_fmt",
+ "rayon",
  "regex",
  "rustc-hash",
  "ryu-js",

--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -46,7 +46,7 @@ futures = "0.3.28"
 fs_extra = "1.3.0"
 glob = "0.3.1"
 clap = { version = "4.3.0", features = ["derive"] }
-swc_ecma_minifier = "0.181.21"
+swc_ecma_minifier = { version = "0.181.21", features = ["concurrent"] }
 swc_error_reporters = "0.15.11"
 pathdiff = "0.2.1"
 anyhow = "1.0.71"


### PR DESCRIPTION
开启了`swc_ecma_minifier`的`concurrent`特性，性能有提升10%，下面是在 Macbook M1 Pro 上跑`with-antd`的耗时对比：

开启前：
```bash
hyperfine --runs 10 "./target/release/mako examples/with-antd --mode=production"
Benchmark 1: ./target/release/mako examples/with-antd --mode=production
  Time (mean ± σ):      3.349 s ±  0.295 s    [User: 5.815 s, System: 1.210 s]
  Range (min … max):    3.140 s …  3.939 s    10 runs
```
开启后：
```bash
hyperfine --runs 10 "./target/release/mako examples/with-antd --mode=production"
Benchmark 1: ./target/release/mako examples/with-antd --mode=production
  Time (mean ± σ):      2.984 s ±  0.065 s    [User: 5.867 s, System: 1.200 s]
  Range (min … max):    2.908 s …  3.073 s    10 runs
```