### PR TITLE
fix(bundler-okam): prefer use lessLoader.modifyVars than theme

### DIFF
--- a/e2e/fixtures.umi/config.less.modifyVars/.umirc.ts
+++ b/e2e/fixtures.umi/config.less.modifyVars/.umirc.ts
@@ -1,0 +1,11 @@
+export default {
+  mfsu: false,
+  theme: {
+    '@primary-color': 'red',
+  },
+  lessLoader: {
+    modifyVars: {
+      '@primary-color': 'blue',
+    },
+  },
+};

--- a/e2e/fixtures.umi/config.less.modifyVars/expect.js
+++ b/e2e/fixtures.umi/config.less.modifyVars/expect.js
@@ -1,0 +1,8 @@
+const assert = require("assert");
+const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+let content = files["umi.css"];
+content = content.replace(/\s/g, "");
+
+assert(content.includes(`color:blue;`), "should prefer less.modifyVars than config.theme");

--- a/e2e/fixtures.umi/config.less.modifyVars/pages/index.less
+++ b/e2e/fixtures.umi/config.less.modifyVars/pages/index.less
@@ -1,0 +1,3 @@
+.a {
+  color: @primary-color;
+}

--- a/e2e/fixtures.umi/config.less.modifyVars/pages/index.tsx
+++ b/e2e/fixtures.umi/config.less.modifyVars/pages/index.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+import './index.less';
+export default () => <div>1</div>;

--- a/packages/bundler-okam/index.js
+++ b/packages/bundler-okam/index.js
@@ -67,7 +67,7 @@ exports.build = async function (opts) {
           config: opts.config,
           // NOTICE: 有个缺点是 如果 alias 配置是 mako 插件修改的 less 这边就感知到不了
           alias: okamConfig.resolve.alias,
-          modifyVars: opts.config.theme,
+          modifyVars: opts.config.lessLoader?.modifyVars || opts.config.theme,
           sourceMap: getLessSourceMapConfig(okamConfig.devtool),
         }),
       },


### PR DESCRIPTION
## 问题

mako 不兼容 umi 的使用方式，不支持 lessLoader.modifyVars。

## 分析

原有逻辑见 https://github.com/umijs/umi/blob/cd327af/packages/bundler-webpack/src/config/cssRules.ts#L26-L28 。

```ts
lessOptions: {
  modifyVars: userConfig.theme,
  ...userConfig.lessLoader,
},
```

一个细节是，如果 lessLoader 下有配置 modifyVars，会覆盖 userConfig.theme 里的定义。所以这里有个选择，1）保持一致，2）改成扩展的形式，让 lessLoader.modifyVars 扩展 userConfig.theme。虽然感觉后者更好，但还是先保持一致吧，用 lessLoader.modifyVars 的毕竟少。

## 方案

修改 bundler-okam/index.js，逻辑如下。

```ts
modifyVars: opts.config.lessLoader?.modifyVars || opts.config.theme,
```
