### PR TITLE
feat(px2rem): support config min_pixel_value

### DIFF
--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -215,6 +215,8 @@ pub struct Px2RemConfig {
     pub selector_blacklist: Vec<String>,
     #[serde(rename = "selectorWhiteList", default)]
     pub selector_whitelist: Vec<String>,
+    #[serde(rename = "minPixelValue", default)]
+    pub min_pixel_value: f64,
 }
 
 impl Default for Px2RemConfig {
@@ -225,6 +227,7 @@ impl Default for Px2RemConfig {
             prop_whitelist: vec![],
             selector_blacklist: vec![],
             selector_whitelist: vec![],
+            min_pixel_value: 0.0,
         }
     }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -368,16 +368,17 @@ publicPath 配置。注：有个特殊值 `"runtime"`，表示会切换到 runti
 
 ## px2rem
 
-- 类型：`false | { root?: number, propBlackList?: string[], propWhiteList?: string[], selectorBlackList?: string[], selectorWhiteList?: string[] }`
+- 类型：`false | { root?: number, propBlackList?: string[], propWhiteList?: string[], selectorBlackList?: string[], selectorWhiteList?: string[], minPixelValue?: number }`
 - 默认值：`false`
 
-是否开启 px2rem 转换，启用时 `root` 的默认值为 `100`。
+是否开启 px2rem 转换。
 
-- `root`，根节点的字体大小
+- `root`，根节点的字体大小，默认值为 `100`
 - `propBlackList`，属性黑名单
 - `propWhiteList`，属性白名单
 - `selectorBlackList`，选择器黑名单
 - `selectorWhiteList`，选择器白名单
+- `minPixelValue`，最小像素值，默认值为 `0`
 
 ## react
 


### PR DESCRIPTION
Close #1139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在`Px2RemConfig`结构体中添加了一个名为`min_pixel_value`的`f64`类型字段。
    - `Px2Rem`结构体的`should_transform`方法现在接受一个`val: f64`参数，影响了转换逻辑。
    - 更新了`px2rem`配置文件，新增了`minPixelValue`属性，并更新了`root`和`minPixelValue`属性的描述。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->