### PR TITLE
fix: vendor css chunk not load bug

### DIFF
--- a/crates/mako/src/generate_chunks.rs
+++ b/crates/mako/src/generate_chunks.rs
@@ -58,7 +58,9 @@ impl Compiler {
             chunks
                 .iter()
                 .filter_map(|chunk| match chunk.chunk_type {
-                    crate::chunk::ChunkType::Async | crate::chunk::ChunkType::Entry(_, _) => {
+                    crate::chunk::ChunkType::Async
+                    | crate::chunk::ChunkType::Entry(_, _)
+                    | crate::chunk::ChunkType::Sync => {
                         let module_ids = chunk.get_modules();
                         let module_ids: Vec<_> = module_ids.iter().collect();
 


### PR DESCRIPTION
修复 vendor chunk 关联的 CSS 不会加载的 bug，原因是 vendor 属于 sync chunk，之前在 generate 阶段只处理了 entry 和 async chunk 的 CSS Map

Close #501 