### PR TITLE
fix: node-libs-browser-okam not found when using @okamjs/okam seperately

### DIFF
--- a/packages/bundler-okam/package.json
+++ b/packages/bundler-okam/package.json
@@ -10,7 +10,6 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "lodash": "^4.17.21",
-    "node-libs-browser-okam": "2.2.4",
     "rimraf": "5.0.1",
     "webpack-5-chain": "8.0.1"
   },

--- a/packages/mako/package.json
+++ b/packages/mako/package.json
@@ -19,6 +19,7 @@
     "@swc/helpers": "0.5.1",
     "less": "^4.2.0",
     "less-plugin-resolve": "^1.0.2",
+    "node-libs-browser-okam": "2.2.4",
     "react-error-overlay": "6.0.9",
     "react-refresh": "^0.14.0",
     "workerpool": "^9.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,9 +361,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      node-libs-browser-okam:
-        specifier: 2.2.4
-        version: 2.2.4
       rimraf:
         specifier: 5.0.1
         version: 5.0.1
@@ -382,6 +379,9 @@ importers:
       less-plugin-resolve:
         specifier: ^1.0.2
         version: 1.0.2
+      node-libs-browser-okam:
+        specifier: 2.2.4
+        version: 2.2.4
       react-error-overlay:
         specifier: 6.0.9
         version: 6.0.9


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated dependencies for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->