### PR TITLE
chore: ➖ less triples

### DIFF
--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -6,14 +6,12 @@
   "napi": {
     "name": "okam",
     "triples": {
+      "defaults": false,
       "additional": [
         "aarch64-apple-darwin",
-        "aarch64-unknown-linux-gnu",
-        "aarch64-unknown-linux-musl",
-        "aarch64-pc-windows-msvc",
-        "armv7-unknown-linux-gnueabihf",
-        "x86_64-unknown-linux-musl",
-        "i686-pc-windows-msvc"
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl"
       ]
     }
   },


### PR DESCRIPTION
为了节约  CI quota ，仅支持

- mac intel 和 arm 架构 
- linux 仅支持 x86 架构
- windows 暂时支持