### PR TITLE
refact: move env_replacer to visitors

### DIFF
--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -20,7 +20,6 @@ use crate::ast_2::file::File;
 use crate::compiler::Context;
 use crate::module::ModuleAst;
 use crate::targets;
-use crate::transformers::transform_env_replacer::{build_env_map, EnvReplacer};
 use crate::transformers::transform_provide::Provide;
 use crate::transformers::transform_px2rem::Px2Rem;
 use crate::transformers::transform_react::mako_react;
@@ -28,6 +27,7 @@ use crate::visitors::css_assets::CSSAssets;
 use crate::visitors::css_flexbugs::CSSFlexbugs;
 use crate::visitors::default_export_namer::DefaultExportNamer;
 use crate::visitors::dynamic_import_to_require::DynamicImportToRequire;
+use crate::visitors::env_replacer::{build_env_map, EnvReplacer};
 use crate::visitors::try_resolve::TryResolve;
 use crate::visitors::virtual_css_modules::VirtualCSSModules;
 

--- a/crates/mako/src/transformers/mod.rs
+++ b/crates/mako/src/transformers/mod.rs
@@ -1,7 +1,6 @@
 pub mod transform_async_module;
 pub mod transform_dep_replacer;
 pub mod transform_dynamic_import;
-pub mod transform_env_replacer;
 pub mod transform_mako_require;
 pub mod transform_meta_url_replacer;
 pub mod transform_optimize_define_utils;

--- a/crates/mako/src/transformers/transform_async_module.rs
+++ b/crates/mako/src/transformers/transform_async_module.rs
@@ -260,7 +260,8 @@ add(1, 2);
         println!(">> CODE\n{}", code);
         assert_eq!(
             code,
-            r#"__mako_require__._async(module, async (handleAsyncDeps, asyncResult)=>{
+            r#"
+__mako_require__._async(module, async (handleAsyncDeps, asyncResult)=>{
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
@@ -277,8 +278,7 @@ add(1, 2);
     0, _async.default(1, 2);
     asyncResult();
 }, true);
-"#
-                .trim()
+            "#.trim()
         );
     }
 

--- a/crates/mako/src/visitors/mod.rs
+++ b/crates/mako/src/visitors/mod.rs
@@ -5,5 +5,6 @@ pub(crate) mod css_imports;
 pub(crate) mod default_export_namer;
 pub(crate) mod dep_analyzer;
 pub(crate) mod dynamic_import_to_require;
+pub(crate) mod env_replacer;
 pub(crate) mod try_resolve;
 pub(crate) mod virtual_css_modules;


### PR DESCRIPTION
move and add testcases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - Reorganized imports in the `transform.rs` file related to visitors and transformers.
    - Adjusted import path for `EnvReplacer` in the `visitors` module.
    - Removed the `transform_env_replacer` module from the list of modules in `transformers/mod.rs`.
    - Modified indentation and formatting in `transform_async_module.rs`.
    - Refactored code structure affecting the generated code snippet in `transform_async_module.rs`.
    - Added imports for `HashMap` and `Value` in `env_replacer.rs`.
    - Reorganized test functions and imports in `env_replacer.rs`.
    - Refactored test cases for different data types in `env_replacer.rs`.
    - Introduced a new test for an undefined environment variable check in `env_replacer.rs`.
    - Refactored the `run` function in `env_replacer.rs` to handle test cases with different data types.
    - Adjusted the `run` function in `env_replacer.rs` to utilize `build_env_map` and `EnvReplacer` for environment replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->