### PR TITLE
fix: error file path

### DIFF
--- a/crates/mako/src/ast.rs
+++ b/crates/mako/src/ast.rs
@@ -43,8 +43,7 @@ pub struct Ast {
 
 pub fn build_js_ast(path: &str, content: &str, context: &Arc<Context>) -> Result<Ast> {
     let absolute_path = PathBuf::from(path);
-    let relative_path =
-        diff_paths(&absolute_path, &context.config.output.path).unwrap_or(absolute_path);
+    let relative_path = diff_paths(&absolute_path, &context.root).unwrap_or(absolute_path);
     let fm = context
         .meta
         .script


### PR DESCRIPTION
Close #662

- [x] 错误文件路径已经修复
- [ ] 错误行号不对，这个是 swc 在使用 `Syntax::Typescript` 语法解析时的问题，在解析 `Syntax::Es` 时错误行号可以对上