### PR TITLE
feat: support externals with commonjs require

### DIFF
--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -308,6 +308,8 @@ pub struct ExternalAdvancedSubpath {
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ExternalAdvanced {
     pub root: String,
+    #[serde(rename = "type")]
+    pub module_type: Option<String>,
     pub script: Option<String>,
     pub subpath: Option<ExternalAdvancedSubpath>,
 }

--- a/crates/mako/src/resolve/mod.rs
+++ b/crates/mako/src/resolve/mod.rs
@@ -86,6 +86,8 @@ fn get_external_target(
             ExternalConfig::Basic(external) => Some((
                 if external.is_empty() {
                     "''".to_string()
+                } else if external.starts_with("commonjs ") {
+                    format!("require(\"{}\")", external.replace("commonjs ", ""))
                 } else {
                     format!("{}.{}", global_obj, external)
                 },
@@ -94,6 +96,8 @@ fn get_external_target(
             ExternalConfig::Advanced(config) => Some((
                 if config.root.is_empty() {
                     "''".to_string()
+                } else if config.module_type.as_ref().is_some_and(|t| t == "commonjs") {
+                    format!("require(\"{}\")", config.root)
                 } else {
                     format!("{}.{}", global_obj, config.root)
                 },
@@ -529,6 +533,7 @@ mod tests {
                 ExternalConfig::Advanced(ExternalAdvanced {
                     root: "antd".to_string(),
                     script: None,
+                    module_type: None,
                     subpath: Some(ExternalAdvancedSubpath {
                         exclude: Some(vec!["style".to_string()]),
                         rules: vec![
@@ -566,6 +571,7 @@ mod tests {
                     root: "ScriptType".to_string(),
                     script: Some("https://example.com/lib/script.js".to_string()),
                     subpath: None,
+                    module_type: None,
                 }),
             ),
         ]);

--- a/docs/config.md
+++ b/docs/config.md
@@ -197,6 +197,20 @@ e.g.
 }
 ```
 
+Then, when the code encounters `import React from "react"`, it will be replaced with `const React = (typeof globalThis !== 'undefined' ? globalThis : self).React`.
+
+If you want to output the external dependencies with `require`, you can set it as follows.
+
+```ts
+{
+  externals: {
+    foo: "commonjs foo",
+  },
+}
+```
+
+Then, when the code encounters `import foo from "foo"`, it will be replaced with `const foo = require("foo")`.
+
 ### flexBugs
 
 - Type: `boolean`

--- a/e2e/fixtures/config.externals/expect.js
+++ b/e2e/fixtures/config.externals/expect.js
@@ -13,6 +13,16 @@ assert.match(
   "should have external module: hoo"
 );
 
+assert(
+  content.includes(`module.exports = require("hoo");`),
+  `should have external module: hoo_require`,
+);
+
+assert(
+  content.includes(`module.exports = require("foo");`),
+  `should have external module: foo_require`,
+);
+
 assert.match(
   content,
   moduleReg(

--- a/e2e/fixtures/config.externals/mako.config.json
+++ b/e2e/fixtures/config.externals/mako.config.json
@@ -2,7 +2,12 @@
   "minify": false,
   "externals": {
     "hoo": "hoo",
+    "hoo_require": "commonjs hoo",
     "empty": "",
+    "foo_require": {
+      "root": "foo",
+      "type": "commonjs"
+    },
     "antd": {
       "root": "antd",
       "subpath": {

--- a/e2e/fixtures/config.externals/src/index.tsx
+++ b/e2e/fixtures/config.externals/src/index.tsx
@@ -1,4 +1,6 @@
 import hoo from "hoo";
+import hoo_require from "hoo_require";
+import foo_require from "foo_require";
 import empty from "empty";
 import "antd/es/button/style";
 import version from "antd/es/version";
@@ -7,5 +9,5 @@ import DatePicker from "antd/es/date-picker";
 import InputGroup from "antd/es/input/Group";
 import ScriptType from 'script';
 
-console.log(hoo, empty, version, zh_CN, InputGroup, DatePicker);
+console.log(hoo, hoo_require, foo_require, empty, version, zh_CN, InputGroup, DatePicker);
 console.log(ScriptType);


### PR DESCRIPTION
Close #1183


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在`ExternalAdvanced`结构体中添加了一个名为`module_type`的新字段，类型为`Option<String>`，并使用serde属性将其重命名为"type"。
    - 更新了处理外部配置以"commonjs"开头的情况的输出格式。
    - 更新了处理JavaScript/TypeScript项目中外部依赖的代码片段。
    - 在`expect.js`中添加了对特定外部模块（`hoo`和`foo`）存在性的断言。
    - 更新了`mako.config.json`文件，添加了`hoo_require`和`foo_require`的配置，并修改了`empty`的配置。
    - 在`index.tsx`文件中添加了对`hoo_require`和`foo_require`的导入，并更新了`console.log`语句。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->