### PR TITLE
fix(stats): xlsx 引入了 fs 模块，使用 file_size 读取 module_id 对应的文件路径大小时，未找到文件…

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -196,7 +196,12 @@ pub fn create_stats_info(compile_time: u128, compiler: &Compiler) -> StatsJsonMa
                 })
                 .map(|module| {
                     let id = module.id.clone();
-                    let size = file_size(&id).unwrap();
+                    // 去拿 module 的文件 size 时，有可能 module 不存在，size 则设为 0
+                    // 场景: xlsx 中引入了 fs 模块
+                    let size = match file_size(&id) {
+                        Ok(size) => size,
+                        Err(..) => 0,
+                    };
                     let module = StatsJsonModuleItem {
                         module_type: StatsJsonType::Module("module".to_string()),
                         size,


### PR DESCRIPTION
xlsx 引入了 fs 模块，使用 file_size 读取 module_id 对应的文件路径大小时，未找到文件报错，没有对应路径的模块文件的 size 均设为 0。

![image](https://github.com/umijs/mako/assets/45666106/88a404ab-90a2-4f2b-a7d6-6bbbdf89f63f)

Close #348
