### PR TITLE
feat: ✨ inject 功能

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -224,13 +224,21 @@ pub enum ExternalConfig {
     Basic(String),
     Advanced(ExternalAdvanced),
 }
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct InjectItem {
+    pub from: String,
+    pub named: Option<String>,
+    pub namespace: Option<bool>,
+    pub exclude: Option<String>,
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MinifishConfig {
     pub mapping: HashMap<String, String>,
     pub meta_path: Option<PathBuf>,
-    #[serde(rename = "mockMY")]
-    pub mock_my: bool,
+    pub inject: Option<HashMap<String, InjectItem>>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use mako_core::anyhow::{anyhow, Result};
 use mako_core::swc_common::errors::Handler;
+use mako_core::swc_common::Mark;
 use mako_core::swc_ecma_ast::Module;
 
 use crate::build::FileRequest;
@@ -34,6 +35,8 @@ pub struct PluginCheckAstParam<'a> {
 pub struct PluginTransformJsParam<'a> {
     pub handler: &'a Handler,
     pub path: &'a str,
+    pub top_level_mark: Mark,
+    pub unresolved_mark: Mark,
 }
 
 pub struct PluginDepAnalyzeParam<'a> {

--- a/crates/mako/src/plugins/minifish.rs
+++ b/crates/mako/src/plugins/minifish.rs
@@ -1,21 +1,30 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use mako_core::anyhow::Result;
 use mako_core::rayon::prelude::*;
+use mako_core::regex::Regex;
+use mako_core::swc_common::{Mark, Span, SyntaxContext, DUMMY_SP};
+use mako_core::swc_ecma_ast::{
+    Ident, ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier,
+    ImportStarAsSpecifier, ModuleDecl,
+};
+use mako_core::swc_ecma_utils::{quote_ident, quote_str};
+use mako_core::swc_ecma_visit::{VisitMut, VisitMutWith};
 use serde::Serialize;
 
 use crate::compiler::Context;
 use crate::load::Content;
 use crate::module::ResolveType;
-use crate::plugin::{Plugin, PluginLoadParam};
+use crate::plugin::{Plugin, PluginLoadParam, PluginTransformJsParam};
 use crate::stats::StatsJsonMap;
 
 pub struct MinifishPlugin {
     pub mapping: HashMap<String, String>,
     pub meta_path: Option<PathBuf>,
-    pub mock: bool,
+    pub inject: Option<HashMap<String, Inject>>,
 }
 
 impl MinifishPlugin {}
@@ -42,6 +51,38 @@ impl Plugin for MinifishPlugin {
             };
         }
         Ok(None)
+    }
+
+    fn transform_js(
+        &self,
+        param: &PluginTransformJsParam,
+        ast: &mut mako_core::swc_ecma_ast::Module,
+        _context: &Arc<Context>,
+    ) -> Result<()> {
+        if let Some(inject) = &self.inject {
+            if inject.is_empty() {
+                return Ok(());
+            }
+
+            let mut matched_injects = HashMap::new();
+
+            for (k, i) in inject {
+                if let Some(exclude) = &i.exclude {
+                    if !exclude.is_match(param.path) {
+                        matched_injects.insert(k.clone(), i);
+                    }
+                } else {
+                    matched_injects.insert(k.clone(), i);
+                }
+            }
+
+            if matched_injects.is_empty() {
+                return Ok(());
+            }
+
+            ast.visit_mut_with(&mut MyInjector::new(param.unresolved_mark, matched_injects));
+        }
+        Ok(())
     }
 
     fn build_success(&self, _stats: &StatsJsonMap, context: &Arc<Context>) -> Result<Option<()>> {
@@ -80,6 +121,116 @@ impl Plugin for MinifishPlugin {
     }
 }
 
