### PR TITLE
feat: advanced externals support absolute path

### DIFF
--- a/crates/mako/src/resolve.rs
+++ b/crates/mako/src/resolve.rs
@@ -110,7 +110,7 @@ fn get_external_target(
         match config {
             ExternalConfig::Advanced(config) => {
                 if let Some(caps) =
-                    Regex::new(&format!(r#"(?:^|node_modules/|[a-zA-Z\d]@){}(/|$)"#, key))
+                    Regex::new(&format!(r#"(?:^|/node_modules/|[a-zA-Z\d]@){}(/|$)"#, key))
                         .ok()
                         .unwrap()
                         .captures(source)


### PR DESCRIPTION
高级 externals 支持匹配绝对路径引入，因为 Umi 插件为了确保依赖版本符合预期，在生成的临时文件中会使用绝对路径引入依赖，避免解析到 node_modules 顶层提升上来的版本（在 pnpm 项目下则是为了解依赖找不到的问题）

仅包含子路径匹配的 externals 规则会匹配绝对路径引入，支持普通 npm 目录，以及 pnpm 和 tnpm 的特有目录