### PR TITLE
fix: 🐛re-resolver to add ctxt back 

### DIFF
--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -327,6 +327,14 @@ impl ModuleAst {
             panic!("ModuleAst is not Css")
         }
     }
+
+    pub fn as_script_mut(&mut self) -> &mut JsAst {
+        if let Self::Script(script) = self {
+            script
+        } else {
+            panic!("ModuleAst is not Css")
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate.rs
@@ -247,7 +247,14 @@ pub fn optimize_module_graph(
                 .get_module_mut(&config.root)
                 .and_then(|module| module.info.as_mut())
             {
-                info.ast.as_script_ast_mut().visit_mut_with(&mut hygiene());
+                let js_ast = info.ast.as_script_mut();
+
+                js_ast.ast.visit_mut_with(&mut hygiene());
+                js_ast.ast.visit_mut_with(&mut resolver(
+                    js_ast.unresolved_mark,
+                    js_ast.top_level_mark,
+                    false,
+                ));
             }
 
             if let Ok(mut concatenate_context) = ConcatenateContext::init(config, module_graph) {
@@ -313,6 +320,11 @@ pub fn optimize_module_graph(
                     let module_info = module.info.as_mut().unwrap();
                     let script_ast = module_info.ast.script_mut().unwrap();
                     script_ast.ast.visit_mut_with(&mut hygiene());
+                    script_ast.ast.visit_mut_with(&mut resolver(
+                        script_ast.unresolved_mark,
+                        script_ast.top_level_mark,
+                        false,
+                    ));
 
                     let inner_print = false;
                     if cfg!(debug_assertions) && inner_print {


### PR DESCRIPTION
hygiene remove all the ctxt, we should re-resolver ast  to add it back


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
	- 在`ModuleAst`实现中添加了一个名为`as_script_mut`的公共方法，用于返回`JsAst`的可变引用。
	- 优化了JavaScript抽象语法树（AST）处理过程，将处理步骤分为卫生检查和解析未解析元素两个独立步骤。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->