### PR TITLE
fix(rsc): add modules property to stats.json

### DIFF
--- a/crates/mako/src/ast/file.rs
+++ b/crates/mako/src/ast/file.rs
@@ -161,6 +161,10 @@ impl File {
         file
     }
 
+    pub fn is_css(&self) -> bool {
+        self.content.is_some() && matches!(self.content.as_ref().unwrap(), Content::Css(_))
+    }
+
     pub fn new_entry(path: String, context: Arc<Context>) -> Self {
         let mut file = File::new(path, context);
         file.is_entry = true;

--- a/crates/mako/src/features/rsc.rs
+++ b/crates/mako/src/features/rsc.rs
@@ -20,6 +20,7 @@ pub struct RscClientInfo {
 #[derive(Serialize, Debug, Clone)]
 pub struct RscCssModules {
     pub path: String,
+    pub modules: bool,
 }
 
 pub struct Rsc {}
@@ -86,6 +87,7 @@ impl Rsc {
         let mut info = context.stats_info.lock().unwrap();
         info.rsc_css_modules.push(RscCssModules {
             path: file.relative_path.to_string_lossy().to_string(),
+            modules: file.is_css() && file.has_param("modules"),
         });
     }
 

--- a/examples/rsc/src/a.less
+++ b/examples/rsc/src/a.less
@@ -1,0 +1,2 @@
+.a { color: red; }
+

--- a/examples/rsc/src/b.module.less
+++ b/examples/rsc/src/b.module.less
@@ -1,0 +1,2 @@
+.a { color: red; }
+

--- a/examples/rsc/src/index.tsx
+++ b/examples/rsc/src/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Foo from './Foo';
+import './a.less';
+import './b.module.less';
 
 export default function App() {
   return (

--- a/packages/create-mako/src/cli.ts
+++ b/packages/create-mako/src/cli.ts
@@ -1,6 +1,6 @@
-import { globSync } from 'glob';
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
+import { globSync } from 'glob';
 
 async function main() {
   let templatePath = path.join(__dirname, '../templates/react');

--- a/packages/create-mako/templates/react/src/index.tsx
+++ b/packages/create-mako/templates/react/src/index.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import { App } from "./App";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
 
-ReactDOM.createRoot(document.getElementById("root")!).render(<App />);
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
Close #1110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
	- 在`mako` crate的`file.rs`模块中，为`File`结构体添加了一个新的公共方法`is_css`，用于检查文件内容是否为CSS。
	- 在`crates/mako/src/features/rsc.rs`文件中，为`RscCssModules`结构体添加了一个`modules: bool`字段。
	- 在`examples/rsc/src/a.less`文件中，引入了一个CSS规则，将类为`.a`的元素样式设置为红色。
	- 在`examples/rsc/src/b.module.less`文件中，引入了一个CSS规则，将类为`.a`的元素样式设置为红色。
	- 在`index.tsx`文件中，添加了对`a.less`和`b.module.less` CSS文件的导入。

- **文档**
	- 更新了`index.tsx`文件中的导入语句，统一使用单引号替换双引号。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->