### PR TITLE
pref: remove regexp external in node_polyfill

### DIFF
--- a/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate.rs
@@ -232,9 +232,6 @@ pub fn optimize_module_graph(
 
     GLOBALS.set(&context.meta.script.globals, || {
         for config in &concat_configurations {
-            if cfg!(debug_assertions) {
-                dbg!(&config);
-            }
             let mut module_items: Vec<ModuleItem> = Vec::new();
 
             let mut concatenate_context = ConcatenateContext::default();
@@ -250,14 +247,6 @@ pub fn optimize_module_graph(
                 }
 
                 let import_source_to_module_id = source_to_module_id(id, module_graph);
-
-                if cfg!(debug_assertions) {
-                    println!("\n*** start for {}", id.id);
-                    println!(
-                        "config.external_interops(id) {:?} ",
-                        &config.external_interops(id)
-                    );
-                }
 
                 if let Some(interop) = config.external_interops(id) {
                     let base_name = uniq_module_prefix(id);

--- a/crates/mako/src/plugins/node_polyfill.rs
+++ b/crates/mako/src/plugins/node_polyfill.rs
@@ -3,10 +3,7 @@ use std::path::Path;
 use mako_core::anyhow::Result;
 
 use crate::compiler::Args;
-use crate::config::{
-    Config, ExternalAdvanced, ExternalAdvancedSubpath, ExternalAdvancedSubpathRule,
-    ExternalAdvancedSubpathTarget, ExternalConfig,
-};
+use crate::config::{Config, ExternalConfig};
 use crate::plugin::Plugin;
 
 pub struct NodePolyfillPlugin {}
@@ -27,20 +24,12 @@ impl Plugin for NodePolyfillPlugin {
         // empty modules
         for name in get_empty_modules().iter() {
             // e.g. support fs and fs/promise
+            config
+                .externals
+                .insert(name.to_string(), ExternalConfig::Basic("".to_string()));
             config.externals.insert(
-                name.to_string(),
-                ExternalConfig::Advanced(ExternalAdvanced {
-                    root: "".into(),
-                    script: None,
-                    subpath: Some(ExternalAdvancedSubpath {
-                        rules: vec![ExternalAdvancedSubpathRule {
-                            regex: ".*".into(),
-                            target: ExternalAdvancedSubpathTarget::Empty,
-                            target_converter: None,
-                        }],
-                        exclude: None,
-                    }),
-                }),
+                format!("{name}/promise"),
+                ExternalConfig::Basic("".to_string()),
             );
         }
         // identifier


### PR DESCRIPTION
Close https://github.com/umijs/mako/issues/997

跑 just bench 性能上没明显区别，但应该不需要用到正则。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed unnecessary debug print statements to clean up console output.
	- Simplified configuration handling in Node polyfills and improved handling of empty modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->