### PR TITLE
refactor: reuse pkg json from module resolved resource data

### DIFF
--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -424,6 +424,7 @@ fn parse_path(path: &str) -> Result<FileRequest> {
         query: query_vec,
     })
 }
+
 #[derive(Debug)]
 pub struct FileRequest {
     pub path: String,


### PR DESCRIPTION
使用 ModuleInfo `resolved_resource` 中的 package.json 来简化目前的 Code Splitting 逻辑，该变更是为了完善 CodeSplitting 功能做准备，降低 PR 的 diff 量

从功能上仅影响 `depPerChunk` 拆分策略下 dev 阶段的 chunk name（从 name@hash => name@version，与 prod 保持一致）