### PR TITLE
chore: 🙈  warn -> debug

### DIFF
--- a/crates/mako/src/module_graph.rs
+++ b/crates/mako/src/module_graph.rs
@@ -6,7 +6,7 @@ use mako_core::petgraph::prelude::EdgeRef;
 use mako_core::petgraph::stable_graph::{StableDiGraph, WalkNeighbors};
 use mako_core::petgraph::visit::IntoEdgeReferences;
 use mako_core::petgraph::Direction;
-use mako_core::tracing::warn;
+use mako_core::tracing::debug;
 
 use crate::module::{Dependencies, Dependency, Module, ModuleId};
 
@@ -257,7 +257,7 @@ impl ModuleGraph {
                 return Some(module_id);
             }
         }
-        warn!(
+        debug!(
             "can not find module by source: {} in module {}",
             source, module_id.id
         );


### PR DESCRIPTION
the warning is too verbose in minifish because minifish ignore all the node native deps