### PR TITLE
fix: 🚑 when cjs convert to script to do preset

### DIFF
--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -134,6 +134,7 @@ fn transform_js(
                         context,
                     )?;
 
+                    // TODO: polyfill
                     let preset_env = swc_preset_env::preset_env(
                         unresolved_mark,
                         Some(NoopComments),
@@ -159,7 +160,7 @@ fn transform_js(
                         }),
                         // simplify, but keep top level dead code
                         // e.g. import x from 'foo'; but x is not used
-                        // this must be keeped for tree shaking to work
+                        // this must be kept for tree shaking to work
                         simplifier(
                             unresolved_mark,
                             SimpilifyConfig {


### PR DESCRIPTION
## 问题
target to chrome: 45 

react-dom
query-string 等 cjs 导出成为 undefined

## hotfix

如果是 cjs ，转换成 Script 再做 preset env，让 help 也以  cjs 形式插入，preset 做完以后，stmt 再 copy 回来 