### PR TITLE
fix: 🐛 support  relative path not starts with .

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -332,17 +332,13 @@ impl Config {
                 .clone()
                 .into_iter()
                 .map(|(k, v)| {
-                    let path_buf: PathBuf = v.into();
+                    let path_buf: PathBuf = v.clone().into();
 
                     let p = if path_buf.is_absolute() {
-                        path_buf
+                        v
                     } else {
-                        root.join(path_buf)
-                            .canonicalize()
-                            .expect(&format!("can't resolve alias.{}", k))
+                        root.join(path_buf).to_string_lossy().to_string()
                     };
-
-                    let p = p.to_string_lossy().to_string();
 
                     (k, p)
                 })


### PR DESCRIPTION
eg
```json
{
  "resovle": {
     "alias": { "smallfish": "node_module/xxx"}
  }
}
```
移除了 `canonicalize`, 因为 `./src/index`  是一个合法的 source 值，但是实际硬盘上只有 `./src/index.js`文件，canonicalize  就会出错。
