### PR TITLE
feat: register helper modules on demand

### DIFF
--- a/crates/mako/src/lib.rs
+++ b/crates/mako/src/lib.rs
@@ -31,6 +31,7 @@ mod resolve;
 mod runtime;
 mod sourcemap;
 mod stats;
+mod swc_helpers;
 mod targets;
 #[cfg(test)]
 mod test_helper;

--- a/crates/mako/src/main.rs
+++ b/crates/mako/src/main.rs
@@ -45,6 +45,7 @@ mod resolve;
 mod runtime;
 mod sourcemap;
 mod stats;
+mod swc_helpers;
 mod targets;
 #[cfg(test)]
 mod test_helper;

--- a/crates/mako/src/plugins/runtime.rs
+++ b/crates/mako/src/plugins/runtime.rs
@@ -7,6 +7,7 @@ use mako_core::swc_ecma_ast::{
     UnaryOp,
 };
 use mako_core::swc_ecma_utils::{quote_ident, ExprFactory, StmtOrModuleItem};
+use mako_core::tracing::debug;
 
 use crate::ast::{build_js_ast, js_ast_to_code};
 use crate::build::Task;
@@ -57,11 +58,12 @@ impl MakoRuntime {
     }
 
     fn helper_runtime(&self, context: &Arc<Context>) -> Result<String> {
-        let helpers = [
-            "@swc/helpers/_/_interop_require_default",
-            "@swc/helpers/_/_interop_require_wildcard",
-            "@swc/helpers/_/_export_star",
-        ];
+        let helpers = context.swc_helpers.lock().unwrap().get_helpers();
+        debug!("swc helpers: {:?}", helpers);
+
+        if helpers.is_empty() {
+            return Ok("".to_string());
+        }
 
         let props = helpers
             .into_iter()

--- a/crates/mako/src/swc_helpers.rs
+++ b/crates/mako/src/swc_helpers.rs
@@ -1,0 +1,83 @@
+use std::collections::HashSet;
+
+use mako_core::swc_ecma_ast::{
+    CallExpr, Callee, Decl, Expr, Lit, Module, ModuleItem, Stmt, VarDecl, VarDeclarator,
+};
+
+pub struct SwcHelpers {
+    pub helpers: HashSet<String>,
+}
+
+impl SwcHelpers {
+    pub fn new(helpers: Option<HashSet<String>>) -> Self {
+        let helpers = if let Some(helpers) = helpers {
+            helpers
+        } else {
+            HashSet::new()
+        };
+        Self { helpers }
+    }
+
+    pub fn extends(&mut self, helpers: HashSet<String>) {
+        self.helpers.extend(helpers);
+    }
+
+    pub fn get_helpers(&self) -> Vec<String> {
+        self.helpers.iter().map(|h| h.to_string()).collect()
+    }
+
+    // for watch mode
+    pub fn full_helpers(&self) -> HashSet<String> {
+        let mut helpers = HashSet::new();
+        helpers.insert("@swc/helpers/_/_interop_require_default".into());
+        helpers.insert("@swc/helpers/_/_interop_require_wildcard".into());
+        helpers.insert("@swc/helpers/_/_export_star".into());
+        helpers
+    }
+
+    pub fn get_swc_helpers(ast: &Module) -> HashSet<String> {
+        let mut swc_helpers = HashSet::new();
+        // Top level require only
+        // why top level only? because swc helpers is only used in top level
+        // why require only? because cjs transform is done before this
+        ast.body.iter().for_each(|stmt| {
+            // e.g.
+            // var _interop_require_wildcard = __mako_require__("@swc/helpers/_/_interop_require_wildcard");
+            if let ModuleItem::Stmt(Stmt::Decl(Decl::Var(box VarDecl { decls, .. }))) = stmt {
+                if decls.is_empty() {
+                    return;
+                }
+                let decl = decls.first().unwrap();
+                if let VarDeclarator {
+                    init: Some(box Expr::Call(CallExpr { callee, args, .. })),
+                    ..
+                } = decl
+                {
+                    let is_require = if let Callee::Expr(box Expr::Ident(ident)) = &callee {
+                        ident.sym.as_ref() == "__mako_require__"
+                    } else {
+                        false
+                    };
+                    if !is_require {
+                        return;
+                    }
+                    if let Some(arg) = args.first() {
+                        if let Expr::Lit(Lit::Str(dep)) = arg.expr.as_ref() {
+                            let is_swc_helper = dep.value.starts_with("@swc/helpers/_/");
+                            if is_swc_helper {
+                                swc_helpers.insert(dep.value.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        swc_helpers
+    }
+}
+
+impl Default for SwcHelpers {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -755,6 +755,7 @@ const require = window.require;
             resolvers,
             optimize_infos: Mutex::new(None),
             static_cache: Default::default(),
+            swc_helpers: Mutex::new(Default::default()),
         });
 
         // add fake chunk for dynamic import


### PR DESCRIPTION
用例：https://github.com/umijs/mako-e2e/commit/bd0b09be55936013581b497b584fa182b7668c82

1、context 里新增 swc_helpers 用于保存相关信息
2、在 transform_in_generate 里分析 @swc/helpers 相关依赖，有则存到 context 里
3、runtime.rs 里基于 context.swc_helpers 信息生产 helper 模块
4、watch 模式下不做分析，用全量 helper，因为 watch 时尺寸不重要
