### PR TITLE
feat: improve config and config check for umi

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -81,6 +81,8 @@ pub struct LessConfig {
     pub theme: HashMap<String, String>,
     #[serde(rename(deserialize = "lesscPath"))]
     pub lessc_path: String,
+    #[serde(rename(deserialize = "javascriptEnabled"))]
+    pub javascript_enabled: bool,
 }
 
 #[derive(Deserialize, Clone, Copy, Debug)]
@@ -174,7 +176,7 @@ const DEFAULT_CONFIG: &str = r#"
     "publicPath": "/",
     "inlineLimit": 10000,
     "targets": { "chrome": 80 },
-    "less": { "theme": {}, "lesscPath": "" },
+    "less": { "theme": {}, "lesscPath": "", javascriptEnabled: true },
     "define": {},
     "manifest": false,
     "manifestConfig": { "fileName": "asset-manifest.json", "basePath": "" },

--- a/crates/mako/src/generate.rs
+++ b/crates/mako/src/generate.rs
@@ -102,20 +102,18 @@ impl Compiler {
         // minify
         let t_minify = Instant::now();
         debug!("minify");
-        if self.context.config.minify {
+        if self.context.config.minify && matches!(self.context.config.mode, Mode::Production) {
             chunk_asts
                 .par_iter_mut()
                 .try_for_each(|file| -> Result<()> {
-                    if matches!(self.context.config.mode, Mode::Production) {
-                        match &mut file.ast {
-                            ModuleAst::Script(ast) => {
-                                minify_js(ast, &self.context)?;
-                            }
-                            ModuleAst::Css(ast) => {
-                                minify_css(ast, &self.context)?;
-                            }
-                            _ => (),
+                    match &mut file.ast {
+                        ModuleAst::Script(ast) => {
+                            minify_js(ast, &self.context)?;
                         }
+                        ModuleAst::Css(ast) => {
+                            minify_css(ast, &self.context)?;
+                        }
+                        _ => (),
                     }
                     Ok(())
                 })?;

--- a/crates/mako/src/plugins/less.rs
+++ b/crates/mako/src/plugins/less.rs
@@ -53,7 +53,9 @@ fn compile_less(param: &PluginLoadParam, _content: &str, context: &Arc<Context>)
     } else {
         args.push(lessc_path);
     }
-    args.push("--js".to_string());
+    if context.config.less.javascript_enabled {
+        args.push("--js".to_string());
+    }
     if !theme.is_empty() {
         theme.iter().for_each(|(k, v)| {
             args.push(format!("--modify-var={}=\'{}\'", k, v));


### PR DESCRIPTION
> 纯体力活。

## 配置对照表

注：不包含非构建配置。

| **umi**              | **mako**                  | **notes**                                                                                                      |
| -------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
| alias                | alias                     | mako 的 alias 使用相对路径有点问题，见 #309                                                                    |
| autoprefixer         | n/a                       | umi 的 autoprefixer 的配置项 mako 是不支持的，功能上可能也在细节上有不同，比如 umi 默认是 `flexbox: 'no-2009'` |
| analyze              | n/a                       | not supported                                                                                                  |
| cacheDirectoryPath   | n/a                       | 不需要                                                                                                         |
| chainWebpack         | n/a                       | 不需要                                                                                                         |
| clickToComponent     | n/a                       | not supported                                                                                                  |
| codeSplitting        | codeSplitting             | mako 的 codeSplitting 默认是 auto                                                                              |
| copy                 | copy                      | mako 的 copy 是 `string[]`，暂不支持 `{ from, to }` 这种格式                                                   |
| cssMinifier          | n/a                       | mako 只有 swc 的压缩策略                                                                                       |
| cssMinifierOptions   | n/a                       | 不需要                                                                                                         |
| cssLoader            | n/a                       | 不需要                                                                                                         |
| cssLoaderModules     | n/a                       | 不需要                                                                                                         |
| deadCode             | n/a                       | not supported                                                                                                  |
| define               | define                    | 配的值有些不同，mako 配的是 NODE_ENV，而不是 process.env.NODE_ENV                                              |
| devtool              | devtool                   | mako 的 devtool 默认是 source-map，且不支持切换到其他的                                                        |
| classPropertiesLoose | n/a                       | not supported                                                                                                  |
| esbuildMinifyIIFE    | n/a                       | 不需要                                                                                                         |
| externals            | externals                 | 不支持 webpack 5 的 remote external                                                                            |
| extraBabelIncludes   | n/a                       | 不需要                                                                                                         |
| extraBabelPlugins    | n/a                       | 不需要                                                                                                         |
| extraBabelPresets    | n/a                       | 不需要                                                                                                         |
| extraPostCSSPlugins  | n/a                       | not supported，因为没有用 postcss                                                                              |
| forkTSChecker        | n/a                       | not supported                                                                                                  |
| hash                 | hash                      |                                                                                                                |
| ignoreMomentLocale   | n/a                       | not supported                                                                                                  |
| inlineLimit          | inlineLimit               |                                                                                                                |
| jsMinifier           | minify                    | jsMinifier 时 mako 的 minify 为 false，不压缩                                                                  |
| jsMinifierOptions    | n/a                       | 不需要                                                                                                         |
| lessLoader           | less                      |                                                                                                                |
| legacy               | n/a                       | not supported                                                                                                  |
| manifest             | manifest + manifestConfig |                                                                                                                |
| mdx                  | mdx                       | mako 的 mdx 只有是否开启，不支持子属性配置                                                                     |
| mfsu                 | n/a                       | not supported                                                                                                  |
| outputPath           | output.path               |                                                                                                                |
| polyfill             | n/a                       | not supported，但暂不需要，因为 umi 的实现里，polyfill 是 prebuild 的                                          |
| postcssLoader        | n/a                       | 不需要                                                                                                         |
| publicPath           | publicPath                |                                                                                                                |
| runtimePublicPath    | runtimePublicPath         | 格式不是，umi 是 object，mako 是 bool                                                                          |
| sassLoader           | n/a                       | not supported                                                                                                  |
| styleLoader          | n/a                       | not supported                                                                                                  |
| stylusLoader         | n/a                       | not supported                                                                                                  |
| srcTranspiler        | n/a                       | 不需要                                                                                                         |
| srcTranspilerOptions | n/a                       | 不需要                                                                                                         |
| svgr                 | n/a                       | 默认开启                                                                                                       |
| svgo                 | n/a                       | not supported                                                                                                  |
| targets              | targets                   |                                                                                                                |
| theme                | less.theme                |                                                                                                                |
| writeToDisk          | n/a                       | 默认开启                                                                                                               |

非构建配置如下：

- base
- clientLoader
- conventionLayout
- conventionRoutes
- crossorigin
- exportStatic
- favicons
- headScripts
- helmet
- history
- historyWithQuery
- https
- icons
- links
- metas
- mock
- mountElementId
- monorepoRedirect
- mpa（非构建配置，但需要明确不支持）
- phantomDependency
- plugins
- polyfill
- presets
- proxy
- reactRouter5Compat
- routes
- routeLoader
- run
- scripts
- styles
- title
- verifyCommit
- vite
