### PR TITLE
refactor: treats ignore module as normal module

### DIFF
--- a/crates/mako/src/load.rs
+++ b/crates/mako/src/load.rs
@@ -70,6 +70,11 @@ pub enum LoadError {
 pub fn load(task: &task::Task, context: &Arc<Context>) -> Result<Content> {
     mako_core::mako_profile_function!(&task.path);
     debug!("load: {:?}", task);
+
+    if task.ignore {
+        return Ok(Content::Js("export {};".to_string()));
+    }
+
     let path = &task.request.path;
     let exists = Path::new(path).exists();
     if !exists {

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -47,7 +47,6 @@ pub struct ModuleInfo {
     pub raw: String,
     pub raw_hash: u64,
     pub missing_deps: HashMap<String, Dependency>,
-    pub ignored_deps: Vec<String>,
     /// Modules with top-level-await
     pub top_level_await: bool,
     /// The top-level-await module must be an async module, in addition, for example, wasm is also an async module

--- a/crates/mako/src/plugins/bundless_compiler.rs
+++ b/crates/mako/src/plugins/bundless_compiler.rs
@@ -182,7 +182,6 @@ pub fn transform_modules(module_ids: Vec<ModuleId>, context: &Arc<Context>) -> R
             let deps_to_replace = DependenciesToReplace {
                 resolved: resolved_deps,
                 missing: info.missing_deps.clone(),
-                ignored: vec![],
             };
 
             if let ModuleAst::Script(ast) = ast {

--- a/crates/mako/src/plugins/farm_tree_shake/shake/find_export_source.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/find_export_source.rs
@@ -460,7 +460,6 @@ mod tests {
                 raw: "".to_string(),
                 raw_hash: 0,
                 missing_deps: Default::default(),
-                ignored_deps: vec![],
                 top_level_await: false,
                 is_async: false,
                 resolved_resource: None,

--- a/crates/mako/src/plugins/runtime.rs
+++ b/crates/mako/src/plugins/runtime.rs
@@ -133,7 +133,11 @@ impl MakoRuntime {
         let ast = build_js_ast(&resolved, &content, context)?;
         let mut script = ModuleAst::Script(ast);
 
-        transform(&mut script, context, &Task::from_normal_path(resolved))?;
+        transform(
+            &mut script,
+            context,
+            &Task::from_normal_path(resolved, false),
+        )?;
 
         let module_id = source.into();
 
@@ -149,7 +153,6 @@ impl MakoRuntime {
             dep_map: &DependenciesToReplace {
                 resolved: Default::default(),
                 missing: Default::default(),
-                ignored: vec![],
             },
             async_deps: &Vec::<Dependency>::new(),
             module_id: &module_id,

--- a/crates/mako/src/resolve/mod.rs
+++ b/crates/mako/src/resolve/mod.rs
@@ -224,9 +224,9 @@ fn do_resolve(
                 }
             }
             Err(oxc_resolve_err) => match oxc_resolve_err {
-                OxcResolveError::Ignored(_) => {
+                OxcResolveError::Ignored(path) => {
                     debug!("resolve ignored: {:?}", source);
-                    Ok(ResolverResource::Ignored)
+                    Ok(ResolverResource::Ignored(path))
                 }
                 _ => {
                     eprintln!(
@@ -377,7 +377,7 @@ mod tests {
         Config, ExternalAdvanced, ExternalAdvancedSubpath, ExternalAdvancedSubpathConverter,
         ExternalAdvancedSubpathRule, ExternalAdvancedSubpathTarget, ExternalConfig,
     };
-    use crate::resolve::ResolverType;
+    use crate::resolve::{ExternalResource, ResolverResource, ResolverType};
 
     #[test]
     fn test_resolve() {
@@ -677,8 +677,12 @@ mod tests {
         )
         .unwrap();
         let path = resource.get_resolved_path();
-        let external = resource.get_external();
-        let script = resource.get_script();
+        let (external, script) = match resource {
+            ResolverResource::External(ExternalResource {
+                external, script, ..
+            }) => (Some(external), script),
+            _ => (None, None),
+        };
         println!("> path: {:?}, {:?}", path, external);
         let path = path.replace(format!("{}/", fixture.to_str().unwrap()).as_str(), "");
         (path, external, script)

--- a/crates/mako/src/resolve/resource.rs
+++ b/crates/mako/src/resolve/resource.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use oxc_resolver::Resolution;
 
 #[derive(Debug, Clone)]
@@ -14,7 +16,7 @@ pub struct ResolvedResource(pub Resolution);
 pub enum ResolverResource {
     External(ExternalResource),
     Resolved(ResolvedResource),
-    Ignored,
+    Ignored(PathBuf),
 }
 
 impl ResolverResource {
@@ -24,21 +26,7 @@ impl ResolverResource {
             ResolverResource::Resolved(ResolvedResource(resolution)) => {
                 resolution.full_path().to_string_lossy().to_string()
             }
-            ResolverResource::Ignored => "".to_string(),
-        }
-    }
-    pub fn get_external(&self) -> Option<String> {
-        match self {
-            ResolverResource::External(ExternalResource { external, .. }) => Some(external.clone()),
-            ResolverResource::Resolved(_) => None,
-            ResolverResource::Ignored => None,
-        }
-    }
-    pub fn get_script(&self) -> Option<String> {
-        match self {
-            ResolverResource::External(ExternalResource { script, .. }) => script.clone(),
-            ResolverResource::Resolved(_) => None,
-            ResolverResource::Ignored => None,
+            ResolverResource::Ignored(path) => path.to_string_lossy().to_string(),
         }
     }
 }

--- a/crates/mako/src/task.rs
+++ b/crates/mako/src/task.rs
@@ -16,10 +16,15 @@ pub struct Task {
     pub is_entry: bool,
     pub parent_resource: Option<ResolverResource>,
     pub ext_name: Option<String>,
+    pub ignore: bool,
 }
 
 impl Task {
-    pub fn new(task_type: TaskType, parent_resource: Option<ResolverResource>) -> Self {
+    pub fn new(
+        task_type: TaskType,
+        parent_resource: Option<ResolverResource>,
+        ignore: bool,
+    ) -> Self {
         let (path, is_entry) = match task_type {
             TaskType::Entry(path) => (path, true),
             TaskType::Normal(path) => (path, false),
@@ -32,12 +37,13 @@ impl Task {
             is_entry,
             request,
             ext_name,
+            ignore,
         }
     }
 
-    pub fn from_normal_path(path: String) -> Self {
+    pub fn from_normal_path(path: String, ignore: bool) -> Self {
         let task_type = TaskType::Normal(path);
-        Self::new(task_type, None)
+        Self::new(task_type, None, ignore)
     }
 
     pub fn is_match(&self, ext_names: Vec<&str>) -> bool {
@@ -60,6 +66,7 @@ impl Default for Task {
                 query: vec![],
             },
             ext_name: None,
+            ignore: false,
         }
     }
 }

--- a/crates/mako/src/test_helper.rs
+++ b/crates/mako/src/test_helper.rs
@@ -62,7 +62,6 @@ pub fn create_mock_module(path: PathBuf, code: &str) -> Module {
         raw_hash: 0,
         resolved_resource: None,
         missing_deps: HashMap::new(),
-        ignored_deps: vec![],
         top_level_await: false,
         is_async: false,
         source_map_chain: vec![],

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -812,6 +812,7 @@ const require = window.require;
             &Task::new(
                 crate::task::TaskType::Normal(root.join(path).to_string_lossy().to_string()),
                 None,
+                false,
             ),
             ast.top_level_mark,
             ast.unresolved_mark,
@@ -824,7 +825,6 @@ const require = window.require;
             dep_map: &DependenciesToReplace {
                 resolved: dep,
                 missing: HashMap::new(),
-                ignored: vec![],
             },
             async_deps: &vec![],
             wrap_async: false,

--- a/crates/mako/src/transform_in_generate.rs
+++ b/crates/mako/src/transform_in_generate.rs
@@ -128,7 +128,6 @@ pub fn transform_modules_in_thread(
             let deps_to_replace = DependenciesToReplace {
                 resolved: resolved_deps,
                 missing: info.missing_deps.clone(),
-                ignored: info.ignored_deps.clone(),
             };
             if let ModuleAst::Script(mut ast) = ast {
                 let ret = transform_js_generate(TransformJsParam {

--- a/crates/mako/src/transformers/transform_optimize_package_imports.rs
+++ b/crates/mako/src/transformers/transform_optimize_package_imports.rs
@@ -237,7 +237,7 @@ fn parse_barrel_file(
     }
     // build_module
     let path = resource.get_resolved_path();
-    let task = Task::new(TaskType::Normal(path), Some(resource.clone()));
+    let task = Task::new(TaskType::Normal(path), Some(resource.clone()), false);
     let (m, deps, task) = cached_build_module(context, task)?;
     let info = m.info.as_ref().unwrap();
     if !exports_all && !info.is_barrel {

--- a/crates/mako/src/transformers/transform_react.rs
+++ b/crates/mako/src/transformers/transform_react.rs
@@ -276,7 +276,7 @@ mod tests {
                 mako_react(
                     Default::default(),
                     &context,
-                    &Task::new(task_type, None),
+                    &Task::new(task_type, None, false),
                     &Mark::new(),
                     &Mark::new(),
                 )

--- a/crates/mako/src/update.rs
+++ b/crates/mako/src/update.rs
@@ -271,7 +271,7 @@ impl Compiler {
                     TaskType::Normal(path)
                 };
                 let (module, dependencies, _task) =
-                    Compiler::build_module(&self.context, Task::new(task_type, None))
+                    Compiler::build_module(&self.context, Task::new(task_type, None, false))
                         .map_err(|err| BuildError::BuildTasksError { errors: vec![err] })?;
 
                 debug!(
@@ -359,7 +359,7 @@ impl Compiler {
             .map(|path| {
                 let path = path.to_string_lossy().to_string();
                 let task_type = TaskType::Normal(path);
-                Task::new(task_type, None)
+                Task::new(task_type, None, false)
             })
             .collect::<Vec<_>>();
         self.build_tasks(tasks, false)

--- a/crates/mako/templates/app_runtime.stpl
+++ b/crates/mako/templates/app_runtime.stpl
@@ -3,7 +3,6 @@ function createRuntime(makoModules, entryModuleId) {
   var modulesRegistry = {};
 
   function requireModule(moduleId) {
-    if (moduleId === '$$IGNORED$$') return {};
     var cachedModule = modulesRegistry[moduleId];
 
     if (cachedModule !== undefined) {

--- a/e2e/fixtures/resolve.ignored/expect.js
+++ b/e2e/fixtures/resolve.ignored/expect.js
@@ -1,7 +1,14 @@
 const assert = require("assert");
-const { parseBuildResult, trim, moduleReg } = require("../../../scripts/test-utils");
+const { parseBuildResult } = require("../../../scripts/test-utils");
 const { files } = parseBuildResult(__dirname);
 
 const content = files["index.js"];
 
-assert(content.includes(`__mako_require__("$$IGNORED$$")`), `should contain __mako_require__("$$IGNORED$$")`);
+assert(
+  content.includes(`/*./node_modules/ignored/index.js*/ "node_modules/ignored/index.js": function(module, exports, __mako_require__) {
+            __mako_require__.d(exports, "__esModule", {
+                value: true
+            });
+        },`),
+  `ignored module should compile to empty module`
+);


### PR DESCRIPTION
将 oxc-resolver 解析出的 ignored module 当 normal module 处理，normal module 的内容固定为 "export {};"。下线原基于 "$$IGNOED$$" 的 ast 替换机制