### PR TITLE
fix(less): remove \n in theme's values

### DIFF
--- a/crates/mako/src/plugins/less.rs
+++ b/crates/mako/src/plugins/less.rs
@@ -65,7 +65,10 @@ fn compile_less(param: &PluginLoadParam, _content: &str, context: &Arc<Context>)
     args.push(format!("--aliases-fork={}", alias_params));
     if !theme.is_empty() {
         theme.iter().for_each(|(k, v)| {
-            args.push(format!("--modify-var={}={}", k, v));
+            // remove \n
+            // cli don't support \n in values
+            let vv = v.replace('\n', "");
+            args.push(format!("--modify-var={}={}", k, vv));
         });
     }
     args.push(param.path.to_string());


### PR DESCRIPTION
项目排查时发现好几例，有些是意外引入的，比如 font-family 的值，有些是故意引入的，比如 animate 的值。