### PR TITLE
fix: 🐛 repalce later source to first source, thoes resolve to the same target

### DIFF
--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -244,7 +244,7 @@ impl Compiler {
 
                     let used_source = resolved_deps_to_source
                         .entry(id_str.clone())
-                        .or_insert(dep.source.clone());
+                        .or_insert_with(|| dep.source.clone());
 
                     if dep.source.eq(used_source) {
                         dependencies.push((resolved.clone(), external, dep.clone()));


### PR DESCRIPTION
fix  #311 

1.  这个一轮的替换，应该替换成一个**语义**上正确的地址，所以替换成第一个 source。
2.  build_module  只返回一条边，其中的 source 为第一个，其他的相同的结果的 source，替换为第一个。