### PR TITLE
feat: ✨ publish okam locally 

### DIFF
--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -27,9 +27,11 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
+    "artifacts:local": "napi artifacts --dir . --dist npm",
     "build": "napi build --platform --release",
     "build:mac:x86": "napi build --platform --release --target x86_64-apple-darwin",
     "build:mac:aarch": "napi build --platform --release --target aarch64-apple-darwin",
+    "build:linux:x86": "napi build --platform --release --target x86_64-unknown-linux-gnu",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "ava",
@@ -37,15 +39,8 @@
     "version": "napi version"
   },
   "optionalDependencies": {
-    "@okamjs/okam-win32-x64-msvc": "0.0.1-alpha.2",
-    "@okamjs/okam-darwin-x64": "0.0.1-alpha.2",
-    "@okamjs/okam-linux-x64-gnu": "0.0.1-alpha.2",
-    "@okamjs/okam-darwin-arm64": "0.0.1-alpha.2",
-    "@okamjs/okam-linux-arm64-gnu": "0.0.1-alpha.2",
-    "@okamjs/okam-linux-arm64-musl": "0.0.1-alpha.2",
-    "@okamjs/okam-win32-arm64-msvc": "0.0.1-alpha.2",
-    "@okamjs/okam-linux-arm-gnueabihf": "0.0.1-alpha.2",
-    "@okamjs/okam-linux-x64-musl": "0.0.1-alpha.2",
-    "@okamjs/okam-win32-ia32-msvc": "0.0.1-alpha.2"
+    "@okamjs/okam-darwin-arm64": "0.0.15",
+    "@okamjs/okam-darwin-x64": "0.0.15",
+    "@okamjs/okam-linux-x64-gnu": "0.0.15"
   }
 }

--- a/crates/node/scripts/release.ts
+++ b/crates/node/scripts/release.ts
@@ -1,0 +1,82 @@
+import 'zx/globals';
+import * as process from 'process';
+
+(async () => {
+  console.log('Check branch');
+  const branch = (await $`git branch --show-current`).stdout.trim();
+  if (branch !== 'master') {
+    throw new Error('Please run this script in master branch');
+  }
+
+  // Check git status
+  console.log('Check git status');
+  const status = (await $`git status --porcelain`).stdout.trim();
+  if (status) {
+    throw new Error('Please commit all changes before release');
+  }
+
+  // bump version
+  console.log('Bump version');
+  const nodePkgDir = path.resolve(__dirname, '..');
+  const nodePkgPath = path.join(nodePkgDir, 'package.json');
+  const nodePkg = JSON.parse(fs.readFileSync(nodePkgPath, 'utf-8'));
+  const currentVersion = nodePkg.version;
+
+  console.log('current version: ', currentVersion);
+  const newVersion = (await question(`What's next version? `)).trim();
+
+  let tag = 'latest';
+  if (
+    newVersion.includes('-alpha.') ||
+    newVersion.includes('-beta.') ||
+    newVersion.includes('-rc.')
+  )
+    tag = 'next';
+  if (newVersion.includes('-canary.')) tag = 'canary';
+  if (newVersion.includes('-dev.')) tag = 'dev';
+
+  nodePkg.version = newVersion;
+
+  console.log(`${nodePkg.name}@${newVersion} will be published`);
+  const willContinue = ((await question(`Continue? y/[n]`)) || 'n').trim();
+
+  if (willContinue !== 'y') {
+    console.log('Abort!');
+    process.exit(0);
+  }
+
+  fs.writeFileSync(nodePkgPath, JSON.stringify(nodePkg, null, 2) + '\n');
+
+  // build macOs *.node
+  await $`rm -rf ./*.node`;
+  await $`pnpm run build:mac:x86`;
+  await $`pnpm run build:mac:aarch`;
+
+  // ref https://gist.github.com/shqld/256e2c4f4b97957fb0ec250cdc6dc463
+  $.env.CC_X86_64_UNKNOWN_LINUX_GNU = 'x86_64-unknown-linux-gnu-gcc';
+  $.env.CXX_X86_64_UNKNOWN_LINUX_GNU = 'x86_64-unknown-linux-gnu-g++';
+  $.env.AR_X86_64_UNKNOWN_LINUX_GNU = 'x86_64-unknown-linux-gnu-ar';
+  $.env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER =
+    'x86_64-unknown-linux-gnu-gcc';
+  await $`pnpm run build:linux:x86`;
+
+  await $`strip -x ./okam.darwin-*.node`;
+  await $`docker run  --rm   -v $PWD:/workspace -w /workspace  ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian   bash -c "strip okam.linux-x64-gnu.node"`;
+
+  await $`pnpm run artifacts:local`;
+
+  // --ignore-scripts because we don't publish optional pkg
+  await $`npm publish --tag ${tag} --access public`;
+
+  await $`git commit -a -m "release: ${nodePkg.name}@${newVersion}"`;
+  // tag
+  console.log('Tag');
+  await $`git tag v${newVersion}`;
+
+  // push
+  console.log('Push');
+  await $`git push origin ${branch} --tags`;
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
GH actions 发布 okam ~15m

本地构建  mac linux 两个平台 三个架构的产物

```txt
real    5m48.240s
user    48m32.542s
sys     2m11.241s
```
这个时间是 删除了 target 目录执行的结果，如果平时发的勤快这个时间很更短。（缓存立功。。 


### 前置条件
1. 配置 交叉编译器  https://gist.github.com/shqld/256e2c4f4b97957fb0ec250cdc6dc463
2. 安装 docker 和 镜像 ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian （应该可以用其他的 linux发行版，我本地刚好有就用了它

### 如何发

```
cd mako/crates/node
pnpm esno scripts/release.ts
```

