### PR TITLE
fix: optimize empty chunk without runtime bug

### DIFF
--- a/crates/mako/src/chunk_graph.rs
+++ b/crates/mako/src/chunk_graph.rs
@@ -100,8 +100,8 @@ impl ChunkGraph {
         hasher.finish()
     }
 
-    pub fn sync_dependencies_chunk(&self, chunk: &Chunk) -> Vec<ChunkId> {
-        let idx = self.id_index_map.get(&chunk.id).unwrap();
+    pub fn sync_dependencies_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
+        let idx = self.id_index_map.get(chunk_id).unwrap();
         self.graph
             .neighbors_directed(*idx, Direction::Outgoing)
             .filter(|idx| matches!(self.graph[*idx].chunk_type, ChunkType::Sync))
@@ -109,16 +109,16 @@ impl ChunkGraph {
             .collect::<Vec<ChunkId>>()
     }
 
-    pub fn dependents_chunk(&self, chunk: &Chunk) -> Vec<ChunkId> {
-        let idx = self.id_index_map.get(&chunk.id).unwrap();
+    pub fn dependents_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
+        let idx = self.id_index_map.get(chunk_id).unwrap();
         self.graph
             .neighbors_directed(*idx, Direction::Incoming)
             .map(|idx| self.graph[idx].id.clone())
             .collect::<Vec<ChunkId>>()
     }
 
-    pub fn entry_dependents_chunk(&self, chunk: &Chunk) -> Vec<ChunkId> {
-        let idx = self.id_index_map.get(&chunk.id).unwrap();
+    pub fn entry_dependents_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
+        let idx = self.id_index_map.get(chunk_id).unwrap();
         self.graph
             .neighbors_directed(*idx, Direction::Incoming)
             .filter(|idx| matches!(self.graph[*idx].chunk_type, ChunkType::Entry(_, _)))
@@ -126,8 +126,8 @@ impl ChunkGraph {
             .collect::<Vec<ChunkId>>()
     }
 
-    pub fn entry_ancestors_chunk(&self, chunk: &Chunk) -> Vec<ChunkId> {
-        let idx = self.id_index_map.get(&chunk.id).unwrap();
+    pub fn entry_ancestors_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
+        let idx = self.id_index_map.get(chunk_id).unwrap();
         let mut ret = vec![];
         self.graph
             .neighbors_directed(*idx, Direction::Incoming)
@@ -136,7 +136,7 @@ impl ChunkGraph {
                     ret.push(self.graph[idx].id.clone());
                 }
                 _ => {
-                    ret.extend(self.entry_ancestors_chunk(&self.graph[idx]));
+                    ret.extend(self.entry_ancestors_chunk(&self.graph[idx].id));
                 }
             });
         ret

--- a/crates/mako/src/group_chunk.rs
+++ b/crates/mako/src/group_chunk.rs
@@ -194,7 +194,7 @@ impl Compiler {
                 };
 
                 if let Some(chunk) = chunk_graph.chunk(&chunk_id) {
-                    let dependent_chunks = chunk_graph.dependents_chunk(chunk);
+                    let dependent_chunks = chunk_graph.dependents_chunk(&chunk.id);
 
                     // remove edge for dependent chunks
                     for dependent_id in dependent_chunks {
@@ -284,7 +284,7 @@ impl Compiler {
             if let ChunkType::Entry(_, _) = chunk.chunk_type {
                 ret.push(chunk.filename());
             } else {
-                for chunk_id in chunk_graph.entry_ancestors_chunk(chunk) {
+                for chunk_id in chunk_graph.entry_ancestors_chunk(&chunk.id) {
                     ret.push(chunk_graph.chunk(&chunk_id).unwrap().filename());
                 }
             }

--- a/crates/mako/src/transformers/transform_dynamic_import.rs
+++ b/crates/mako/src/transformers/transform_dynamic_import.rs
@@ -33,7 +33,7 @@ impl VisitMut for DynamicImport<'_> {
                     let chunk_ids = match chunk {
                         Some(chunk) => {
                             let mut ids = chunk_graph
-                                .sync_dependencies_chunk(chunk)
+                                .sync_dependencies_chunk(&chunk.id)
                                 .iter()
                                 .map(|chunk_id| {
                                     generate_module_id(chunk_id.id.clone(), self.context)


### PR DESCRIPTION
重新优化空 chunk 的问题，之前 PR 的逻辑有 bug 会导致运行时 `__mako_require__.ensure` 缺少必要 chunk 导致报错

mako-e2e: https://github.com/umijs/mako-e2e/pull/21