### PR TITLE
fix: chunk modules order may unstable if enable code splitting

### DIFF
--- a/crates/mako/src/group_chunk.rs
+++ b/crates/mako/src/group_chunk.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use anyhow::Result;
 use cached::proc_macro::cached;
+use indexmap::IndexSet;
 use serde::Deserialize;
 use tracing::debug;
 use twox_hash::XxHash64;
@@ -37,10 +38,13 @@ impl Compiler {
     pub fn group_dep_per_chunk(&self) {
         let mut chunk_graph = self.context.chunk_graph.write().unwrap();
 
-        let entries = chunk_graph.mut_chunks();
+        let mut entries = chunk_graph.mut_chunks();
 
-        let mut pkg_modules: HashMap<String, HashSet<ModuleId>> = HashMap::new();
-        let mut pkg_chunk_dependant: HashMap<String, HashSet<ChunkId>> = HashMap::new();
+        let mut pkg_modules: HashMap<String, IndexSet<ModuleId>> = HashMap::new();
+        let mut pkg_chunk_dependant: HashMap<String, IndexSet<ChunkId>> = HashMap::new();
+
+        // keep module order stable for each splitting
+        entries.sort_by_key(|c| c.id.id.clone());
 
         for chunk in entries {
             let mut to_remove = vec![];
@@ -141,13 +145,16 @@ impl Compiler {
     fn group_big_vendor_chunk(&self) {
         // big vendors chunk policy
         let mut chunk_graph = self.context.chunk_graph.write().unwrap();
-        let chunks = chunk_graph.mut_chunks();
+        let mut chunks = chunk_graph.mut_chunks();
         let mut big_vendor_chunk = Chunk::new("all_vendors".into(), ChunkType::Sync);
 
         let mut entries = Vec::new();
 
+        // keep module order stable for each splitting
+        chunks.sort_by_key(|c| c.id.id.clone());
+
         for c in chunks {
-            let mut vendors_to_move = HashSet::new();
+            let mut vendors_to_move = IndexSet::new();
 
             for m in c
                 .mut_modules()


### PR DESCRIPTION
修复在启用代码拆分时 chunk modules 的顺序不稳定的问题，这可能会导致 HMR 时 CSS chunk 的规则顺序不稳定，以及可能会影响 #361 里计算 chunk hash 缓存键的实现方案

原因是在代码拆分时没有先对 chunk_graph 中的 chunks 做排序再遍历，加上排序并改用 IndexSet 后 chunk 顺序稳定、chunk 所属的 modules 顺序稳定，那么它们被拆分到新 chunk 中的顺序也将是稳定的