### PR TITLE
fix: siblings missed in client chunks for rsc sdk

### DIFF
--- a/packages/rsc/src/index.ts
+++ b/packages/rsc/src/index.ts
@@ -5,7 +5,7 @@ interface MakoStats {
     files: string[];
     entry: boolean;
     modules: { type: 'module'; size: number; id: string; chunks: string[] }[];
-    siblings: unknown[];
+    siblings: string[];
     origins: unknown[];
   }[];
   rscClientComponents: { path: string }[];
@@ -42,8 +42,7 @@ export function parseClientStats(stats: MakoStats): ClientManifest {
   for (let chunk of stats.chunks) {
     if (chunk.entry) continue;
     let id = chunk.id;
-    let chunks = chunk.files.filter((file) => file.endsWith('.js'));
-    // TODO: add child chunks
+    const chunks = chunk.siblings.concat(chunk.id);
     // TODO: support module_id_strategy: hashed
     ret.clientComponents[id] = {
       '*': {


### PR DESCRIPTION
修复 RSC SDK 产出的 clientManifest 中，`chunks` 数据缺少 `siblings` 的问题，这会导致被 ensure 的 chunk 中的模块找不到

另外这里的 `chunks` 数据从原本的文件名改成 `chunk_id`，以解决 `__mako_chunk_load__` 不能正常加载的问题

Close #1133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **功能变更**
	- 更新了`MakoStats`接口中`siblings`属性的数据类型，从`unknown`数组改为`string`数组。
	- 调整了`parseClientStats`函数的逻辑，修改了`siblings`的处理方式。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->