### PR TITLE
feat: support load with jsx enabled js

### DIFF
--- a/crates/mako/src/ast/file.rs
+++ b/crates/mako/src/ast/file.rs
@@ -25,8 +25,23 @@ pub struct Asset {
 }
 
 #[derive(Debug, Clone)]
+pub struct JsContent {
+    pub is_jsx: bool,
+    pub content: String,
+}
+
+impl Default for JsContent {
+    fn default() -> Self {
+        JsContent {
+            is_jsx: false,
+            content: "".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum Content {
-    Js(String),
+    Js(JsContent),
     Css(String),
     // TODO: unify the assets handler
     // it's used in minifish plugin(bundless mode) only
@@ -159,7 +174,9 @@ impl File {
 
     pub fn get_content_raw(&self) -> String {
         match &self.content {
-            Some(Content::Js(content)) | Some(Content::Css(content)) => content.clone(),
+            Some(Content::Js(JsContent { content, .. })) | Some(Content::Css(content)) => {
+                content.clone()
+            }
             Some(Content::Assets(asset)) => asset.content.clone(),
             None => "".to_string(),
         }
@@ -169,7 +186,7 @@ impl File {
         let mut hasher: XxHash64 = Default::default();
         if let Some(content) = &self.content {
             match content {
-                Content::Js(content)
+                Content::Js(JsContent { content, .. })
                 | Content::Css(content)
                 | Content::Assets(Asset { content, .. }) => {
                     // hasher.write_u64(init);
@@ -234,6 +251,13 @@ impl File {
         let digest = context.compute();
         let hash = format!("{:x}", digest);
         Ok(hash[0..8].to_string())
+    }
+
+    pub fn is_content_jsx(&self) -> bool {
+        match &self.content {
+            Some(Content::Js(JsContent { is_jsx, .. })) => *is_jsx,
+            _ => false,
+        }
     }
 
     pub fn has_param(&self, key: &str) -> bool {

--- a/crates/mako/src/ast/js_ast.rs
+++ b/crates/mako/src/ast/js_ast.rs
@@ -18,7 +18,7 @@ use mako_core::swc_ecma_visit::{VisitMutWith, VisitWith};
 use swc_core::base::try_with_handler;
 use swc_core::common::Spanned;
 
-use super::file::Content;
+use super::file::{Content, JsContent};
 use crate::ast::file::File;
 use crate::ast::{error, utils};
 use crate::compiler::Context;
@@ -59,9 +59,8 @@ impl JsAst {
                 ..Default::default()
             })
         } else {
-            let jsx = extname == "jsx"
-                // when use svg as svgr, it should come here and be treated as jsx
-                || extname == "svg"
+            let jsx = file.is_content_jsx()
+                || extname == "jsx"
                 || (extname == "js" && !file.is_under_node_modules);
             Syntax::Es(EsConfig {
                 jsx,
@@ -119,10 +118,14 @@ impl JsAst {
     }
 
     pub fn build(path: &str, content: &str, context: Arc<Context>) -> Result<Self> {
+        let is_jsx = path.ends_with(".jsx") || path.ends_with(".tsx");
         JsAst::new(
             &File::with_content(
                 path.to_string(),
-                Content::Js(content.to_string()),
+                Content::Js(JsContent {
+                    content: content.to_string(),
+                    is_jsx,
+                }),
                 context.clone(),
             ),
             context.clone(),

--- a/crates/mako/src/ast/tests.rs
+++ b/crates/mako/src/ast/tests.rs
@@ -6,7 +6,7 @@ use mako_core::swc_ecma_visit::VisitMutWith;
 use swc_core::common::GLOBALS;
 
 use super::css_ast::{CSSAstGenerated, CssAst};
-use super::file::{Content, File};
+use super::file::{Content, File, JsContent};
 use super::js_ast::{JSAstGenerated, JsAst};
 use crate::compiler::Context;
 use crate::config::Mode;
@@ -67,6 +67,7 @@ impl TestUtils {
         } else {
             "test.js".to_string()
         };
+        let is_jsx = file.ends_with(".jsx") || file.ends_with(".tsx");
         let mut file = File::new(file, context.clone());
         let is_css = file.extname == "css";
         let content = if let Some(content) = opts.content {
@@ -77,7 +78,7 @@ impl TestUtils {
         if is_css {
             file.set_content(Content::Css(content));
         } else {
-            file.set_content(Content::Js(content));
+            file.set_content(Content::Js(JsContent { content, is_jsx }));
         }
         let ast = if is_css {
             TestAst::Css(CssAst::new(&file, context.clone(), false).unwrap())

--- a/crates/mako/src/build.rs
+++ b/crates/mako/src/build.rs
@@ -8,7 +8,7 @@ use mako_core::colored::Colorize;
 use mako_core::thiserror::Error;
 
 use crate::analyze_deps::AnalyzeDeps;
-use crate::ast::file::{Content, File};
+use crate::ast::file::{Content, File, JsContent};
 use crate::chunk_pot::util::hash_hashmap;
 use crate::compiler::{Compiler, Context};
 use crate::load::Load;
@@ -164,7 +164,10 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
         } else {
             format!("module.exports = {};", external_name)
         };
-        file.set_content(Content::Js(code));
+        file.set_content(Content::Js(JsContent {
+            content: code,
+            ..Default::default()
+        }));
         let ast = Parse::parse(&file, context)
             // safe
             .unwrap();
@@ -188,7 +191,10 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
     fn create_error_module(file: &File, err: String, context: Arc<Context>) -> Result<Module> {
         let mut file = file.clone();
         let code = format!("throw new Error(`Module build failed:\n{:}`)", err);
-        file.set_content(Content::Js(code));
+        file.set_content(Content::Js(JsContent {
+            content: code,
+            ..Default::default()
+        }));
         let ast = Parse::parse(&file, context.clone())?;
         let path = file.path.to_string_lossy().to_string();
         let module_id = ModuleId::new(path.clone());
@@ -211,7 +217,10 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
         let info = {
             let file = File::with_content(
                 path.to_owned(),
-                Content::Js("export {};".to_string()),
+                Content::Js(JsContent {
+                    content: "export {};".to_string(),
+                    ..Default::default()
+                }),
                 context.clone(),
             );
             let ast = Parse::parse(&file, context.clone()).unwrap();

--- a/crates/mako/src/plugins/context_module.rs
+++ b/crates/mako/src/plugins/context_module.rs
@@ -9,7 +9,7 @@ use mako_core::swc_ecma_ast::{
 use mako_core::swc_ecma_utils::{member_expr, quote_ident, quote_str, ExprExt, ExprFactory};
 use mako_core::swc_ecma_visit::{VisitMut, VisitMutWith};
 
-use crate::ast::file::Content;
+use crate::ast::file::{Content, JsContent};
 use crate::ast::utils::{is_commonjs_require, is_dynamic_import};
 use crate::compiler::Context;
 use crate::plugin::{Plugin, PluginLoadParam};
@@ -88,7 +88,7 @@ impl Plugin for ContextModulePlugin {
                 }
             }
 
-            let code = format!(
+            let content = format!(
                 r#"
 const map = {{
     {}
@@ -105,7 +105,10 @@ module.exports = (id) => {{
 "#,
                 key_values.join(",\n")
             );
-            Ok(Some(Content::Js(code)))
+            Ok(Some(Content::Js(JsContent {
+                content,
+                ..Default::default()
+            })))
         } else {
             Ok(None)
         }

--- a/crates/mako/src/plugins/farm_tree_shake/shake/find_export_source.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/find_export_source.rs
@@ -186,7 +186,7 @@ mod tests {
     use swc_core::common::GLOBALS;
 
     use super::TreeShakeModule;
-    use crate::ast::file::{Content, File};
+    use crate::ast::file::{Content, File, JsContent};
     use crate::ast::js_ast::JsAst;
     use crate::compiler::Context;
     use crate::module::{Module, ModuleAst, ModuleInfo};
@@ -453,7 +453,10 @@ mod tests {
 
         let file = File::with_content(
             "test.js".to_string(),
-            Content::Js(code.to_string()),
+            Content::Js(JsContent {
+                content: code.to_string(),
+                ..Default::default()
+            }),
             context.clone(),
         );
         let ast = JsAst::new(&file, context.clone()).unwrap();

--- a/crates/mako/src/plugins/minifish.rs
+++ b/crates/mako/src/plugins/minifish.rs
@@ -13,7 +13,7 @@ use mako_core::swc_ecma_visit::VisitMutWith;
 use serde::Serialize;
 use unsimplify::UnSimplify;
 
-use crate::ast::file::{Asset, Content};
+use crate::ast::file::{Asset, Content, JsContent};
 use crate::compiler::Context;
 use crate::load::FileSystem;
 use crate::module::{Dependency as ModuleDependency, ModuleAst, ResolveType};
@@ -58,7 +58,10 @@ impl Plugin for MinifishPlugin {
                 .unwrap();
 
             return match self.mapping.get(relative) {
-                Some(js_content) => Ok(Some(Content::Js(js_content.to_string()))),
+                Some(js_content) => Ok(Some(Content::Js(JsContent {
+                    content: js_content.to_string(),
+                    ..Default::default()
+                }))),
 
                 None => {
                     let content = FileSystem::read_file(&param.file.pathname)?;

--- a/crates/mako/src/plugins/minifish/inject.rs
+++ b/crates/mako/src/plugins/minifish/inject.rs
@@ -218,7 +218,7 @@ mod tests {
 
     use super::*;
     use crate::analyze_deps::AnalyzeDeps;
-    use crate::ast::file::File;
+    use crate::ast::file::{File, JsContent};
     use crate::ast::js_ast::JsAst;
     use crate::compiler::{Args, Context};
     use crate::module::ModuleAst;
@@ -493,7 +493,10 @@ my.call("toast");
         let context = Arc::new(context);
         let file = File::with_content(
             "cut.js".to_string(),
-            crate::ast::file::Content::Js(code.to_string()),
+            crate::ast::file::Content::Js(JsContent {
+                content: code.to_string(),
+                ..Default::default()
+            }),
             context.clone(),
         );
         let mut ast = JsAst::new(&file, context.clone()).unwrap();

--- a/crates/mako/src/transform.rs
+++ b/crates/mako/src/transform.rs
@@ -46,11 +46,11 @@ impl Transform {
                     let cm = context.meta.script.cm.clone();
                     let origin_comments = context.meta.script.origin_comments.read().unwrap();
                     let is_ts = file.extname == "ts" || file.extname == "tsx";
-                    let is_jsx = file.extname == "jsx"
+                    let is_jsx = file.is_content_jsx()
+                        || file.extname == "jsx"
                         || file.extname == "js"
                         || file.extname == "ts"
-                        || file.extname == "tsx"
-                        || file.extname == "svg";
+                        || file.extname == "tsx";
 
                     // visitors
                     let mut visitors: Vec<Box<dyn VisitMut>> = vec![];

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,7 +72,7 @@ less 配置。
       endTime: number;
     };
   }) => void;
-  load?: (filePath: string) => Promise<{ content: string, type: 'css'|'javascript' }>;
+  load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
 }
 ```
 
@@ -82,7 +82,7 @@ hooks 是一些钩子函数，用于扩展 Mako 的编译过程。
 
 - `buildStart`，在 Build 开始前会调用
 - `generateEnd`，在 Generate 完成后会调用，通过 `isFirstCompile` 可以判断是否是第一次编译，`time` 为编译时间，`stats` 为编译统计信息
-- `load`，用于加载文件，返回文件内容和类型，类型支持 `css`、`javascript`
+- `load`，用于加载文件，返回文件内容和类型，类型支持 `css`、`js`、`jsx`、`ts`、`tsx`
 
 ### forkTsChecker
 

--- a/e2e/fixtures/hooks/expect.js
+++ b/e2e/fixtures/hooks/expect.js
@@ -4,3 +4,4 @@ const { parseBuildResult, trim, moduleReg } = require("../../../scripts/test-uti
 const { files } = parseBuildResult(__dirname);
 
 const content = files["index.js"];
+assert(content.includes(`(0, _jsxdevruntime.jsxDEV)(Foooo, {`), `jsx in foo.bar works`);

--- a/e2e/fixtures/hooks/hooks.config.js
+++ b/e2e/fixtures/hooks/hooks.config.js
@@ -13,6 +13,12 @@ module.exports = {
     console.log('>> generate end after delay 1s');
   },
   async load(path) {
+    if (path.endsWith('foo.bar')) {
+      return {
+        content: `export default () => <Foooo>foo.bar</Foooo>;`,
+        type: 'jsx',
+      };
+    }
     console.log('>> load:', path);
   }
 };

--- a/e2e/fixtures/hooks/src/foo.bar
+++ b/e2e/fixtures/hooks/src/foo.bar
@@ -1,0 +1,1 @@
+// should be handled with load hook

--- a/e2e/fixtures/hooks/src/index.tsx
+++ b/e2e/fixtures/hooks/src/index.tsx
@@ -1,1 +1,1 @@
-console.log(1);
+console.log(require('./foo.bar'));


### PR DESCRIPTION
Close #1017


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for handling additional content types like `"ts"`, `"tsx"`, and `"jsx"` in the app.
  - Enhanced the structure of returned content with the introduction of a new struct `JsContent`.
  - Updated file processing logic to include new properties for JavaScript content handling.
  - Modified the `load` function signature to support more file types like `jsx`, `ts`, and `tsx`.
  - Improved JSX file identification within the codebase.

- **Bug Fixes**
  - Fixed handling of specific cases in the `load` function to ensure correct object returns.
  
- **Documentation**
  - Updated documentation related to the `load` function within the `MakoPlugin` interface and `hooks` section.

- **Refactor**
  - Restructured content handling for various file types like CSS, JS, SVG, TOML, YAML, XML, and JSON.

- **Style**
  - Adjusted import statements and variable names for consistency and clarity in different modules.

- **Tests**
  - Added an assertion for checking a specific JSX pattern in the content.
  
- **Chores**
  - Introduced a new file `foo.bar` with a comment indicating it should be handled with a load hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->