### PR TITLE
fix: add module condition name for resolver

### DIFF
--- a/crates/mako/src/resolve.rs
+++ b/crates/mako/src/resolve.rs
@@ -80,6 +80,7 @@ pub fn get_resolver(config: &Config) -> Resolver {
         ],
         condition_names: if is_browser {
             HashSet::from([
+                "module".to_string(),
                 "browser".to_string(),
                 "import".to_string(),
                 "default".to_string(),
@@ -87,6 +88,7 @@ pub fn get_resolver(config: &Config) -> Resolver {
             ])
         } else {
             HashSet::from([
+                "module".to_string(),
                 "node".to_string(),
                 "import".to_string(),
                 "default".to_string(),

--- a/examples/with-tslib/package.json
+++ b/examples/with-tslib/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "tslib": "^2"
+        "tslib": "2.5.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -140,8 +140,8 @@ importers:
   examples/with-tslib:
     dependencies:
       tslib:
-        specifier: ^2
-        version: 2.5.2
+        specifier: 2.5.0
+        version: 2.5.0
 
   examples/with-umi:
     devDependencies:
@@ -3054,7 +3054,7 @@ packages:
       is-glob: 4.0.3
       open: 9.1.0
       picocolors: 1.0.0
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.14.0)(webpack@5.84.1):
@@ -4215,7 +4215,7 @@ packages:
       react-redux: 8.0.7(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.1.0)(react@18.1.0)(redux@4.2.1)
       redux: 4.2.1
       styled-components: 6.0.0-rc.0(react-dom@18.1.0)(react@18.1.0)
-      tslib: 2.5.2
+      tslib: 2.5.0
       warning: 4.0.3
     transitivePeerDependencies:
       - '@reduxjs/toolkit'
@@ -4751,7 +4751,7 @@ packages:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /array-buffer-byte-length@1.0.0:
@@ -5275,7 +5275,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /camelcase-keys@6.2.2:
@@ -5973,7 +5973,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /duplexify@4.1.2:
@@ -7837,7 +7837,7 @@ packages:
     dependencies:
       copy-anything: 2.0.6
       parse-node-version: 1.0.1
-      tslib: 2.5.2
+      tslib: 2.5.0
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.11
@@ -8029,7 +8029,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /lru-cache@5.1.1:
@@ -8294,7 +8294,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /node-abort-controller@3.1.1:
@@ -8649,7 +8649,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /parent-module@1.0.1:
@@ -8692,7 +8692,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /path-browserify@0.0.1:
@@ -11611,7 +11611,7 @@ packages:
       react-dom: 18.1.0(react@18.1.0)
       shallowequal: 1.1.0
       stylis: 4.2.0
-      tslib: 2.5.2
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11782,7 +11782,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.4.1
-      tslib: 2.5.2
+      tslib: 2.5.0
     dev: true
 
   /table@6.8.1:
@@ -11924,6 +11924,9 @@ packages:
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
+
+  /tslib@2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
   /tslib@2.5.2:
     resolution: {integrity: sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==}


### PR DESCRIPTION
给 resolver 增加 `module` 条件导出的识别，有些库在 `exports` 中只配置了 `module`（比如 tslib@2.5.0）

Close #134 