### PR TITLE
fix: panic when import() with empty args

### DIFF
--- a/crates/mako/src/transformers/transform_dep_replacer.rs
+++ b/crates/mako/src/transformers/transform_dep_replacer.rs
@@ -85,6 +85,9 @@ impl VisitMut for DepReplacer<'_> {
         if let Expr::Call(call_expr) = expr {
             if is_commonjs_require(call_expr, &self.unresolved_mark) || is_dynamic_import(call_expr)
             {
+                if call_expr.args.is_empty() {
+                    return;
+                }
                 if let ExprOrSpread {
                     expr: box Expr::Lit(Lit::Str(ref mut source)),
                     ..

--- a/crates/mako/src/transformers/transform_dynamic_import.rs
+++ b/crates/mako/src/transformers/transform_dynamic_import.rs
@@ -17,6 +17,9 @@ impl VisitMut for DynamicImport<'_> {
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
         if let Expr::Call(call_expr) = expr {
             if is_dynamic_import(call_expr) {
+                if call_expr.args.is_empty() {
+                    return;
+                }
                 if let ExprOrSpread {
                     expr: box Expr::Lit(Lit::Str(ref mut source)),
                     ..


### PR DESCRIPTION
e.g.

```
import()
```

will panic as follows.

```
Building with mako for development...
16 modules transformed in 537ms.
thread '<unnamed>' panicked at crates/mako/src/transformers/transform_dynamic_import.rs:26:40:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Rayon: detected unexpected panic; aborting
[1]    86629 abort      cargo run --bin mako /tmp/sorrycc-xKM485 --mode development --watch
```