### PR TITLE
fix: 修复 import self 案例

### DIFF
--- a/crates/mako/src/plugins/farm_tree_shake/shake.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake.rs
@@ -311,9 +311,13 @@ fn add_used_exports_by_import_info(
 
         //  import "xxx"
         if import_info.specifiers.is_empty() {
-            imported_tree_shake_module.used_exports.use_all();
             imported_tree_shake_module.side_effects = true;
-            return Some(imported_tree_shake_module.topo_order);
+
+            if imported_tree_shake_module.used_exports.use_all() {
+                return Some(imported_tree_shake_module.topo_order);
+            }
+
+            return None;
         }
 
         let mut added = false;


### PR DESCRIPTION
#### 最简复现
// index.js
import "./index";
#### 造成原因:
原来对 import "**" 的处理不完善，tree-shaking 结束后，没有做判断直接返回当前 imported_tree_module 的 order_id，导致如果使用 import "**"，引用自己的文件，order_id 永远不会改变，变成死循环。
#### 解决方案
加一层判断，如果没有新增 used_exported 就返回 None，使 tree-shaking 继续遍历模块。