### PR TITLE
fix: do not load css for node

### DIFF
--- a/e2e/fixtures/runtime.load-css-in-node/expect.js
+++ b/e2e/fixtures/runtime.load-css-in-node/expect.js
@@ -9,3 +9,6 @@ assert(
   !content.includes(`requireModule.chunkEnsures.css`),
   `requireModule.chunkEnsures.css should not be included in the output`
 );
+
+const hasCSSInFiles = Object.keys(files).some((file) => file.endsWith(".css"));
+assert(!hasCSSInFiles, `should not have any CSS files in the output`);


### PR DESCRIPTION
node 场景下不需要用到 css，从源头（load 和 parse）阶段就不处理，理论上也会有性能提升，少了 css ast 相关的操作。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated variable scopes and method calls in the `parse.rs` file for improved CSS and JavaScript parsing based on configuration.
- **Tests**
	- Added a check in `expect.js` to ensure no CSS files in output files during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->