### PR TITLE
refactor: hoist all url css import rules

### DIFF
--- a/examples/normal/index.css
+++ b/examples/normal/index.css
@@ -6,5 +6,3 @@ h1 {
     background-size: 20px 20px;
     font-family: 'Open Sans';
 }
-
-@import "https://example.com/foo.css";

--- a/examples/normal/mako.config.json
+++ b/examples/normal/mako.config.json
@@ -1,3 +1,4 @@
 {
-  "devtool": "source-map"
+  "devtool": "source-map",
+  "extract_css": true
 }


### PR DESCRIPTION
把所有 url 值的 CSS `@import` 规则挪到其他规则的前面，确保浏览器会正常处理这些 `@import` 规则