### PR TITLE
fix: transfrom default export error when do optimizePackageImports

### DIFF
--- a/crates/mako/src/transformers/transform_optimize_package_imports.rs
+++ b/crates/mako/src/transformers/transform_optimize_package_imports.rs
@@ -286,9 +286,9 @@ fn parse_barrel_file(
                         // (source, orig, exported)
                         for (k, v) in more_export_infos {
                             if is_barrel_file {
-                                export_infos.insert(k, (v.0.clone(), v.2.clone(), v.2));
+                                export_infos.insert(k, (v.0.clone(), v.1.clone(), v.2));
                             } else {
-                                export_infos.insert(k, (path.clone(), v.1.clone(), v.1));
+                                export_infos.insert(k, (path.clone(), v.1.clone(), v.2));
                             }
                         }
                     }

--- a/e2e/fixtures/optimize-package-imports/expect.js
+++ b/e2e/fixtures/optimize-package-imports/expect.js
@@ -12,12 +12,13 @@ assert(content.includes(`var _a3exportfrom = __mako_require__("node_modules/a-si
 assert(content.includes(`var _a4 = __mako_require__("node_modules/a-side-effects-false/a4.js");`), "should include a4.js");
 assert(content.includes(`_a4.a41`), "should include _a4.a41");
 assert(content.includes(`var _a5 = __mako_require__("node_modules/a-side-effects-false/a5.js");`), "should include a5.js");
-assert(content.includes(`var _a61 = __mako_require__("node_modules/a-side-effects-false/a61.js");`), "should include a61.js");
+assert(content.includes(`var _a61 = _interop_require_default._(__mako_require__("node_modules/a-side-effects-false/a61.js"));`), "should include a61.js");
 
 assert(content.includes(`var _bsideeffectstrue = __mako_require__("node_modules/b-side-effects-true/index.js");`), "should include a-side-effects-true/index.js (barrel file) but sideEffects: true");
 
 // 判断 barrel_file 时忽略 side_effects:false 且有 var x = a.b 的场景
 assert(content.includes(`var _aaa = __mako_require__("node_modules/d-side-effects-false/aaa.js");`), "should include d-side-effects-true/aaa.js (barrel file)");
+
 
 // TODO:
 // [x] 1\ export * as foo from './foo';

--- a/e2e/fixtures/optimize-package-imports/node_modules/a-side-effects-false/a61.js
+++ b/e2e/fixtures/optimize-package-imports/node_modules/a-side-effects-false/a61.js
@@ -1,1 +1,2 @@
-export const a61 = 'a61';
+const a61 = 'a61';
+export default a61;


### PR DESCRIPTION
close https://github.com/umijs/mako/issues/825

```javascript
// index.js
export * from './a6';
```

```javascript
// a6.js
export { default as a61 } from './a61';
```

```javascript
// a61.js
const a61 = 'a61';
export default a61;
```

`export *` 与 `export { default as}` 同时出现，最终的 `export_infos` 的 `import` 和 `export` 都会被设置为 `a61`，实际应该是 `import` 为 `default`， `export` 为 `a61`
