### PR TITLE
fix: 🐛 when use config#hash=true entry chunk use wrong chunk name

### DIFF
--- a/crates/mako/src/chunk.rs
+++ b/crates/mako/src/chunk.rs
@@ -4,7 +4,7 @@ use std::path::{Component, Path};
 use indexmap::IndexSet;
 use twox_hash::XxHash64;
 
-use crate::module::ModuleId;
+use crate::module::{ModuleId, ModuleType};
 use crate::module_graph::ModuleGraph;
 
 pub type ChunkId = ModuleId;
@@ -37,6 +37,37 @@ impl Chunk {
             content: None,
             source_map: None,
         }
+    }
+
+    pub fn js_hash(&self, mg: &ModuleGraph) -> u64 {
+        get_related_module_hash(self, mg, false)
+    }
+    pub fn css_hash(&self, mg: &ModuleGraph) -> u64 {
+        get_related_module_hash(self, mg, true)
+    }
+
+    pub fn js_chunk_name_with_hash(&self, mg: &ModuleGraph) -> String {
+        let filename = self.filename();
+        let hash = self.js_hash(mg);
+        self.with_hash(&filename, hash, "js")
+    }
+
+    pub fn css_chunk_name_with_hash(&self, mg: &ModuleGraph) -> String {
+        let filename = self.filename();
+        let hash = self.css_hash(mg);
+        self.with_hash(&filename, hash, "css")
+    }
+
+    fn with_hash(&self, filename: &String, hash: u64, ext: &str) -> String {
+        let filename = if let Some((left, _)) = filename.rsplit_once('.') {
+            left
+        } else {
+            filename
+        };
+
+        let hash = &format!("{:08x}", hash)[0..8];
+
+        format!("{}.{}.{}", filename, hash, ext)
     }
 
     pub fn filename(&self) -> String {
@@ -104,6 +135,35 @@ impl Chunk {
 
         hash.finish()
     }
+}
+
+// 给 output_ast 计算 hash 值，get_chunk_emit_files 时会根据此 hash 值做缓存
+fn get_related_module_hash(
+    chunk: &crate::chunk::Chunk,
+    module_graph: &crate::module_graph::ModuleGraph,
+    is_css_ast: bool,
+) -> u64 {
+    let mut hash: XxHash64 = Default::default();
+    let mut module_ids_used = chunk
+        .get_modules()
+        .iter()
+        .cloned()
+        .collect::<Vec<ModuleId>>();
+    // 因为存在 code splitting，可能存在用户引入依赖的顺序发生改变但依赖背后的 module 没有改变的情况
+    // 此时 js chunk 不需要重新生成，所以在计算 ast_module_hash 针对 js 的场景先对 module 做轮排序
+    if !is_css_ast {
+        module_ids_used.sort_by_key(|m| m.id.clone());
+    }
+
+    for id in module_ids_used {
+        let m = module_graph.get_module(&id).unwrap();
+        let m_type = m.get_module_type();
+
+        if matches!(m_type, ModuleType::Css) == is_css_ast {
+            hash.write_u64(m.info.as_ref().unwrap().raw_hash);
+        }
+    }
+    hash.finish()
 }
 
 #[cfg(test)]

--- a/crates/mako/src/generate_chunks.rs
+++ b/crates/mako/src/generate_chunks.rs
@@ -1,4 +1,3 @@
-use std::hash::Hasher;
 use std::sync::Arc;
 use std::vec;
 
@@ -12,11 +11,10 @@ use swc_ecma_ast::{
     FnExpr, Function, Ident, KeyValueProp, MemberExpr, MemberProp, ModuleItem, ObjectLit, Param,
     Pat, Prop, PropOrSpread, Stmt, Str, VarDecl,
 };
-use twox_hash::XxHash64;
 
 use crate::ast::build_js_ast;
 use crate::compiler::{Compiler, Context};
