### PR TITLE
fix: read file error if contains non-utf8 symbol

### DIFF
--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -365,6 +365,7 @@ mod tests {
 
     use super::Compiler;
     use crate::config::Config;
+    use crate::load::read_content;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_config_inline_limit() {
@@ -595,7 +596,7 @@ mod tests {
             .collect::<Vec<_>>();
         for file in files.iter() {
             if file.ends_with(".js") || file.ends_with(".css") {
-                let content = std::fs::read_to_string(dist.join(file)).unwrap();
+                let content = read_content(dist.join(file)).unwrap();
                 file_contents.insert(file.to_string(), content);
             }
         }

--- a/crates/mako/src/load.rs
+++ b/crates/mako/src/load.rs
@@ -1,6 +1,6 @@
-use std::fs;
+use std::fs::{self, File};
 use std::hash::Hasher;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -134,8 +134,13 @@ pub fn handle_asset<T: AsRef<str>>(
 }
 
 pub fn read_content<P: AsRef<Path>>(path: P) -> Result<String> {
-    std::fs::read_to_string(path.as_ref())
-        .with_context(|| format!("read file error: {:?}", path.as_ref()))
+    let mut file = File::open(path.as_ref())
+        .with_context(|| format!("open file error: {:?}", path.as_ref()))?;
+    let mut buf = vec![];
+
+    file.read_to_end(&mut buf)
+        .with_context(|| format!("read file error: {:?}", path.as_ref()))?;
+    Ok(String::from_utf8_lossy(&buf).to_string())
 }
 
 // 获取文件名称


### PR DESCRIPTION
修复读取文件遇到非 utf-8 字符会报错导致构建失败的问题，解法是改用 buffer 读取再转成 utf-8 的字符串，同时忽略掉不识别的字符改用 `�` 代替。

报错示例：

```bash
Build failed.
fatal - [Error: read file error: "/path/to/file.js"] {
  code: 'GenericFailure'
}
```

不识别的字符示例：
```tsx
<iframe title="ҵ������" />
```