### PR TITLE
fix(node-polyfill): node polyfill not work when ident in shorthand notation

### DIFF
--- a/crates/mako/src/visitors/provide.rs
+++ b/crates/mako/src/visitors/provide.rs
@@ -38,47 +38,39 @@ impl VisitMut for Provide {
             &self.var_decls,
         ))
     }
-    fn visit_mut_expr(&mut self, expr: &mut Expr) {
-        if let Expr::Ident(Ident { ref sym, span, .. }) = expr {
-            let has_binding = span.ctxt.outer() != self.unresolved_mark;
-            let name = &sym.to_string();
-            let provider = self.providers.get(name);
-            if !has_binding && provider.is_some() {
-                if let Some((from, key)) = provider {
-                    let require_decl: ModuleItem = {
-                        if key.is_empty() {
-                            // eg: const process = require('process');
-                            quote_ident!("__mako_require__")
-                                .as_call(DUMMY_SP, vec![quote_str!(from.as_str()).as_arg()])
-                                .into_var_decl(
-                                    VarDeclKind::Const,
-                                    quote_ident!(*span, sym.clone()).into(),
-                                )
-                                .into()
-                        } else {
-                            // require("buffer")
-                            let require_expr = quote_ident!("__mako_require__")
-                                .as_call(DUMMY_SP, vec![quote_str!(from.as_str()).as_arg()]);
+    fn visit_mut_ident(&mut self, n: &mut Ident) {
+        let has_binding = n.span.ctxt.outer() != self.unresolved_mark;
+        let name = &n.sym.to_string();
+        let provider = self.providers.get(name);
 
-                            // eg const Buffer = require("buffer").Buffer;
-                            Expr::Member(MemberExpr {
-                                obj: require_expr.into(),
-                                span: DUMMY_SP,
-                                prop: quote_ident!(key.as_str()).into(),
-                            })
-                            .into_var_decl(
-                                VarDeclKind::Const,
-                                quote_ident!(*span, sym.clone()).into(),
-                            )
+        if !has_binding && provider.is_some() {
+            if let Some((from, key)) = provider {
+                let require_decl: ModuleItem = {
+                    if key.is_empty() {
+                        // eg: const process = require('process');
+                        quote_ident!("__mako_require__")
+                            .as_call(DUMMY_SP, vec![quote_str!(from.as_str()).as_arg()])
+                            .into_var_decl(VarDeclKind::Const, n.clone().into())
                             .into()
-                        }
-                    };
+                    } else {
+                        // require("buffer")
+                        let require_expr = quote_ident!("__mako_require__")
+                            .as_call(DUMMY_SP, vec![quote_str!(from.as_str()).as_arg()]);
 
-                    self.var_decls.insert(name.to_string(), require_decl);
-                }
+                        // eg const Buffer = require("buffer").Buffer;
+                        Expr::Member(MemberExpr {
+                            obj: require_expr.into(),
+                            span: DUMMY_SP,
+                            prop: quote_ident!(key.as_str()).into(),
+                        })
+                        .into_var_decl(VarDeclKind::Const, n.clone().into())
+                        .into()
+                    }
+                };
+
+                self.var_decls.insert(name.to_string(), require_decl);
             }
         }
-        expr.visit_mut_children_with(self);
     }
 }
 
@@ -157,7 +149,7 @@ function foo() {
             .trim()
         );
     }
-    
+
     #[test]
     fn test_provide_in_shorthand_notation() {
         assert_eq!(
@@ -170,10 +162,9 @@ console.log({
     process
 });
             "#
-                .trim()
+            .trim()
         );
     }
-
 
     fn run(js_code: &str) -> String {
         let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());


### PR DESCRIPTION
## problem

```js
console.log({process}); 
```
the origin implementation don't handle the ident in object which not wrapped in Expression.

## solution 
visit ident directly




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Refactored the `visit_mut_expr` method into `visit_mut_ident` in the `Provide` implementation for improved identifier processing.
  - Added a new test function `test_provide_in_shorthand_notation` to test shorthand notation for providing modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->