### PR TITLE
feat: improve error handler and print

### DIFF
--- a/crates/mako/src/ast.rs
+++ b/crates/mako/src/ast.rs
@@ -28,7 +28,7 @@ use crate::config::{DevtoolConfig, Mode};
 use crate::sourcemap::build_source_map;
 
 #[derive(Debug, Error)]
-#[error("{error_message:?}")]
+#[error("{error_message:}")]
 struct ParseError {
     resolved_path: String,
     error_message: String,

--- a/crates/mako/src/main.rs
+++ b/crates/mako/src/main.rs
@@ -90,7 +90,6 @@ async fn main() -> Result<()> {
 
     // compiler
     let compiler = compiler::Compiler::new(config, root.clone(), Args { watch: cli.watch }, None)?;
-    let compiler = Arc::new(compiler);
 
     #[cfg(feature = "profile")]
     {
@@ -121,8 +120,12 @@ async fn main() -> Result<()> {
 
     #[cfg(not(feature = "profile"))]
     {
-        compiler.compile()?;
+        if let Err(e) = compiler.compile() {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
         if cli.watch {
+            let compiler = Arc::new(compiler);
             let d = crate::dev::DevServer::new(root.clone(), compiler);
             // TODO: when in Dev Mode, Dev Server should start asap, and provider a loading  while in first compiling
             d.serve(move |_params| {}).await;

--- a/crates/mako/src/module_graph.rs
+++ b/crates/mako/src/module_graph.rs
@@ -204,7 +204,11 @@ impl ModuleGraph {
             let dependencies = self.graph.edge_weight(edge_index).unwrap();
             let module = self.graph.node_weight(node_index).unwrap();
             dependencies.iter().for_each(|dep| {
-                let is_async = module.info.as_ref().unwrap().is_async;
+                let info = module
+                    .info
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("Get info failed: {:}", module.id.id));
+                let is_async = info.is_async;
                 deps.push((&module.id, dep, is_async));
             })
         }

--- a/crates/mako/src/update.rs
+++ b/crates/mako/src/update.rs
@@ -7,6 +7,7 @@ use mako_core::anyhow::{anyhow, Ok, Result};
 use mako_core::rayon::prelude::*;
 use mako_core::tracing::debug;
 
+use crate::build::BuildError;
 use crate::compiler::Compiler;
 use crate::module::{Dependency, Module, ModuleId};
 use crate::resolve;
@@ -268,7 +269,8 @@ impl Compiler {
                     TaskType::Normal(path)
                 };
                 let (module, dependencies, _task) =
-                    Compiler::build_module(&self.context, Task::new(task_type, None))?;
+                    Compiler::build_module(&self.context, Task::new(task_type, None))
+                        .map_err(|err| BuildError::BuildTasksError { errors: vec![err] })?;
 
                 debug!(
                     "  > missing deps: {:?}",

--- a/examples/dead-simple/foo/index.js
+++ b/examples/dead-simple/foo/index.js
@@ -1,2 +1,2 @@
 export const foo = 1;
-export const bar = 2;
+// export const bar x= 2;

--- a/examples/dead-simple/index.ts
+++ b/examples/dead-simple/index.ts
@@ -1,2 +1,3 @@
 import { foo } from './foo';
+import './foo/foo';
 console.log(foo);

--- a/examples/dead-simple/public/index.html
+++ b/examples/dead-simple/public/index.html
@@ -5,3 +5,4 @@
 		<script src="index.js"></script>
 	</body>
 </html>
+

--- a/packages/bundler-okam/index.js
+++ b/packages/bundler-okam/index.js
@@ -49,20 +49,27 @@ exports.build = async function (opts) {
   }
 
   const { build } = require('@okamjs/okam');
-  await build({
-    root: cwd,
-    config: okamConfig,
-    hooks: {
-      onCompileLess: onCompileLess.bind(null, {
-        cwd,
-        config: opts.config,
-        // NOTICE: 有个缺点是 如果 alias 配置是 mako 插件修改的 less 这边就感知到不了
-        alias: okamConfig.resolve.alias,
-        modifyVars: okamConfig.less.theme,
-      }),
-    },
-    watch: false,
-  });
+  try {
+    await build({
+      root: cwd,
+      config: okamConfig,
+      hooks: {
+        onCompileLess: onCompileLess.bind(null, {
+          cwd,
+          config: opts.config,
+          // NOTICE: 有个缺点是 如果 alias 配置是 mako 插件修改的 less 这边就感知到不了
+          alias: okamConfig.resolve.alias,
+          modifyVars: okamConfig.less.theme,
+        }),
+      },
+      watch: false,
+    });
+  } catch(e) {
+    console.error(e.message);
+    const err = new Error('Build with mako failed.');
+    err.stack = null;
+    throw err;
+  }
 
   // TODO: use stats
   const manifest = JSON.parse(
@@ -175,22 +182,29 @@ exports.dev = async function (opts) {
   okamConfig.hmrPort = String(hmrPort);
   okamConfig.hmrHost = opts.host;
   const cwd = opts.cwd;
-  await build({
-    root: cwd,
-    config: okamConfig,
-    hooks: {
-      onCompileLess: onCompileLess.bind(null, {
-        cwd,
-        config: opts.config,
-        alias: okamConfig.resolve.alias,
-        modifyVars: okamConfig.less.theme,
-      }),
-      onBuildComplete: (args) => {
-        opts.onDevCompileDone(args);
+  try {
+    await build({
+      root: cwd,
+      config: okamConfig,
+      hooks: {
+        onCompileLess: onCompileLess.bind(null, {
+          cwd,
+          config: opts.config,
+          alias: okamConfig.resolve.alias,
+          modifyVars: okamConfig.less.theme,
+        }),
+        onBuildComplete: (args) => {
+          opts.onDevCompileDone(args);
+        },
       },
-    },
-    watch: true,
-  });
+      watch: true,
+    });
+  } catch(e) {
+    console.error(e.message);
+    const err = new Error('Build with mako failed.');
+    err.stack = null;
+    throw err;
+  }
 };
 
 function getDevBanner(protocol, host, port, ip) {


### PR DESCRIPTION
e.g.

1、修复 build 和 dev 时的报错信息带了 GenericFailure
2、dev Compiling 的时机问题，现在是编译后再显示个 Compiling，在引入大模块时可能会让用户感觉卡一下，所以改成 Checking... 放在 watch 之后打印
3、build 函数里直接 eprint 错误信息，感觉不好。改成全部往上抛，然后在最外面 eprint。
4、删除 format_error 函数，原因是之前在里面用 `{:?}` 做了转义，改成 `{:}` 就好了
