### PR TITLE
refactor: 🔥 entry chunk 删除 cache

### DIFF
--- a/crates/mako/src/chunk_pot/ast_impl.rs
+++ b/crates/mako/src/chunk_pot/ast_impl.rs
@@ -162,7 +162,7 @@ pub(crate) fn render_entry_js_chunk(
     };
 
     Ok(ChunkFile {
-        raw_hash: pot.js_hash,
+        raw_hash: hmr_hash,
         content,
         hash,
         source_map,

--- a/crates/mako/src/chunk_pot/str_impl.rs
+++ b/crates/mako/src/chunk_pot/str_impl.rs
@@ -83,7 +83,7 @@ pub(super) fn render_entry_js_chunk(
     }
 
     Ok(ChunkFile {
-        raw_hash: pot.js_hash,
+        raw_hash: hmr_hash,
         content,
         hash: None,
         source_map: None,


### PR DESCRIPTION
## why
一旦 full hash 和上次 full hash 不一致，说明代码有改动，那么 hmr hash 必然不同（hmr hash 可以理解成代码内容+时间戳的 hash，即使相同的代码内容，出现在不同时间点那么 hmr hash 也是不同的），
entry chunk 中的 hmr_hash 初始值 (`require._h` 的值)也必须要修改，所以 entry chunk 必然要重新生成，所以 entry chunk 就没有缓存的必要了。

## 问题的表现
原来用 fullhash 作为 cache key 会表现出 ”热更重放的现象“

1. 当前代码状态0，fullhash hmrhash 分别为 `fh1` ，`hh1`， entry chunk 缓存key 为 `fh1`, chunk 中内容为 `hh1` 的 hmr hash 值。
2. 重复各种代码变更 ，fullhash ，hmrhash 分别为 `fh_x`, `hh_x`
3. 删除之前的代码变更，回到代码状态 0，此时 `fh1`,  `hh_y`,  `fh1` 命中 1 中的缓存，读取内容为 `hh1` 的 entry chunk 
4. 发生任何变动，运行时会从 `hh1` 重复 2 中的编辑改动，然后在更新到 4 的变动；重复的过程就好像飞速重放一样

## solution
hmr hash 的属性是永远不重复的，所以一旦需要生成新的 entry chunk ，那么必然是缓存没有的，自然就没有必要 cache 了

