### PR TITLE
feat: add watch.ignorePaths config

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -133,6 +133,9 @@ pub struct BuildParams {
     experimental?: {
         webpackSyntaxValidate?: string[];
     };
+    watch?: {
+        ignoredPaths?: string[];
+    };
 }"#)]
     pub config: serde_json::Value,
     pub hooks: JsHooks,

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -385,6 +385,12 @@ pub struct ExperimentalConfig {
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct WatchConfig {
+    pub ignore_paths: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct HmrConfig {
     pub host: String,
     pub port: u16,
@@ -471,6 +477,7 @@ pub struct Config {
     )]
     pub rsc_client: Option<RscClientConfig>,
     pub experimental: ExperimentalConfig,
+    pub watch: WatchConfig,
 }
 
 #[allow(dead_code)]
@@ -624,7 +631,8 @@ const DEFAULT_CONFIG: &str = r#"
     "inlineCSS": false,
     "rscServer": false,
     "rscClient": false,
-    "experimental": { "webpackSyntaxValidate": [] }
+    "experimental": { "webpackSyntaxValidate": [] },
+    "watch": { "ignorePaths": [] }
 }
 "#;
 

--- a/crates/mako/src/dev/watch.rs
+++ b/crates/mako/src/dev/watch.rs
@@ -79,9 +79,7 @@ impl<'a> Watcher<'a> {
 
     pub fn refresh_watch(&mut self) -> anyhow::Result<()> {
         let t_refresh_watch = Instant::now();
-
         self.watch()?;
-
         let t_refresh_watch_duration = t_refresh_watch.elapsed();
         debug!(
             "{}",
@@ -91,7 +89,6 @@ impl<'a> Watcher<'a> {
             )
             .green()
         );
-
         Ok(())
     }
 
@@ -100,6 +97,15 @@ impl<'a> Watcher<'a> {
         if with_output_dir {
             ignore_list.push(self.compiler.context.config.output.path.to_str().unwrap());
         }
+        ignore_list.extend(
+            self.compiler
+                .context
+                .config
+                .watch
+                .ignore_paths
+                .iter()
+                .map(|p| p.as_str()),
+        );
 
         // node_modules of root dictionary and root dictionary's parent dictionaries should be ignored
         // for resolving the issue of "too many files open" in monorepo
@@ -111,7 +117,6 @@ impl<'a> Watcher<'a> {
                 dirs.push(path);
             })
         });
-
         dirs
     }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -472,7 +472,24 @@ e.g.
 - Type: `false | string`
 - Default: `false`
 
-Whether to output umd format
+Whether to output umd format.
+
+### watch
+
+- Type: `{ ignorePaths: string[] }`
+- Default: `{ ignorePaths: [] }`
+
+Watch related configuration.
+
+e.g. If you want to ignore the `foo` directory under root directory, you can set it as follows.
+
+```ts
+{
+  watch: {
+    ignorePaths: ["foo"],
+  },
+}
+```
 
 ### writeToDisk
 

--- a/examples/dead-simple/mako.config.json
+++ b/examples/dead-simple/mako.config.json
@@ -5,5 +5,10 @@
     "alias": {
       "@": "./foo"
     }
+  },
+  "watch": {
+    "ignorePaths": [
+      "bar"
+    ]
   }
 }

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -145,6 +145,9 @@ export interface BuildParams {
     experimental?: {
       webpackSyntaxValidate?: string[];
     };
+    watch?: {
+      ignoredPaths?: string[];
+    };
   };
   hooks: JsHooks;
   watch: boolean;


### PR DESCRIPTION
## 背景

dumi 的场景，

```
foo/node_modules
node_modules
src
package.json
```

在 root 启，然后 foo/node_modules 也进了 watch，并且其中有目录之间因为 link 导致的循环依赖，报错如下。

```
Error watching files: File system loop found: /Users/.../work/dumi/suites/theme-mobile/node_modules/dumi/suites/theme-mobile/node_modules/dumi points to an ancestor /Users/.../work/dumi/suites/theme-mobile/node_modules/dumi
```

## 尝试的解法

- watch + RecursiveMode::Recursive 时加 node_moduels 的 ignore，但是看了下，无法干涉，是否递归的属性是传给 notify crate 的底层库的。

## 当前解

提供额外配置项，但缺点是需要用户感知。

## 可能的其他解

把 watch 挪到 node 层实现。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在`BuildParams`结构体中添加了一个新字段`watch`，其中包括一个可选的`ignoredPaths`字符串数组。
    - `Config`结构体现在包括一个`WatchConfig`类型的`watch`字段，以及现有字段。
    - 在`mako.config.json`文件中添加了一个新的`watch`配置选项，包括`ignorePaths`设置。
    - 在`packages/mako/binding.d.ts`文件中的`BuildParams`接口中添加了一个新的`watch`属性，其中包括一个可选的`ignoredPaths`字符串数组。

- **文档**
    - 在`docs/config.md`文件中添加了一个新的配置选项`watch`，具体为`ignorePaths`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->