### PR TITLE
WIP: feat: ✨ POC tree-shaking 环移除

### DIFF
--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -166,6 +166,7 @@ pub struct Module {
     pub is_entry: bool,
     pub info: Option<ModuleInfo>,
     pub side_effects: bool,
+    pub in_cycle: bool,
 }
 #[allow(dead_code)]
 
@@ -176,6 +177,7 @@ impl Module {
             is_entry,
             info,
             side_effects: is_entry,
+            in_cycle: false,
         }
     }
 


### PR DESCRIPTION
WIP POC 代码 
原理：
1 执行两轮 shake-treeing
2 执行过程中，在环上的 tree-shake-module （TSM）无副作用。
3 第一轮：执行过程中，如果环上的  TSM 被依赖了，那么修改环上的所有 TSM 为有 side_effects 且配置为 used_all_exports
4. 第二轮执行，如果环上的 TSM 上一轮和当前第二轮都没有依赖，则认为环是孤立的执行删除。

优点:
流程简单，好理解。

可能得缺陷：
1. 第一轮中可能会，漏掉 环上节点变成 used_all_export 节点变更对后背节点的依赖增加，而误增加“孤立环”的数量
2. 第二轮中同理，会造成“孤立”环增加，而多删模块。

这个两个“可能”缺陷还没碰到，分析中也没有举出例子。


## 效果

### with antd-Pro 

4179.89K dist-mako-advanced/ewlg.js
3560.99K dist-mako-basic/ewlg.js (159% webpack)
2232.66K dist-webpack/index.js


###without antd-Pro (pro-field 有一处 treeshake 不友好)

1349.08K dist-mako-advanced/ewlg.js
 887.79K dist-mako-basic/ewlg.js (134% webpack)
 661.30K dist-webpack/index.js

不用 antd-pro 的情况下，未压缩（为了方便分析）

模块数和 webpack 基本持平
 639 mako.advanced.module.list.txt
 329 mako.basic.module.list.txt
 352 webpack.module.list.txt

尺寸也相差不大
4775.50K dist-mako-advanced/index.js
3154.42K dist-mako-basic/index.js
3072.64K dist-webpack/index.js

