### PR TITLE
fix: add node ignore libs

### DIFF
--- a/crates/mako/src/features/node.rs
+++ b/crates/mako/src/features/node.rs
@@ -98,17 +98,25 @@ impl Node {
 
     fn get_empty_modules() -> Vec<String> {
         [
+            "async_hooks",
             "child_process",
             "cluster",
             "dgram",
+            "diagnostics_channel",
             "dns",
             "fs",
+            "http2",
+            "inspector",
             "module",
             "net",
+            "perf_hooks",
             "readline",
             "repl",
             "tls",
-            "async_hooks",
+            "trace_events",
+            "v8",
+            "wasi",
+            "worker_threads",
         ]
         .iter()
         .map(|s| s.to_string())


### PR DESCRIPTION
Close #1174

和 `require('module').builtinModules` 手动对齐了下。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
	- 更新了`Node`结构中的`get_empty_modules`函数，现在包括`async_hooks`、`diagnostics_channel`、`http2`、`inspector`、`perf_hooks`、`trace_events`、`v8`、`wasi`和`worker_threads`等模块。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->