### PR TITLE
feat: ✨ support x86_64 linux musl

### DIFF
--- a/packages/mako/package.json
+++ b/packages/mako/package.json
@@ -13,7 +13,8 @@
       "additional": [
         "aarch64-apple-darwin",
         "x86_64-apple-darwin",
-        "x86_64-unknown-linux-gnu"
+        "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl"
       ]
     }
   },


### PR DESCRIPTION
内部 ACI 已经支持
release:quick 可以直接发

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在`package.json`文件中添加了对`"x86_64-unknown-linux-musl"`平台的支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->