### PR TITLE
feat: ✨ 输出 module/chunk graph dot 文件

### DIFF
--- a/crates/mako/src/chunk.rs
+++ b/crates/mako/src/chunk.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Debug, Formatter};
 use std::hash::Hasher;
 use std::path::{Component, Path};
 
@@ -13,7 +14,7 @@ use crate::module_graph::ModuleGraph;
 
 pub type ChunkId = ModuleId;
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ChunkType {
     #[allow(dead_code)]
     Runtime,
@@ -34,6 +35,19 @@ pub struct Chunk {
     pub modules: IndexSet<ModuleId>,
     pub content: Option<String>,
     pub source_map: Option<String>,
+}
+
+impl Debug for Chunk {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}#{}({:?})",
+            self.id.id,
+            self.modules.len(),
+            self.chunk_type
+        )?;
+        Ok(())
+    }
 }
 
 impl Chunk {

--- a/crates/mako/src/chunk_graph.rs
+++ b/crates/mako/src/chunk_graph.rs
@@ -12,7 +12,7 @@ use crate::module::ModuleId;
 use crate::module_graph::ModuleGraph;
 
 pub struct ChunkGraph {
-    graph: StableDiGraph<Chunk, ()>,
+    pub(crate) graph: StableDiGraph<Chunk, ()>,
     id_index_map: HashMap<ChunkId, NodeIndex<DefaultIx>>,
 }
 

--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -252,6 +252,10 @@ impl Compiler {
             plugins.insert(0, Arc::new(plugins::bundless_compiler::BundlessCompiler {}));
         }
 
+        if std::env::var("DEBUG_GRAPH").is_ok_and(|v| v == "true") {
+            plugins.push(Arc::new(plugins::graphviz::Graphviz {}));
+        }
+
         if let Some(minifish_config) = &config._minifish {
             let inject = if let Some(inject) = &minifish_config.inject {
                 let mut map = HashMap::new();

--- a/crates/mako/src/generate.rs
+++ b/crates/mako/src/generate.rs
@@ -53,6 +53,8 @@ impl Compiler {
     }
 
     pub fn generate(&self) -> Result<()> {
+        self.context.plugin_driver.before_generate(&self.context)?;
+
         debug!("generate");
         let t_generate = Instant::now();
 
@@ -93,6 +95,11 @@ impl Compiler {
         let t_group_chunks = t_group_chunks.elapsed();
 
         let t_optimize_chunks = Instant::now();
+
+        self.context
+            .plugin_driver
+            .before_optimize_chunk(&self.context)?;
+
         self.optimize_chunk();
         let t_optimize_chunks = t_optimize_chunks.elapsed();
 

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -98,6 +98,10 @@ pub trait Plugin: Any + Send + Sync {
         Ok(None)
     }
 
+    fn generate_beg(&self, _context: &Arc<Context>) -> Result<()> {
+        Ok(())
+    }
+
     fn generate_end(
         &self,
         _params: &PluginGenerateEndParams,
@@ -115,6 +119,10 @@ pub trait Plugin: Any + Send + Sync {
         _module_graph: &mut ModuleGraph,
         _context: &Arc<Context>,
     ) -> Result<()> {
+        Ok(())
+    }
+
+    fn before_optimize_chunk(&self, _context: &Arc<Context>) -> Result<()> {
         Ok(())
     }
 
@@ -136,6 +144,7 @@ pub trait Plugin: Any + Send + Sync {
 pub struct PluginDriver {
     plugins: Vec<Arc<dyn Plugin>>,
 }
+
 impl PluginDriver {
     pub fn new(plugins: Vec<Arc<dyn Plugin>>) -> Self {
         Self { plugins }
@@ -209,6 +218,13 @@ impl PluginDriver {
         Ok(())
     }
 
+    pub fn before_generate(&self, context: &Arc<Context>) -> Result<()> {
+        for plugin in &self.plugins {
+            plugin.generate_beg(context)?;
+        }
+        Ok(())
+    }
+
     pub fn generate(&self, context: &Arc<Context>) -> Result<Option<()>> {
         for plugin in &self.plugins {
             let ret = plugin.generate(context)?;
@@ -234,6 +250,13 @@ impl PluginDriver {
     ) -> Result<Option<()>> {
         for plugin in &self.plugins {
             plugin.generate_end(param, context)?;
+        }
+        Ok(None)
+    }
+
+    pub fn generate_beg(&self, context: &Arc<Context>) -> Result<Option<()>> {
+        for plugin in &self.plugins {
+            plugin.generate_beg(context)?;
         }
         Ok(None)
     }
@@ -264,6 +287,14 @@ impl PluginDriver {
     ) -> Result<()> {
         for p in &self.plugins {
             p.optimize_module_graph(module_graph, context)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn before_optimize_chunk(&self, context: &Arc<Context>) -> Result<()> {
+        for p in &self.plugins {
+            p.before_optimize_chunk(context)?;
         }
 
         Ok(())

--- a/crates/mako/src/plugins/graphviz.rs
+++ b/crates/mako/src/plugins/graphviz.rs
@@ -1,0 +1,73 @@
+use std::fmt::Debug;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use mako_core::anyhow::Result;
+use mako_core::petgraph::dot::{Config, Dot};
+use mako_core::petgraph::visit::{
+    GraphProp, IntoEdgeReferences, IntoNodeReferences, NodeIndexable,
+};
+
+use crate::compiler::Context;
+use crate::plugin::{Plugin, PluginGenerateEndParams};
+
+pub struct Graphviz {}
+
+impl Graphviz {
+    fn write_graph<G, P>(dot_filename: P, graph: G) -> Result<()>
+    where
+        P: AsRef<Path>,
+        G: IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,
+        G::EdgeWeight: Debug,
+        G::NodeWeight: Debug,
+    {
+        let dot = Dot::with_config(graph, &[Config::EdgeNoLabel]);
+        let mut file = File::create(dot_filename.as_ref())
+            .unwrap_or_else(|_| panic!("{} cant create", dot_filename.as_ref().display()));
+
+        write!(file, "{:?}", dot)?;
+        Ok(())
+    }
+}
+
+impl Plugin for Graphviz {
+    fn name(&self) -> &str {
+        "graphviz"
+    }
+
+    fn generate_beg(&self, context: &Arc<Context>) -> Result<()> {
+        Graphviz::write_graph(
+            context.root.join("_mako_module_graph_origin.dot"),
+            &context.module_graph.read().unwrap().graph,
+        )?;
+        Ok(())
+    }
+
+    fn before_optimize_chunk(&self, context: &Arc<Context>) -> Result<()> {
+        Graphviz::write_graph(
+            context.root.join("_mako_chunk_graph_origin.dot"),
+            &context.chunk_graph.read().unwrap().graph,
+        )?;
+        Ok(())
+    }
+
+    fn generate_end(
+        &self,
+        _params: &PluginGenerateEndParams,
+        context: &Arc<Context>,
+    ) -> Result<Option<()>> {
+        Graphviz::write_graph(
+            context.root.join("_mako_chunk_graph_finale.dot"),
+            &context.chunk_graph.read().unwrap().graph,
+        )?;
+
+        Graphviz::write_graph(
+            context.root.join("_mako_module_graph_finale.dot"),
+            &context.module_graph.read().unwrap().graph,
+        )?;
+
+        Ok(None)
+    }
+}

--- a/crates/mako/src/plugins/mod.rs
+++ b/crates/mako/src/plugins/mod.rs
@@ -4,6 +4,7 @@ pub mod context_module;
 pub mod copy;
 pub mod emotion;
 pub mod farm_tree_shake;
+pub mod graphviz;
 pub mod hmr_runtime;
 pub mod ignore;
 pub mod import;


### PR DESCRIPTION
##  功能
`DEBUG_GRAPH=true` 环境变量开启，开启在项目根目录输出项目的 module chunk graph

```txt
_mako_chunk_graph_finale.dot
_mako_chunk_graph_origin.dot
_mako_module_graph_finale.dot
_mako_module_graph_origin.dot
```

好处，发现一些review 无法发现的在 graph 上的问题 比如 #1065  #1066 

### 如何使用
`DEBUG_GRAPH=true` 开启后，执行构建
目前可将 dot 文件内容贴到  https://edotor.net/  or http://magjac.com/graphviz-visual-editor/ 查看可视化的结果
在联系 antv 的同学帮忙做一个可视化的页面，看是有更好的效果


## 改动
增加
* before_optimize_chunk
* generate_beg 
插件切面

为了能够取到最原始的 module 和 chunk graph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added custom formatting method for `Chunk` instances to enhance debugging capabilities.
    - Changed visibility of `graph` field in `ChunkGraph` struct to `pub(crate)`.
    - Introduced `Graphviz` plugin based on environment variable in `Compiler` implementation.
    - Extended `Plugin` trait with new methods for plugin execution hooks.
    - Added functionality in `graphviz.rs` for generating Graphviz dot files from graphs.
    - Included a new module `graphviz` in the `plugins` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->