### PR TITLE
fix: node polyfill, support empty modules

### DIFF
--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -168,7 +168,12 @@ impl Compiler {
     ) -> Result<Module> {
         let module = match external {
             Some(external) => {
-                let code = format!("module.exports = {};", external);
+                // support empty external
+                let code = if external.is_empty() {
+                    "module.exports = {};".to_string()
+                } else {
+                    format!("module.exports = {};", external)
+                };
                 let ast = build_js_ast(
                     format!("external_{}", &resolved_path).as_str(),
                     code.as_str(),

--- a/crates/mako/src/config_node_polyfill.rs
+++ b/crates/mako/src/config_node_polyfill.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 
-fn get_node_builtins() -> Vec<String> {
+fn get_polyfill_modules() -> Vec<String> {
     vec![
         "assert",
         "buffer",
@@ -31,22 +31,40 @@ fn get_node_builtins() -> Vec<String> {
     .collect()
 }
 
+fn get_empty_modules() -> Vec<String> {
+    vec![
+        "child_process",
+        "cluster",
+        "dgram",
+        "dns",
+        "fs",
+        "module",
+        "net",
+        "readline",
+        "repl",
+        "tls",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
 impl Config {
     pub fn config_node_polyfill(config: &mut Config) {
-        let builtins = get_node_builtins();
-
-        for name in builtins.iter() {
-            config
-                .resolve
-                .alias
-                // why replace / ?
-                // since a/b is not a valid js variable name
-                .insert(
-                    name.to_string(),
-                    format!("node-libs-browser-okam/polyfill/{}", name),
-                );
+        // polyfill modules
+        for name in get_polyfill_modules().iter() {
+            config.resolve.alias.insert(
+                name.to_string(),
+                format!("node-libs-browser-okam/polyfill/{}", name),
+            );
         }
 
+        // empty modules
+        for name in get_empty_modules().iter() {
+            config.externals.insert(name.to_string(), "".to_string());
+        }
+
+        // identifier
         config
             .providers
             .insert("process".into(), ("process".into(), "".into()));

--- a/examples/with-node-polyfill/index.ts
+++ b/examples/with-node-polyfill/index.ts
@@ -1,6 +1,14 @@
-// process
+// identifier
 if ('production' !== process.env.NODE_ENV && process) {
   console.log(process.env.NODE_ENV, process);
 } else {
   console.log('HAHA');
 }
+
+// empty module
+const fs = require('fs');
+console.log(fs);
+
+// polyfill module
+const path = require('path');
+console.log(path.join('a', 'b'));


### PR DESCRIPTION
比如 fs 这类模块，不可能有 browser 侧的补丁，只需要 require 时不报错就好。