### PR TITLE
feat: support to preload async scripts

### DIFF
--- a/crates/mako/src/chunk_pot/util.rs
+++ b/crates/mako/src/chunk_pot/util.rs
@@ -22,7 +22,7 @@ use swc_core::common::{Span, GLOBALS};
 
 use crate::chunk_pot::ChunkPot;
 use crate::compiler::Context;
-use crate::config::Mode;
+use crate::config::{get_pkg_name, Mode};
 use crate::load::file_content_hash;
 use crate::module::{relative_to_root, Module, ModuleAst};
 use crate::runtime::AppRuntimeTemplate;
@@ -112,6 +112,7 @@ pub(crate) fn runtime_code(context: &Arc<Context>) -> Result<String> {
         is_browser: matches!(context.config.platform, crate::config::Platform::Browser),
         cjs: context.config.cjs,
         chunk_loading_global: context.config.output.chunk_loading_global.clone(),
+        pkg_name: get_pkg_name(&context.root),
     };
     let app_runtime = app_runtime.render_once()?;
     let app_runtime = app_runtime.replace(

--- a/crates/mako/src/runtime.rs
+++ b/crates/mako/src/runtime.rs
@@ -8,6 +8,7 @@ pub struct AppRuntimeTemplate {
     pub has_hmr: bool,
     pub umd: Option<String>,
     pub cjs: bool,
+    pub pkg_name: Option<String>,
     pub chunk_loading_global: String,
     pub is_browser: bool,
 }

--- a/crates/mako/templates/app_runtime.stpl
+++ b/crates/mako/templates/app_runtime.stpl
@@ -259,9 +259,19 @@ function createRuntime(makoModules, entryModuleId) {
       if (inProgress[url]) {
         return inProgress[url].push(done);
       }
-      var script = document.createElement('script');
-      script.timeout = 120;
-      script.src = url;
+      var script = document.querySelector(
+        'script[src="' + url + '"]'
+        <% if pkg_name.is_some() { %>
+        + ', script[data-mako="' + '<%= pkg_name.clone().unwrap() %>' + ':' + key + '"]'
+        <% } %>
+      );
+
+      if (!script) {
+        script = document.createElement('script');
+        script.timeout = 120;
+        script.src = url;
+      }
+
       inProgress[url] = [done];
       var onLoadEnd = function (prev, event) {
         clearTimeout(timeout);


### PR DESCRIPTION
运行时支持复用 HTML 中预加载的 async chunk script，实现思路参考自 webpack，在 loadScript 时通过判断 `src` 或自定义属性 `data-mako="{pkg_name}:{chunk_id}"` 来识别已存在的 script 标签并进行复用

ref: https://github.com/webpack/webpack/blob/1f13ff9fe587e094df59d660b4611b1bd19aed4c/lib/runtime/LoadScriptRuntimeModule.js#L131-L136