### PR TITLE
feat(okam): handle non-string theme value

### DIFF
--- a/packages/bundler-okam/index.js
+++ b/packages/bundler-okam/index.js
@@ -230,6 +230,17 @@ function checkConfig(opts) {
       }
     });
 
+  // 不支持非字符串形式的 theme
+  Object.values(opts.config.theme || {})
+    .reduce((ret, v) => {
+      const type = typeof v;
+      if (type !== 'string') ret.add(type);
+      return ret;
+    }, new Set())
+    .forEach((type) => {
+      warningKeys.push(`theme.[${type} value]`);
+    });
+
   if (warningKeys.length) {
     console.warn(
       chalk.yellow(
@@ -377,7 +388,8 @@ async function getOkamConfig(opts) {
     devtool: devtool === false ? 'none' : 'source-map',
     less: {
       theme: {
-        ...theme,
+        // ignore function value
+        ...lodash.pickBy(theme, lodash.isString),
         ...lessLoader?.modifyVars,
       },
       javascriptEnabled: lessLoader?.javascriptEnabled,


### PR DESCRIPTION
okam 增加对非字符串 `theme` 配置值的处理，有项目会直接把 `antd/lib/theme` 传给 `theme` 配置项，但实际上生效的还是字符串值，所以做 warning + 过滤