### PR TITLE
refactor: 🎨 调整 require 判定

### DIFF
--- a/crates/mako/src/plugins/javascript.rs
+++ b/crates/mako/src/plugins/javascript.rs
@@ -233,8 +233,12 @@ pub fn is_dynamic_import(call_expr: &CallExpr) -> bool {
 }
 
 pub fn is_commonjs_require(call_expr: &CallExpr, unresolved_mark: &Mark) -> bool {
-    if let Callee::Expr(box Expr::Ident(ident)) = &call_expr.callee {
-        ident.sym == *"require" && is_native_ident(ident, unresolved_mark)
+    if call_expr.args.len() == 1 {
+        if let Callee::Expr(box Expr::Ident(ident)) = &call_expr.callee {
+            ident.sym == *"require" && is_native_ident(ident, unresolved_mark)
+        } else {
+            false
+        }
     } else {
         false
     }


### PR DESCRIPTION
case from minifish ：

✅ `require("dep")`， dep 是依赖
❌ `require("dep", ()=>{})` dep 不是一个依赖，不应该去 resolve 



