### PR TITLE
fix(tree-shake): 🐛 stmt hash 不稳定, 导致死循环

### DIFF
--- a/crates/mako/src/plugins/farm_tree_shake/statement_graph.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/statement_graph.rs
@@ -282,13 +282,11 @@ impl StatementGraph {
             let mut visited = HashSet::new();
 
             let hash_stmt = |stmt_id: &StatementId, used_defined_idents: &HashSet<String>| {
-                let mut hash = format!("{}:", stmt_id);
+                let mut sorted_idents =
+                    used_defined_idents.iter().cloned().collect::<Vec<String>>();
+                sorted_idents.sort();
 
-                for ident in used_defined_idents {
-                    hash += ident;
-                }
-
-                hash
+                format!("{}:{}", stmt_id, sorted_idents.join(""))
             };
 
             while let Some((stmt_id, used_defined_idents, used_dep_idents)) = stmts.pop_front() {


### PR DESCRIPTION
eg
第 1️⃣轮的时候，72 号 语句已经使用4 个变量，Ye#4 ，cx#4，A#4，hE#4 访问过了。
继续访问的时候，
第 2️⃣ 轮的时候，72 号语句因为使用的变量不变，所以可以不用继续反问了，但是由于 hash 不稳定，认为访问就继续访问，导致死循环。

这个问题，之前也有，可能以前语句的变量数目较少，hash 很快就碰撞了；但是 @splinetool/runtime 是个压缩的后的 esm ，语句的变量数较多( 74 语句变量更多)，就大大的降低了 hash 碰撞的概率，导致死循环。

```txt
1️⃣ the hash is 72:Ye#4cx#4A#4hE#4
the hash is 74:qt#4se#4ra#4Ki#4um#4S3#4fE#4pE#4w3#4hi#4vc#4
2️⃣ the hash is 72:Ye#4hE#4A#4cx#4
the hash is 31:Wn#4
the hash is 74:pE#4ra#4w3#4fE#4S3#4vc#4se#4qt#4Ki#4um#4hi#4
```