### PR TITLE
fix: css remote url support // prefix and uppercase

### DIFF
--- a/crates/mako/src/analyze_deps.rs
+++ b/crates/mako/src/analyze_deps.rs
@@ -32,7 +32,11 @@ fn analyze_deps_css(ast: &swc_css_ast::Stylesheet) -> Result<Vec<Dependency>> {
 }
 
 pub fn is_url_ignored(url: &str) -> bool {
-    url.starts_with("http://") || url.starts_with("https://") || url.starts_with("data:")
+    let lower_url = url.to_lowercase();
+    lower_url.starts_with("http://")
+        || url.starts_with("https://")
+        || url.starts_with("data:")
+        || url.starts_with("//")
 }
 
 pub fn handle_css_url(url: String) -> String {


### PR DESCRIPTION
用例： https://github.com/umijs/mako-e2e/commit/f4e605a454e472851c076c4c53ba570a8430cf64
