### PR TITLE
chore: use kB, mB to align with size in Mac Finder

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -258,13 +258,13 @@ pub fn write_stats(stats: &StatsJsonMap, compiler: &Compiler) {
 
 // 文件大小转换
 pub fn human_readable_size(size: u64) -> String {
-    let units = ["KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    let units = ["kB", "mB", "gB"];
     // 把 B 转为 KB
-    let mut size = (size as f64) / 1024.0;
+    let mut size = (size as f64) / 1000.0;
     let mut i = 0;
 
-    while size >= 1024.0 && i < units.len() - 1 {
-        size /= 1024.0;
+    while size >= 1000.0 && i < units.len() - 1 {
+        size /= 1000.0;
         i += 1;
     }
 


### PR DESCRIPTION
和 mac 下的尺寸计算保持一致，Vite 也是如此。