### PR TITLE
chore: ✏️ remove to_string() in unit test

### DIFF
--- a/crates/mako/src/ast/js_ast.rs
+++ b/crates/mako/src/ast/js_ast.rs
@@ -304,7 +304,7 @@ class Bar {}
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let code = test_utils.js_ast_to_code();
         println!("{}", code);
         code

--- a/crates/mako/src/plugins/farm_tree_shake.rs
+++ b/crates/mako/src/plugins/farm_tree_shake.rs
@@ -127,7 +127,7 @@ var b = 2;
     }
 
     fn split_top_decl(code: &str) -> String {
-        let mut tu = TestUtils::gen_js_ast(code.to_string());
+        let mut tu = TestUtils::gen_js_ast(code);
 
         tu.ast
             .js_mut()

--- a/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate/concatenate_context.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate/concatenate_context.rs
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_export_default_class_expr_with_ident() {
-        let tu = TestUtils::gen_js_ast("export default class C{};".to_string());
+        let tu = TestUtils::gen_js_ast("export default class C{};");
         let js = tu.ast.js();
 
         GLOBALS.set(&tu.context.meta.script.globals, || {
@@ -461,7 +461,7 @@ mod tests {
 
     #[test]
     fn test_export_default_fn_expr_with_ident() {
-        let tu = TestUtils::gen_js_ast("export default function fn(){};".to_string());
+        let tu = TestUtils::gen_js_ast("export default function fn(){};");
         let js = tu.ast.js();
 
         GLOBALS.set(&tu.context.meta.script.globals, || {
@@ -471,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_export_default_anonymous_fn_expr_with_ident() {
-        let tu = TestUtils::gen_js_ast("export default function (){};".to_string());
+        let tu = TestUtils::gen_js_ast("export default function (){};");
         let js = tu.ast.js();
 
         GLOBALS.set(&tu.context.meta.script.globals, || {
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_export_default_anonymous_class_expr_with_ident() {
-        let tu = TestUtils::gen_js_ast("export default class {};".to_string());
+        let tu = TestUtils::gen_js_ast("export default class {};");
         let js = tu.ast.js();
 
         GLOBALS.set(&tu.context.meta.script.globals, || {

--- a/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate/exports_transform.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/module_concatenate/exports_transform.rs
@@ -201,7 +201,7 @@ mod tests {
     }
 
     fn extract_export(code: &str) -> HashSet<String> {
-        let mut ast = TestUtils::gen_js_ast(code.to_string());
+        let mut ast = TestUtils::gen_js_ast(code);
         let mut collectort = ExportsCollector::default();
 
         ast.ast.js_mut().ast.visit_with(&mut collectort);

--- a/crates/mako/src/visitors/async_module.rs
+++ b/crates/mako/src/visitors/async_module.rs
@@ -403,7 +403,7 @@ __mako_require__._async(module, async (handleAsyncDeps, asyncResult)=>{
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let mut chunk = Chunk::new(
             "./async".to_string().into(),
             ChunkType::Entry("./async".to_string().into(), "async".to_string(), false),

--- a/crates/mako/src/visitors/default_export_namer.rs
+++ b/crates/mako/src/visitors/default_export_namer.rs
@@ -138,7 +138,7 @@ mod tests {
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut visitor = DefaultExportNamer::new();

--- a/crates/mako/src/visitors/dep_analyzer.rs
+++ b/crates/mako/src/visitors/dep_analyzer.rs
@@ -211,7 +211,7 @@ mod tests {
     }
 
     fn run(js_code: &str) -> Vec<String> {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         let mut analyzer = super::DepAnalyzer::new(ast.unresolved_mark);
         GLOBALS.set(&test_utils.context.meta.script.globals, || {

--- a/crates/mako/src/visitors/dep_replacer.rs
+++ b/crates/mako/src/visitors/dep_replacer.rs
@@ -409,7 +409,7 @@ try {
         resolved: HashMap<String, (ResolvedModuleId, ResolvedModulePath)>,
         missing: HashMap<String, Dependency>,
     ) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut visitor = DepReplacer {

--- a/crates/mako/src/visitors/dynamic_import.rs
+++ b/crates/mako/src/visitors/dynamic_import.rs
@@ -191,7 +191,7 @@ Promise.all([
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         {
             let mut foo = Chunk::new("foo".to_string().into(), ChunkType::Async);
             foo.add_module("foo".to_string().into());

--- a/crates/mako/src/visitors/dynamic_import_to_require.rs
+++ b/crates/mako/src/visitors/dynamic_import_to_require.rs
@@ -125,7 +125,7 @@ import(`3-${MODULE}`);
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut visitor = DynamicImportToRequire {

--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -363,7 +363,7 @@ log([
     }
 
     fn run(js_code: &str, envs: HashMap<String, Value>) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let envs = build_env_map(envs, &test_utils.context).unwrap();
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {

--- a/crates/mako/src/visitors/fix_helper_inject_position.rs
+++ b/crates/mako/src/visitors/fix_helper_inject_position.rs
@@ -154,7 +154,7 @@ export { foo };
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         let unresolved_mark = ast.unresolved_mark;
         GLOBALS.set(&test_utils.context.meta.script.globals, || {

--- a/crates/mako/src/visitors/mako_require.rs
+++ b/crates/mako/src/visitors/mako_require.rs
@@ -99,7 +99,7 @@ require("foo");
     }
 
     fn run(js_code: &str, ignores: Vec<Regex>) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut visitor = MakoRequire {

--- a/crates/mako/src/visitors/meta_url_replacer.rs
+++ b/crates/mako/src/visitors/meta_url_replacer.rs
@@ -40,7 +40,7 @@ mod tests {
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut visitor = MetaUrlReplacer {};

--- a/crates/mako/src/visitors/new_url_assets.rs
+++ b/crates/mako/src/visitors/new_url_assets.rs
@@ -124,7 +124,7 @@ mod tests {
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let current_dir = std::env::current_dir().unwrap();

--- a/crates/mako/src/visitors/provide.rs
+++ b/crates/mako/src/visitors/provide.rs
@@ -167,7 +167,7 @@ console.log({
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut providers = HashMap::new();

--- a/crates/mako/src/visitors/react.rs
+++ b/crates/mako/src/visitors/react.rs
@@ -229,7 +229,7 @@ const Foo = () => (
     }
 
     fn run(js_code: &str, use_refresh: bool) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut visitor = react(

--- a/crates/mako/src/visitors/try_resolve.rs
+++ b/crates/mako/src/visitors/try_resolve.rs
@@ -188,7 +188,7 @@ try {
     }
 
     fn run(js_code: &str) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut visitor = TryResolve {

--- a/crates/mako/src/visitors/virtual_css_modules.rs
+++ b/crates/mako/src/visitors/virtual_css_modules.rs
@@ -68,7 +68,7 @@ mod tests {
     }
 
     fn run(js_code: &str, auto_css_modules: bool) -> String {
-        let mut test_utils = TestUtils::gen_js_ast(js_code.to_string());
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
             let mut visitor = VirtualCSSModules { auto_css_modules };


### PR DESCRIPTION
用了 AsRef<String>  就不用写 to_string 了，lint 一直让改就改了吧


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **功能更新**
    - 在`mako` crate的`js_ast.rs`文件中，更新了在`TestUtils`结构体中的`gen_js_ast`方法，现在直接传递对`js_code`的引用而不是在传递之前将其转换为字符串。
    - 在`dynamic_import_to_require.rs`文件中的`visitors`模块中，修改了`run`函数，现在在将`js_code`传递给`gen_js_ast`之前不再进行转换为字符串的操作。

- **公开实体声明变更**
    - `mako` crate中`js_ast.rs`中的`fn run(js_code: &str) -> String` → `mako` crate中`js_ast.rs`中的`fn run(js_code: &str) -> String`
    - `dynamic_import_to_require.rs`中`mako` crate中`dynamic_import_to_require.rs`模块中的`fn run(js_code: &str) -> String` → `dynamic_import_to_require.rs`中`mako` crate中`dynamic_import_to_require.rs`模块中的`fn run(js_code: &str) -> String`


<!-- end of auto-generated comment: release notes by coderabbit.ai -->