### PR TITLE
fix(bundler-okam): enable flexBugs by default

### DIFF
--- a/packages/bundler-okam/index.js
+++ b/packages/bundler-okam/index.js
@@ -543,6 +543,7 @@ async function getOkamConfig(opts) {
     transformImport,
     externals: externalsConfig,
     clean,
+    flexBugs: true,
     ...(opts.disableCopy ? { copy: [] } : { copy: ['public'].concat(copy) }),
   };
 


### PR DESCRIPTION
用例：https://github.com/umijs/mako-e2e/commit/b4ec0a6094982352a3a426b0adf567389d7d9c26
