### PR TITLE
feat: 实现PseudoElement

### DIFF
--- a/crates/mako/src/visitors/css_px2rem.rs
+++ b/crates/mako/src/visitors/css_px2rem.rs
@@ -171,8 +171,8 @@ fn parse_compound_selector(selector: &CompoundSelector) -> String {
             SubclassSelector::PseudoClass(pseudo) => {
                 result.push_str(format!(":{}", pseudo.name.value).as_str());
             }
-            _ => {
-                // TODO: support more subclass selectors
+            SubclassSelector::PseudoElement(pse_element) => {
+                result.push_str(format!("::{}", pse_element.name.value).as_str());
             }
         }
     }
@@ -454,26 +454,63 @@ mod tests {
     fn test_class_pseudo() {
         assert_eq!(
             run(
-                r#".jj:before,.jj:after{width:100px;}"#,
+                r#".jj:hover,.jj:focus{width:100px;}"#,
                 Px2RemConfig {
                     ..Default::default()
                 }
             ),
-            r#".jj:before,.jj:after{width:1rem}"#
+            r#".jj:hover,.jj:focus{width:1rem}"#
         );
     }
-
+    #[test]
+    fn test_element_pseudo() {
+        assert_eq!(
+            run(
+                r#".jj::before,.jj::after{width:100px;}"#,
+                Px2RemConfig {
+                    ..Default::default()
+                }
+            ),
+            r#".jj::before,.jj::after{width:1rem}"#
+        );
+    }
+    #[test]
+    fn test_element_pseudo_select_black() {
+        assert_eq!(
+            run(
+                r#".jj::before,.jj::after{width:100px;}"#,
+                Px2RemConfig {
+                    selector_blacklist: vec![".jj::after".to_string()],
+                    ..Default::default()
+                }
+            ),
+            r#".jj::before,.jj::after{width:100px}"#
+        );
+    }
+    #[test]
+    fn test_element_pseudo_select_white() {
+        assert_eq!(
+            run(
+                r#".jj::before,.jj::after{width:100px;}"#,
+                Px2RemConfig {
+                    selector_whitelist: vec![".jj::after".to_string()],
+                    ..Default::default()
+                }
+            ),
+            r#".jj::before,.jj::after{width:100px}"#
+        );
+    }
     #[test]
     fn test_class_pseudo_select_black() {
         assert_eq!(
             run(
-                r#".jj:before,.jj:after{width:100px;}"#,
+                r#".jj:hover,.jj:focus{width:100px;}"#,
                 Px2RemConfig {
-                    selector_blacklist: vec![".jj:after".to_string()],
+                    selector_blacklist: vec![".jj:focus".to_string()],
                     ..Default::default()
                 }
             ),
-            r#".jj:before,.jj:after{width:100px}"#
+            r#".jj:hover,.jj:focus{width:100px}"#
         );
     }
 
@@ -481,13 +518,23 @@ mod tests {
     fn test_class_pseudo_select_white() {
         assert_eq!(
             run(
-                r#".jj:before,.jj:after{width:100px;}"#,
+                r#".jj:hover,.jj:focus{width:100px;}"#,
                 Px2RemConfig {
-                    selector_whitelist: vec![".jj:after".to_string()],
+                    selector_whitelist: vec![".jj:focus".to_string(), ".jj:hover".to_string()],
                     ..Default::default()
                 }
             ),
-            r#".jj:before,.jj:after{width:100px}"#
+            r#".jj:hover,.jj:focus{width:1rem}"#
+        );
+        assert_eq!(
+            run(
+                r#".jj:hover,.jj:focus{width:100px;}"#,
+                Px2RemConfig {
+                    selector_whitelist: vec![".jj:hover".to_string()],
+                    ..Default::default()
+                }
+            ),
+            r#".jj:hover,.jj:focus{width:100px}"#
         );
     }
 


### PR DESCRIPTION
feat: 实现PseudoElement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在`parse_compound_selector`函数中添加对`PseudoElement`子类选择器的支持，包括处理带有`::`符号的伪元素。
    - 添加了用于覆盖元素伪类和选择器黑名单和白名单配置的新测试用例。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->