### PR TITLE
fix: wrong stats origins for sync chunks

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use mako_core::colored::*;
+use mako_core::indexmap::IndexMap;
 use mako_core::pathdiff::diff_paths;
 use mako_core::serde::Serialize;
 use swc_core::common::source_map::Pos;
@@ -259,27 +260,50 @@ pub fn create_stats_info(compile_time: u128, compiler: &Compiler) -> StatsJsonMa
                 .iter()
                 .map(|id| id.id.clone())
                 .collect::<Vec<_>>();
-            let origins = module_graph
-                .get_dependents(chunk.modules.last().unwrap())
-                .iter()
-                .map(|(id, dep)| StatsJsonChunkOriginItem {
-                    module: id.id.clone(),
-                    module_identifier: id.id.clone(),
-                    module_name: module_graph
-                        .get_module(id)
-                        .unwrap()
-                        .info
-                        .clone()
-                        .map(|info| info.path)
-                        .unwrap_or("".to_string()),
-                    // -> "lo-hi"
-                    loc: dep
-                        .span
-                        .map(|span| format!("{}-{}", span.lo.to_u32(), span.hi.to_u32()))
-                        .unwrap_or("".to_string()),
-                    request: dep.source.clone(),
-                })
-                .collect::<Vec<_>>();
+            let origin_chunk_modules = match chunk.chunk_type {
+                // sync chunk is the common dependency of async chunk
+                // so the origin chunk module within its dependent async chunk rather than itself
+                ChunkType::Sync => chunk_graph
+                    .dependents_chunk(&chunk.id)
+                    .iter()
+                    .filter_map(|chunk_id| chunk_graph.chunk(chunk_id).unwrap().modules.last())
+                    .collect::<Vec<_>>(),
+                _ => vec![chunk.modules.last().unwrap()],
+            };
+            let mut origins_set = IndexMap::new();
+            for origin_chunk_module in origin_chunk_modules {
+                let origin_deps = module_graph.get_dependents(origin_chunk_module);
+
+                for (id, dep) in origin_deps {
+                    let unique_key = format!("{}:{}", id.id, dep.source);
+
+                    if !origins_set.contains_key(&unique_key) {
+                        origins_set.insert(
+                            unique_key,
+                            StatsJsonChunkOriginItem {
+                                module: id.id.clone(),
+                                module_identifier: id.id.clone(),
+                                module_name: module_graph
+                                    .get_module(id)
+                                    .unwrap()
+                                    .info
+                                    .clone()
+                                    .map(|info| info.path)
+                                    .unwrap_or("".to_string()),
+                                // -> "lo-hi"
+                                loc: dep
+                                    .span
+                                    .map(|span| {
+                                        format!("{}-{}", span.lo.to_u32(), span.hi.to_u32())
+                                    })
+                                    .unwrap_or("".to_string()),
+                                request: dep.source.clone(),
+                            },
+                        );
+                    }
+                }
+            }
+            let origins = origins_set.into_values().collect::<Vec<_>>();
 
             StatsJsonChunkItem {
                 chunk_type: StatsJsonType::Chunk("chunk".to_string()),


### PR DESCRIPTION
修复 stats 数据中，sync chunks（即从 async chunks 提出来的依赖 chunks）的 origins 数据错误的问题

对于 sync chunks，其 origins 应当是被提取前的 async chunks 被引入的来源，与 Webpack 的逻辑保持一致，举个例子：

```bash
# 原始 chunks
routes.tsx -> page_Home.js

# Code Splitting 后
routes.tsx -> page_Home.js & vendors.js

# PR 改动前 vendors.js 的 origins 是自身第一个模块被引入的位置
# PR 改动后 vendors.js 的 origins 是 page_Home.js 被 routes.tsx 引入的位置
```