### PR TITLE
feat(okam): check full compatibility before run

### DIFF
--- a/packages/bundler-okam/index.js
+++ b/packages/bundler-okam/index.js
@@ -148,7 +148,7 @@ function checkConfig(opts) {
 
   // 处理构建不支持的配置项
   unsupportedKeys.forEach((key) => {
-    assert(!opts.config[key], `${key} is not supported in okam bundler`);
+    assert(!opts.config[key], `${key} is not supported in Mako bundler`);
   });
 
   // 暂不支持 { from, to } 格式
@@ -157,14 +157,14 @@ function checkConfig(opts) {
     for (const item of copy) {
       assert(
         typeof item === 'string',
-        `copy config item must be string in okam bundler, but got ${item}`,
+        `copy config item must be string in Mako bundler, but got ${item}`,
       );
     }
   }
 
   // 不支持数组 externals
   if (Array.isArray(opts.config.externals)) {
-    throw new Error('externals array is not supported in okam bundler');
+    throw new Error('externals array is not supported in Mako bundler');
   }
 
   // 不支持但对构建影响不明确的配置项，会统一警告
@@ -245,7 +245,7 @@ function checkConfig(opts) {
        ░░░   ░░░      ░░░░░   ░░░░░ ░░░░░   ░░░░░ ░░░░░    ░░░░░ ░░░░░ ░░░░░    ░░░░░   ░░░░░░░░░
 
 
-  Okam bundler does not support the following options:
+  Mako bundler does not support the following options:
     - ${warningKeys.join('\n    - ')}
 
   So this project may fail in compile-time or error in runtime, ${chalk.bold(


### PR DESCRIPTION
Okam 在执行前检查传入配置的完整兼容性，并执行报错或给出统一的警告，警告效果如下：

![图片](https://github.com/umijs/mako/assets/5035925/d6268c56-0afe-4c4f-b068-142165db5061)

另外优化了 3 个配置项的转换：
1. `legacy`: 从检查报错改为忽略，因为 Mako 能识别 legacy 修改的 targets 值，理论上也能达到 legacy 目的
2. `disableCopy` 和 `copy`: 从不识别改为处理转换，如果 disableCopy 则将 copy 置为空数组覆盖默认值，否则 concat 用户值和默认值
3. `clean`: 从 okam 独立实现改为给 Mako 传递配置项，master 分支已支持该配置