+struct MyInjector<'a> {
+    unresolved_mark: Mark,
+    injects: HashMap<String, &'a Inject>,
+    will_inject: HashSet<(&'a Inject, SyntaxContext)>,
+}
+
+impl<'a> MyInjector<'a> {
+    fn new(unresolved_mark: Mark, injects: HashMap<String, &'a Inject>) -> Self {
+        Self {
+            unresolved_mark,
+            will_inject: Default::default(),
+            injects,
+        }
+    }
+}
+
+impl VisitMut for MyInjector<'_> {
+    fn visit_mut_ident(&mut self, n: &mut Ident) {
+        if self.injects.is_empty() {
+            return;
+        }
+
+        if n.span.ctxt.outer() == self.unresolved_mark {
+            let name = n.sym.to_string();
+
+            if let Some(inject) = self.injects.remove(&name) {
+                self.will_inject.insert((inject, n.span.ctxt));
+            }
+        }
+    }
+
+    fn visit_mut_module(&mut self, n: &mut mako_core::swc_ecma_ast::Module) {
+        n.visit_mut_children_with(self);
+
+        self.will_inject.iter().for_each(|&(inject, ctxt)| {
+            let module_dcl: ImportDecl = inject.clone().into_with(ctxt);
+            let module_dcl: ModuleDecl = module_dcl.into();
+
+            n.body.insert(0, module_dcl.into());
+        });
+    }
+}
+
+#[derive(Eq, Clone)]
+pub struct Inject {
+    pub from: String,
+    pub name: String,
+    pub named: Option<String>,
+    pub namespace: Option<bool>,
+    pub exclude: Option<Regex>,
+}
+
+impl PartialEq for Inject {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Hash for Inject {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.name.as_bytes());
+    }
+}
+
+impl Inject {
+    fn into_with(self, ctxt: SyntaxContext) -> ImportDecl {
+        let name_span = Span { ctxt, ..DUMMY_SP };
+        let specifier: ImportSpecifier = match (&self.named, &self.namespace) {
+            // import { named as x }
+            (Some(named), None | Some(false)) => ImportNamedSpecifier {
+                span: DUMMY_SP,
+                local: quote_ident!(name_span, self.name.clone()),
+                imported: if *named == self.name {
+                    None
+                } else {
+                    Some(quote_ident!(named.to_string()).into())
+                },
+                is_type_only: false,
+            }
+            .into(),
+
+            // import * as x
+            (None, Some(true)) => ImportStarAsSpecifier {
+                span: DUMMY_SP,
+                local: quote_ident!(name_span, self.name),
+            }
+            .into(),
+
+            // import x
+            (None, None | Some(false)) => ImportDefaultSpecifier {
+                span: DUMMY_SP,
+                local: quote_ident!(name_span, self.name),
+            }
+            .into(),
+
+            (Some(_), Some(true)) => {
+                panic!("Cannot use both `named` and `namespaced`")
+            }
+        };
+
+        ImportDecl {
+            span: DUMMY_SP,
+            specifiers: vec![specifier],
+            type_only: false,
+            with: None,
+            src: quote_str!(self.from).into(),
+        }
+    }
+}
+
 #[derive(Serialize)]
 struct ModuleGraphOutput {
     modules: Vec<Module>,
@@ -96,4 +247,233 @@ struct Module {
 struct Dependency {
     module: String,
     import_type: ResolveType,
+}
+
+#[cfg(test)]
+mod tests {
+    use mako_core::swc_common::GLOBALS;
+    use mako_core::swc_ecma_transforms::resolver;
+    use maplit::hashmap;
+
+    use super::*;
+    use crate::ast::{build_js_ast, js_ast_to_code};
+    use crate::config::DevtoolConfig;
+
+    #[test]
+    fn no_inject() {
+        let mut context = Context::default();
+        context.config.devtool = DevtoolConfig::None;
+        let context = Arc::new(context);
+
+        let mut ast = build_js_ast(
+            "test.no.inject.js",
+            r#"let my = 1;my.call("toast");"#,
+            &context,
+        )
+        .unwrap();
+
+        let i = Inject {
+            name: "my".to_string(),
+            named: None,
+            from: "mock-lib".to_string(),
+            namespace: None,
+            exclude: None,
+        };
+
+        let mut injector = MyInjector {
+            unresolved_mark: ast.unresolved_mark,
+            injects: hashmap! {
+                "my".to_string() =>&i
+            },
+            will_inject: HashSet::new(),
+        };
+
+        GLOBALS.set(&context.meta.script.globals, || {
+            ast.ast.visit_mut_with(&mut resolver(
+                ast.unresolved_mark,
+                ast.top_level_mark,
+                false,
+            ));
+            ast.ast.visit_mut_with(&mut injector);
+        });
+
+        let (code, _) = js_ast_to_code(&ast.ast, &context, "x.js").unwrap();
+
+        assert_eq!(
+            code,
+            r#"let my = 1;
+my.call("toast");
+"#
+        );
+    }
+
+    #[test]
+    fn inject_from_default() {
+        let mut context = Context::default();
+        context.config.devtool = DevtoolConfig::None;
+        let context = Arc::new(context);
+
+        let mut ast = build_js_ast("test.1.js", r#"my.call("toast");"#, &context).unwrap();
+
+        let i = Inject {
+            name: "my".to_string(),
+            named: None,
+            from: "mock-lib".to_string(),
+            namespace: None,
+            exclude: None,
+        };
+
+        let mut injector = MyInjector {
+            unresolved_mark: ast.unresolved_mark,
+            injects: hashmap! {
+                "my".to_string()=> &i
+            },
+            will_inject: HashSet::new(),
+        };
+
+        GLOBALS.set(&context.meta.script.globals, || {
+            ast.ast.visit_mut_with(&mut resolver(
+                ast.unresolved_mark,
+                ast.top_level_mark,
+                false,
+            ));
+            ast.ast.visit_mut_with(&mut injector);
+        });
+
+        let (code, _) = js_ast_to_code(&ast.ast, &context, "x.js").unwrap();
+
+        assert_eq!(
+            code,
+            r#"import my from "mock-lib";
+my.call("toast");
+"#
+        );
+    }
+
+    #[test]
+    fn inject_from_named() {
+        let mut context = Context::default();
+        context.config.devtool = DevtoolConfig::None;
+        let context = Arc::new(context);
+
+        let mut ast = build_js_ast("test.1.js", r#"my.call("toast");"#, &context).unwrap();
+
+        let i = Inject {
+            name: "my".to_string(),
+            named: Some("her".to_string()),
+            from: "mock-lib".to_string(),
+            namespace: None,
+            exclude: None,
+        };
+        let mut injector = MyInjector {
+            unresolved_mark: ast.unresolved_mark,
+            injects: hashmap! {
+                "my".to_string()=> &i
+            },
+            will_inject: HashSet::new(),
+        };
+
+        GLOBALS.set(&context.meta.script.globals, || {
+            ast.ast.visit_mut_with(&mut resolver(
+                ast.unresolved_mark,
+                ast.top_level_mark,
+                false,
+            ));
+            ast.ast.visit_mut_with(&mut injector);
+        });
+
+        let (code, _) = js_ast_to_code(&ast.ast, &context, "x.js").unwrap();
+
+        assert_eq!(
+            code,
+            r#"import { her as my } from "mock-lib";
+my.call("toast");
+"#
+        );
+    }
+
+    #[test]
+    fn inject_from_named_same_name() {
+        let mut context = Context::default();
+        context.config.devtool = DevtoolConfig::None;
+        let context = Arc::new(context);
+
+        let mut ast = build_js_ast("test.1.js", r#"my.call("toast");"#, &context).unwrap();
+
+        let i = Inject {
+            name: "my".to_string(),
+            named: Some("my".to_string()),
+            from: "mock-lib".to_string(),
+            namespace: None,
+            exclude: None,
+        };
+        let mut injector = MyInjector {
+            unresolved_mark: ast.unresolved_mark,
+            injects: hashmap! {
+                "my".to_string() => &i
+            },
+            will_inject: HashSet::new(),
+        };
+
+        GLOBALS.set(&context.meta.script.globals, || {
+            ast.ast.visit_mut_with(&mut resolver(
+                ast.unresolved_mark,
+                ast.top_level_mark,
+                false,
+            ));
+            ast.ast.visit_mut_with(&mut injector);
+        });
+
+        let (code, _) = js_ast_to_code(&ast.ast, &context, "x.js").unwrap();
+
+        assert_eq!(
+            code,
+            r#"import { my } from "mock-lib";
+my.call("toast");
+"#
+        );
+    }
+
+    #[test]
+    fn inject_from_namespace() {
+        let mut context = Context::default();
+        context.config.devtool = DevtoolConfig::None;
+        let context = Arc::new(context);
+
+        let mut ast = build_js_ast("test.1.js", r#"my.call("toast");"#, &context).unwrap();
+
+        let i = Inject {
+            name: "my".to_string(),
+            named: None,
+            from: "mock-lib".to_string(),
+            namespace: Some(true),
+            exclude: None,
+        };
+
+        let mut injector = MyInjector {
+            unresolved_mark: ast.unresolved_mark,
+            injects: hashmap! {
+                "my".to_string()=> &i
+            },
+            will_inject: HashSet::new(),
+        };
+
+        GLOBALS.set(&context.meta.script.globals, || {
+            ast.ast.visit_mut_with(&mut resolver(
+                ast.unresolved_mark,
+                ast.top_level_mark,
+                false,
+            ));
+            ast.ast.visit_mut_with(&mut injector);
+        });
+
+        let (code, _) = js_ast_to_code(&ast.ast, &context, "x.js").unwrap();
+
+        assert_eq!(
+            code,
+            r#"import * as my from "mock-lib";
+my.call("toast");
+"#
+        );
+    }
 }

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -154,6 +154,8 @@ fn transform_js(
                         &PluginTransformJsParam {
                             handler,
                             path: &task.path,
+                            top_level_mark,
+                            unresolved_mark,
                         },
                         ast,
                         context,

--- a/crates/node/index.d.ts
+++ b/crates/node/index.d.ts
@@ -71,6 +71,9 @@ ignores?: string[];
 _minifish?: {
 mapping: Record<string, string>;
 metaPath?: string;
-mockMY: boolean;
+inject?: Record<string, { from:string;exclude?:string; } |
+{ from:string; named:string; exclude?:string } |
+{ from:string; namespace: true; exclude?:string }
+>;
 };
 }, watch: boolean): Promise<void>

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -83,7 +83,10 @@ pub async fn build(
     _minifish?: {
         mapping: Record<string, string>;
         metaPath?: string;
-        mockMY: boolean;
+        inject?: Record<string, { from:string;exclude?:string; } |
+            { from:string; named:string; exclude?:string } |
+            { from:string; namespace: true; exclude?:string }
+            >;
     };
 }"#)]
     config: serde_json::Value,


### PR DESCRIPTION
for minifish 对齐 https://github.com/rollup/plugins/tree/master/packages/inject 
应用场景：

替换应用中 `my` 为指定的 mock 中的实现来测试应用；需要排除部分的文件不做替换。
