### PR TITLE
fix: 🐛 catch the un-accessible error in hmr runtime

### DIFF
--- a/crates/mako/src/visitors/react.rs
+++ b/crates/mako/src/visitors/react.rs
@@ -145,8 +145,12 @@ function $RefreshIsReactComponentLike$(moduleExports) {
     return true;
   }
   for (var key in moduleExports) {
-    if (RefreshRuntime.isLikelyComponentType(moduleExports[key])) {
-      return true;
+    try{
+      if (RefreshRuntime.isLikelyComponentType(moduleExports[key])) {
+        return true;
+      }
+    }catch(e){
+       // in case the moduleExports[key] is not accessible due depedence loop
     }
   }
   return false;


### PR DESCRIPTION
root cause analysis: https://github.com/umijs/mako/issues/989#issuecomment-2123062975

close https://github.com/umijs/mako/issues/989


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- 修复了处理依赖循环导致`moduleExports[key]`不可访问的问题，增强了错误处理和控制流程。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->