### PR TITLE
fix(px2rem): panic when using attribute selector without value

### DIFF
--- a/crates/mako/src/visitors/css_px2rem.rs
+++ b/crates/mako/src/visitors/css_px2rem.rs
@@ -188,16 +188,20 @@ fn parse_attribute(attr: &AttributeSelector) -> String {
         ..
     } = attr;
     let val_str = if let Some(val_str) = value.as_ref() {
-        val_str.as_str().unwrap().value.to_string()
+        if let Some(val_str) = val_str.as_str() {
+            val_str.value.to_string()
+        } else {
+            "".to_string()
+        }
     } else {
         "".to_string()
     };
-    res_str.push_str(&format!(
-        "[{}{}{}]",
-        name.value.value,
-        matcher.as_ref().unwrap().value,
-        val_str
-    ));
+    let matcher = if let Some(x) = matcher.as_ref() {
+        x.value.to_string()
+    } else {
+        "".to_string()
+    };
+    res_str.push_str(&format!("[{}{}{}]", name.value.value, matcher, val_str));
     res_str
 }
 
@@ -229,6 +233,18 @@ mod tests {
         assert_eq!(
             run_with_default(r#".a{width:100px;height:200px;}"#),
             r#".a{width:1rem;height:2rem}"#
+        );
+    }
+
+    #[test]
+    fn test_attribute_selector() {
+        assert_eq!(
+            run_with_default(r#".a[b]{width:100px;}"#),
+            r#".a[b]{width:1rem}"#
+        );
+        assert_eq!(
+            run_with_default(r#".a[b=c]{width:100px;}"#),
+            r#".a[b=c]{width:1rem}"#
         );
     }
 


### PR DESCRIPTION
Close #1137



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- 修复了`css_px2rem.rs`中`parse_attribute`函数对`val_str`的处理方式，现在在访问其值之前会先检查是否为`Some`。
	- 简化了`parse_attribute`中`res_str`的格式。
- **Tests**
	- 在模块中添加了一个新的测试`test_attribute_selector`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->