### PR TITLE
feat: build module with path and query

### DIFF
--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -203,12 +203,13 @@ impl Compiler {
     ) -> Result<(Module, ModuleDeps, Task)> {
         let mut dependencies = Vec::new();
         let module_id = ModuleId::new(task.path.clone());
+        let request = parse_path(&task.path)?;
 
         // load
-        let content = load(&task.path, task.is_entry, &context)?;
+        let content = load(&request, task.is_entry, &context)?;
 
         // parse
-        let mut ast = parse(&content, &task.path, &context)?;
+        let mut ast = parse(&content, &request, &context)?;
 
         // transform & resolve
         // TODO: 支持同时有多个 resolve error
@@ -303,13 +304,78 @@ fn get_entries(root: &Path, config: &Config) -> Option<Vec<std::path::PathBuf>> 
     None
 }
 
+fn parse_path(path: &str) -> Result<FileRequest> {
+    let mut iter = path.split('?');
+    let path = iter.next().unwrap();
+    let query = iter.next().unwrap_or("");
+    let mut query_vec = vec![];
+    for pair in query.split('&') {
+        if pair.contains('=') {
+            let mut it = pair.split('=').take(2);
+            let kv = match (it.next(), it.next()) {
+                (Some(k), Some(v)) => (k.to_string(), v.to_string()),
+                _ => continue,
+            };
+            query_vec.push(kv);
+        } else if !pair.is_empty() {
+            query_vec.push((pair.to_string(), "".to_string()));
+        }
+    }
+    Ok(FileRequest {
+        path: path.to_string(),
+        query: query_vec,
+    })
+}
+
+#[derive(Debug)]
+pub struct FileRequest {
+    pub path: String,
+    pub query: Vec<(String, String)>,
+}
+
+impl FileRequest {
+    pub fn has_query(&self, key: &str) -> bool {
+        self.query.iter().any(|(k, _)| *k == key)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use petgraph::prelude::EdgeRef;
     use petgraph::visit::IntoEdgeReferences;
 
+    use super::parse_path;
     use crate::compiler;
     use crate::config::Config;
+
+    #[test]
+    fn test_parse_path() {
+        let result = parse_path("foo").unwrap();
+        assert_eq!(result.path, "foo");
+        assert_eq!(result.query, vec![]);
+
+        let result = parse_path("foo?bar=1&hoo=2").unwrap();
+        assert_eq!(result.path, "foo");
+        assert_eq!(
+            result.query.get(0).unwrap(),
+            &("bar".to_string(), "1".to_string())
+        );
+        assert_eq!(
+            result.query.get(1).unwrap(),
+            &("hoo".to_string(), "2".to_string())
+        );
+        assert!(result.has_query("bar"));
+        assert!(result.has_query("hoo"));
+        assert!(!result.has_query("foo"));
+
+        let result = parse_path("foo?bar").unwrap();
+        assert_eq!(result.path, "foo");
+        assert_eq!(
+            result.query.get(0).unwrap(),
+            &("bar".to_string(), "".to_string())
+        );
+        assert!(result.has_query("bar"));
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_build_normal() {

--- a/crates/mako/src/css_modules.rs
+++ b/crates/mako/src/css_modules.rs
@@ -4,7 +4,6 @@ use swc_css_modules::{compile, CssClassName, TransformConfig, TransformResult};
 use tracing::warn;
 
 const CSS_MODULES_PATH_SUFFIX: &str = ".module.css";
-pub const MAKO_CSS_MODULES_SUFFIX: &str = ".MAKO_CSS_MODULES";
 
 pub struct CssModuleRename {
     pub path: String,
@@ -28,10 +27,6 @@ fn ident_name(path: &str, name: &str) -> String {
 
 pub fn is_css_modules_path(path: &str) -> bool {
     path.ends_with(CSS_MODULES_PATH_SUFFIX)
-}
-
-pub fn is_mako_css_modules(path: &str) -> bool {
-    path.ends_with(MAKO_CSS_MODULES_SUFFIX)
 }
 
 pub fn compile_css_modules(path: &str, ast: &mut Stylesheet) -> TransformResult {
@@ -68,11 +63,10 @@ pub fn generate_code_for_css_modules(path: &str, ast: &mut Stylesheet) -> String
     }
     format!(
         r#"
-import "{}{}";
+import "{}?modules";
 export default {{{}}}
 "#,
         path,
-        MAKO_CSS_MODULES_SUFFIX,
         export_names
             .iter()
             .map(|(name, classes)| format!("\"{}\": `{}`", name, classes.join(" ").trim()))

--- a/crates/mako/src/load.rs
+++ b/crates/mako/src/load.rs
@@ -11,8 +11,8 @@ use thiserror::Error;
 use tracing::debug;
 use twox_hash::XxHash64;
 
+use crate::build::FileRequest;
 use crate::compiler::Context;
-use crate::css_modules::{is_mako_css_modules, MAKO_CSS_MODULES_SUFFIX};
 use crate::plugin::PluginLoadParam;
 
 pub struct Asset {
@@ -54,13 +54,9 @@ pub enum LoadError {
     ToSvgrError { path: String, reason: String },
 }
 
-pub fn load(path: &str, is_entry: bool, context: &Arc<Context>) -> Result<Content> {
-    debug!("load: {}", path);
-    let path = if is_mako_css_modules(path) {
-        path.trim_end_matches(MAKO_CSS_MODULES_SUFFIX)
-    } else {
-        path
-    };
+pub fn load(request: &FileRequest, is_entry: bool, context: &Arc<Context>) -> Result<Content> {
+    debug!("load: {:?}", request);
+    let path = &request.path;
     let exists = Path::new(path).exists();
     if !exists {
         return Err(anyhow!(LoadError::FileNotFound {

--- a/crates/mako/src/parse.rs
+++ b/crates/mako/src/parse.rs
@@ -6,51 +6,53 @@ use swc_css_visit::VisitMutWith;
 use tracing::debug;
 
 use crate::ast::{build_css_ast, build_js_ast};
+use crate::build::FileRequest;
 use crate::compiler::Context;
-use crate::css_modules::{
-    compile_css_modules, generate_code_for_css_modules, is_css_modules_path, is_mako_css_modules,
-    MAKO_CSS_MODULES_SUFFIX,
-};
+use crate::css_modules::{compile_css_modules, generate_code_for_css_modules, is_css_modules_path};
 use crate::load::{Asset, Content};
 use crate::module::ModuleAst;
 
-pub fn parse(content: &Content, path: &str, context: &Arc<Context>) -> Result<ModuleAst> {
-    debug!("parse {}", path);
+pub fn parse(
+    content: &Content,
+    request: &FileRequest,
+    context: &Arc<Context>,
+) -> Result<ModuleAst> {
+    debug!("parse {:?}", request);
     let ast = match content {
-        Content::Js(content) => parse_js(content, path, context)?,
-        Content::Css(content) => parse_css(content, path, context)?,
-        Content::Assets(asset) => parse_asset(asset, path, context)?,
+        Content::Js(content) => parse_js(content, request, context)?,
+        Content::Css(content) => parse_css(content, request, context)?,
+        Content::Assets(asset) => parse_asset(asset, request, context)?,
     };
     Ok(ast)
 }
 
-fn parse_js(content: &str, path: &str, context: &Arc<Context>) -> Result<ModuleAst> {
-    let ast = build_js_ast(path, content, context)?;
+fn parse_js(content: &str, request: &FileRequest, context: &Arc<Context>) -> Result<ModuleAst> {
+    let ast = build_js_ast(&request.path, content, context)?;
     Ok(ModuleAst::Script(ast))
 }
 
-fn parse_css(content: &str, path: &str, context: &Arc<Context>) -> Result<ModuleAst> {
-    let mut ast = build_css_ast(path, content, context)?;
+fn parse_css(content: &str, request: &FileRequest, context: &Arc<Context>) -> Result<ModuleAst> {
+    let mut ast = build_css_ast(&request.path, content, context)?;
+    let is_modules = request.has_query("modules");
     // parse css module as js
-    if is_css_modules_path(path) {
-        let code = generate_code_for_css_modules(path, &mut ast);
-        let js_ast = build_js_ast(path, &code, context)?;
+    if is_css_modules_path(&request.path) && !is_modules {
+        let code = generate_code_for_css_modules(&request.path, &mut ast);
+        let js_ast = build_js_ast(&request.path, &code, context)?;
         Ok(ModuleAst::Script(js_ast))
     } else {
         // TODO: move to transform step
         // compile css compat
         compile_css_compat(&mut ast);
         // for mako css module, compile it and parse it as css
-        if is_mako_css_modules(path) {
-            // should remove the suffix to generate the same hash
-            compile_css_modules(path.trim_end_matches(MAKO_CSS_MODULES_SUFFIX), &mut ast);
+        if is_modules {
+            compile_css_modules(&request.path, &mut ast);
         }
         Ok(ModuleAst::Css(ast))
     }
 }
 
-fn parse_asset(asset: &Asset, path: &str, context: &Arc<Context>) -> Result<ModuleAst> {
-    let ast = build_js_ast(path, &asset.content, context)?;
+fn parse_asset(asset: &Asset, request: &FileRequest, context: &Arc<Context>) -> Result<ModuleAst> {
+    let ast = build_js_ast(&request.path, &asset.content, context)?;
     Ok(ModuleAst::Script(ast))
 }
 


### PR DESCRIPTION
Notes.

- build.rs build_module 里的 path 支持 query 的形式
- 简化 css module 的处理，基于 query `?modules`
- 后续的 svgr 也应基于此区分处理是 svgr 还是 svg

