### PR TITLE
fix(binding): emitAssets and cssModulesExportOnlyLocales should be optional

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -126,8 +126,8 @@ pub struct BuildParams {
         importSource?: string;
         pragmaFrag?: string;
     };
-    emitAssets: boolean;
-    cssModulesExportOnlyLocales: boolean;
+    emitAssets?: boolean;
+    cssModulesExportOnlyLocales?: boolean;
     inlineCSS?: false | {};
 }"#)]
     pub config: serde_json::Value,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Converted certain fields in the `BuildParams` struct to optional by adding `?` to their declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->