### PR TITLE
Revert "fix: caches of emit module in str_impl may be invalid"

### DIFF
--- a/crates/mako/src/generate/chunk_pot/str_impl.rs
+++ b/crates/mako/src/generate/chunk_pot/str_impl.rs
@@ -155,13 +155,12 @@ type EmittedWithMapping = (String, Option<Vec<(BytePos, LineCol)>>);
     key = "String",
     type = "SizedCache<String , EmittedWithMapping>",
     create = "{ SizedCache::with_size(20000) }",
-    convert = r#"{format!("{}-{}-{}", _chunk_id, _raw_hash, module_id)}"#
+    convert = r#"{format!("{}-{}", _raw_hash, module_id)}"#
 )]
 fn emit_module_with_mapping(
     module_id: &str,
     module: &Module,
-    _raw_hash: u64,  // used for cache key
-    _chunk_id: &str, // used for cache key
+    _raw_hash: u64, // used for cache key
     context: &Arc<Context>,
 ) -> Result<EmittedWithMapping> {
     match &module.info.as_ref().unwrap().ast {
@@ -234,13 +233,7 @@ fn pot_to_chunk_module_object_string(
     let emitted_modules_with_mapping = sorted_kv
         .par_iter()
         .map(|(module_id, module_and_hash)| {
-            emit_module_with_mapping(
-                module_id,
-                module_and_hash.0,
-                module_and_hash.1,
-                &pot.chunk_id,
-                context,
-            )
+            emit_module_with_mapping(module_id, module_and_hash.0, module_and_hash.1, context)
         })
         .collect::<Result<Vec<(String, Option<Vec<(BytePos, LineCol)>>)>>>()?;
 


### PR DESCRIPTION
Reverts umijs/mako#1112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **功能更新**
	- 优化了宏定义中的转换字段，从格式字符串中移除了`_chunk_id`。
	- 重新排列了`emit_module_with_mapping`函数中的参数`_raw_hash`和`_chunk_id`。
	- 重构了`pot_to_chunk_module_object_string`函数，使其在传递参数给`emit_module_with_mapping`时不再显式指定`_chunk_id`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->