### PR TITLE
chore: 🐛 remove stupid leftovers

### DIFF
--- a/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate/external_transformer.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate/external_transformer.rs
@@ -266,17 +266,6 @@ impl VisitMut for ExternalTransformer<'_> {
                 n.visit_mut_children_with(self);
             }
         }
-
-        if let Expr::Call(call_expr) = n
-            && is_commonjs_require(call_expr, &self.unresolved_mark)
-        {
-            if let Some(((namespace, _), _)) = self.require_arg_to_module_namespace(&call_expr.args)
-            {
-                *n = quote_ident!(namespace.clone()).into();
-            }
-        } else {
-            n.visit_mut_children_with(self);
-        }
     }
 
     fn visit_mut_module(&mut self, n: &mut Module) {


### PR DESCRIPTION
一个 visitor 里面调用了两次  visit_mut_children_with 就会导致死循环

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- 修复了与CommonJS require调用相关的特定条件检查和转换逻辑，以提高外部转换器的性能。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->