### PR TITLE
fix: cannot use global mako require in entry module

### DIFF
--- a/crates/mako/templates/app_runtime.stpl
+++ b/crates/mako/templates/app_runtime.stpl
@@ -1,5 +1,4 @@
-function createRuntime(makoModules, entryModuleId) {
-  var global = typeof globalThis !== 'undefined' ? globalThis : self;
+function createRuntime(makoModules, entryModuleId, global) {
   var modulesRegistry = {};
 
   function requireModule(moduleId) {
@@ -332,6 +331,7 @@ function createRuntime(makoModules, entryModuleId) {
 
   // __inject_runtime_code__
 
+  global.__mako_require_module__ = requireModule;
 <% if umd.is_some() || cjs { %>
   var exports = requireModule(entryModuleId);
 <% } else { %>
@@ -353,8 +353,11 @@ function createRuntime(makoModules, entryModuleId) {
 }
 
 var root = typeof globalThis !== 'undefined' ? globalThis : self;
-var runtime = createRuntime(m, e);
-root.__mako_require_module__ = runtime.requireModule;
+<% if has_dynamic_chunks || has_hmr || umd.is_some() || cjs { %>
+var runtime = createRuntime(m, e, root);
+<% } else { %>
+createRuntime(m, e, root);
+<% } %>
 <% if has_dynamic_chunks { %>
 root.jsonpCallback = runtime._jsonpCallback;
 <% } %>


### PR DESCRIPTION
修复 `__mako_require_module__` 初始化时机，在 entry module 中如果访问了该方法在初始化时会报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated `createRuntime` function to accept an additional `global` parameter.
  - Updated assignment of `__mako_require_module__` based on conditional logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->