### PR TITLE
fix: css hmr lost when set runtime public path with hostname

### DIFF
--- a/crates/mako/templates/app_runtime.stpl
+++ b/crates/mako/templates/app_runtime.stpl
@@ -119,7 +119,7 @@ function createRuntime(makoModules, entryModuleId) {
 
   /* mako/runtime/ensure load css chunk */
   !(function () {
-    let publicPathWithoutOrigin;
+    var publicPathWithoutOrigin;
 
     try {
       publicPathWithoutOrigin = new URL(


### PR DESCRIPTION
修复在开启 runtimePublicPath 且实际 publicPath 带 hostname 的情况（比如 qiankun 微前端场景）下，CSS 热更新失效的问题

mako-e2e: https://github.com/umijs/mako-e2e/pull/35