### PR TITLE
Fix/export default be skipped

### DIFF
--- a/crates/mako/src/plugins/farm_tree_shake/module_side_effects_flag.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/module_side_effects_flag.rs
@@ -8,7 +8,6 @@ use crate::resolve::{ResolvedResource, ResolverResource};
 
 impl ModuleInfo {
     pub fn described_side_effect(&self) -> Option<bool> {
-
         if let Some(ResolverResource::Resolved(ResolvedResource(source))) = &self.resolved_resource
         {
             match &source.package_json() {
@@ -19,10 +18,9 @@ impl ModuleInfo {
                     let root: &Path = desc.directory();
                     let root: PathBuf = root.into();
 
-                    let s = side_effects.map(|side_effect| {
+                    side_effects.map(|side_effect| {
                         Self::match_flag(side_effect, relative_to_root(&self.path, &root).as_str())
-                    });
-                    s
+                    })
                 }
                 None => None,
             }

--- a/crates/mako/src/plugins/farm_tree_shake/shake/find_export_source.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/find_export_source.rs
@@ -101,7 +101,8 @@ impl TreeShakeModule {
                             }
                             ExportSpecifierInfo::Default(export_default_ident) => {
                                 if ident == "default" {
-                                    if let Some(_default_ident) = export_default_ident {
+                                    if export_default_ident.is_some() {
+                                        // TODO figure out how webpack handle this
                                         // re_export_type = Some(ReExportType::Default);
                                         // local_ident = Some(default_ident.clone());
                                         break;


### PR DESCRIPTION
无害的改动，但是会弱化优化

后继和 webpack 对齐再做最终解。

https://github.com/umijs/mako/issues/1253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 在`find_export_source.rs`文件中对处理默认导出的代码进行了注释处理，并修改了测试用例中的断言，以检查`None`而不是特定描述。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->