### PR TITLE
feat: append entry info into stats

### DIFF
--- a/crates/mako/src/chunk_graph.rs
+++ b/crates/mako/src/chunk_graph.rs
@@ -117,6 +117,15 @@ impl ChunkGraph {
             .collect::<Vec<ChunkId>>()
     }
 
+    pub fn entry_dependencies_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
+        let idx = self.id_index_map.get(chunk_id).unwrap();
+        self.graph
+            .neighbors_directed(*idx, Direction::Outgoing)
+            .filter(|idx| matches!(self.graph[*idx].chunk_type, ChunkType::Entry(_, _, _)))
+            .map(|idx| self.graph[idx].id.clone())
+            .collect::<Vec<ChunkId>>()
+    }
+
     pub fn dependents_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
         let idx = self.id_index_map.get(chunk_id).unwrap();
         self.graph


### PR DESCRIPTION
将 entry 信息添加到 stats.json 的 `chunks` 数据中，可用于框架生成多 entry 的 HTML 文件，改动点：
1. `entry` 字段从 `bool` 调整为 `enum`，类型为 `false | string`，字符串值为 entry name
2. 增加 `dependencies` 字段，声明该 chunk 依赖的其他 entry chunk id（即 shared entry chunk id）