### PR TITLE
fix: node polyfill support timers

### DIFF
--- a/crates/mako/src/resolve/mod.rs
+++ b/crates/mako/src/resolve/mod.rs
@@ -235,7 +235,7 @@ fn do_resolve(
                 }
                 _ => {
                     eprintln!(
-                        "failed to resolve {} from {} with oxc-resolver err: {:?}",
+                        "failed to resolve {} from {} with resolver err: {:?}",
                         source,
                         path.to_string_lossy(),
                         oxc_resolve_err

--- a/e2e/fixtures/node-polyfill/expect.js
+++ b/e2e/fixtures/node-polyfill/expect.js
@@ -15,6 +15,10 @@ assert.match(
   "should have empty module: fs/promise"
 );
 assert(
-  content.includes(`var _path = /*#__PURE__*/ _interop_require_default._(__mako_require__("../../../node_modules/.pnpm/node-libs-browser-okam@2.2.4/node_modules/node-libs-browser-okam/polyfill/path.js"));`),
+  content.includes(`var _path = /*#__PURE__*/ _interop_require_default._(__mako_require__("../../../node_modules/.pnpm/node-libs-browser-okam`),
   "should have polyfill module: path"
+);
+assert(
+  content.includes(`exports.setTimeout = function() {`),
+  "should have polyfill module: timers"
 );

--- a/e2e/fixtures/node-polyfill/src/index.tsx
+++ b/e2e/fixtures/node-polyfill/src/index.tsx
@@ -6,3 +6,6 @@ console.log(fs_promise);
 
 import path from "path";
 console.log(path);
+
+import { setTimeout } from 'timers';
+console.log(setTimeout);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "get-port": "^7.1.0",
     "husky": "^8.0.3",
     "less": "^4.2.0",
-    "node-libs-browser-okam": "2.2.4",
+    "node-libs-browser-okam": "^2.2.5",
     "playwright": "^1.39.0",
     "portfinder": "^1.0.32",
     "react": "18.2.0",

--- a/packages/mako/package.json
+++ b/packages/mako/package.json
@@ -23,7 +23,7 @@
     "yargs-parser": "^21.1.1",
     "less": "^4.2.0",
     "less-plugin-resolve": "^1.0.2",
-    "node-libs-browser-okam": "2.2.4",
+    "node-libs-browser-okam": "^2.2.5",
     "react-error-overlay": "6.0.9",
     "react-refresh": "^0.14.0",
     "workerpool": "^9.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       node-libs-browser-okam:
-        specifier: 2.2.4
-        version: 2.2.4
+        specifier: ^2.2.5
+        version: 2.2.5
       playwright:
         specifier: ^1.39.0
         version: 1.40.1
@@ -394,8 +394,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       node-libs-browser-okam:
-        specifier: 2.2.4
-        version: 2.2.4
+        specifier: ^2.2.5
+        version: 2.2.5
       react-error-overlay:
         specifier: 6.0.9
         version: 6.0.9
@@ -10330,8 +10330,8 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
 
-  /node-libs-browser-okam@2.2.4:
-    resolution: {integrity: sha512-BOfs1wV/mMzKp8AmlCw6q1envTMzoDL0hxWUPmpuctHnbqF9ssmiyNmTjPoVOLlOBLH9dGF8jm4w5HQ1oIzDIQ==}
+  /node-libs-browser-okam@2.2.5:
+    resolution: {integrity: sha512-kD+WXACEThc6C5DA146KoCNbubjpXeYzXDrukvtXWr6MRzV3uvHCI0eb/GuugWVYnMoD4g3/uaIzvDYOpC4QWw==}
     dependencies:
       assert-okam: 1.5.0
       browserify-zlib: 0.2.0


### PR DESCRIPTION
Close #1138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- 在`crates/mako/src/resolve/mod.rs`中的`do_resolve`函数中，优化了错误消息，将日志消息中的"oxc-resolver"替换为"resolver"。
	- 在`e2e/fixtures/node-polyfill/expect.js`文件中，添加了`path`和`timers`的polyfill模块。
	- 在`e2e/fixtures/node-polyfill/src/index.tsx`中，新增了对`timers`中`setTimeout`的导入语句。
	- 更新了`package.json`和`packages/mako/package.json`中的`"node-libs-browser-okam"`版本，从`"2.2.4"`升级到`"^2.2.5"`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->