### PR TITLE
feat: support jsx for js files

### DIFF
--- a/crates/mako/src/ast.rs
+++ b/crates/mako/src/ast.rs
@@ -50,8 +50,11 @@ pub fn build_js_ast(path: &str, content: &str, context: &Arc<Context>) -> Result
     let comments = context.meta.script.origin_comments.read().unwrap();
     let is_ts = path.ends_with(".ts") || path.ends_with(".tsx");
     // treat svgr as jsx
-    let jsx = path.ends_with(".jsx") || path.ends_with(".svg");
-    let tsx = path.ends_with(".tsx");
+    let jsx = path.ends_with(".jsx")
+        || path.ends_with(".svg")
+        // exclude files under node_modules is for performance
+        || (path.ends_with(".js") && !path.contains("node_modules"));
+    let tsx = path.ends_with(".tsx") || path.ends_with(".ts");
     let syntax = if is_ts {
         Syntax::Typescript(TsConfig {
             decorators: true,


### PR DESCRIPTION
验项目时发现有 .js 文件用了 jsx 语法，会报错如下。

```
Build failed.

  × Expression expected
    ╭─[../src/pages/Flow/defaultConfig.js:34:1]
 34 │   {
 35 │     type: NodeTypeConstants.START_NODE,
 36 │     text: '开始节点',
 37 │     icon: <PlayCircleOutlined style={{ color: 'green', fontSize: '14px' }} />,
    ·           ─
 38 │     width: 130,
 39 │     height: 42,
 40 │     nodeStyle: 'circleInfo',
    ╰────
```

之前 Umi 是支持的，所以加上。
