### PR TITLE
fix: try resolve support assignment statements

### DIFF
--- a/crates/mako/src/transformers/snapshots/mako__transformers__transform_try_resolve__tests__try_require_with_exports.snap
+++ b/crates/mako/src/transformers/snapshots/mako__transformers__transform_try_resolve__tests__try_require_with_exports.snap
@@ -1,0 +1,13 @@
+---
+source: crates/mako/src/transformers/transform_try_resolve.rs
+expression: "transform(r#\"\n            try {\n                exports.xxx = require('foo');\n            } catch (e) {\n                console.log(e);\n            }\n            \"#)"
+---
+try {
+    exports.xxx = require(Object(function makoMissingModule() {
+        var e = new Error("Cannot find module 'foo'");
+        e.code = "MODULE_NOT_FOUND";
+        throw e;
+    }()));
+} catch (e) {
+    console.log(e);
+}


### PR DESCRIPTION
react-sketch@0.5.1 里会依赖 jsdom，jsdom@22.1.0/lib/jsdom/util.js 里有一段这样，

```
try {
  exports.Canvas = require('canvas');
} catch {
  exports.Canvas = null;
}
```