### PR TITLE
feat: improve build api (break change)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,11 +10,8 @@ Mako 目前通过 @umijs/mako 暴露 API 供 node 工具使用，以下为 @umij
 const { build } = require('@umijs/mako');
 await build({
   root: process.cwd(),
-  config: {},
-  plugins: [],
-  less: {},
-  forkTsChecker: true,
   watch: false,
+  config: {},
 }: BuildOptions);
 ```
 
@@ -33,68 +30,6 @@ await build({
 - 默认值：`{}`
 
 详见[配置](./config.md)。
-
-### less
-
-- 类型：`Object`
-- 默认值：`{}`
-
-less 配置。
-
-比如。
-
-```ts
-{
-  modifyVars: {
-    'primary-color': '#1DA57A',
-    'link-color': '#1DA57A',
-  },
-  sourceMap: {
-    sourceMapFileInline: true,
-    outputSourceFiles: true,
-  },
-  math: 'always',
-  plugins: [
-    [require.resolve("less-plugin-clean-css"), { roundingPrecision: 1 }]
-  ]
-}
-```
-
-### Plugin
-
-- 类型：
-
-```ts
-{
-  name?: string;
-  buildStart?: () => void;
-  generateEnd?: (data: {
-    isFirstCompile: boolean;
-    time: number;
-    stats: {
-      startTime: number;
-      endTime: number;
-    };
-  }) => void;
-  load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
-}
-```
-
-- 默认值：`{}`
-
-hooks 是一些钩子函数，用于扩展 Mako 的编译过程。
-
-- `name`，插件名称
-- `buildStart`，在 Build 开始前会调用
-- `load`，用于加载文件，返回文件内容和类型，类型支持 `css`、`js`、`jsx`、`ts`、`tsx`
-- `generateEnd`，在 Generate 完成后会调用，通过 `isFirstCompile` 可以判断是否是第一次编译，`time` 为编译时间，`stats` 为编译统计信息
-
-### forkTsChecker
-
-- 类型：`boolean`
-- 默认值：`false`
-
-是否开启构建时 TypeScript 类型校验。
 
 ### watch
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -234,6 +234,13 @@ Then, when the code encounters `import foo from "foo"`, it will be replaced with
 
 Whether to fix flexbugs.
 
+### forkTsChecker
+
+- Type: `boolean`
+- Default: `false`
+
+Whether to run TypeScript type checker on a separate process.
+
 ### hash
 
 - Type: `boolean`
@@ -289,6 +296,32 @@ Notice: This configuration can only be used with umd, because injecting CSS is n
 - Default: `10000`
 
 Specify the size limit of the assets file that needs to be converted to `base64` format.
+
+### less
+
+- Type: `Object`
+- Default: `{}`
+
+Specify the less configuration.
+
+e.g.
+
+```ts
+{
+  modifyVars: {
+    'primary-color': '#1DA57A',
+    'link-color': '#1DA57A',
+  },
+  sourceMap: {
+    sourceMapFileInline: true,
+    outputSourceFiles: true,
+  },
+  math: 'always',
+  plugins: [
+    [require.resolve("less-plugin-clean-css"), { roundingPrecision: 1 }]
+  ],
+}
+```
 
 ### manifest
 
@@ -365,6 +398,37 @@ Specify the configuration to optimize the build artifacts. Currently, the follow
 Specify the platform to build, `"browser"` or `"node"`.
 
 Notice: When using `"node"`, you also need to set `dynamicImportToRequire` to `true`, because the runtime does not yet support node-style chunk loading.
+
+### plugins
+
+- Type: `(string | JSHooks)[]`
+- Default: `[]`
+
+Specify the plugins to use.
+
+```ts
+// JSHooks
+{
+  name?: string;
+  buildStart?: () => void;
+  generateEnd?: (data: {
+    isFirstCompile: boolean;
+    time: number;
+    stats: {
+      startTime: number;
+      endTime: number;
+    };
+  }) => void;
+  load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
+}
+```
+
+JSHooks is a set of hook functions used to extend the compilation process of Mako.
+
+- `name`, plugin name
+- `buildStart`, called before Build starts
+- `load`, used to load files, return file content and type, type supports `css`, `js`, `jsx`, `ts`, `tsx`
+- `generateEnd`, called after Generate completes, `isFirstCompile` can be used to determine if it is the first compilation, `time` is the compilation time, and `stats` is the compilation statistics information
 
 ### providers
 

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -37,17 +37,7 @@ exports.build = async function (opts) {
     await build({
       root: cwd,
       config: makoConfig,
-      less: {
-        modifyVars: opts.config.lessLoader?.modifyVars || opts.config.theme,
-        sourceMap: getLessSourceMapConfig(makoConfig.devtool),
-        math: opts.config.lessLoader?.math,
-        plugins: opts.config.lessLoader?.plugins,
-      },
-      plugins: opts.plugins || [],
-      forkTSChecker: makoConfig.forkTSChecker,
       watch: opts.watch || false,
-      hmr: opts.hmr || false,
-      devServer: opts.devServer || false,
     });
   } catch (e) {
     console.error(e.message);
@@ -201,25 +191,17 @@ exports.dev = async function (opts) {
   const makoConfig = await getMakoConfig(opts);
   makoConfig.hmr = {};
   makoConfig.devServer = { port: hmrPort, host: opts.host };
+  makoConfig.plugins.push({
+    name: 'mako-dev',
+    generateEnd: (args) => {
+      opts.onDevCompileDone(args);
+    },
+  });
   const cwd = opts.cwd;
   try {
     await build({
       root: cwd,
       config: makoConfig,
-      less: {
-        modifyVars: opts.config.lessLoader?.modifyVars || opts.config.theme,
-        sourceMap: getLessSourceMapConfig(makoConfig.devtool),
-        math: opts.config.lessLoader?.math,
-        plugins: opts.config.lessLoader?.plugins,
-      },
-      forkTSChecker: makoConfig.forkTSChecker,
-      plugins: (opts.plugins || []).concat({
-        name: 'default',
-        generateEnd: (args) => {
-          opts.onDevCompileDone(args);
-        },
-      }),
-
       watch: true,
     });
   } catch (e) {
@@ -546,6 +528,7 @@ async function getMakoConfig(opts) {
   const outputPath = path.resolve(opts.cwd, opts.config.outputPath || 'dist');
   const tsConfig = getTsConfig(opts);
 
+  const normalizedDevtool = devtool === false ? false : 'source-map';
   const makoConfig = {
     entry: opts.entry,
     output: { path: outputPath },
@@ -560,7 +543,7 @@ async function getMakoConfig(opts) {
     manifest,
     mdx: !!mdx,
     codeSplitting: codeSplitting === false ? false : 'auto',
-    devtool: devtool === false ? false : 'source-map',
+    devtool: normalizedDevtool,
     cjs,
     dynamicImportToRequire,
     platform,
@@ -575,10 +558,19 @@ async function getMakoConfig(opts) {
     react: opts.react || {},
     emotion,
     inlineCSS,
-    forkTSChecker: !!forkTSChecker,
     ...(opts.disableCopy ? { copy: [] } : { copy: ['public'].concat(copy) }),
     useDefineForClassFields:
       tsConfig.compilerOptions.useDefineForClassFields ?? true,
+    hmr: opts.hmr || false,
+    devServer: opts.devServer || false,
+    forkTSChecker: !!forkTSChecker,
+    less: {
+      modifyVars: opts.config.lessLoader?.modifyVars || opts.config.theme,
+      sourceMap: getLessSourceMapConfig(normalizedDevtool),
+      math: opts.config.lessLoader?.math,
+      plugins: opts.config.lessLoader?.plugins,
+    },
+    plugins: opts.plugins || [],
   };
 
   return makoConfig;

--- a/packages/mako/src/index.ts
+++ b/packages/mako/src/index.ts
@@ -5,12 +5,18 @@ import * as binding from '../binding';
 import { ForkTSChecker as ForkTSChecker } from './forkTSChecker';
 import { LessLoaderOpts, lessLoader } from './lessLoader';
 
-interface ExtraBuildParams {
+type Config = binding.BuildParams['config'] & {
+  plugins?: binding.BuildParams['plugins'];
   less?: LessLoaderOpts;
   forkTSChecker?: boolean;
-}
+};
 
-type BuildParams = binding.BuildParams & ExtraBuildParams;
+type BuildParams = {
+  config: Config;
+  root: binding.BuildParams['root'];
+  watch: binding.BuildParams['watch'];
+};
+
 export { BuildParams };
 
 // ref:
@@ -30,12 +36,12 @@ function blockStdout() {
 export async function build(params: BuildParams) {
   blockStdout();
 
-  params.plugins = params.plugins || [];
+  params.config.plugins = params.config.plugins || [];
   params.config.resolve = params.config.resolve || {};
   params.config.resolve.alias = params.config.resolve.alias || {};
 
   let makoConfig: any = {};
-  const makoConfigPath = path.join(params.root, 'mako.config.json');
+  let makoConfigPath = path.join(params.root, 'mako.config.json');
   if (fs.existsSync(makoConfigPath)) {
     try {
       makoConfig = JSON.parse(fs.readFileSync(makoConfigPath, 'utf-8'));
@@ -65,15 +71,15 @@ export async function build(params: BuildParams) {
 
   // built-in less-loader
   let less = lessLoader(null, {
-    modifyVars: params.less?.modifyVars || {},
-    math: params.less?.math,
-    sourceMap: params.less?.sourceMap || false,
+    modifyVars: params.config.less?.modifyVars || {},
+    math: params.config.less?.math,
+    sourceMap: params.config.less?.sourceMap || false,
     plugins: [
       ['less-plugin-resolve', { aliases: params.config.resolve.alias! }],
-      ...(params.less?.plugins || []),
+      ...(params.config.less?.plugins || []),
     ],
   });
-  params.plugins.push({
+  params.config.plugins.push({
     name: 'less',
     async load(filePath: string) {
       let lessResult = await less(filePath);
@@ -111,12 +117,19 @@ export async function build(params: BuildParams) {
     });
   }
 
-  const buildParams = omit(params, ['less', 'forkTSChecker']);
+  let plugins = params.config.plugins;
+  params.config = omit(params.config, [
+    'less',
+    'forkTSChecker',
+    'plugins',
+  ]) as BuildParams['config'];
+  await binding.build({
+    ...params,
+    plugins,
+  });
 
-  await binding.build(buildParams);
-
-  if (params.forkTSChecker) {
-    const forkTypeChecker = new ForkTSChecker({
+  if (params.config.forkTSChecker) {
+    let forkTypeChecker = new ForkTSChecker({
       root: params.root,
       watch: params.watch,
     });

--- a/scripts/mako.js
+++ b/scripts/mako.js
@@ -10,10 +10,6 @@ const config = getMakoConfig();
 build({
   root: cwd,
   config,
-  less: {
-    modifyVars: config.less?.theme || {},
-  },
-  plugins: getPlugins(),
   watch: process.argv.includes('--watch'),
 }).catch((e) => {
   console.error(e);
@@ -42,6 +38,10 @@ function getMakoConfig() {
   }
   makoConfig.resolve = makoConfig.resolve || {};
   makoConfig.resolve.alias = makoConfig.resolve.alias || {};
+  makoConfig.less = {
+    modifyVars: makoConfig.less?.theme || {},
+  };
+  makoConfig.plugins = getPlugins();
   Object.keys(makoConfig.resolve.alias).forEach((key) => {
     makoConfig.resolve.alias[key] = path.join(
       cwd,


### PR DESCRIPTION
Close #1239


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
	- `docs/api.md`中删除了`forkTsChecker`选项，调整了`@umijs/mako`提供的`build`函数中的`watch`选项。此外，还删除了关于`less`配置、`Plugin`接口和`forkTsChecker`选项的部分内容。
	- `docs/config.md`中增加和修改了与TypeScript类型检查、less配置、资源大小限制、插件和提供程序相关的配置选项。引入了新选项如`forkTsChecker`、`less`和`plugins`，并详细说明了它们的用法。
- **功能**
	- `bundler-mako`包的`index.js`文件中对`build`和`dev`函数进行了多项更改，调整了`less`、`plugins`、`forkTSChecker`、`watch`、`hmr`和`devServer`配置。
	- `index.ts`文件重构了`BuildParams`类型，将`plugins`和`less`配置移入了`BuildParams`内的嵌套`Config`类型中。
	- `scripts/mako.js`中重构了与`less`配置和插件相关的功能，将它们从`build`函数移至`getMakoConfig`函数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->