### PR TITLE
feat: support disable dynamic import

### DIFF
--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -74,6 +74,7 @@ indexmap = "2.0.0"
 eframe = "0.22.0"
 puffin = "0.16.0"
 puffin_egui = "0.22.0"
+
 [dev-dependencies]
 insta = { version = "1.30.0", features = ["yaml"] }
 maplit = "1.0.2"

--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -165,6 +165,7 @@ pub struct Config {
     pub tree_shake: TreeShakeStrategy,
     #[serde(rename = "autoCSSModules")]
     pub auto_css_modules: bool,
+    pub dynamic_import_to_require: bool,
 }
 
 const CONFIG_FILE: &str = "mako.config.json";
@@ -199,7 +200,8 @@ const DEFAULT_CONFIG: &str = r#"
     "px2rem": false,
     "px2remConfig": { "root": 100, "propBlackList": [], "propWhiteList": [], "selectorBlackList": [], "selectorWhiteList": [] },
     "treeShake": "basic",
-    "autoCSSModules": false
+    "autoCSSModules": false,
+    "dynamicImportToRequire": false
 }
 "#;
 

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -25,6 +25,7 @@ use crate::plugin::PluginTransformJsParam;
 use crate::resolve::Resolvers;
 use crate::targets;
 use crate::transformers::transform_css_url_replacer::CSSUrlReplacer;
+use crate::transformers::transform_dynamic_import_to_require::DynamicImportToRequire;
 use crate::transformers::transform_env_replacer::{build_env_map, EnvReplacer};
 use crate::transformers::transform_optimizer::Optimizer;
 use crate::transformers::transform_provide::Provide;
