### PR TITLE
fix: expected basic empty external

### DIFF
--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -223,13 +223,7 @@ impl Compiler {
         let resolved_path = resource.get_resolved_path();
         let module = match external {
             Some(external) => {
-                // support empty external
-                let code = if external.is_empty() {
-                    "module.exports = {};".to_string()
-                } else {
-                    format!("module.exports = {};", external)
-                };
-
+                let code = format!("module.exports = {};", external);
                 let ast = build_js_ast(
                     format!("external_{}", &resolved_path).as_str(),
                     code.as_str(),


### PR DESCRIPTION
修复基础 externals 的空模块在运行时报错的问题，统一处理为 `''`