### PR TITLE
fix: js plugin param change file.pathname to file.path

### DIFF
--- a/crates/node/src/js_plugin.rs
+++ b/crates/node/src/js_plugin.rs
@@ -34,7 +34,7 @@ impl Plugin for JsPlugin {
             let (tx, rx) = mpsc::channel::<napi::Result<Option<LoadResult>>>();
             hook.call(
                 ReadMessage {
-                    message: (param.file.path.to_string_lossy()).to_string(),
+                    message: param.file.path.to_string_lossy().to_string(),
                     tx,
                 },
                 threadsafe_function::ThreadsafeFunctionCallMode::Blocking,


### PR DESCRIPTION
js plugin 中会透传 file.pathname 会丢失 query 信息, 需要透传file.path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected file path reference in message construction for improved plugin functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->