### PR TITLE
fix: parse differently between ts and js

### DIFF
--- a/crates/mako/src/analyze_deps.rs
+++ b/crates/mako/src/analyze_deps.rs
@@ -210,7 +210,7 @@ import 'bar';
     fn resolve(code: &str) -> String {
         let root = PathBuf::from("/path/to/root");
         let ast = build_js_ast(
-            "test.js",
+            "test.ts",
             code,
             &Arc::new(Context {
                 config: Default::default(),

--- a/crates/mako/src/ast.rs
+++ b/crates/mako/src/ast.rs
@@ -14,7 +14,7 @@ use swc_ecma_ast::Module;
 use swc_ecma_codegen::text_writer::JsWriter;
 use swc_ecma_codegen::{Config as JsCodegenConfig, Emitter};
 use swc_ecma_parser::lexer::Lexer;
-use swc_ecma_parser::{Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{EsConfig, Parser, StringInput, Syntax, TsConfig};
 use thiserror::Error;
 
 use crate::compiler::Context;
@@ -37,11 +37,21 @@ pub fn build_js_ast(path: &str, content: &str, context: &Arc<Context>) -> Result
         .script
         .cm
         .new_source_file(FileName::Real(relative_path), content.to_string());
-    let syntax = Syntax::Typescript(TsConfig {
-        decorators: true,
-        tsx: path.ends_with(".tsx") || path.ends_with(".jsx"),
-        ..Default::default()
-    });
+    let is_ts = path.ends_with(".ts") || path.ends_with(".tsx");
+    let jsx = path.ends_with(".jsx");
+    let tsx = path.ends_with(".tsx");
+    let syntax = if is_ts {
+        Syntax::Typescript(TsConfig {
+            decorators: true,
+            tsx,
+            ..Default::default()
+        })
+    } else {
+        Syntax::Es(EsConfig {
+            jsx,
+            ..Default::default()
+        })
+    };
     let lexer = Lexer::new(
         syntax,
         swc_ecma_ast::EsVersion::Es2015,


### PR DESCRIPTION
1、区分 parse，更准确一些，比如 js 文件中不应该出现 import type
2、同时也方便后续给不同类型的文件区分做不同的配置
3、benchmark 上没啥变化