### PR TITLE
refactor: stats still follow webpack specs

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -67,23 +68,18 @@ pub struct StatsJsonModuleItem {
     pub chunk_id: String,
 }
 #[derive(Serialize, Debug)]
-#[serde(untagged)]
-pub enum StatsJsonChunkEntry {
-    /**
-     * only can be `false`, internal logic so omit deserialize fn
-     */
-    False(bool),
-    Name(String),
-}
-#[derive(Serialize, Debug)]
 pub struct StatsJsonChunkItem {
     #[serde(flatten)]
     pub chunk_type: StatsJsonType,
     pub chunk_id: String,
-    pub dependencies: Vec<String>,
     pub files: Vec<String>,
-    pub entry: StatsJsonChunkEntry,
+    pub entry: bool,
     pub modules: Vec<StatsJsonModuleItem>,
+}
+#[derive(Serialize, Debug)]
+pub struct StatsJsonEntryItem {
+    pub name: String,
+    pub chunks: Vec<String>,
 }
 #[derive(Serialize, Debug)]
 pub struct StatsJsonMap {
@@ -95,6 +91,7 @@ pub struct StatsJsonMap {
     assets: Vec<StatsJsonAssetsItem>,
     modules: Vec<StatsJsonModuleItem>,
     chunks: Vec<StatsJsonChunkItem>,
+    entrypoints: HashMap<String, StatsJsonEntryItem>,
 }
 
 impl StatsJsonMap {
@@ -108,6 +105,7 @@ impl StatsJsonMap {
             assets: vec![],
             modules: vec![],
             chunks: vec![],
+            entrypoints: HashMap::new(),
         }
     }
 }
@@ -206,10 +204,7 @@ pub fn create_stats_info(compile_time: u128, compiler: &Compiler) -> StatsJsonMa
         .iter()
         .map(|chunk| {
             let modules = chunk.get_modules();
-            let entry = match &chunk.chunk_type {
-                ChunkType::Entry(_, name, _) => StatsJsonChunkEntry::Name(name.clone()),
-                _ => StatsJsonChunkEntry::False(false),
-            };
+            let entry = matches!(chunk.chunk_type, ChunkType::Entry(_, _, _));
             let id = chunk.id.id.clone();
             let chunk_modules: Vec<StatsJsonModuleItem> = modules
                 .iter()
@@ -245,22 +240,39 @@ pub fn create_stats_info(compile_time: u128, compiler: &Compiler) -> StatsJsonMa
                 .filter(|asset| asset.chunk_id == id)
                 .map(|asset| asset.name.clone())
                 .collect();
-            let dependencies = chunk_graph
-                .entry_dependencies_chunk(&chunk.id)
-                .into_iter()
-                .map(|id| id.id)
-                .collect::<Vec<_>>();
 
             StatsJsonChunkItem {
                 chunk_type: StatsJsonType::Chunk("chunk".to_string()),
                 chunk_id: id,
-                dependencies,
                 files,
                 entry,
                 modules: chunk_modules,
             }
         })
         .collect();
+    stats_map.entrypoints = chunks
+        .iter()
+        .filter_map(|chunk| match &chunk.chunk_type {
+            ChunkType::Entry(_, name, _) => {
+                let mut chunks = chunk_graph
+                    .entry_dependencies_chunk(&chunk.id)
+                    .into_iter()
+                    .map(|id| id.id)
+                    .collect::<Vec<_>>();
+
+                chunks.push(chunk.id.id.clone());
+
+                Some((
+                    name.clone(),
+                    StatsJsonEntryItem {
+                        name: name.clone(),
+                        chunks,
+                    },
+                ))
+            }
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
 
     // 获取 modules
     let modules: Vec<StatsJsonModuleItem> = modules_vec.borrow().iter().cloned().collect();


### PR DESCRIPTION
对 #823 做调整，stats.json 仍然维持 Webpack 的结构，目前是个子集