### PR TITLE
fix: transform error for svgr namespace element

### DIFF
--- a/crates/mako/src/transformers/snapshots/mako__transformers__transform_react__tests__svgr_with_namespace.snap
+++ b/crates/mako/src/transformers/snapshots/mako__transformers__transform_react__tests__svgr_with_namespace.snap
@@ -1,0 +1,65 @@
+---
+source: crates/mako/src/transformers/transform_react.rs
+expression: "transform(TransformTask {\n        code: r#\"const SvgComponent = (props) => (\n    <svg\n        xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\n        xmlns:cc=\"http://creativecommons.org/ns#\"\n        xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n        xmlns:svg=\"http://www.w3.org/2000/svg\"\n        xmlns=\"http://www.w3.org/2000/svg\"\n        xmlns:sodipodi=\"http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd\"\n        xmlns:inkscape=\"http://www.inkscape.org/namespaces/inkscape\"\n        width={240}\n        height={144}\n        id=\"svg4136\"\n        inkscape:version=\"0.91 r13725\"\n        sodipodi:docname=\"jsoneditor-icons.svg\"\n        {...props}\n    >\n        <metadata id=\"metadata4148\">\n            <rdf:RDF></rdf:RDF>\n        </metadata>\n    </svg>\n)\"#.to_string(),\n        is_entry: false,\n        path: \"index.jsx\".to_string(),\n    })"
+---
+import * as RefreshRuntime from 'react-refresh';
+var prevRefreshReg;
+var prevRefreshSig;
+prevRefreshReg = self.$RefreshReg$;
+prevRefreshSig = self.$RefreshSig$;
+self.$RefreshReg$ = (type, id)=>{
+    RefreshRuntime.register(type, module.id + id);
+};
+self.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
+const SvgComponent = (props)=>_jsxDEV("svg", {
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        "xmlns:cc": "http://creativecommons.org/ns#",
+        "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "xmlns:svg": "http://www.w3.org/2000/svg",
+        xmlns: "http://www.w3.org/2000/svg",
+        "xmlns:sodipodi": "http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd",
+        "xmlns:inkscape": "http://www.inkscape.org/namespaces/inkscape",
+        width: 240,
+        height: 144,
+        id: "svg4136",
+        "inkscape:version": "0.91 r13725",
+        "sodipodi:docname": "jsoneditor-icons.svg",
+        ...props,
+        children: _jsxDEV("metadata", {
+            id: "metadata4148",
+            children: _jsxDEV("rdf:RDF", {}, void 0, false, {
+                fileName: "<<jsx-config-pragmaFrag.js>>",
+                lineNumber: 1,
+                columnNumber: 648
+            }, this)
+        }, void 0, false, {
+            fileName: "<<jsx-config-pragmaFrag.js>>",
+            lineNumber: 1,
+            columnNumber: 607
+        }, this)
+    }, void 0, false, {
+        fileName: "<<jsx-config-pragmaFrag.js>>",
+        lineNumber: 1,
+        columnNumber: 19
+    }, this);
+_c = SvgComponent;
+var _c;
+$RefreshReg$(_c, "SvgComponent");
+self.$RefreshReg$ = prevRefreshReg;
+self.$RefreshSig$ = prevRefreshSig;
+function $RefreshIsReactComponentLike$(moduleExports) {
+    if (RefreshRuntime.isLikelyComponentType(moduleExports.default || moduleExports)) {
+        return true;
+    }
+    for(var key in moduleExports){
+        if (RefreshRuntime.isLikelyComponentType(moduleExports[key])) {
+            return true;
+        }
+    }
+    return false;
+}
+if ($RefreshIsReactComponentLike$(module.exports)) {
+    module.meta.hot.accept();
+    RefreshRuntime.performReactRefresh();
+}

--- a/crates/mako/src/transformers/transform_react.rs
+++ b/crates/mako/src/transformers/transform_react.rs
@@ -52,6 +52,8 @@ pub fn mako_react(
             // support react 17 + only
             runtime: Some(Runtime::Automatic),
             development: Some(is_dev),
+            // to avoid throw error for svg namespace element
+            throw_if_namespace: Some(false),
             refresh: if use_refresh {
                 Some(RefreshOptions::default())
             } else {
@@ -230,6 +232,37 @@ mod tests {
     pub fn normal_module_with_react_refresh() {
         assert_display_snapshot!(transform(TransformTask {
             code: "export default function R(){return <h1></h1>}".to_string(),
+            is_entry: false,
+            path: "index.jsx".to_string()
+        }));
+    }
+
+    #[test]
+    pub fn svgr_with_namespace() {
+        assert_display_snapshot!(transform(TransformTask {
+            // part of jsoneditor/dist/img/jsoneditor-icons.svg
+            code: r#"const SvgComponent = (props) => (
+    <svg
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:cc="http://creativecommons.org/ns#"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:svg="http://www.w3.org/2000/svg"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+        xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+        width={240}
+        height={144}
+        id="svg4136"
+        inkscape:version="0.91 r13725"
+        sodipodi:docname="jsoneditor-icons.svg"
+        {...props}
+    >
+        <metadata id="metadata4148">
+            <rdf:RDF></rdf:RDF>
+        </metadata>
+    </svg>
+)"#
+            .to_string(),
             is_entry: false,
             path: "index.jsx".to_string()
         }));


### PR DESCRIPTION
修复 svgr 转换时如果存在 namespace 元素（比如 `<rdf:RDF></rdf:RDF>`）时编译报错的问题

报错示例：
```bash
Build failed.
Error:
  × JSX Namespace is disabled by default because react does not support it yet. You can specify jsc.transform.react.throwIfNamespace to false to override default behavior
     ╭─[node_modules/jsoneditor/dist/img/jsoneditor-icons.svg:1:1]
   1 │     import * as React from "react";
   2 │ ╭─▶ const SvgComponent = (props)=><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width={240} height={144} id="svg4136" inkscape:version="0.91 r13725" sodipodi:docname="jsoneditor-icons.svg" {...props}><title id="title6512">{"JSON Editor Icons"}</title><metadata id="metadata4148"><rdf:RDF><cc:Work rdf:about=""><dc:format>{"image/svg+xml"}</dc:format><dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/><dc:title>{"JSON Editor Icons"}</dc:title></cc:Work></rdf:RDF>
...
```