### PR TITLE
chore: fix biome format

### DIFF
--- a/examples/with-tslib/index.ts
+++ b/examples/with-tslib/index.ts
@@ -1,3 +1,3 @@
-import { __spreadArray as e, __assign as t } from 'tslib';
+import { __assign as t, __spreadArray as e } from 'tslib';
 console.log(e([1, 2, 3], [4, 5, 6]));
 console.log(t({ a: 1 }, { b: 2 }));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "pnpm --filter @umijs/mako build && pnpm --filter @umijs/mako src:build && pnpm biome:format && pnpm --filter client build",
     "build:debug": "pnpm --filter @umijs/mako build:debug && pnpm --filter @umijs/mako src:build && pnpm biome:format && pnpm --filter client build",
     "biome:check": "biome check .",
-    "biome:format": "biome check --write .",
+    "biome:format": "biome check --apply .",
     "test": "npm run test:e2e && npm run test:hmr && npm run test:umi",
     "test:e2e": "node scripts/test-e2e.mjs",
     "test:umi": "node scripts/test-e2e.mjs --fixtures e2e/fixtures.umi --umi",


### PR DESCRIPTION
<img width="454" alt="image" src="https://github.com/umijs/mako/assets/16577489/a0843ea2-97b3-4f13-945e-926102655aaf">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **代码变更**
    - **功能变更**
        - 更改了`index.ts`中对`'tslib'`中`__assign`和`__spreadArray`的导入顺序，影响了后续对这些函数的使用。
    - **声明的更改**
        - `examples/with-tslib/index.ts`中的`import { __spreadArray as e, __assign as t } from 'tslib';` → `examples/with-tslib/index.ts`中的`import { __assign as t, __spreadArray as e } from 'tslib';`
    - **包管理**
        - 在`package.json`文件中，将`biome:format`脚本从`"biome check --write ."`更新为`"biome check --apply ."`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->