### PR TITLE
fix: 传给 Rust 侧的 config 不应该 stringify

### DIFF
--- a/packages/bundler-okam/index.js
+++ b/packages/bundler-okam/index.js
@@ -219,7 +219,7 @@ async function getOkamConfig(opts) {
       if (key.startsWith('process.env.')) {
         define[key.replace(/^process\.env\./, '')] = opts.config.define[key];
       } else {
-        define[key] = JSON.stringify(opts.config.define[key]);
+        define[key] = opts.config.define[key];
       }
     }
   }


### PR DESCRIPTION
修复内网项目 code:KunPeng/rms-alarm、KunPeng/rms-log 在 build 阶段的报错问题，在 bundler-okam 中 对象类型的 define 配置被转换为 string 了。

```bash
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "\n  \u{1b}[31mx\u{1b}[0m Expected ';', '}' or <eof>\n   ,-[\u{1b}[36;1;4m_define_.js\u{1b}[0m:1:1]\n \u{1b}[2m1\u{1b}[0m | {\"APP_ENV\":\"TRAAS\",\"USE_OPENAPI\":false}\n   : \u{1b}[31;1m          ^\u{1b}[0m\n   `----\n"', crates/mako/src/transformers/transform_env_replacer.rs:201:64
```