### PR TITLE
fix: less loader worker threads not terminated by time when run e2e test

### DIFF
--- a/packages/mako/src/index.ts
+++ b/packages/mako/src/index.ts
@@ -82,14 +82,14 @@ export async function build(params: BuildParams) {
   params.config.plugins.push({
     name: 'less',
     async load(filePath: string) {
-      let lessResult = await less(filePath);
+      let lessResult = await less.render(filePath);
       if (lessResult) {
         return lessResult;
       }
     },
     generateEnd() {
       if (!params.watch) {
-        lessLoader.terminate();
+        less.terminate();
       }
     },
   });

--- a/packages/mako/src/lessLoader/parallelLessLoader.ts
+++ b/packages/mako/src/lessLoader/parallelLessLoader.ts
@@ -2,23 +2,13 @@ import path from 'path';
 import { Piscina } from 'piscina';
 import { LessLoaderOpts } from '.';
 
-const threadPool = new Piscina<
-  { filename: string; opts: LessLoaderOpts },
-  { content: string; type: 'css' }
->({
-  filename: path.resolve(__dirname + '/render.js'),
-  idleTimeout: 30000,
-  recordTiming: false,
-  useAtomics: false,
-});
-
-export async function render(
-  filename: string,
-  opts: LessLoaderOpts,
-): Promise<{ content: string; type: 'css' }> {
-  return await threadPool.run({ filename, opts });
-}
-
-export function terminatePool() {
-  threadPool.close();
-}
+export const createParallelLoader = () =>
+  new Piscina<
+    { filename: string; opts: LessLoaderOpts },
+    { content: string; type: 'css' }
+  >({
+    filename: path.resolve(__dirname + '/render.js'),
+    idleTimeout: 30000,
+    recordTiming: false,
+    useAtomics: false,
+  });


### PR DESCRIPTION
在跑 e2e 用例时 ，less loader 创建的 worker 线程会存活 30s 不按时销毁，需要把 Piscina 的 close 方法改成 destroy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在`index.ts`中的`build`函数中，`load`函数现在使用`less.render`而不是`less`，并且在`generateEnd`函数中，`lessLoader.terminate()`被替换为`less.terminate()`。

- **Bug修复**
    - 重构了`index.ts`中`lessLoader`函数的功能，现在返回一个带有`render`和`terminate`功能的对象。`parallelLessLoader`导入已更改为使用命名导入`createParallelLoader`，`lessLoader`中的逻辑已调整为创建和管理用于渲染less文件的`parallelLessLoader`实例。

- **重构**
    - 在`parallelLessLoader.ts`文件中重构线程池的创建和终止。`render`函数和`terminatePool`函数已被替换为一个新的`createParallelLoader`函数，用于初始化线程池。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->