### PR TITLE
refactor: use dfs collect chunks to avoid stack overflow

### DIFF
--- a/crates/mako/src/chunk_graph.rs
+++ b/crates/mako/src/chunk_graph.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hasher;
 
 use mako_core::petgraph::stable_graph::{DefaultIx, NodeIndex, StableDiGraph};
+use mako_core::petgraph::visit::Dfs;
 use mako_core::petgraph::Direction;
 use mako_core::twox_hash::XxHash64;
 
@@ -134,35 +135,55 @@ impl ChunkGraph {
     }
 
     pub fn entry_ancestors_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
-        let idx = self.id_index_map.get(chunk_id).unwrap();
+        let mut dfs = Dfs::new(&self.graph, *self.id_index_map.get(chunk_id).unwrap());
         let mut ret = vec![];
-        self.graph
-            .neighbors_directed(*idx, Direction::Incoming)
-            .for_each(|idx| {
-                if matches!(self.graph[idx].chunk_type, ChunkType::Entry(_, _, _)) {
-                    ret.push(self.graph[idx].id.clone());
-                }
-                // continue to collect entry ancestors (include shared entry ancestors)
-                ret.extend(self.entry_ancestors_chunk(&self.graph[idx].id));
-            });
+        let mut visited = vec![];
+
+        while let Some(idx) = dfs.next(&self.graph) {
+            if visited.contains(&idx.index()) {
+                continue;
+            }
+            visited.push(idx.index());
+
+            if matches!(self.graph[idx].chunk_type, ChunkType::Entry(_, _, _)) {
+                ret.push(self.graph[idx].id.clone());
+            }
+
+            // continue to collect entry ancestors (include shared entry ancestors)
+            self.graph
+                .neighbors_directed(idx, Direction::Incoming)
+                .for_each(|idx| {
+                    dfs.stack.push(idx);
+                });
+        }
         ret
     }
 
     pub fn installable_descendants_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
-        let idx = self.id_index_map.get(chunk_id).unwrap();
+        let mut dfs = Dfs::new(&self.graph, *self.id_index_map.get(chunk_id).unwrap());
         let mut ret = vec![];
-        self.graph
-            .neighbors_directed(*idx, Direction::Outgoing)
-            .for_each(|idx| {
-                if matches!(
-                    self.graph[idx].chunk_type,
-                    ChunkType::Async | ChunkType::Sync
-                ) {
-                    ret.push(self.graph[idx].id.clone());
-                }
-                // continue to collect installable descendants
-                ret.extend(self.installable_descendants_chunk(&self.graph[idx].id));
-            });
+        let mut visited = vec![];
+
+        while let Some(idx) = dfs.next(&self.graph) {
+            if visited.contains(&idx.index()) {
+                continue;
+            }
+            visited.push(idx.index());
+
+            if matches!(
+                self.graph[idx].chunk_type,
+                ChunkType::Async | ChunkType::Sync
+            ) {
+                ret.push(self.graph[idx].id.clone());
+            }
+
+            // continue to collect installable descendants
+            self.graph
+                .neighbors_directed(idx, Direction::Outgoing)
+                .for_each(|idx| {
+                    dfs.stack.push(idx);
+                });
+        }
         ret
     }
 


### PR DESCRIPTION
在 Chunk Graph 中用 DFS 替代递归搜集 Chunk，避免 Chunk 成环时 Stack Overflow Error