### PR TITLE
feat: add stats.modules config to generate modules with deps and dependents

### DIFF
--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -101,6 +101,7 @@ create_deserialize_fn!(deserialize_minifish, MinifishConfig);
 create_deserialize_fn!(deserialize_inline_css, InlineCssConfig);
 create_deserialize_fn!(deserialize_rsc_client, RscClientConfig);
 create_deserialize_fn!(deserialize_rsc_server, RscServerConfig);
+create_deserialize_fn!(deserialize_stats, StatsConfig);
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -184,6 +185,11 @@ pub enum ModuleIdStrategy {
     Hashed,
     #[serde(rename = "named")]
     Named,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct StatsConfig {
+    pub modules: bool,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -430,7 +436,7 @@ pub struct Config {
     pub platform: Platform,
     pub module_id_strategy: ModuleIdStrategy,
     pub define: HashMap<String, Value>,
-    pub stats: bool,
+    pub stats: Option<StatsConfig>,
     pub mdx: bool,
     #[serde(deserialize_with = "deserialize_hmr")]
     pub hmr: Option<HmrConfig>,
@@ -612,7 +618,6 @@ const DEFAULT_CONFIG: &str = r#"
     "targets": { "chrome": 80 },
     "less": { "theme": {}, "lesscPath": "", javascriptEnabled: true },
     "define": {},
-    "stats": false,
     "mdx": false,
     "platform": "browser",
     "hmr": { "host": "127.0.0.1", "port": 3000 },

--- a/crates/mako/src/generate/mod.rs
+++ b/crates/mako/src/generate/mod.rs
@@ -70,6 +70,16 @@ impl Compiler {
         debug!("generate");
         let t_generate = Instant::now();
 
+        if self
+            .context
+            .config
+            .stats
+            .as_ref()
+            .is_some_and(|s| s.modules)
+        {
+            self.context.stats_info.parse_modules(self.context.clone());
+        }
+
         debug!("tree_shaking");
         let t_tree_shaking = Instant::now();
 
@@ -164,7 +174,7 @@ impl Compiler {
 
         // generate stats
         let stats = create_stats_info(0, self);
-        if self.context.config.stats {
+        if self.context.config.stats.is_some() {
             write_stats(&stats, self);
         }
 
@@ -248,6 +258,16 @@ impl Compiler {
 
         let t_generate = Instant::now();
 
+        if self
+            .context
+            .config
+            .stats
+            .as_ref()
+            .is_some_and(|s| s.modules)
+        {
+            self.context.stats_info.parse_modules(self.context.clone());
+        }
+
         // ensure output dir exists
         let config = &self.context.config;
         if !config.output.path.exists() {
@@ -283,7 +303,7 @@ impl Compiler {
         // TODO: do not write to fs, using jsapi hooks to pass stats
         // why generate stats?
         // ref: https://github.com/umijs/mako/issues/1107
-        if self.context.config.stats {
+        if self.context.config.stats.is_some() {
             let stats = create_stats_info(0, self);
             write_stats(&stats, self);
         }

--- a/docs/config.md
+++ b/docs/config.md
@@ -469,12 +469,21 @@ Configuration related to RSC client.
 
 Configuration related to RSC server.
 
+Child configuration items:
+
+- `clientComponentTpl`, client component template, use `{{path}}` to represent the path of the component, and use `{{id}}` to represent the id of the module.
+- `emitCSS`, whether to output CSS components.
+
 ### stats
 
-- Type: `boolean`
+- Type: `{ modules: bool } | false`
 - Default: `false`
 
 Whether to generate stats.json file.
+
+Child configuration items:
+
+- `modules`, whether to generate module information, it may be useful when you want to analyze the size of the module but may slow down the build speed.
 
 ### transformImport
 

--- a/e2e/fixtures/rsc.client.dynamic_client/mako.config.json
+++ b/e2e/fixtures/rsc.client.dynamic_client/mako.config.json
@@ -7,5 +7,7 @@
   "moduleIdStrategy": "named",
   "hash": true,
   "minify": false,
-  "stats": true
+  "stats": {
+    "modules": false
+  }
 }

--- a/e2e/fixtures/rsc.server/mako.config.json
+++ b/e2e/fixtures/rsc.server/mako.config.json
@@ -4,7 +4,9 @@
     "emitCSS": true
   },
   "minify": false,
-  "stats": true,
+  "stats": {
+    "modules": true
+  },
   "optimization": {
     "concatenateModules": false
   }

--- a/examples/rsc/build.js
+++ b/examples/rsc/build.js
@@ -17,19 +17,21 @@ const fs = require('fs');
         index: path.join(root, 'src/index.tsx'),
         runtime: path.join(root, 'src/server-runtime.tsx'),
       },
-      moduleIdStrategy: 'hashed',
+      // moduleIdStrategy: 'hashed',
       output: {
         path: serverOutputPath,
       },
       rscServer: {
         clientComponentTpl: `
-module.exports = {$$typeof: Symbol.for(\"react.module.reference\"),filepath:\"{{path}}\",name:\"*\"};
+module.exports = {$$typeof: Symbol.for(\"react.module.reference\"),filepath:\"{{id}}\",_path:\"{{path}}\",name:\"*\"};
         `,
         emitCSS: true,
       },
       umd: '__rsc_server__',
       platform: 'node',
-      stats: true,
+      stats: {
+        modules: true,
+      },
     },
     hooks: {},
     watch: false,
@@ -68,14 +70,16 @@ export default () => {
         index: path.join(root, 'tmp/index.tsx'),
       },
       platform: 'node',
-      stats: true,
+      stats: {
+        modules: false,
+      },
       umd: '__rsc_client__',
       rscServer: false,
       rscClient: {
         logServerComponent: 'error',
       },
       mode: 'production',
-      moduleIdStrategy: 'hashed',
+      // moduleIdStrategy: 'hashed',
     },
     hooks: {},
     watch: false,

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -22,7 +22,9 @@ exports.build = async function (opts) {
   const makoConfig = await getMakoConfig(opts);
   const originStats = makoConfig.stats;
   // always enable stats to provide json for onBuildComplete hook
-  makoConfig.stats = true;
+  makoConfig.stats = {
+    modules: false,
+  };
   makoConfig.mode = 'production';
   makoConfig.hash = !!opts.config.hash;
   if (makoConfig.hash) {


### PR DESCRIPTION

1、for #1175 , we need to know the relationship between modules
2、since module concat will modify the module graph, so we need to parse the modules before optimization


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了新的统计配置（StatsConfig），允许用户配置模块统计信息。

- **文档**
  - 更新了配置文档，增加了有关 `clientComponentTpl`、`emitCSS` 和 `modules` 的描述。

- **修复**
  - 修改了多个配置文件中的 `stats` 配置，从布尔值更改为包含 `modules` 属性的对象。

- **重构**
  - 调整了统计信息的处理逻辑，改用 `Option<StatsConfig>` 代替布尔值。
  - 更新了统计信息的结构和方法，以支持模块统计。

- **样式**
  - 更新了 `build.js` 文件中的注释，禁用了 `moduleIdStrategy: 'hashed'` 配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->