@@ -112,6 +113,11 @@ fn transform_js(
 
                     let mut optimizer = Optimizer {};
                     ast.visit_mut_with(&mut optimizer);
+
+                    if context.config.dynamic_import_to_require {
+                        let mut dynamic_import_to_require = DynamicImportToRequire {};
+                        ast.visit_mut_with(&mut dynamic_import_to_require);
+                    }
 
                     // TODO: polyfill
                     let preset_env = swc_preset_env::preset_env(

--- a/crates/mako/src/transformers/mod.rs
+++ b/crates/mako/src/transformers/mod.rs
@@ -3,6 +3,7 @@ pub mod transform_css_handler;
 pub mod transform_css_url_replacer;
 pub mod transform_dep_replacer;
 pub mod transform_dynamic_import;
+pub mod transform_dynamic_import_to_require;
 pub mod transform_env_replacer;
 pub mod transform_optimizer;
 pub mod transform_provide;
@@ -10,6 +11,7 @@ pub mod transform_px2rem;
 pub mod transform_react;
 pub mod transform_try_resolve;
 pub mod transform_virtual_css_modules;
+pub mod utils;
 
 #[cfg(test)]
 mod test_helper;

--- a/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__basic_import.snap
+++ b/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__basic_import.snap
@@ -1,0 +1,5 @@
+---
+source: crates/mako/src/transformers/transform_dynamic_import_to_require.rs
+expression: "transform(r#\"\nconst testModule = import('test-module');\n            \"#)"
+---
+const testModule = Promise.resolve().then(()=>require("test-module"));

--- a/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__chained_import.snap
+++ b/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__chained_import.snap
@@ -1,0 +1,10 @@
+---
+source: crates/mako/src/transformers/transform_dynamic_import_to_require.rs
+expression: "transform(r#\"\nimport('test-module').then(() => (\nimport('test-module-2')\n));\n\nPromise.all([\nimport('test-1'),\nimport('test-2'),\nimport('test-3'),\n]).then(() => {});\n            \"#)"
+---
+Promise.resolve().then(()=>require("test-module")).then(()=>(Promise.resolve().then(()=>require("test-module-2"))));
+Promise.all([
+    Promise.resolve().then(()=>require("test-1")),
+    Promise.resolve().then(()=>require("test-2")),
+    Promise.resolve().then(()=>require("test-3"))
+]).then(()=>{});

--- a/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__dynamic_import.snap
+++ b/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__dynamic_import.snap
@@ -1,0 +1,12 @@
+---
+source: crates/mako/src/transformers/transform_dynamic_import_to_require.rs
+expression: "transform(r#\"\nimport(MODULE);\n\nlet i = 0;\nimport(i++);\n\nimport(fn());\n\nasync () => import(await \"x\");\n\nfunction* f() { import(yield \"x\"); }\n            \"#)"
+---
+import(MODULE);
+let i = 0;
+import(i++);
+import(fn());
+async ()=>import(await "x");
+function* f() {
+    import(yield "x");
+}

--- a/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__import_with_comment.snap
+++ b/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__import_with_comment.snap
@@ -1,0 +1,6 @@
+---
+source: crates/mako/src/transformers/transform_dynamic_import_to_require.rs
+expression: "transform(r#\"\nimport(/* test comment */ 'my-module');\nimport('my-module' /* test comment */ );\n            \"#)"
+---
+Promise.resolve().then(()=>require("my-module"));
+Promise.resolve().then(()=>require("my-module"));

--- a/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__template_argument.snap
+++ b/crates/mako/src/transformers/snapshots/mako__transformers__transform_dynamic_import_to_require__tests__template_argument.snap
@@ -1,0 +1,7 @@
+---
+source: crates/mako/src/transformers/transform_dynamic_import_to_require.rs
+expression: "transform(r#\"\nimport(`1`);\nimport(tag`2`);\nimport(`3-${MODULE}`);\n            \"#)"
+---
+import(`1`);
+import(tag`2`);
+import(`3-${MODULE}`);

--- a/crates/mako/src/transformers/transform_dynamic_import.rs
+++ b/crates/mako/src/transformers/transform_dynamic_import.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
 use swc_common::DUMMY_SP;
-use swc_ecma_ast::{
-    ArrayLit, CallExpr, Callee, Expr, ExprOrSpread, Ident, Lit, MemberExpr, MemberProp,
-};
+use swc_ecma_ast::{ArrayLit, Expr, ExprOrSpread, Lit};
 use swc_ecma_visit::{VisitMut, VisitMutWith};
 
+use super::utils::{id, member_call, member_prop, promise_all, require_ensure};
 use crate::analyze_deps::is_dynamic_import;
 use crate::compiler::Context;
 use crate::module::{generate_module_id, ModuleId};
@@ -100,52 +99,6 @@ impl VisitMut for DynamicImport<'_> {
 }
 
 // utils fn
-fn id(s: &str) -> Ident {
-    Ident {
-        span: DUMMY_SP,
-        sym: s.into(),
-        optional: false,
-    }
-}
-fn member_prop(s: &str) -> MemberProp {
-    MemberProp::Ident(Ident {
-        span: DUMMY_SP,
-        sym: s.into(),
-        optional: false,
-    })
-}
-
-fn promise_all(promises: ExprOrSpread) -> Expr {
-    member_call(
-        Expr::Ident(id("Promise")),
-        member_prop("all"),
-        vec![promises],
-    )
-}
-
-fn member_call(obj: Expr, member_prop: MemberProp, args: Vec<ExprOrSpread>) -> Expr {
-    Expr::Call(CallExpr {
-        span: DUMMY_SP,
-        callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
-            span: DUMMY_SP,
-            obj: Box::new(obj),
-            prop: member_prop,
-        }))),
-        args,
-        type_args: None,
-    })
-}
-
-fn require_ensure(source: String) -> Expr {
-    member_call(
-        Expr::Ident(id("require")),
-        MemberProp::Ident(id("ensure")),
-        vec![ExprOrSpread {
-            spread: None,
-            expr: Box::new(Expr::Lit(Lit::Str(source.into()))),
-        }],
-    )
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/mako/src/transformers/transform_dynamic_import_to_require.rs
+++ b/crates/mako/src/transformers/transform_dynamic_import_to_require.rs
@@ -1,0 +1,120 @@
+use swc_ecma_ast::{Expr, ExprOrSpread, Lit};
+use swc_ecma_visit::{VisitMut, VisitMutWith};
+
+use super::utils::{arrow_fn, call, id, member_call, member_prop, promise_resolve};
+use crate::analyze_deps::is_dynamic_import;
+
+pub struct DynamicImportToRequire {}
+
+// import('xxx') -> Promise.resolve().then(() => require('xxx'))
+impl VisitMut for DynamicImportToRequire {
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        if let Expr::Call(call_expr) = expr {
+            if is_dynamic_import(call_expr) {
+                if let ExprOrSpread {
+                    expr: box Expr::Lit(Lit::Str(ref mut source)),
+                    ..
+                } = &mut call_expr.args[0]
+                {
+                    // Promise.resolve().then(() => require('xxx'))
+                    *expr = member_call(
+                        promise_resolve(),
+                        member_prop("then"),
+                        vec![ExprOrSpread {
+                            spread: None,
+                            expr: Box::new(arrow_fn(
+                                vec![],
+                                call(
+                                    Expr::Ident(id("require")),
+                                    vec![ExprOrSpread {
+                                        spread: None,
+                                        expr: Box::new(Expr::Lit(Lit::Str(
+                                            source.value.clone().into(),
+                                        ))),
+                                    }],
+                                ),
+                            )),
+                        }],
+                    );
+                }
+            }
+        }
+        expr.visit_mut_children_with(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_basic_import() {
+        crate::assert_display_snapshot!(transform(
+            r#"
+const testModule = import('test-module');
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_chained_import() {
+        crate::assert_display_snapshot!(transform(
+            r#"
+import('test-module').then(() => (
+import('test-module-2')
+));
+
+Promise.all([
+import('test-1'),
+import('test-2'),
+import('test-3'),
+]).then(() => {});
+            "#,
+        ));
+    }
+
+    // TODO: support this?
+    #[test]
+    fn test_dynamic_import() {
+        crate::assert_display_snapshot!(transform(
+            r#"
+import(MODULE);
+
+let i = 0;
+import(i++);
+
+import(fn());
+
+async () => import(await "x");
+
+function* f() { import(yield "x"); }
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_import_with_comment() {
+        crate::assert_display_snapshot!(transform(
+            r#"
+import(/* test comment */ 'my-module');
+import('my-module' /* test comment */ );
+            "#,
+        ));
+    }
+
+    // TODO: support this?
+    #[test]
+    fn test_template_argument() {
+        crate::assert_display_snapshot!(transform(
+            r#"
+import(`1`);
+import(tag`2`);
+import(`3-${MODULE}`);
+            "#,
+        ));
+    }
+
+    fn transform(code: &str) -> String {
+        let context = std::sync::Arc::new(Default::default());
+        let mut visitor = super::DynamicImportToRequire {};
+        crate::transformers::test_helper::transform_js_code(code, &mut visitor, &context)
+    }
+}

--- a/crates/mako/src/transformers/utils.rs
+++ b/crates/mako/src/transformers/utils.rs
@@ -1,0 +1,77 @@
+use swc_common::DUMMY_SP;
+use swc_ecma_ast::{
+    ArrowExpr, BlockStmtOrExpr, CallExpr, Callee, Expr, ExprOrSpread, Ident, Lit, MemberExpr,
+    MemberProp, Pat,
+};
+
+pub fn id(s: &str) -> Ident {
+    Ident {
+        span: DUMMY_SP,
+        sym: s.into(),
+        optional: false,
+    }
+}
+pub fn member_prop(s: &str) -> MemberProp {
+    MemberProp::Ident(Ident {
+        span: DUMMY_SP,
+        sym: s.into(),
+        optional: false,
+    })
+}
+
+pub fn promise_all(promises: ExprOrSpread) -> Expr {
+    member_call(
+        Expr::Ident(id("Promise")),
+        member_prop("all"),
+        vec![promises],
+    )
+}
+
+pub fn promise_resolve() -> Expr {
+    member_call(Expr::Ident(id("Promise")), member_prop("resolve"), vec![])
+}
+
+pub fn member_call(obj: Expr, member_prop: MemberProp, args: Vec<ExprOrSpread>) -> Expr {
+    Expr::Call(CallExpr {
+        span: DUMMY_SP,
+        callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
+            span: DUMMY_SP,
+            obj: Box::new(obj),
+            prop: member_prop,
+        }))),
+        args,
+        type_args: None,
+    })
+}
+
+pub fn call(obj: Expr, args: Vec<ExprOrSpread>) -> Expr {
+    Expr::Call(CallExpr {
+        span: DUMMY_SP,
+        callee: Callee::Expr(Box::new(obj)),
+        args,
+        type_args: None,
+    })
+}
+
+pub fn arrow_fn(args: Vec<Pat>, body: Expr) -> Expr {
+    Expr::Arrow(ArrowExpr {
+        span: DUMMY_SP,
+        params: args,
+        body: Box::new(BlockStmtOrExpr::Expr(Box::new(body))),
+        is_async: false,
+        is_generator: false,
+        type_params: None,
+        return_type: None,
+    })
+}
+
+pub fn require_ensure(source: String) -> Expr {
+    member_call(
+        Expr::Ident(id("require")),
+        MemberProp::Ident(id("ensure")),
+        vec![ExprOrSpread {
+            spread: None,
+            expr: Box::new(Expr::Lit(Lit::Str(source.into()))),
+        }],
+    )
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -51,6 +51,7 @@ pub async fn build(
     stats?: boolean;
     hash?: boolean;
     autoCssModules?: boolean;
+    dynamicImportToRequire?: boolean;
 }"#)]
     config: serde_json::Value,
     watch: bool,


### PR DESCRIPTION
`dynamicImportToRequire: true` + `codeSplitting: none` 可实现产物全部合到一起的效果。

配置如下，

```
{
  "minify": false,
  "dynamicImportToRequire": true,
  "codeSplitting": "none"
}
```

打包日志如下，

```
Building with mako for production...
512 modules transformed in 40ms.
basic optimize in 7ms.
dist/umi.css       0.09 kB │ map: 0.24 kB
dist/umi.js        1.29 mB │ map: 1.38 mB
✓ Built in 114ms
Complete!
```