### PR TITLE
feat: improve css parser error print

### DIFF
--- a/crates/mako/src/ast.rs
+++ b/crates/mako/src/ast.rs
@@ -138,7 +138,16 @@ pub fn build_css_ast(
     if parse_result.is_err() {
         parse_errors.push(parse_result.clone().unwrap_err());
     };
-    if !parse_errors.is_empty() {
+    // why?
+    // 1、默认配置是，项目 css 有错误就报错，node_modules 下的 css 不报错
+    //    因为 node_modules 下的 css 有很多是不符合规范的，但却不是自己可控的
+    // 2、增加一个 ignore_css_parser_errors 配置，用于忽略 css parser 的错误
+    //    因为 less 编译 less 时，会把 node_modules 下的 less 也编译进去，此时
+    //    不能区分是否来自 node_modules 下
+    if !context.config.ignore_css_parser_errors
+        && !path.contains("node_modules")
+        && !parse_errors.is_empty()
+    {
         let mut error_message = vec![];
         for err in parse_errors {
             println!("parse_errors: {:?}", err.message().to_string().as_str());

--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -163,6 +163,8 @@ pub struct Config {
     pub tree_shake: TreeShakeStrategy,
     #[serde(rename = "autoCSSModules")]
     pub auto_css_modules: bool,
+    #[serde(rename = "ignoreCSSParserErrors")]
+    pub ignore_css_parser_errors: bool,
     pub dynamic_import_to_require: bool,
     pub umd: String,
     pub write_to_disk: bool,
@@ -200,6 +202,7 @@ const DEFAULT_CONFIG: &str = r#"
     "px2remConfig": { "root": 100, "propBlackList": [], "propWhiteList": [], "selectorBlackList": [], "selectorWhiteList": [] },
     "treeShake": "basic",
     "autoCSSModules": false,
+    "ignoreCSSParserErrors": false,
     "dynamicImportToRequire": false,
     "umd": "none",
     "writeToDisk": true

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -52,6 +52,7 @@ pub async fn build(
     stats?: boolean;
     hash?: boolean;
     autoCssModules?: boolean;
+    ignoreCSSParserErrors?: boolean;
     dynamicImportToRequire?: boolean;
     umd?: string;
 }"#)]


### PR DESCRIPTION
why?

1、默认配置是，项目 css 有错误就报错，node_modules 下的 css 不报错。因为 node_modules 下的 css 有很多是不符合规范的，但却不是自己可控的
2、增加一个 ignore_css_parser_errors 配置，用于忽略 css parser 的错误。因为 less 编译 less 时，会把 node_modules 下的 less 也编译进去，此时不能区分是否来自 node_modules 下
