### PR TITLE
feat: ✨ 支持 ignored 配置

### DIFF
--- a/crates/mako/src/analyze_deps.rs
+++ b/crates/mako/src/analyze_deps.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use mako_core::anyhow::Result;
 
 use crate::compiler::Context;
-use crate::config::OutputMode;
 use crate::module::{Dependency, ModuleAst};
 use crate::plugin::PluginDepAnalyzeParam;
 
@@ -16,9 +15,7 @@ pub fn analyze_deps(ast: &ModuleAst, context: &Arc<Context>) -> Result<Vec<Depen
         .plugin_driver
         .analyze_deps(&mut analyze_deps_param, context)?;
 
-    if context.config.output.mode == OutputMode::MinifishPrebuild {
-        deps.retain(|dep| !dep.source.ends_with("_minifish_global_provider.js"));
-    }
+    context.plugin_driver.before_resolve(&mut deps, context)?;
 
     Ok(deps)
 }

--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -268,6 +268,8 @@ pub struct Config {
     pub transform_import: Vec<TransformImportConfig>,
     pub dev_eval: bool,
     pub clean: bool,
+    pub node_polyfill: bool,
+    pub ignores: Vec<String>,
 }
 
 pub(crate) fn hash_config(c: &Config) -> u64 {
@@ -321,7 +323,9 @@ const DEFAULT_CONFIG: &str = r#"
     "writeToDisk": true,
     "transformImport": [],
     "devEval": false,
-    "clean": true
+    "clean": true,
+    "nodePolyfill": true,
+    "ignores": []
 }
 "#;
 

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -80,6 +80,10 @@ pub trait Plugin: Any + Send + Sync {
         Ok(None)
     }
 
+    fn before_resolve(&self, _deps: &mut Vec<Dependency>, _context: &Arc<Context>) -> Result<()> {
+        Ok(())
+    }
+
     fn generate(&self, _context: &Arc<Context>) -> Result<Option<()>> {
         Ok(None)
     }
@@ -168,6 +172,17 @@ impl PluginDriver {
             }
         }
         Ok(vec![])
+    }
+
+    pub fn before_resolve(
+        &self,
+        param: &mut Vec<Dependency>,
+        context: &Arc<Context>,
+    ) -> Result<()> {
+        for plugin in &self.plugins {
+            plugin.before_resolve(param, context)?;
+        }
+        Ok(())
     }
 
     pub fn generate(&self, context: &Arc<Context>) -> Result<Option<()>> {

--- a/crates/mako/src/plugins/ignore.rs
+++ b/crates/mako/src/plugins/ignore.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use mako_core::anyhow::Result;
+use mako_core::regex::Regex;
+
+use crate::compiler::Context;
+use crate::module::Dependency;
+use crate::plugin::Plugin;
+
+pub struct IgnorePlugin {
+    pub ignores: Vec<Regex>,
+}
+
+impl Plugin for IgnorePlugin {
+    fn name(&self) -> &str {
+        "simple_ignore"
+    }
+
+    fn before_resolve(&self, deps: &mut Vec<Dependency>, _context: &Arc<Context>) -> Result<()> {
+        deps.retain(|dep| !self.ignores.iter().any(|ig| ig.is_match(&dep.source)));
+
+        Ok(())
+    }
+}

--- a/crates/mako/src/plugins/mod.rs
+++ b/crates/mako/src/plugins/mod.rs
@@ -4,6 +4,7 @@ pub mod copy;
 pub mod css;
 pub mod farm_tree_shake;
 pub mod hmr_runtime;
+pub mod ignore;
 pub mod import;
 pub mod invalid_syntax;
 pub mod javascript;

--- a/crates/node/index.d.ts
+++ b/crates/node/index.d.ts
@@ -66,4 +66,6 @@ dynamicImportToRequire?: boolean;
 umd?: string;
 transformImport?: { libraryName: string; libraryDirectory?: string; style?: boolean | string }[];
 clean?: boolean;
+nodePolyfill?: boolean;
+ignores?: string[];
 }, watch: boolean): Promise<void>

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -78,6 +78,8 @@ pub async fn build(
     umd?: string;
     transformImport?: { libraryName: string; libraryDirectory?: string; style?: boolean | string }[];
     clean?: boolean;
+    nodePolyfill?: boolean;
+    ignores?: string[];
 }"#)]
     config: serde_json::Value,
     watch: bool,


### PR DESCRIPTION
1. node polyfill 可配置开启（ minifish 说不要 mako poyfill 交给 appx ，保持原有逻辑
2. 支持 ignore 
   *  一是因为没有 polyfill 部分依赖需要 ignore 比如 `assert`
   *  二是 minifish 配合 mako  需要有部分文件不需要 mako 处理

```
"ignores":  [
"^assert$", "xxxx.provider.js$"
]
```
