### PR TITLE
Revert "fix: 🐛 support  relative path not starts with ."

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -343,15 +343,16 @@ impl Config {
                 .clone()
                 .into_iter()
                 .map(|(k, v)| {
-                    let path_buf: PathBuf = v.clone().into();
-
-                    let p = if path_buf.is_absolute() {
-                        v
+                    let v = if v.starts_with('.') {
+                        root.join(v)
+                            .canonicalize()
+                            .unwrap()
+                            .to_string_lossy()
+                            .to_string()
                     } else {
-                        root.join(path_buf).to_string_lossy().to_string()
+                        v
                     };
-
-                    (k, p)
+                    (k, v)
                 })
                 .collect();
         }


### PR DESCRIPTION
Reverts umijs/mako#576

原因是 umi 项目挂了，umi 项目中有 `umi: '@@/exports'` 的 alias 配置，这个配置会接着去找其他的 alias。
