### PR TITLE
fix(config): 🐛  remove canonicalize

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -333,11 +333,7 @@ impl Config {
                 .into_iter()
                 .map(|(k, v)| {
                     let v = if v.starts_with('.') {
-                        root.join(v)
-                            .canonicalize()
-                            .unwrap()
-                            .to_string_lossy()
-                            .to_string()
+                        root.join(v).to_string_lossy().to_string()
                     } else {
                         v
                     };


### PR DESCRIPTION
支持

```
“home”："./src/pages/home/index"
```
实际物理文件 `./src/pages/home/index.ts`

如果在 config.rs 中 canonicalize,  会因为文件不存在而报错。
