### PR TITLE
feat: add global __mako_chunk_load__

### DIFF
--- a/crates/mako/templates/app_runtime.stpl
+++ b/crates/mako/templates/app_runtime.stpl
@@ -334,6 +334,7 @@ function createRuntime(makoModules, entryModuleId, global) {
   // __inject_runtime_code__
 
   global.__mako_require_module__ = requireModule;
+  global.__mako_chunk_load__ = requireModule.ensure;
 <% if umd.is_some() || cjs { %>
   var exports = requireModule(entryModuleId);
 <% } else { %>

--- a/examples/rsc/build.js
+++ b/examples/rsc/build.js
@@ -36,8 +36,11 @@ module.exports = {$$typeof: Symbol.for(\"react.module.reference\"),filepath:\"{{
   });
 
   // build client
-  fs.rmdirSync(path.join(root, 'tmp'), { recursive: true });
-  fs.mkdirSync(path.join(root, 'tmp'));
+  let tmpDir = path.join(root, 'tmp');
+  if (fs.existsSync(tmpDir)) {
+    fs.rmdirSync(tmpDir, { recursive: true });
+  }
+  fs.mkdirSync(tmpDir);
   let stats = fs.readFileSync(
     path.join(serverOutputPath, 'stats.json'),
     'utf-8',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 在构建过程中修改了处理临时目录创建和删除逻辑，现在在尝试删除临时目录之前会检查其是否存在。
		- 在 `build.js` 中，`fs.rmdirSync(path.join(root, 'tmp'), { recursive: true });` 被替换为：
			- `let tmpDir = path.join(root, 'tmp');`
			- `if (fs.existsSync(tmpDir)) {`
			- `fs.rmdirSync(tmpDir, { recursive: true });`
		- 在 `build.js` 中，`fs.mkdirSync(path.join(root, 'tmp'));` 被替换为：
			- `fs.mkdirSync(tmpDir);`

- **New Features**
	- 在 `app_runtime.stpl` 文件中添加了一个新的全局变量 `__mako_chunk_load__`，并赋予其值 `requireModule.ensure`。
		- `global.__mako_chunk_load__ = requireModule.ensure` 添加在 `crates/mako/templates/app_runtime.stpl`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->