### PR TITLE
fix: hooks miss transmission

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -40,6 +40,9 @@ exports.build = async function (opts) {
         math: opts.config.lessLoader?.math,
         plugins: opts.config.lessLoader?.plugins,
       },
+      hooks: {
+        ...opts.config.hooks,
+      },
       forkTSChecker: makoConfig.forkTSChecker,
       watch: false,
     });
@@ -179,6 +182,7 @@ exports.dev = async function (opts) {
         generateEnd: (args) => {
           opts.onDevCompileDone(args);
         },
+        ...opts.config.hooks,
       },
       watch: true,
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在`bundler-mako`包的`index.js`文件中，为`exports.build`和`exports.dev`函数添加了扩展运算符，以在特定对象中包含`opts.config.hooks`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->