### PR TITLE
fix: revert import() and require() as css modules

### DIFF
--- a/crates/mako/src/transformers/transform_virtual_css_modules.rs
+++ b/crates/mako/src/transformers/transform_virtual_css_modules.rs
@@ -3,11 +3,10 @@ use std::sync::Arc;
 use mako_core::lazy_static::lazy_static;
 use mako_core::regex::Regex;
 use mako_core::swc_common::Mark;
-use mako_core::swc_ecma_ast::{CallExpr, Expr, ImportDecl, Lit, Str};
+use mako_core::swc_ecma_ast::{ImportDecl, Str};
 use mako_core::swc_ecma_visit::{VisitMut, VisitMutWith};
 
 use crate::compiler::Context;
-use crate::plugins::javascript::{is_commonjs_require, is_dynamic_import};
 
 pub struct VirtualCSSModules<'a> {
     pub context: &'a Arc<Context>,
@@ -37,21 +36,6 @@ impl VisitMut for VirtualCSSModules<'_> {
             self.replace_source(&mut import_decl.src);
         }
         import_decl.visit_mut_children_with(self);
-    }
-
-    fn visit_mut_call_expr(&mut self, call_expr: &mut CallExpr) {
-        if is_dynamic_import(call_expr) || is_commonjs_require(call_expr, &self.unresolved_mark) {
-            if let Some(arg) = call_expr.args.first_mut() {
-                if let box Expr::Lit(Lit::Str(ref mut str)) = &mut arg.expr {
-                    if is_css_modules_path(&str.value)
-                        || (self.context.config.auto_css_modules && is_css_path(&str.value))
-                    {
-                        self.replace_source(str);
-                    }
-                }
-            }
-        }
-        call_expr.visit_mut_children_with(self);
     }
 }
 


### PR DESCRIPTION
Revert #646
用例 https://github.com/umijs/mako-e2e/commit/3d3a1781b9762787f2ea36e3c6a093743789cdbb

遇到的问题是，

```
require('./a.css')
```

会被当做是 css modules。