### PR TITLE
fix: 🐛  installable chunks contains empty chunk

### DIFF
--- a/crates/mako/src/chunk_graph.rs
+++ b/crates/mako/src/chunk_graph.rs
@@ -177,11 +177,12 @@ impl ChunkGraph {
             }
             visited.push(idx.index());
 
-            if matches!(
-                self.graph[idx].chunk_type,
-                ChunkType::Async | ChunkType::Sync
-            ) {
-                ret.push(self.graph[idx].id.clone());
+            let chunk = &self.graph[idx];
+
+            if !chunk.modules.is_empty()
+                && matches!(chunk.chunk_type, ChunkType::Async | ChunkType::Sync)
+            {
+                ret.push(chunk.id.clone());
             }
         }
         ret


### PR DESCRIPTION
## problem
并发构建 chunk 暴露这个问题
chunk_graph.get_chunks() 获得的 chunk 数量 < chunk_graph.installable_descendants_chunk() 
再为多出来 installable chunk 查找替换字符串的时候，就会发现找不到，不符合预期报错。

## solution
`installable_descendants_chunk` 对齐 `get_chunks` 数量。

get_chunks 会决定生成的 chunk 文件的数量，所以在未实现并发构建 chunk 之前，多出的 installable chunk 的 id 对应一个 404 文件，加载肯定出错；现在只是移除了该 id。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified logic in `ChunkGraph` to consider modules for chunk type matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->