### PR TITLE
fix: node version check in less loader

### DIFF
--- a/packages/mako/src/lessLoader/index.ts
+++ b/packages/mako/src/lessLoader/index.ts
@@ -1,16 +1,15 @@
 import url from 'url';
 /**
- * When on platform linux ant node version is lower then 20,
+ * When on platform linux ant node version is lower then 20.3.0,
  * the worker pool may exit unexpectedly, we need to disable it.
- * This may be is problem of nodejs, may related issue: https://github.com/nodejs/node/issues/51129.
+ * This may be is problem of nodejs.
  */
 const [NodeMajorVersion, NodeMirrorVersion] = process.versions.node
   .split('.')
   .map((v) => parseInt(v));
 const DisableParallelLess =
   process.platform === 'linux' &&
-  (NodeMajorVersion < 20 ||
-    (NodeMajorVersion === 20 && NodeMirrorVersion < 12));
+  (NodeMajorVersion < 20 || (NodeMajorVersion === 20 && NodeMirrorVersion < 3));
 
 export interface LessLoaderOpts {
   modifyVars: Record<string, string>;


### PR DESCRIPTION
重新二分验证了下，parallel less loader 可支持的最低 node 版本是 20.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- 根据 Node.js 版本调整了在 Linux 环境中禁用工作池的条件。
	- 将 NodeMirrorVersion 的比较值从 12 更改为 3。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->