### PR TITLE
docs: profiling with release dist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,8 +126,7 @@ debug = true
 - capture instruments trace with:
 
 ```bash
-$ cargo build --release
-$ cargo instruments -t sys --package mako --bin mako examples/with-antd
+$ cargo instruments --release -t sys --package mako --bin mako examples/with-antd
 ```
 
 - you can open the trace file with instruments again with:


### PR DESCRIPTION
使用 release 的产物做性能分析，确保耗时准确，执行时如果没有最新的 release 产物，会自动构建，所以不需要先执行 build