### PR TITLE
fix: tree shaking should mark cycle modules as side effects

### DIFF
--- a/crates/mako/src/tree_shaking.rs
+++ b/crates/mako/src/tree_shaking.rs
@@ -21,8 +21,8 @@ impl Compiler {
         self.markup_entry_modules_as_side_effects(entry_modules);
 
         // 循环依赖模块设置为副作用
-        // NOTE: 目前暂时没有发现循环依赖走 treeShaking 产生的问题，暂时先放弃打标
-        // self.markup_cycle_modules_as_side_effects(cycle_modules);
+        // 场景比如：在 app.ts 里使用 umi 的 createGlobalStyle 时
+        self.markup_cycle_modules_as_side_effects(cycle_modules);
 
         let (tree_shaking_module_ids, mut tree_shaking_module_map) =
             self.create_tree_shaking_module_map(sorted_modules);


### PR DESCRIPTION
一个场景 Bigfish 脚手架会报错，app.ts 里依赖 @alipay/bigfish 的 createGlobalStyle，而 createGlobalStyle 会被意外删除。

