### PR TITLE
fix: try resolve should support config.ignores

### DIFF
--- a/crates/mako/src/visitors/try_resolve.rs
+++ b/crates/mako/src/visitors/try_resolve.rs
@@ -23,6 +23,21 @@ impl TryResolve {
         if is_commonjs_require(call_expr, &self.unresolved_mark) {
             let first_arg = get_first_str_arg(call_expr);
             if let Some(source) = first_arg {
+                // support ignores config
+                let mut deps = vec![Dependency {
+                    source: source.clone(),
+                    resolve_as: None,
+                    resolve_type: ResolveType::Require,
+                    order: 0,
+                    span: None,
+                }];
+                self.context
+                    .plugin_driver
+                    .before_resolve(&mut deps, &self.context)
+                    .unwrap(); // before_resolve won't panic
+                if deps.is_empty() {
+                    return;
+                }
                 let result = resolve::resolve(
                     self.path.as_str(),
                     &Dependency {

--- a/e2e/fixtures/config.platform.node/expect.js
+++ b/e2e/fixtures/config.platform.node/expect.js
@@ -28,9 +28,10 @@ assert.match(
   content,
   /readFileSync\("src\/index.ts"/,
   "should transform __filename"
-)
+);
 assert.match(
   content,
   /console\.log\('dirname', "src"\);/,
   "should transform __dirname"
-)
+);
+assert(content.includes(`require('crypto');`), `should keep require for crypto`);

--- a/e2e/fixtures/config.platform.node/src/index.ts
+++ b/e2e/fixtures/config.platform.node/src/index.ts
@@ -9,7 +9,6 @@ readFile(__filename, { encoding: ENCODING });
 
 console.log('dirname', __dirname);
 
-require('crypto');
 require('http2');
 
 try {


### PR DESCRIPTION
Close #1258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在解析过程中添加了基于插件驱动程序处理依赖关系的新代码块。如果处理后依赖列表为空，则函数会提前返回。
    - 在 `expect.js` 文件中添加了一个新断言，用于检查内容中特定 `require` 语句的存在性。
    - 在 `index.ts` 中移除了 `require('crypto');` 语句，保留了 `require('http2');` 语句。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->