### PR TITLE
feat: support to patch flex bugs like postcss plugin

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -293,6 +293,7 @@ pub struct Config {
     #[serde(rename = "optimizePackageImports")]
     pub optimize_package_imports: bool,
     pub emotion: bool,
+    pub flex_bugs: bool,
 }
 
 pub(crate) fn hash_config(c: &Config) -> u64 {
@@ -353,6 +354,7 @@ const DEFAULT_CONFIG: &str = r#"
     "_minifish": null,
     "optimizePackageImports": false,
     "emotion": false,
+    "flexBugs": false,
 }
 "#;
 

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -26,6 +26,7 @@ use crate::module::ModuleAst;
 use crate::plugin::PluginTransformJsParam;
 use crate::resolve::Resolvers;
 use crate::targets;
+use crate::transformers::transform_css_flexbugs::CSSFlexbugs;
 use crate::transformers::transform_css_url_replacer::CSSUrlReplacer;
 use crate::transformers::transform_dynamic_import_to_require::DynamicImportToRequire;
 use crate::transformers::transform_env_replacer::{build_env_map, EnvReplacer};
@@ -209,6 +210,12 @@ fn transform_css(
         context,
     };
     ast.visit_mut_with(&mut css_handler);
+
+    // same ability as postcss-flexbugs-fixes
+    if context.config.flex_bugs {
+        ast.visit_mut_with(&mut CSSFlexbugs {});
+    }
+
     if context.config.px2rem {
         let mut px2rem = Px2Rem {
             path: &task.path,

--- a/crates/mako/src/transformers/mod.rs
+++ b/crates/mako/src/transformers/mod.rs
@@ -1,4 +1,5 @@
 pub mod transform_async_module;
+pub mod transform_css_flexbugs;
 pub mod transform_css_handler;
 pub mod transform_css_url_replacer;
 pub mod transform_dep_replacer;

--- a/crates/mako/src/transformers/transform_css_flexbugs.rs
+++ b/crates/mako/src/transformers/transform_css_flexbugs.rs
@@ -1,0 +1,326 @@
+use mako_core::swc_css_ast::{
+    ComponentValue, Declaration, DeclarationName, Dimension, Function, FunctionName, Ident,
+    Integer, Length, LengthPercentage, Number, Percentage, SimpleBlock,
+};
+use mako_core::swc_css_visit::{VisitMut, VisitMutWith};
+
+/**
+ * Rust version of postcss-flexbugs-fixes
+ */
+pub struct CSSFlexbugs;
+
+impl CSSFlexbugs {
+    fn get_0_percent_value(&self) -> ComponentValue {
+        ComponentValue::LengthPercentage(Box::new(LengthPercentage::Percentage(Percentage {
+            value: Number {
+                value: 0.0,
+                raw: None,
+                span: Default::default(),
+            },
+            span: Default::default(),
+        })))
+    }
+
+    fn proper_basis(&self, basis: &mut ComponentValue) {
+        // transform 0/0px to 0%
+        if match basis {
+            ComponentValue::Integer(box Integer { value, .. }) => value == &0,
+            ComponentValue::Dimension(box Dimension::Length(Length {
+                value: Number { value, .. },
+                unit: Ident { value: unit, .. },
+                ..
+            })) => unit == "px" && value == &0.0,
+            _ => false,
+        } {
+            *basis = self.get_0_percent_value();
+        }
+    }
+}
+
+impl VisitMut for CSSFlexbugs {
+    fn visit_mut_declaration(&mut self, n: &mut Declaration) {
+        if let Declaration {
+            name: DeclarationName::Ident(Ident { value: name, .. }),
+            value: decl_value,
+            ..
+        } = n
+        {
+            if name == "flex"
+                // skip reserved words and custom properties
+                && !matches!(
+                    decl_value.first(),
+                    Some(ComponentValue::Ident(..) | ComponentValue::Function(..))
+                )
+            {
+                // same behavior with postcss-flexbugs-fixes bug4 and bug6
+                // ref: https://github.com/luisrudge/postcss-flexbugs-fixes/blob/683560e1f0a4e67009331b564d530ccfefb831ad/bugs/bug4.js
+                // ref: https://github.com/luisrudge/postcss-flexbugs-fixes/blob/683560e1f0a4e67009331b564d530ccfefb831ad/bugs/bug6.js
+                let default_flex_shrink = ComponentValue::Integer(Box::new(Integer {
+                    value: 1,
+                    raw: None,
+                    span: Default::default(),
+                }));
+                let mut default_flex_basis = self.get_0_percent_value();
+
+                *decl_value = vec![
+                    // fallback flex-grow to 0
+                    decl_value
+                        .first()
+                        .unwrap_or(&ComponentValue::Integer(Box::new(Integer {
+                            value: 0,
+                            raw: None,
+                            span: Default::default(),
+                        })))
+                        .clone(),
+                    // fallback flex-shrink to 1
+                    decl_value
+                        .get(1)
+                        .map(|v| match v {
+                            ComponentValue::Integer(_) => v.clone(),
+                            _ => {
+                                // treat non-numeric 2th value as flex-basis
+                                default_flex_basis = v.clone();
+
+                                // ignore non-numeric flex-shrink and fallback to 1
+                                default_flex_shrink.clone()
+                            }
+                        })
+                        .unwrap_or(default_flex_shrink.clone()),
+                    // fallback flex-basis to numeric 2th value or 0%
+                    decl_value.get(2).unwrap_or(&default_flex_basis).clone(),
+                ];
+
+                // normalize flex-basis
+                self.proper_basis(&mut decl_value[2]);
+
+                // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
+                // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
+                // already defined somewhere else.
+                if let Some(ComponentValue::LengthPercentage(box LengthPercentage::Percentage(
+                    Percentage {
+                        value: Number { value, .. },
+                        ..
+                    },
+                ))) = decl_value.get(2)
+                {
+                    if value == &0.0 {
+                        decl_value.remove(2);
+                    }
+                }
+            }
+        }
+    }
+
+    fn visit_mut_simple_block(&mut self, n: &mut SimpleBlock) {
+        let mut i = 0;
+
+        while i < n.value.len() {
+            if let ComponentValue::Declaration(box Declaration {
+                name: DeclarationName::Ident(Ident { value: name, .. }),
+                value,
+                important,
+                span,
+            }) = &n.value[i]
+            {
+                if let Some(ComponentValue::Function(box Function {
+                    name:
+                        FunctionName::Ident(Ident {
+                            value: basis_fn_name,
+                            ..
+                        }),
+                    ..
+                })) = value.get(2)
+                {
+                    if name == "flex" && basis_fn_name == "calc" {
+                        // same behavior with postcss-flexbugs-fixes bug81a
+                        // ref: https://github.com/luisrudge/postcss-flexbugs-fixes/blob/683560e1f0a4e67009331b564d530ccfefb831ad/bugs/bug81a.js
+                        n.value.splice(
+                            i..i + 1,
+                            vec![(0, "flex-grow"), (1, "flex-shrink"), (2, "flex-basis")]
+                                .into_iter()
+                                .map(|(i, name)| {
+                                    ComponentValue::Declaration(Box::new(Declaration {
+                                        name: DeclarationName::Ident(Ident {
+                                            value: name.into(),
+                                            raw: None,
+                                            span: Default::default(),
+                                        }),
+                                        value: vec![value[i].clone()],
+                                        important: important.clone(),
+                                        span: *span,
+                                    }))
+                                })
+                                .collect::<Vec<_>>(),
+                        );
+
+                        // skip expanded declarations
+                        i += 2;
+                    }
+                }
+            }
+
+            i += 1;
+        }
+
+        n.visit_mut_children_with(self);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use mako_core::swc_css_visit::VisitMutWith;
+
+    use crate::ast::{build_css_ast, css_ast_to_code};
+    use crate::compiler::Context;
+    use crate::config::{Config, DevtoolConfig, Mode};
+
+    // migrate from https://github.com/luisrudge/postcss-flexbugs-fixes/blob/683560e1f0a4e67009331b564d530ccfefb831ad/specs/bug4Spec.js
+    #[test]
+    fn bug4() {
+        assert_eq!(
+            transform("div{flex:1}".into()),
+            "div{flex:1 1}",
+            "set 0% for default flex-basis and 1 for flex-shrink in flex shorthand"
+        );
+        assert_eq!(
+            transform("div{flex:1}".into()),
+            "div{flex:1 1}",
+            "set 0% for default flex-basis and 1 for flex-shrink in flex shorthand"
+        );
+        assert_eq!(
+            transform("div{flex:1 1}".into()),
+            "div{flex:1 1}",
+            "set 0% for default flex-basis when not specified"
+        );
+        assert_eq!(
+            transform("div{flex:1 0 0}".into()),
+            "div{flex:1 0}",
+            "set flex-basis === 0% for flex-basis with plain 0"
+        );
+        assert_eq!(
+            transform("div{flex:1 0 0px}".into()),
+            "div{flex:1 0}",
+            "set flex-basis === 0% for flex-basis with 0px"
+        );
+        assert_eq!(
+            transform("div{flex:1 50%}".into()),
+            "div{flex:1 1 50%}",
+            "set flex-basis when second value is not a number"
+        );
+
+        // do nothing
+        assert_eq!(
+            transform("a{display:flex}".into()),
+            "a{display:flex}",
+            "when not flex declarations"
+        );
+        assert_eq!(
+            transform("div{flex:1 0 100%}".into()),
+            "div{flex:1 0 100%}",
+            "when flex-basis with percent is set"
+        );
+        assert_eq!(
+            transform("div{flex:1 0 10px}".into()),
+            "div{flex:1 0 10px}",
+            "when flex-basis with pixels is set"
+        );
+        assert_eq!(
+            transform("div{flex:1 1 auto}".into()),
+            "div{flex:1 1 auto}",
+            "does not change auto flex-basis is set explicitly"
+        );
+
+        // when flex value is reserved word
+        let string_values = ["none", "auto", "content", "inherit", "initial", "unset"];
+        string_values.into_iter().for_each(|s| {
+            assert_eq!(
+                transform(format!("div{{flex:{}}}", s)),
+                format!("div{{flex:{}}}", s),
+                "does not change for flex:{}",
+                s
+            );
+        });
+
+        assert_eq!(
+            transform("div{flex:var(--foo)}".into()),
+            "div{flex:var(--foo)}",
+            "is a custom property"
+        );
+    }
+
+    // migrate from https://github.com/luisrudge/postcss-flexbugs-fixes/blob/683560e1f0a4e67009331b564d530ccfefb831ad/specs/bug6Spec.js
+    #[test]
+    fn bug6() {
+        assert_eq!(
+            transform("div{flex:1}".into()),
+            "div{flex:1 1}",
+            "Set flex-shrink to 1 by default"
+        );
+
+        // do nothing
+        assert_eq!(
+            transform("div{flex:none}".into()),
+            "div{flex:none}",
+            "when flex is set to none"
+        );
+
+        assert_eq!(
+            transform("div{flex:1 0 0%}".into()),
+            "div{flex:1 0 0%}",
+            "when flex-shrink is set explicitly to zero"
+        );
+
+        assert_eq!(
+            transform("div{flex:1 2 0%}".into()),
+            "div{flex:1 2 0%}",
+            "when flex-shrink is set explicitly to non-zero value"
+        );
+    }
+
+    // migrate from https://github.com/luisrudge/postcss-flexbugs-fixes/blob/683560e1f0a4e67009331b564d530ccfefb831ad/specs/bug81aSpec.js
+    #[test]
+    fn bug81a() {
+        assert_eq!(
+            transform("a{flex:1 0 calc(1vw - 1px)}".into()),
+            "a{flex-grow:1;flex-shrink:0;flex-basis:calc(1vw - 1px)}",
+            "Expands the shorthand when calc() is used"
+        );
+
+        // do nothing
+        assert_eq!(
+            transform("a{flex:0}".into()),
+            "a{flex:0 1}",
+            "when using only first value"
+        );
+
+        assert_eq!(
+            transform("a{flex:0 0}".into()),
+            "a{flex:0 0}",
+            "when using only first and second values"
+        );
+
+        assert_eq!(
+            transform("a{flex:0 0 1px}".into()),
+            "a{flex:0 0 1px}",
+            "when not using calc"
+        );
+    }
+
+    fn transform(code: String) -> String {
+        let context: Arc<Context> = Arc::new(Context {
+            config: Config {
+                mode: Mode::Production,
+                devtool: DevtoolConfig::None,
+                minify: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut ast = build_css_ast("test.css", &code, &context, false).unwrap();
+
+        ast.visit_mut_with(&mut super::CSSFlexbugs);
+        css_ast_to_code(&ast, &context, "text.css").0
+    }
+}


### PR DESCRIPTION
支持 `flex_bugs` 配置项以提供与 https://github.com/luisrudge/postcss-flexbugs-fixes 对等的能力，Umi 等常见框架都内置了该插件以抹平 flex 规范变更前后在不同浏览器中（主要是为了兼容 IE10 和 IE11）的行为差异

场景举例，antd v4 中有使用到 `flex: 1 1 0`，在启用该插件后值会变成 `flex: 1 1`，如果不做转换则会导致样式异常，ref: https://unpkg.com/browse/antd@4.24.15/es/form/style/horizontal.less ，但实际上 antd 这里直接写成 `flex: 1 1` 会更好，最后一位 `0` 会导致 `flex-basis` 为 `0px` 应该也不是期望结果

逻辑及用例均参考自原仓库