### PR TITLE
refact: use rayon scope, avoid channel on generate stage

### DIFF
--- a/crates/mako/src/thread_pool.rs
+++ b/crates/mako/src/thread_pool.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use mako_core::rayon::{ThreadPool, ThreadPoolBuilder};
+use mako_core::rayon::{Scope, ThreadPool, ThreadPoolBuilder};
 
 static THREAD_POOL: OnceLock<ThreadPool> = OnceLock::new();
 
@@ -18,10 +18,10 @@ where
     THREAD_POOL.get_or_init(build_rayon_thread_pool).spawn(func)
 }
 
-pub fn install<OP, R>(op: OP) -> R
+pub fn scope<'scope, OP, R>(op: OP) -> R
 where
-    OP: FnOnce() -> R + Send,
+    OP: FnOnce(&Scope<'scope>) -> R + Send,
     R: Send,
 {
-    THREAD_POOL.get_or_init(build_rayon_thread_pool).install(op)
+    THREAD_POOL.get_or_init(build_rayon_thread_pool).scope(op)
 }


### PR DESCRIPTION
1. generate 阶段，直接把任务丢进 rayon scope， 等待返回值即可，不需要用 channel