### PR TITLE
fix: px2rem min_pixel_value should accept abs val

### DIFF
--- a/crates/mako/src/visitors/css_px2rem.rs
+++ b/crates/mako/src/visitors/css_px2rem.rs
@@ -34,7 +34,7 @@ impl Px2Rem {
     }
 
     fn should_transform(&self, val: f64) -> bool {
-        if val < self.config.min_pixel_value {
+        if val.abs() < self.config.min_pixel_value {
             return false;
         }
         let is_prop_valid = if let Some(decl) = &self.current_decl {
@@ -243,6 +243,10 @@ mod tests {
         assert_eq!(
             run_with_min_pixel_value(r#".a{width:100px;height:200px;}"#, 101.0),
             r#".a{width:100px;height:2rem}"#
+        );
+        assert_eq!(
+            run_with_min_pixel_value(r#".a{width:100px;height:-200px;}"#, 101.0),
+            r#".a{width:100px;height:-2rem}"#
         );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
  - 改进了 px 转 rem 的逻辑，现在支持处理负像素值的转换。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->