### PR TITLE
fix: ts file should not parse tsx syntax

### DIFF
--- a/crates/mako/src/ast.rs
+++ b/crates/mako/src/ast.rs
@@ -56,7 +56,7 @@ pub fn build_js_ast(path: &str, content: &str, context: &Arc<Context>) -> Result
         || path.ends_with(".svg")
         // exclude files under node_modules is for performance
         || (path.ends_with(".js") && !path.contains("node_modules"));
-    let tsx = path.ends_with(".tsx") || path.ends_with(".ts");
+    let tsx = path.ends_with(".tsx");
     let syntax = if is_ts {
         Syntax::Typescript(TsConfig {
             decorators: true,


### PR DESCRIPTION
e.g.

```
Build failed.
fatal - [Error:
  x Unexpected token `UrlItemType`. Expected jsx identifier
    ,-[../src/pages/DocsPage/states/global.ts:24:1]
 24 |
 25 | export const globalState = proxyWithComputed(
 26 |   {
 27 |     splitViewHistoryList: <UrlItemType[]>[], // 存储分屏的历史记录
    :                            ^^^^^^^^^^^
 28 |     showLeftMenu: true, // 显示左侧菜单
 29 |   },
 30 |   {
    `----
```