### PR TITLE
fix(bundler-okam): use real assets stats

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -251,7 +251,7 @@ pub fn create_stats_info(compile_time: u128, compiler: &Compiler) -> StatsJsonMa
 }
 
 pub fn write_stats(stats: &StatsJsonMap, compiler: &Compiler) {
-    let path = &compiler.context.root.join("stats.json");
+    let path = &compiler.context.config.output.path.join("stats.json");
     let stats_json = serde_json::to_string_pretty(stats).unwrap();
     fs::write(path, stats_json).unwrap();
 }


### PR DESCRIPTION
1、修复 umi/bigfish build 的 html 产物没有 umi.css（表象）的问题
2、把 stats.json 挪到 output.path 里
3、透传 hash 配置给 mako（build only）