-use crate::module::{ModuleAst, ModuleId, ModuleType};
+use crate::module::{ModuleAst, ModuleId};
 use crate::transform_in_generate::transform_css_generate;
 
 pub struct OutputAst {
@@ -33,6 +31,8 @@ impl Compiler {
         let module_graph = self.context.module_graph.read().unwrap();
         let chunk_graph = self.context.chunk_graph.write().unwrap();
 
+        let use_hash = self.context.config.hash;
+
         let chunks = chunk_graph.get_chunks();
         // TODO: remove this
         let chunks_map_str: Vec<String> = chunks
@@ -41,7 +41,11 @@ impl Compiler {
                 format!(
                     "chunksIdToUrlMap[\"{}\"] = `{}`;",
                     chunk.id.generate(&self.context),
-                    chunk.filename()
+                    if use_hash {
+                        chunk.js_chunk_name_with_hash(&module_graph)
+                    } else {
+                        chunk.filename()
+                    }
                 )
             })
             .collect();
@@ -67,7 +71,11 @@ impl Compiler {
                                         let str = format!(
                                             "cssChunksIdToUrlMap[\"{}\"] = `{}`;",
                                             chunk.id.generate(&self.context),
-                                            get_css_chunk_filename(chunk.filename()),
+                                            if use_hash {
+                                                chunk.css_chunk_name_with_hash(&module_graph)
+                                            } else {
+                                                get_css_chunk_filename(chunk.filename())
+                                            }
                                         );
 
                                         match chunk.chunk_type {
@@ -264,14 +272,14 @@ impl Compiler {
                     path: filename,
                     ast: ModuleAst::Script(js_ast),
                     chunk_id: chunk.id.id.clone(),
-                    ast_module_hash: get_related_module_hash(chunk, &module_graph, false),
+                    ast_module_hash: chunk.js_hash(&module_graph),
                 });
                 if let Some(merged_css_ast) = merged_css_ast {
                     output.push(OutputAst {
                         path: css_filename,
                         ast: ModuleAst::Css(merged_css_ast),
                         chunk_id: chunk.id.id.clone(),
-                        ast_module_hash: get_related_module_hash(chunk, &module_graph, true),
+                        ast_module_hash: chunk.css_hash(&module_graph),
                     });
                 }
                 Ok(output)
@@ -290,35 +298,6 @@ fn get_css_chunk_filename(js_chunk_filename: String) -> String {
         "{}.css",
         js_chunk_filename.strip_suffix(".js").unwrap_or("")
     )
-}
-
-// 给 output_ast 计算 hash 值，get_chunk_emit_files 时会根据此 hash 值做缓存
-pub fn get_related_module_hash(
-    chunk: &crate::chunk::Chunk,
-    module_graph: &std::sync::RwLockReadGuard<crate::module_graph::ModuleGraph>,
-    is_css_ast: bool,
-) -> u64 {
-    let mut hash: XxHash64 = Default::default();
-    let mut module_ids_used = chunk
-        .get_modules()
-        .iter()
-        .cloned()
-        .collect::<Vec<ModuleId>>();
-    // 因为存在 code splitting，可能存在用户引入依赖的顺序发生改变但依赖背后的 module 没有改变的情况
-    // 此时 js chunk 不需要重新生成，所以在计算 ast_module_hash 针对 js 的场景先对 module 做轮排序
-    if !is_css_ast {
-        module_ids_used.sort_by_key(|m| m.id.clone());
-    }
-
-    for id in module_ids_used {
-        let m = module_graph.get_module(&id).unwrap();
-        let m_type = m.get_module_type();
-
-        if matches!(m_type, ModuleType::Css) == is_css_ast {
-            hash.write_u64(m.info.as_ref().unwrap().raw_hash);
-        }
-    }
-    hash.finish()
 }
 
 fn compile_runtime_entry(has_wasm: bool, has_async: bool) -> String {

--- a/crates/mako/src/load.rs
+++ b/crates/mako/src/load.rs
@@ -200,6 +200,7 @@ pub fn content_hash(file_path: &str) -> Result<String> {
     Ok(hash_to_8(hash))
 }
 
+#[allow(dead_code)]
 pub fn file_content_hash(content: String) -> String {
     let digest = md5::compute(content);
     let hash = format!("{:x}", digest);


### PR DESCRIPTION
## problem 
### expect
```js
// entry chunk
  (chunksIdToUrlMap.GeH9muJP = 'Tzs-w4hv-async.hhhhhhhhhash.js'),
```
### actual 

```js
// entry chunk
  (chunksIdToUrlMap.GeH9muJP = 'Tzs-w4hv-async.js'),
```
## 解

使用 module 的 raw hash 来计算 chunk 的 hash 

### 缺点

不同的 mako 配置（不同的 mako 版本） 但是源码没有变的情况下 chunk hash 不会变


### 后继 
generate_chunk 部分梳理清楚，重构后调整 chunk hash 策略
