### PR TITLE
chore: remove config_hash from context

### DIFF
--- a/crates/mako/src/ast_2/file.rs
+++ b/crates/mako/src/ast_2/file.rs
@@ -152,14 +152,14 @@ impl File {
         }
     }
 
-    pub fn get_raw_hash(&self, init: u64) -> u64 {
+    pub fn get_raw_hash(&self) -> u64 {
         let mut hasher: XxHash64 = Default::default();
         if let Some(content) = &self.content {
             match content {
                 Content::Js(content)
                 | Content::Css(content)
                 | Content::Assets(Asset { content, .. }) => {
-                    hasher.write_u64(init);
+                    // hasher.write_u64(init);
                     hasher.write(content.as_bytes());
                     hasher.finish()
                 }

--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -284,7 +284,7 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
         // raw_hash is only used in watch mode
         // so we don't need to calculate when watch is off
         let raw_hash = if context.args.watch {
-            file.get_raw_hash(context.config_hash)
+            file.get_raw_hash()
                 .wrapping_add(hash_hashmap(&deps.missing_deps))
         } else {
             0

--- a/crates/mako/src/chunk_pot/util.rs
+++ b/crates/mako/src/chunk_pot/util.rs
@@ -93,13 +93,6 @@ pub(crate) fn empty_module_fn_expr() -> FnExpr {
     }
 }
 
-#[cached(
-    result = true,
-    key = "u64",
-    type = "SizedCache<u64, String>",
-    convert = r#"{context.config_hash}"#,
-    create = "{ SizedCache::with_size(5) }"
-)]
 pub(crate) fn runtime_code(context: &Arc<Context>) -> Result<String> {
     let umd = context.config.umd.clone();
     let chunk_graph = context.chunk_graph.read().unwrap();

--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -13,7 +13,7 @@ use mako_core::swc_ecma_ast::Ident;
 
 use crate::chunk_graph::ChunkGraph;
 use crate::comments::Comments;
-use crate::config::{hash_config, Config, OutputMode};
+use crate::config::{Config, OutputMode};
 use crate::module_graph::ModuleGraph;
 use crate::optimize_chunk::OptimizeChunksInfo;
 use crate::plugin::{Plugin, PluginDriver, PluginGenerateEndParams, PluginGenerateStats};
@@ -30,7 +30,6 @@ pub struct Context {
     pub assets_info: Mutex<HashMap<String, String>>,
     pub modules_with_missing_deps: RwLock<Vec<String>>,
     pub config: Config,
-    pub config_hash: u64,
     pub args: Args,
     pub root: PathBuf,
     pub meta: Meta,
@@ -112,10 +111,8 @@ impl Default for Context {
     fn default() -> Self {
         let config: Config = Default::default();
         let resolvers = get_resolvers(&config);
-        let config_hash = hash_config(&config);
         Self {
             config,
-            config_hash,
             args: Args { watch: false },
             root: PathBuf::from(""),
             module_graph: RwLock::new(ModuleGraph::new()),
@@ -317,7 +314,6 @@ impl Compiler {
                 } else {
                     Default::default()
                 },
-                config_hash: hash_config(&config),
                 config,
                 args,
                 root,

--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::hash::Hasher;
 use std::path::{Path, PathBuf};
 
 use mako_core::anyhow::{anyhow, Result};
@@ -11,7 +10,6 @@ use mako_core::serde::{Deserialize, Deserializer};
 use mako_core::serde_json::Value;
 use mako_core::swc_ecma_ast::EsVersion;
 use mako_core::thiserror::Error;
-use mako_core::twox_hash::XxHash64;
 use mako_core::{clap, config, thiserror};
 use miette::{miette, ByteOffset, Diagnostic, NamedSource, SourceOffset, SourceSpan};
 use serde::Serialize;
@@ -415,12 +413,6 @@ pub struct Config {
     pub emit_assets: bool,
     #[serde(rename = "cssModulesExportOnlyLocales")]
     pub css_modules_export_only_locales: bool,
-}
-
-pub(crate) fn hash_config(c: &Config) -> u64 {
-    let mut hasher = XxHash64::default();
-    hasher.write(serde_json::to_string(c).unwrap().as_bytes());
-    hasher.finish()
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
1、config_hash 有两处用途，1）build 阶段用作 raw_hash 的计算，2）generate 阶段用于 entry runtime 的缓存 key
2、由于我们没有物理缓存或者按需热更，config_hash 目前其实是没有用处的
3、generate 阶段的 entry runtime 删除的原因是 entry 有限所以 entry runtime 也有限，没有做 cache 的必要
