### PR TITLE
fix: use different exports conditions by platform

### DIFF
--- a/crates/mako/src/resolve.rs
+++ b/crates/mako/src/resolve.rs
@@ -78,13 +78,21 @@ pub fn get_resolver(config: &Config) -> Resolver {
             ".mjs".to_string(),
             ".cjs".to_string(),
         ],
-        condition_names: HashSet::from([
-            "node".to_string(),
-            "require".to_string(),
-            "import".to_string(),
-            "browser".to_string(),
-            "default".to_string(),
-        ]),
+        condition_names: if is_browser {
+            HashSet::from([
+                "browser".to_string(),
+                "import".to_string(),
+                "default".to_string(),
+                "require".to_string(),
+            ])
+        } else {
+            HashSet::from([
+                "node".to_string(),
+                "import".to_string(),
+                "default".to_string(),
+                "require".to_string(),
+            ])
+        },
         main_fields: if is_browser {
             vec![
                 "browser".to_string(),


### PR DESCRIPTION
对不同的 platform 使用不同的 exports condition_names，避免在某些包中拿到错误的依赖，比如 `tslib`

Close #134 