### PR TITLE
chore: improve ensure_synced script

### DIFF
--- a/packages/bundler-okam/scripts/ensure_synced.ts
+++ b/packages/bundler-okam/scripts/ensure_synced.ts
@@ -11,16 +11,15 @@ import 'zx/globals';
         await $`tnpm info --json @okamjs/okam@${makoVersion}`.quiet();
 
       const optionDeps = JSON.parse(info.stdout)['optionalDependencies'];
-
       await Promise.all(
         Object.keys(optionDeps).map((key) => {
-          return $`tnpm info ${key}@${optionDeps[key]}`.quiet();
+          return $`tnpm sync ${key} && tnpm info ${key}@${optionDeps[key]}`.quiet();
         }),
       );
     })();
   });
 
-  console.error(chalk.bgGreen(chalk.white('SUCCEED')), chalk.green('synced'));
+  console.log(chalk.bgGreen(chalk.white('SUCCEED')), chalk.green('synced'));
 })().catch((err) => {
   console.error(err);
   console.error(


### PR DESCRIPTION
跑了几遍 optional dep 都 sync 不到，最后手动一个个 tnpm info 才找到哪个没 sync 出来。所以不能信任 tnpm sync @okamjs/okam 时会 sync 全 optional dep，在 info 之前先做下 sync。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the dependency synchronization process in the build tooling, enhancing the accuracy of fetched dependency information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->