### PR TITLE
feat: add rscClient.logServerComponent config

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -128,8 +128,13 @@ pub struct BuildParams {
     emitAssets?: boolean;
     cssModulesExportOnlyLocales?: boolean;
     inlineCSS?: false | {};
-    rscServer?: false | {};
-    rscClient?: false | {};
+    rscServer?: false | {
+        "emitCSS": boolean;
+        "clientComponentTpl": string;
+    };
+    rscClient?: false | {
+        "logServerComponent": "error" | "ignore";
+    };
     experimental?: {
         webpackSyntaxValidate?: string[];
     };

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -376,8 +376,19 @@ pub struct RscServerConfig {
     pub emit_css: bool,
 }
 
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, ValueEnum, Clone)]
+pub enum LogServerComponent {
+    #[serde(rename = "error")]
+    Error,
+    #[serde(rename = "ignore")]
+    Ignore,
+}
+
 #[derive(Deserialize, Serialize, Debug)]
-pub struct RscClientConfig {}
+#[serde(rename_all = "camelCase")]
+pub struct RscClientConfig {
+    pub log_server_component: LogServerComponent,
+}
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/crates/mako/src/features/rsc.rs
+++ b/crates/mako/src/features/rsc.rs
@@ -9,7 +9,7 @@ use crate::ast::file::File;
 use crate::ast::js_ast::JsAst;
 use crate::build::parse::ParseError;
 use crate::compiler::Context;
-use crate::config::Config;
+use crate::config::{Config, LogServerComponent};
 use crate::module::ModuleAst;
 
 #[derive(Serialize, Debug, Clone)]
@@ -37,9 +37,9 @@ impl Rsc {
                 )));
             }
         }
-        if context.config.rsc_client.is_some() {
+        if let Some(rsc_client) = &context.config.rsc_client {
             let is_server = Rsc::is_server(ast)?;
-            if is_server {
+            if is_server && matches!(rsc_client.log_server_component, LogServerComponent::Error) {
                 return Err(anyhow!(ParseError::UnsupportedServerAction {
                     path: file.path.to_string_lossy().to_string(),
                 }));

--- a/docs/config.md
+++ b/docs/config.md
@@ -455,6 +455,20 @@ e.g.
 }
 ```
 
+### rscClient
+
+- Type: `{ logServerComponent: 'error' | 'ignore' } | false`
+- Default: `false`
+
+Configuration related to RSC client.
+
+### rscServer
+
+- Type: `{ clientComponentTpl: string, emitCSS: boolean } | false`
+- Default: `false`
+
+Configuration related to RSC server.
+
 ### stats
 
 - Type: `boolean`

--- a/e2e/fixtures/rsc.client.dynamic_client/mako.config.json
+++ b/e2e/fixtures/rsc.client.dynamic_client/mako.config.json
@@ -1,7 +1,8 @@
 {
   "rscClient": {
     "// ref: https://github.com/umijs/mako/issues/1062": [],
-    "TODO: REMOVE ME": 1
+    "TODO: REMOVE ME": 1,
+    "logServerComponent": "error"
   },
   "moduleIdStrategy": "named",
   "hash": true,

--- a/e2e/fixtures/rsc.client.error/mako.config.json
+++ b/e2e/fixtures/rsc.client.error/mako.config.json
@@ -1,7 +1,8 @@
 {
   "rscClient": {
     "// ref: https://github.com/umijs/mako/issues/1062": [],
-    "TODO: REMOVE ME": 1
+    "TODO: REMOVE ME": 1,
+    "logServerComponent": "error"
   },
   "minify": false
 }

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -140,8 +140,17 @@ export interface BuildParams {
     emitAssets?: boolean;
     cssModulesExportOnlyLocales?: boolean;
     inlineCSS?: false | {};
-    rscServer?: false | {};
-    rscClient?: false | {};
+    rscServer?:
+      | false
+      | {
+          emitCSS: boolean;
+          clientComponentTpl: string;
+        };
+    rscClient?:
+      | false
+      | {
+          logServerComponent: 'error' | 'ignore';
+        };
     experimental?: {
       webpackSyntaxValidate?: string[];
     };


### PR DESCRIPTION
Close #1195


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 为 `rscClient` 和 `rscServer` 添加了更详细的配置选项。
  - `rscClient` 现在支持 `logServerComponent` 配置，可以设置为 `error` 或 `ignore`。
  - `rscServer` 现在支持 `emitCSS` 和 `clientComponentTpl` 配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->