### PR TITLE
chore: inlineCSS 可以通过应用配置传入

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -426,6 +426,7 @@ async function getMakoConfig(opts) {
     copy = [],
     clean,
     forkTSChecker,
+    inlineCSS,
   } = opts.config;
   // TODO:
   // 暂不支持 $ 结尾，等 resolve 支持后可以把这段去掉
@@ -541,6 +542,7 @@ async function getMakoConfig(opts) {
     flexBugs: true,
     react: opts.react || {},
     emotion,
+    inlineCSS,
     forkTSChecker: !!forkTSChecker,
     ...(opts.disableCopy ? { copy: [] } : { copy: ['public'].concat(copy) }),
     useDefineForClassFields:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 更新了`bundler-mako`包中的`getMakoConfig`函数，现在包括了从`opts.config`中解构赋值的`inlineCSS`变量。此外，返回的对象中添加了`inlineCSS`属性，其值来源于`opts.config`。这个变化将`inlineCSS`变量引入了函数的逻辑中。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->