### PR TITLE
perf: speed up optimize chunks

### DIFF
--- a/crates/mako/src/optimize_chunk.rs
+++ b/crates/mako/src/optimize_chunk.rs
@@ -35,7 +35,7 @@ pub struct OptimizeChunkGroup {
 
 pub struct OptimizeChunksInfo {
     pub group_options: OptimizeChunkGroup,
-    pub module_to_chunks: HashMap<ModuleId, Vec<ChunkId>>,
+    pub module_to_chunks: IndexMap<ModuleId, Vec<ChunkId>>,
 }
 
 #[derive(PartialEq, Eq, Clone)]
@@ -53,7 +53,7 @@ impl Compiler {
                 .iter()
                 .map(|group| OptimizeChunksInfo {
                     group_options: group.clone(),
-                    module_to_chunks: HashMap::new(),
+                    module_to_chunks: IndexMap::new(),
                 })
                 .collect::<Vec<_>>();
 
@@ -270,7 +270,7 @@ impl Compiler {
                 // split new chunks until chunk size is less than max_size and there has more than 1 package can be split
                 while chunk_size > info.group_options.max_size && package_size_map.len() > 1 {
                     let mut new_chunk_size = 0;
-                    let mut new_module_to_chunks = HashMap::new();
+                    let mut new_module_to_chunks = IndexMap::new();
 
                     // collect modules by package name until chunk size is very to max_size
                     while !package_size_map.is_empty()
@@ -324,8 +324,8 @@ impl Compiler {
             let info_chunk = Chunk {
                 modules: info
                     .module_to_chunks
-                    .iter()
-                    .map(|cm| cm.0.clone())
+                    .keys()
+                    .cloned()
                     .collect::<IndexSet<_>>(),
                 id: info_chunk_id.clone(),
                 chunk_type: ChunkType::Sync,


### PR DESCRIPTION
优化 optimize chunks 阶段的效率，主要做了两件事：
1. 在 module 与 chunk 的关系存储上从 Vec 切换为 HashMap，降低修改数据时遍历的耗时
2. 跳过不必要的 optimize groups 条件判定，并且在判定过程中尽量减少迭代数（比如 `min_chunks` 大于 1 才进行计算，且计算方式改成点到为止）

在 tun 项目中的数据：
```bash
# 优化前
DEBUG mako::generate:   - optimize chunks: 19596ms

# 优化后
DEBUG mako::generate:   - optimize chunks: 2003ms
```

为什么前后没改多少代码，但耗时降低了这么多？因为 Code Splitting 要遍历的是每一个 chunk 的每一个 module，由于 module 在 chunk 中存在重复，在该项目中共计算了 33w+ 次 module 与 chunk 的关系，所以多做几次不必要的计算在 33w+ 次的累加上就变得十分恐怖了