### PR TITLE
chore: update three10x bench

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -20,7 +20,7 @@ import 'zx/globals';
 
   async function buildBaselineMako() {
     if (!isGitClean) {
-      await $`git stash`;
+      await $`git stash --include-untracked`;
     }
     await $`git checkout ${baseline}`;
     await $`cargo build --release`;
@@ -52,5 +52,5 @@ import 'zx/globals';
   await $`cargo build --release`;
 
   // run benchmark
-  await $`hyperfine --warmup 1 --runs 3 "./target/release/mako ${casePath} --mode production" "./tmp/${makoBaselineName} ${casePath} --mode production"`;
+  await $`hyperfine --warmup 3 --runs 10 "./target/release/mako ${casePath} --mode production" "./tmp/${makoBaselineName} ${casePath} --mode production"`;
 })();


### PR DESCRIPTION
1.  git stash 添加 --include-untracked 参数， stash 掉新增文件；
2. 使用 hyperfine --warmup 3 --run 10。--warmup 1 --runs 3 评估结果不是很稳定，同样的二进制文件，将目标和基线互换一下，有时会得到不一样的结果