### PR TITLE
chore(sourcemap): 🎨 move internal files to mako_internal

### DIFF
--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -192,7 +192,7 @@ fn get_env_expr(v: Value, context: &Arc<Context>) -> Result<Expr> {
     match v {
         Value::String(v) => {
             // the string content is treat as expression, so it has to be parsed
-            let ast = JsAst::build("_define_.js", &v, context.clone()).unwrap();
+            let ast = JsAst::build("_mako_internal/_define_.js", &v, context.clone()).unwrap();
             let module = ast.ast.body.first().unwrap();
 
             match module {

--- a/crates/mako/src/visitors/react.rs
+++ b/crates/mako/src/visitors/react.rs
@@ -63,7 +63,12 @@ struct PrefixCode {
 
 impl VisitMut for PrefixCode {
     fn visit_mut_module(&mut self, module: &mut Module) {
-        let ast = JsAst::build("_pre_code.js", &self.code, self.context.clone()).unwrap();
+        let ast = JsAst::build(
+            "_mako_internal/hmr_pre_code.js",
+            &self.code,
+            self.context.clone(),
+        )
+        .unwrap();
         module.body.splice(0..0, ast.ast.body);
         module.visit_mut_children_with(self);
     }
@@ -76,7 +81,12 @@ struct PostfixCode {
 
 impl VisitMut for PostfixCode {
     fn visit_mut_module(&mut self, module: &mut Module) {
-        let ast = JsAst::build("_post_code.js", &self.code, self.context.clone()).unwrap();
+        let ast = JsAst::build(
+            "_mako_internal/hmr_post_code.js",
+            &self.code,
+            self.context.clone(),
+        )
+        .unwrap();
         module.body.extend(ast.ast.body);
 
         module.visit_mut_children_with(self);


### PR DESCRIPTION
## after
![image](https://github.com/umijs/mako/assets/415655/11235c92-7be2-421b-af16-e13b125c0d14)


## before
![image](https://github.com/umijs/mako/assets/415655/c23834a0-1ca2-4021-bd15-0d0a614eb72e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - Updated file paths and filenames for better integration of JavaScript AST construction and module visitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->