### PR TITLE
fix: module path comment broken by context glob query

### DIFF
--- a/crates/mako/src/chunk_pot/util.rs
+++ b/crates/mako/src/chunk_pot/util.rs
@@ -179,6 +179,8 @@ pub(crate) fn pot_to_module_object(pot: &ChunkPot, context: &Arc<Context>) -> Re
                     let span = Span::dummy_with_cmt();
                     let id = module.0.id.id.clone();
                     let id = relative_to_root(id, &context.root);
+                    // to avoid comment broken by glob=**/* for context module
+                    let id = id.replace("*/", "*\\/");
                     comments.add_leading(
                         span.hi,
                         Comment {

--- a/e2e/fixtures/javascript.require-dynamic/expect.js
+++ b/e2e/fixtures/javascript.require-dynamic/expect.js
@@ -64,3 +64,11 @@ assert.match(
   moduleReg("src/index.ts", '"." \\+ file', true),
   "should replace bin left string @/i18n with .",
 );
+
+assert.doesNotMatch(
+  content,
+  // /*.../glob=**/**/ should be escaped to /*.../glob=**\/**/
+  //                                                     ^^
+  /glob=\*\*\/\*\s*\*\//,
+  "should escape glob pattern in module id debug comment"
+);


### PR DESCRIPTION
修复 module id 注释中包含 context module 的 glob 表达式时，注释被意外中断导致产物执行报错的问题