### PR TITLE
perf: improve transform in generate

### DIFF
--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -425,7 +425,7 @@ module.exports = new Promise((resolve, reject) => {{
         Ok((module, dependencies_resource))
     }
 
-    pub fn create_thread_pool() -> (Arc<ThreadPool>, Sender<Error>, Receiver<Error>) {
+    pub fn create_thread_pool<T>() -> (Arc<ThreadPool>, Sender<T>, Receiver<T>) {
         let pool = Arc::new(ThreadPoolBuilder::new().build().unwrap());
         let (rs, rr) = channel();
         (pool, rs, rr)

--- a/crates/mako/src/transform_in_generate.rs
+++ b/crates/mako/src/transform_in_generate.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
+use std::time::Instant;
 
 use mako_core::anyhow::Result;
+use mako_core::rayon::{ThreadPool, ThreadPoolBuilder};
 use mako_core::swc_common::errors::HANDLER;
 use mako_core::swc_common::GLOBALS;
 use mako_core::swc_css_visit::VisitMutWith as CSSVisitMutWith;
@@ -14,6 +17,7 @@ use mako_core::swc_ecma_transforms::modules::util::{Config, ImportInterop};
 use mako_core::swc_ecma_transforms::{fixer, hygiene};
 use mako_core::swc_ecma_visit::VisitMutWith;
 use mako_core::swc_error_reporters::handler::try_with_handler;
+use mako_core::tracing::debug;
 use mako_core::{swc_css_ast, swc_css_prefixer};
 
 use crate::ast::Ast;
@@ -32,80 +36,131 @@ use crate::transformers::transform_react::react_refresh_entry_prefix;
 impl Compiler {
     pub fn transform_all(&self) -> Result<()> {
         let context = &self.context;
+        let t = Instant::now();
         let module_graph = context.module_graph.read().unwrap();
         // Reversed after topo sorting, in order to better handle async module
         let (mut module_ids, _) = module_graph.toposort();
         module_ids.reverse();
         drop(module_graph);
+        debug!(">> toposort & reverse in {}ms", t.elapsed().as_millis());
         transform_modules(module_ids, context)?;
         Ok(())
     }
 }
 
 pub fn transform_modules(module_ids: Vec<ModuleId>, context: &Arc<Context>) -> Result<()> {
+    let t = Instant::now();
+    let async_deps_by_module_id = mark_async(&module_ids, context);
+    debug!(">> mark async in {}ms", t.elapsed().as_millis());
+    let t = Instant::now();
+    transform_modules_in_thread(&module_ids, context, async_deps_by_module_id)?;
+    debug!(">> transform modules in {}ms", t.elapsed().as_millis());
+    Ok(())
+}
+
+fn mark_async(
+    module_ids: &Vec<ModuleId>,
+    context: &Arc<Context>,
+) -> HashMap<ModuleId, Vec<Dependency>> {
     mako_core::mako_profile_function!();
+    let mut async_deps_by_module_id = HashMap::new();
+    let mut module_graph = context.module_graph.write().unwrap();
+    // TODO: 考虑成环的场景
     module_ids.iter().for_each(|module_id| {
-        let module_graph = context.module_graph.read().unwrap();
         let deps = module_graph.get_dependencies_info(module_id);
-        // whether to have async deps
         let async_deps: Vec<Dependency> = deps
-            .clone()
             .into_iter()
-            .filter(|(_, dep, info)| {
-                matches!(dep.resolve_type, ResolveType::Import | ResolveType::Require)
-                    && info.is_async
+            .filter(|(_, dep, is_async)| {
+                matches!(dep.resolve_type, ResolveType::Import | ResolveType::Require) && *is_async
             })
-            .map(|(_, dep, _)| dep)
+            .map(|(_, dep, _)| dep.clone())
             .collect();
-        let mut resolved_deps: HashMap<String, String> = deps
-            .into_iter()
-            .map(|(id, dep, _)| {
-                (
-                    dep.source,
-                    if dep.resolve_type == ResolveType::Worker {
-                        let chunk_id = id.generate(context);
-                        let chunk_graph = context.chunk_graph.read().unwrap();
-                        chunk_graph.chunk(&chunk_id.into()).unwrap().filename()
-                    } else {
-                        id.generate(context)
-                    },
-                )
-            })
-            .collect();
-        insert_swc_helper_replace(&mut resolved_deps, context);
-
-        drop(module_graph);
-
-        // let deps: Vec<(&ModuleId, &crate::module::Dependency)> =
-        //     module_graph.get_dependencies(module_id);
-        let mut module_graph = context.module_graph.write().unwrap();
         let module = module_graph.get_module_mut(module_id).unwrap();
         let info = module.info.as_mut().unwrap();
         // a module with async deps need to be polluted into async module
         if !info.is_async && !async_deps.is_empty() {
             info.is_async = true;
         }
-        let ast = &mut info.ast;
-
-        let deps_to_replace = DependenciesToReplace {
-            resolved: resolved_deps,
-            missing: info.missing_deps.clone(),
-            ignored: info.ignored_deps.clone(),
-        };
-
-        if let ModuleAst::Script(ast) = ast {
-            transform_js_generate(TransformJsParam {
-                _id: &module.id,
-                context,
-                ast,
-                dep_map: &deps_to_replace,
-                async_deps: &async_deps,
-                is_entry: module.is_entry,
-                wrap_async: info.is_async && info.external.is_none(),
-                top_level_await: info.top_level_await,
-            });
-        }
+        async_deps_by_module_id.insert(module_id.clone(), async_deps);
     });
+    async_deps_by_module_id
+}
+
+fn create_thread_pool<T>() -> (Arc<ThreadPool>, Sender<T>, Receiver<T>) {
+    let pool = Arc::new(ThreadPoolBuilder::new().build().unwrap());
+    let (rs, rr) = channel();
+    (pool, rs, rr)
+}
+
+pub fn transform_modules_in_thread(
+    module_ids: &Vec<ModuleId>,
+    context: &Arc<Context>,
+    async_deps_by_module_id: HashMap<ModuleId, Vec<Dependency>>,
+) -> Result<()> {
+    mako_core::mako_profile_function!();
+    let (pool, rs, rr) = create_thread_pool::<(ModuleId, ModuleAst)>();
+    for module_id in module_ids {
+        let context = context.clone();
+        let rs = rs.clone();
+        let module_id = module_id.clone();
+        let async_deps = async_deps_by_module_id.get(&module_id).unwrap().clone();
+        pool.spawn(move || {
+            let module_graph = context.module_graph.read().unwrap();
+            let deps = module_graph.get_dependencies(&module_id);
+            let mut resolved_deps: HashMap<String, String> = deps
+                .into_iter()
+                .map(|(id, dep)| {
+                    (
+                        dep.source.clone(),
+                        if dep.resolve_type == ResolveType::Worker {
+                            let chunk_id = id.generate(&context);
+                            let chunk_graph = context.chunk_graph.read().unwrap();
+                            chunk_graph.chunk(&chunk_id.into()).unwrap().filename()
+                        } else {
+                            id.generate(&context)
+                        },
+                    )
+                })
+                .collect();
+            insert_swc_helper_replace(&mut resolved_deps, &context);
+            let module = module_graph.get_module(&module_id).unwrap();
+            let info = module.info.as_ref().unwrap();
+            let ast = &mut info.ast.clone();
+            let deps_to_replace = DependenciesToReplace {
+                resolved: resolved_deps,
+                missing: info.missing_deps.clone(),
+                ignored: info.ignored_deps.clone(),
+            };
+            if let ModuleAst::Script(ast) = ast {
+                transform_js_generate(TransformJsParam {
+                    _id: &module.id,
+                    context: &context,
+                    ast,
+                    dep_map: &deps_to_replace,
+                    async_deps: &async_deps,
+                    is_entry: module.is_entry,
+                    wrap_async: info.is_async && info.external.is_none(),
+                    top_level_await: info.top_level_await,
+                });
+                rs.send((module_id, ModuleAst::Script(ast.clone())))
+                    .unwrap();
+            }
+        });
+    }
+    drop(rs);
+
+    let mut transform_map: HashMap<ModuleId, ModuleAst> = HashMap::new();
+    for (module_id, ast) in rr {
+        transform_map.insert(module_id, ast);
+    }
+
+    let mut module_graph = context.module_graph.write().unwrap();
+    for (module_id, ast) in transform_map {
+        let module = module_graph.get_module_mut(&module_id).unwrap();
+        let info = module.info.as_mut().unwrap();
+        info.ast = ast;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Close #695
Close #551

1、在油油 pr 的基础上修改
2、m1 跑 yuyanAssets，generate 阶段的 transform modules 从 3431ms 降到 1019ms
3、提前做了一遍 mark_async，这样 transform modules 时就不受顺序的影响了
4、优化 mark async 的逻辑，减少 clone 和数据传递，只要 7ms（之前应该是 1s 多）
