### PR TITLE
chore: 🔧 adjust puffin for easy profile for both long time compiling and watch mode

### DIFF
--- a/crates/mako/src/main.rs
+++ b/crates/mako/src/main.rs
@@ -5,15 +5,15 @@
 use std::sync::Arc;
 
 use mako::compiler::{self, Args};
+#[cfg(not(feature = "profile"))]
+use mako::dev;
 use mako::utils::logger::init_logger;
 #[cfg(feature = "profile")]
 use mako::utils::profile_gui::ProfileApp;
 use mako::utils::tokio_runtime;
-use mako::{cli, config, dev};
+use mako::{cli, config};
 use mako_core::anyhow::{anyhow, Result};
 use mako_core::clap::Parser;
-#[cfg(feature = "profile")]
-use mako_core::tokio::sync::Notify;
 use mako_core::tracing::debug;
 
 #[cfg(not(target_os = "linux"))]
@@ -77,26 +77,13 @@ async fn run() -> Result<()> {
 
     #[cfg(feature = "profile")]
     {
-        let notify = Arc::new(Notify::new());
-        let to_be_notify = notify.clone();
-
-        let for_spawn = compiler.clone();
-        tokio_runtime::spawn(async move {
-            if cli.watch {
-                to_be_notify.notified().await;
-                for_spawn.compile().unwrap();
-                let d = crate::dev::DevServer::new(root.clone(), for_spawn.clone());
-                d.serve(move |_params| {}).await;
-            }
-        });
-
         mako_core::puffin::set_scopes_on(true);
         let native_options = Default::default();
         let for_profile = compiler.clone();
         let _ = mako_core::eframe::run_native(
             "puffin egui eframe",
             native_options,
-            Box::new(move |_cc| Box::new(ProfileApp::new(notify, for_profile))),
+            Box::new(move |_cc| Box::new(ProfileApp::new(for_profile))),
         );
     }
 

--- a/crates/mako/src/utils/mod.rs
+++ b/crates/mako/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod logger;
+#[cfg(feature = "profile")]
 pub mod profile_gui;
 #[cfg(test)]
 pub(crate) mod test_helper;

--- a/crates/mako/src/utils/profile_gui.rs
+++ b/crates/mako/src/utils/profile_gui.rs
@@ -1,44 +1,40 @@
-#[cfg(feature = "profile")]
 use std::sync::Arc;
 
-#[cfg(feature = "profile")]
 use mako_core::eframe::egui;
-#[cfg(feature = "profile")]
-use mako_core::tokio::sync::Notify;
 
 use crate::compiler::Compiler;
+use crate::utils::tokio_runtime;
 
-#[cfg(feature = "profile")]
 pub struct ProfileApp {
-    notified: bool,
+    inited: bool,
     compiler: Arc<Compiler>,
-    notify: Arc<Notify>,
 }
 
-#[cfg(feature = "profile")]
 impl ProfileApp {
-    #[allow(dead_code)]
-    pub fn new(notify: Arc<Notify>, compiler: Arc<Compiler>) -> Self {
+    pub fn new(compiler: Arc<Compiler>) -> Self {
         Self {
-            notified: false,
-            notify,
+            inited: false,
             compiler,
         }
     }
 }
 
-#[cfg(feature = "profile")]
 impl mako_core::eframe::App for ProfileApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut mako_core::eframe::Frame) {
         mako_core::puffin::GlobalProfiler::lock().new_frame(); // call once per frame!
 
-        if !self.notified {
+        if !self.inited {
+            self.compiler.compile().unwrap();
+
             if self.compiler.context.args.watch {
-                self.notify.notify_one();
-            } else {
-                self.compiler.compile().unwrap();
+                let for_spawn = self.compiler.clone();
+                tokio_runtime::spawn(async move {
+                    let root = for_spawn.context.root.clone();
+                    let d = crate::dev::DevServer::new(root, for_spawn);
+                    d.serve(move |_params| {}).await;
+                });
             }
-            self.notified = true;
+            self.inited = true;
         }
         mako_core::puffin_egui::profiler_window(ctx);
     }


### PR DESCRIPTION

1. compile.build 数据放在第一帧，方便抓取长时间构建的项目数据
2. update 的数据在构建后正常显示，方便选择

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- 在`main.rs`中，根据特性进行条件导入，删除未使用的导入，重构异步代码以进行性能分析，更改闭包中的参数传递。
	- 在`utils/mod.rs`中，为`profile_gui`模块的声明添加了条件编译属性`#[cfg(feature = "profile")]`。
	- 在`profile_gui.rs`中，重构以使用`Compiler`结构而不是`Notify`，调整初始化逻辑，并根据编译器上下文参数进行编译和服务器生成。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->