### PR TITLE
feat: open browser when dev server is ready in mako cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2303,16 @@ dependencies = [
  "io-lifetimes",
  "rustix 0.37.19",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2599,6 +2618,7 @@ dependencies = [
  "miette 5.10.0",
  "mimalloc-rust",
  "nanoid",
+ "open",
  "oxc_resolver",
  "percent-encoding",
  "serde",
@@ -3290,6 +3310,17 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "open"
+version = "5.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ca541f22b1c46d4bb9801014f234758ab4297e7870b904b6a8415b980a7388"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
 
 [[package]]
 name = "orbclient"

--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -22,6 +22,7 @@ heck             = "0.4.1"
 mako_core        = { path = "../core" }
 miette           = { version = "5.10.0", features = ["fancy"] }
 nanoid           = "0.4.0"
+open             = "5.1.4"
 oxc_resolver     = "1.5.4"
 percent-encoding = { version = "2.3.1" }
 serde            = { workspace = true }

--- a/crates/mako/src/dev/mod.rs
+++ b/crates/mako/src/dev/mod.rs
@@ -18,6 +18,7 @@ use mako_core::tokio::sync::broadcast;
 use mako_core::tracing::debug;
 use mako_core::tungstenite::Message;
 use mako_core::{hyper, hyper_staticfile, hyper_tungstenite};
+use open;
 
 use crate::compiler::{Compiler, Context};
 use crate::plugin::{PluginGenerateEndParams, PluginGenerateStats};
@@ -111,6 +112,7 @@ impl DevServer {
                     );
                 }
                 println!();
+                open::that(format!("http://localhost:{}/", port)).unwrap();
             }
             debug!("Listening on http://{:?}", addr);
             if let Err(e) = server.await {

--- a/packages/mako/src/cli.ts
+++ b/packages/mako/src/cli.ts
@@ -32,7 +32,7 @@ import yParser from 'yargs-parser';
         config: {
           mode: argv.mode || 'development',
         },
-        hooks: {},
+        plugins: [],
         watch,
       });
       break;


### PR DESCRIPTION
ref #1245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
	- 在应用程序中添加了对 `open` 依赖项的支持。
	- 在 CLI 中的配置对象中，将 `plugins` 属性的空对象 `{}` 更改为空数组 `[]`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->