### PR TITLE
fix: ensure error for merged common async chunk

### DIFF
--- a/crates/mako/src/chunk_graph.rs
+++ b/crates/mako/src/chunk_graph.rs
@@ -39,6 +39,13 @@ impl ChunkGraph {
     }
 
     pub fn get_chunks(&self) -> Vec<&Chunk> {
+        self.get_all_chunks()
+            .into_iter()
+            .filter(|c| !c.modules.is_empty())
+            .collect()
+    }
+
+    pub fn get_all_chunks(&self) -> Vec<&Chunk> {
         self.graph.node_weights().collect()
     }
 
@@ -90,7 +97,7 @@ impl ChunkGraph {
     }
 
     pub fn full_hash(&self, module_graph: &ModuleGraph) -> u64 {
-        let mut chunks = self.get_chunks();
+        let mut chunks = self.get_all_chunks();
         chunks.sort_by_key(|c| c.id.id.clone());
 
         let mut hasher: XxHash64 = Default::default();

--- a/crates/mako/src/group_chunk.rs
+++ b/crates/mako/src/group_chunk.rs
@@ -261,7 +261,7 @@ impl Compiler {
         module_id: &ModuleId,
         chunk_graph: &ChunkGraph,
     ) -> Vec<(ModuleId, String)> {
-        let chunks = chunk_graph.get_chunks();
+        let chunks = chunk_graph.get_all_chunks();
 
         chunks
             .iter()

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -227,6 +227,8 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex, RwLock};
 
+    use mako_core::indexmap::IndexSet;
+
     use super::transform_js;
     use crate::ast::{build_js_ast, js_ast_to_code};
     use crate::chunk::{Chunk, ChunkType};
@@ -727,6 +729,22 @@ console.log(_nodefs.default, fs2, fs3);
             optimize_infos: Mutex::new(None),
             static_cache: Default::default(),
         });
+
+        // add fake chunk for dynamic import
+        let mut chunk_graph = context.chunk_graph.write().unwrap();
+
+        chunk_graph.add_chunk(Chunk {
+            id: ModuleId {
+                id: "./foo".to_string(),
+            },
+            chunk_type: ChunkType::Async,
+            modules: IndexSet::from([ModuleId {
+                id: "./foo".to_string(),
+            }]),
+            content: None,
+            source_map: None,
+        });
+        drop(chunk_graph);
 
         let mut ast = build_js_ast(path, origin, &context).unwrap();
         transform_js(


### PR DESCRIPTION
修复合并到 common 的 async chunk 在生成 ensure 语句时数据错误导致加载失败的问题，思路如下：

1. 基本回退 #687 ，不在 optimize_chunk 阶段从 chunk_graph 里删除空的 chunk，以确保 async chunk 中的模块被提走后，仍然可以找到该 async chunk 对应的 dependencies
2. chunk_graph 新增 get_all_chunks 方法，用于返回所有 chunk，原有的 get_chunks 仅返回非空 chunk，用于 generate chunks，避免生成空 chunk
3. transform_dynamic_import 阶段对拿到的 dependencies 做非空过滤，确保该 async chunk 的 ensure 数据中仅包含被提走后的对应模块及原始 dependencies，而不包含自己

mak-e2e: https://github.com/umijs/mako-e2e/pull/26