### PR TITLE
fix: entry chunk hash

### DIFF
--- a/crates/mako/src/swc_helpers.rs
+++ b/crates/mako/src/swc_helpers.rs
@@ -1,21 +1,21 @@
-use std::collections::HashSet;
+use mako_core::indexmap::IndexSet;
 
 pub struct SwcHelpers {
-    pub helpers: HashSet<String>,
+    pub helpers: IndexSet<String>,
 }
 
 impl SwcHelpers {
-    pub fn new(helpers: Option<HashSet<String>>) -> Self {
+    pub fn new(helpers: Option<IndexSet<String>>) -> Self {
         let helpers = if let Some(helpers) = helpers {
             helpers
         } else {
-            HashSet::new()
+            IndexSet::new()
         };
         Self { helpers }
     }
 
-    pub fn full_helpers() -> HashSet<String> {
-        let mut helpers = HashSet::new();
+    pub fn full_helpers() -> IndexSet<String> {
+        let mut helpers = IndexSet::new();
         helpers.insert("@swc/helpers/_/_interop_require_default".into());
         helpers.insert("@swc/helpers/_/_interop_require_wildcard".into());
         helpers.insert("@swc/helpers/_/_export_star".into());


### PR DESCRIPTION
Close https://github.com/umijs/mako/issues/1002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Switched from using `std::collections::HashSet` to `mako_core::indexmap::IndexSet` in `SwcHelpers` struct.
	- Updated `new` method to accept `Option<IndexSet<String>>` instead of `Option<HashSet<String>>`.
	- Updated `full_helpers` method to return `IndexSet<String>` instead of `HashSet<String>`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->