### PR TITLE
fix: inlineCSS don't work

### DIFF
--- a/crates/mako/src/build/load.rs
+++ b/crates/mako/src/build/load.rs
@@ -66,7 +66,7 @@ impl Load {
 export function moduleToDom(css) {
     var styleElement = document.createElement("style");
     styleElement.type = "text/css";
-    styleElement.innerHTML = css;
+    styleElement.appendChild(document.createTextNode(css))
     // TODO: support nonce
     // styleElement.setAttribute("nonce", nonce);
     document.head.appendChild(styleElement);


### PR DESCRIPTION
old function does not use the css param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **重构**
	- 优化了`moduleToDom`函数，简化了代码逻辑，直接将`styleElement`附加到`document.head`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->