### PR TITLE
chore: throw error for loader syntax with query string

### DIFF
--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -293,7 +293,11 @@ module.exports = new Promise((resolve, reject) => {{
         // analyze deps
         let deps = analyze_deps(&ast, context)?;
         for dep in &deps {
-            if dep.source.contains("-loader!") {
+            // e.g. file-loader!./file.txt
+            if dep.source.contains("-loader!")
+            // e.g. file-loader?esModule=false!./src-noconflict/theme-kr_theme.js
+                || (dep.source.contains("-loader?") && dep.source.contains('!'))
+            {
                 return Err(anyhow!(
                     "webpack loader syntax is not supported, since found dep {:?} in {:?}",
                     dep.source,


### PR DESCRIPTION
用例：
https://github.com/umijs/mako-e2e/commit/bdb0eb2eac92d7873b31d3625a0c8c8f5b3b75ba
