### PR TITLE
fix: outdated css modules content after hmr

### DIFF
--- a/crates/mako/src/update.rs
+++ b/crates/mako/src/update.rs
@@ -189,7 +189,10 @@ impl Compiler {
 
         // concat related query modules for modified paths
         // for example: concat a.module.css?modules for a.module.css
-        for module in modules.iter().filter(|module| module.id.id.contains('?')) {
+        for module in modules
+            .iter()
+            .filter(|module| module.id.id.contains("?modules"))
+        {
             let origin_id = module.id.id.split('?').next().unwrap();
 
             if modified.contains(&PathBuf::from(origin_id)) {


### PR DESCRIPTION
修复 CSS Modules 中的 CSS 内容在 HMR 之后不更新的问题

原因是变更模块的搜集过程中只找了原始路径对应的模块，需要把带 query 的模块也补进去，比如 `a.module.css` 更新时 `a.module.css?modules` 也需要更新