### PR TITLE
fix: not add empty css to chunk

### DIFF
--- a/crates/mako/src/chunk_pot.rs
+++ b/crates/mako/src/chunk_pot.rs
@@ -160,8 +160,12 @@ impl<'cp> ChunkPot<'cp> {
                 {
                     merged_css_modules.remove(index);
                 }
-                merged_css_modules.push((module.id.id.clone(), &ast.ast));
-                css_raw_hashes.push(module_info.raw_hash);
+
+                // not add empty css to chunk
+                if !ast.ast.rules.is_empty() {
+                    merged_css_modules.push((module.id.id.clone(), &ast.ast));
+                    css_raw_hashes.push(module_info.raw_hash);
+                }
             }
         }
 


### PR DESCRIPTION
对于空的 css, 不生成 chunk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty rules in the `ChunkPot` implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->