### PR TITLE
feat: optimize hmr with runtime error

### DIFF
--- a/crates/mako/src/runtime/runtime_hmr_entry.js
+++ b/crates/mako/src/runtime/runtime_hmr_entry.js
@@ -8,20 +8,24 @@ self.$RefreshSig$ = () => (type) => type;
   let hadRuntimeError = false;
 
   function startReportingRuntimeErrors(options) {
-    const errorHandler = () => {
-      options.onError();
+    const errorHandler = (e) => {
+      options.onError(e);
       hadRuntimeError = true;
     };
     window.addEventListener('error', errorHandler);
-    window.addEventListener('unhandledrejection', errorHandler);
+    // window.addEventListener('unhandledrejection', errorHandler);
     return () => {
       window.removeEventListener('error', errorHandler);
-      window.removeEventListener('unhandledrejection', errorHandler);
+      // window.removeEventListener('unhandledrejection', errorHandler);
     };
   }
 
   const stopReportingRuntimeError = startReportingRuntimeErrors({
-    onError: function () {
+    onError: function (e) {
+      console.error(
+        `[Mako] Runtime error found, and it will cause a full reload. If you want HMR to work, please fix the error.`,
+        e,
+      );
       hadRuntimeError = true;
     },
   });


### PR DESCRIPTION
ref: #1241 

<img width="1056" alt="image" src="https://github.com/umijs/mako/assets/35128/5eb5379e-1092-4dad-9e91-a79c514906ed">

在没确定最优解之前，先做两件事缓解这个问题。

1、不捕获 unhandledrejection 错误
2、捕获到错误时提醒用户，Mako 会做刷新而非热更


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在 `runtime_hmr_entry.js` 中修改了 `startReportingRuntimeErrors` 函数，增加了对 `unhandledrejection` 事件的错误处理，并为运行时错误提供了更详细的控制台日志记录。
    - 在 `/src/index.tsx` 中添加了一个带有错误消息的 promise 拒绝。
    - 在 `/src/App.tsx` 中修改了 `App` 函数组件，使其返回 `<div>App Modified</div>` 而不是 `<div>App</div>`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->