### PR TITLE
fix: use non-blocking io because rust does not support it now

### DIFF
--- a/packages/mako/src/index.ts
+++ b/packages/mako/src/index.ts
@@ -16,16 +16,14 @@ export { BuildParams };
 // ref:
 // https://github.com/vercel/next.js/pull/51883
 function blockStdout() {
-  if (process.platform === 'darwin') {
-    // rust needs stdout to be blocking, otherwise it will throw an error (on macOS at least) when writing a lot of data (logs) to it
-    // see https://github.com/napi-rs/napi-rs/issues/1630
-    // and https://github.com/nodejs/node/blob/main/doc/api/process.md#a-note-on-process-io
-    if ((process.stdout as any)._handle != null) {
-      (process.stdout as any)._handle.setBlocking(true);
-    }
-    if ((process.stderr as any)._handle != null) {
-      (process.stderr as any)._handle.setBlocking(true);
-    }
+  // rust needs stdout to be blocking, otherwise it will throw an error (on macOS at least) when writing a lot of data (logs) to it
+  // see https://github.com/napi-rs/napi-rs/issues/1630
+  // and https://github.com/nodejs/node/blob/main/doc/api/process.md#a-note-on-process-io
+  if ((process.stdout as any)._handle != null) {
+    (process.stdout as any)._handle.setBlocking(true);
+  }
+  if ((process.stderr as any)._handle != null) {
+    (process.stderr as any)._handle.setBlocking(true);
   }
 }
 


### PR DESCRIPTION
rust 目前不支持非阻塞 stdio: https://github.com/rust-lang/rust/issues/100673 , 在 antd 项目中跑挂了 https://github.com/ant-design/ant-design/actions/runs/9395487649/job/25875528581?pr=49109。

nextjs 同类问题：https://github.com/vercel/next.js/pull/56789/files#diff-907b7be0cfc75bd37773e5ebc38d1deffa40861b8ac1cde92e4992e284a1ee59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **优化**
	- 简化了`mako`包中`index.ts`中的`blockStdout`函数，移除了对'darwin'平台的检查，并将stdout和stderr的设置合并为阻塞以实现Rust兼容性。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->