### PR TITLE
feat: ✨ minifish 使用 tree-shaking

### DIFF
--- a/crates/mako/src/generate.rs
+++ b/crates/mako/src/generate.rs
@@ -40,14 +40,11 @@ impl Compiler {
     }
 
     pub fn generate(&self) -> Result<()> {
-        if self.context.config.output.mode == OutputMode::Bundless {
-            return self.generate_with_plugin_driver();
-        }
-
         debug!("generate");
         let t_generate = Instant::now();
-        let t_tree_shaking = Instant::now();
+
         debug!("tree_shaking");
+        let t_tree_shaking = Instant::now();
         // Disable tree shaking in watch mode temporarily
         // ref: https://github.com/umijs/mako/issues/396
         if !self.context.args.watch {
@@ -76,6 +73,11 @@ impl Compiler {
             }
         }
         let t_tree_shaking = t_tree_shaking.elapsed();
+
+        if self.context.config.output.mode == OutputMode::Bundless {
+            return self.generate_with_plugin_driver();
+        }
+
         let t_group_chunks = Instant::now();
         self.group_chunk();
         let t_group_chunks = t_group_chunks.elapsed();

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -22,6 +22,7 @@ pub type Dependencies = HashSet<Dependency>;
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Dependency {
     pub source: String,
+    pub resolve_as: Option<String>,
     pub resolve_type: ResolveType,
     pub order: usize,
     pub span: Option<Span>,

--- a/crates/mako/src/plugins/css.rs
+++ b/crates/mako/src/plugins/css.rs
@@ -218,6 +218,7 @@ impl DepCollectVisitor {
     ) {
         self.dependencies.push(Dependency {
             source,
+            resolve_as: None,
             order: self.order,
             resolve_type,
             span,

--- a/crates/mako/src/plugins/javascript.rs
+++ b/crates/mako/src/plugins/javascript.rs
@@ -103,6 +103,7 @@ impl DepCollectVisitor {
     ) {
         self.dependencies.push(Dependency {
             source,
+            resolve_as: None,
             order: self.order,
             resolve_type,
             span,

--- a/crates/mako/src/plugins/minifish.rs
+++ b/crates/mako/src/plugins/minifish.rs
@@ -111,7 +111,10 @@ impl Plugin for MinifishPlugin {
 
         for dep in deps.iter_mut() {
             if dep.source.starts_with('/') {
-                dep.source.replace_range(0..0, src_root);
+                let mut reslove_as = dep.source.clone();
+                reslove_as.replace_range(0..0, src_root);
+
+                dep.resolve_as = Some(reslove_as);
             }
         }
 

--- a/crates/mako/src/plugins/runtime.rs
+++ b/crates/mako/src/plugins/runtime.rs
@@ -116,6 +116,7 @@ impl MakoRuntime {
             virtual_js.to_str().unwrap(),
             &Dependency {
                 source: source.clone(),
+                resolve_as: None,
                 order: 0,
                 span: None,
                 resolve_type: ResolveType::Import,

--- a/crates/mako/src/resolve.rs
+++ b/crates/mako/src/resolve.rs
@@ -98,7 +98,10 @@ pub fn resolve(
     } else {
         &resolvers.esm
     };
-    do_resolve(path, &dep.source, resolver, Some(&context.config.externals))
+
+    let source = dep.resolve_as.as_ref().unwrap_or(&dep.source);
+
+    do_resolve(path, source, resolver, Some(&context.config.externals))
 }
 
 fn get_external_target(

--- a/crates/mako/src/transformers/transform_async_module.rs
+++ b/crates/mako/src/transformers/transform_async_module.rs
@@ -416,6 +416,7 @@ require._async(module, async (handleAsyncDeps, asyncResult)=>{
                 async_deps: &vec![Dependency {
                     resolve_type: ResolveType::Import,
                     source: String::from("./async"),
+                    resolve_as: None,
                     span: Some(DUMMY_SP),
                     order: 1,
                 }],

--- a/crates/mako/src/transformers/transform_css_url_replacer.rs
+++ b/crates/mako/src/transformers/transform_css_url_replacer.rs
@@ -34,6 +34,7 @@ impl VisitMut for CSSUrlReplacer<'_> {
         let url = handle_css_url(url);
         let dep = Dependency {
             source: url,
+            resolve_as: None,
             resolve_type: crate::module::ResolveType::Css,
             order: 0,
             span: None,

--- a/crates/mako/src/transformers/transform_dep_replacer.rs
+++ b/crates/mako/src/transformers/transform_dep_replacer.rs
@@ -250,6 +250,7 @@ mod tests {
                 missing: hashmap! {"react".to_string() => Dependency {
                     resolve_type: ResolveType::Import,
                     source: "react".to_string(),
+                    resolve_as: None,
                     span: None,
                     order: 0,
                 }},
@@ -293,6 +294,7 @@ mod tests {
                 missing: hashmap! {"react".to_string() => Dependency {
                     resolve_type: ResolveType::Import,
                     source: "react".to_string(),
+                    resolve_as: None,
                     span: None,
                     order: 0,
                 }},

--- a/crates/mako/src/transformers/transform_try_resolve.rs
+++ b/crates/mako/src/transformers/transform_try_resolve.rs
@@ -27,6 +27,7 @@ impl TryResolve<'_> {
                     self.path.as_str(),
                     &Dependency {
                         source: source.clone(),
+                        resolve_as: None,
                         resolve_type: ResolveType::Require,
                         order: 0,
                         span: None,


### PR DESCRIPTION
1.  Dependence 增加 Option 字段用来记录实际用来 resolve 的值；source 值保留需要是为了 tree-shaking 的时候能够通过 ast 中的 source 匹配到 Depedence
2. 开启 bundless 根据配置开启 tree-shaking 
3. workround mjs 输出为 mjs.js 文件，避免 appx 构建错误； workaround 在 appx 升级后移除。