### PR TITLE
refactor: change the way of checking variable has been declared

### DIFF
--- a/crates/mako/src/plugins/javascript.rs
+++ b/crates/mako/src/plugins/javascript.rs
@@ -1,14 +1,11 @@
 use std::sync::Arc;
 
 use mako_core::anyhow::Result;
-use mako_core::swc_common::collections::AHashSet;
-use mako_core::swc_common::sync::Lrc;
 use mako_core::swc_common::{self, Mark, GLOBALS};
 use mako_core::swc_ecma_ast::{
-    CallExpr, Callee, Expr, Id, Ident, Import, Lit, MemberExpr, MemberProp, MetaPropExpr,
-    MetaPropKind, Module, ModuleDecl, NewExpr, Str,
+    CallExpr, Callee, Expr, Ident, Import, Lit, MemberExpr, MemberProp, MetaPropExpr, MetaPropKind,
+    ModuleDecl, NewExpr, Str,
 };
-use mako_core::swc_ecma_utils::collect_decls;
 use mako_core::swc_ecma_visit::{Visit, VisitWith};
 
 use super::css::is_url_ignored;
@@ -84,7 +81,6 @@ impl Plugin for JavaScriptPlugin {
 }
 
 struct DepCollectVisitor {
-    bindings: Lrc<AHashSet<Id>>,
     dependencies: Vec<Dependency>,
     order: usize,
     unresolved_mark: Mark,
@@ -93,7 +89,6 @@ struct DepCollectVisitor {
 impl DepCollectVisitor {
     fn new(unresolved_mark: Mark) -> Self {
         Self {
-            bindings: Default::default(),
             dependencies: vec![],
             // start with 1
             // 0 for swc helpers
@@ -119,10 +114,6 @@ impl DepCollectVisitor {
 }
 
 impl Visit for DepCollectVisitor {
-    fn visit_module(&mut self, module: &Module) {
-        self.bindings = Lrc::new(collect_decls(module));
-        module.visit_children_with(self);
-    }
     fn visit_module_decl(&mut self, n: &ModuleDecl) {
         match n {
             ModuleDecl::Import(import) => {

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -109,7 +109,7 @@ fn transform_js(
                         &unresolved_mark,
                     ));
 
-                    let mut env_replacer = EnvReplacer::new(Lrc::new(env_map));
+                    let mut env_replacer = EnvReplacer::new(Lrc::new(env_map), unresolved_mark);
                     ast.visit_mut_with(&mut env_replacer);
 
                     let mut try_resolve = TryResolve {
@@ -119,7 +119,8 @@ fn transform_js(
                     };
                     ast.visit_mut_with(&mut try_resolve);
 
-                    let mut provide = Provide::new(context.config.providers.clone());
+                    let mut provide =
+                        Provide::new(context.config.providers.clone(), unresolved_mark);
                     ast.visit_mut_with(&mut provide);
 
                     let mut import_css_in_js = VirtualCSSModules {


### PR DESCRIPTION
写了一个对比的 `visitor`，让所有的 module 都跑 这个 `visitor`， `visitor`有两个版本，一个用 `collect_decls`，一个用 `unresolved_mark` 判定。用 `normal`的 example 来跑 puffin（yuyanAssets 跑了会栈溢出， `examples/normal` 已能看出差异） 。如下

`collect_decls`版本：
```rust
struct DiffCollectDecls {
    bindings: Lrc<AHashSet<Id>>,
}

impl VisitMut for DiffCollectDecls {
    fn visit_mut_module(&mut self, module: &mut Module) {
        mako_profile_scope!("node_stuff_visit_module");

        self.bindings = Lrc::new(collect_decls(&*module));
        module.visit_mut_children_with(self);
    }
}
```
puffin stat 如下
![image](https://github.com/umijs/mako/assets/37805064/4e7e126a-5f96-4b6a-b600-a1d097fa6a4f)


`unresolved_mark`版本
```rust
struct DiffCollectDecls {
    unresolved_mark: Mark,
}

impl VisitMut for DiffCollectDecls {
    fn visit_mut_module(&mut self, module: &mut Module) {
        mako_profile_scope!("node_stuff_visit_module");

        if module.span.ctxt.outer() == self.unresolved_mark {}
        module.visit_mut_children_with(self);
    }
}
```
puffin stat 如下
![image](https://github.com/umijs/mako/assets/37805064/ed9f935c-6573-4f66-a6b4-1709fbb22ad1)

结论：unresolved_mark 有明显优势 ，pr 把代码中通过 `collect_decls bindings` 的判定方式都改为使用`unresolved_mark`的方式
