### PR TITLE
feat: call onBuildComplete hook with full stats

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -252,7 +252,7 @@ pub fn create_stats_info(compile_time: u128, compiler: &Compiler) -> StatsJsonMa
                 .assets
                 .iter()
                 .filter(|asset| asset.chunk_id == id)
-                .map(|asset| asset.name.clone())
+                .map(|asset| asset.hashname.clone())
                 .collect();
             let siblings = chunk_graph
                 .sync_dependencies_chunk(&chunk.id)


### PR DESCRIPTION
调用 `onBuildComplete` hook 时传入全量的 stats compilation 数据，主要改动点：
1. bundler-okam 默认设置 `stats: true` 产出 stats.json，如果用户没有启用 stats，会在读取后自动删除该文件，不影响产物内容
2. bundler-okam 默认关闭 `manifest: {}`，此前使用 manifest 来生成 stats.assets 数据，现在应该用不到了
3. `onBuildComplete` 调用时用 `stats.json` 的数据替代此前 `assets-manifest.json` 的数据，前者包含了后者的信息量，便于 Umi 内置插件消费完整的 stats 数据
4. 对 `onBuildComplete` 的调用改为 `await`，确保 Umi 的钩子顺序不混乱，比如不做 await 会导致 `modifyHTML` 先于 `onBuildComplete` 执行
5. stats.json 的 `chunks[i].files` 改用 hashname，确保开启 hash 时文件名能对上