### PR TITLE
fix(bundler-okam): normalize define config values

### DIFF
--- a/packages/bundler-okam/index.js
+++ b/packages/bundler-okam/index.js
@@ -219,7 +219,7 @@ async function getOkamConfig(opts) {
       if (key.startsWith('process.env.')) {
         define[key.replace(/^process\.env\./, '')] = opts.config.define[key];
       } else {
-        define[key] = JSON.stringify(opts.config.define[key]);
+        define[key] = normalizeDefineValue(opts.config.define[key]);
       }
     }
   }
@@ -280,4 +280,19 @@ async function getOkamConfig(opts) {
   }
 
   return okamConfig;
+}
+
+function normalizeDefineValue(val) {
+  if (!isPlainObject(val)) {
+    return JSON.stringify(val);
+  } else {
+    return Object.keys(val).reduce((obj, key) => {
+      obj[key] = normalizeDefineValue(val[key]);
+      return obj;
+    }, {});
+  }
+}
+
+function isPlainObject(obj) {
+  return Object.prototype.toString.call(obj) === '[object Object]';
 }


### PR DESCRIPTION
Close https://github.com/umijs/mako/pull/579

考虑多种格式，非 Object 需要 stringify 才正常。

配置，

```
export default {
  mfsu: false,
  define: {
    AAA: 'aaa',
    BBB: {
      value: 'bbb',
      ccc: {
        d: 1,
        e: '2',
        c: [1, "2", true],
      }
    },
    CCC: 1,
    DDD: true,
    EEE: false,
    FFF: null,
    GGG: ["a", 1],
  },
};
```

输入

```
  process.env.NODE_ENV;
  (AAA);
  (BBB);
  CCC;
  DDD;
  EEE;
  FFF;
  GGG;
```

输出

```
"production";
"aaa";
({
    ccc: {
        e: "2",
        d: 1,
        c: [
            1,
            "2",
            true
        ]
    },
    value: "bbb"
});
1;
true;
false;
null;
[
    "a",
    1
];
```