### PR TITLE
fix: downgrade oxc_resolver to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3380,9 +3380,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "oxc_resolver"
-version = "1.8.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd177c1f521d3c6631fa96abb6d97220ce4bed102e1e0172b11496ed9442fae"
+checksum = "ab805c61c1758a7bf350c52ab8962307d1c0fe9677ffa0ac5007789c2e98858f"
 dependencies = [
  "dashmap 5.5.3",
  "dunce",

--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -11,19 +11,20 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
-bitflags         = { version = "2.4.2", features = ["serde"] }
-cached           = { workspace = true }
-dashmap          = "4.0.1"
-delegate         = "0.12.0"
-fixedbitset      = "0.4.2"
-get_if_addrs     = "0.5.3"
-glob-match       = "0.2.1"
-heck             = "0.4.1"
-mako_core        = { path = "../core" }
-miette           = { version = "5.10.0", features = ["fancy"] }
-nanoid           = "0.4.0"
-open             = "5.1.4"
-oxc_resolver     = { version = "1.8.1", features = ["package_json_raw_json_api"] }
+bitflags     = { version = "2.4.2", features = ["serde"] }
+cached       = { workspace = true }
+dashmap      = "4.0.1"
+delegate     = "0.12.0"
+fixedbitset  = "0.4.2"
+get_if_addrs = "0.5.3"
+glob-match   = "0.2.1"
+heck         = "0.4.1"
+mako_core    = { path = "../core" }
+miette       = { version = "5.10.0", features = ["fancy"] }
+nanoid       = "0.4.0"
+open         = "5.1.4"
+# On oxc_resolver 1.8.0 version, this pr https://github.com/oxc-project/oxc-resolver/pull/168 will break alias resolving
+oxc_resolver     = { version = "=1.7.0", features = ["package_json_raw_json_api"] }
 percent-encoding = { version = "2.3.1" }
 serde            = { workspace = true }
 serde_json       = { workspace = true }


### PR DESCRIPTION
oxc_resolver 1.8.0 报如下错误
<img width="1099" alt="image" src="https://github.com/umijs/mako/assets/16577489/d0d4e46d-f378-4160-b4f6-a132ffc38d8e">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
    - 由于版本`1.8.0`中的别名解析问题，将`oxc_resolver`版本回滚至`1.7.0`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->