### PR TITLE
refact: remove TODOs under build

### DIFF
--- a/crates/mako/src/build/analyze_deps.rs
+++ b/crates/mako/src/build/analyze_deps.rs
@@ -77,10 +77,8 @@ impl AnalyzeDeps {
                 .map(|dep| Self::get_resolved_error(dep, context.clone()))
                 .collect::<Vec<String>>()
                 .join("\n");
-            // TODO:
-            // should we just throw an error here and decide whether to print or exit at the upper level?
             if context.args.watch {
-                eprint!("{}", messages);
+                eprintln!("{}", messages);
             } else {
                 return Err(anyhow!(AnalyzeDepsError::ModuleNotFound {
                     message: messages

--- a/crates/mako/src/build/load.rs
+++ b/crates/mako/src/build/load.rs
@@ -67,8 +67,6 @@ export function moduleToDom(css) {
     var styleElement = document.createElement("style");
     styleElement.type = "text/css";
     styleElement.appendChild(document.createTextNode(css))
-    // TODO: support nonce
-    // styleElement.setAttribute("nonce", nonce);
     document.head.appendChild(styleElement);
 }
                                 "#
@@ -225,7 +223,6 @@ export function moduleToDom(css) {
         }
 
         // json
-        // TODO: json5 should be more complex
         if JSON_EXTENSIONS.contains(&file.extname.as_str()) {
             let content = FileSystem::read_file(&file.pathname)?;
             return Ok(Content::Js(JsContent {
@@ -267,8 +264,6 @@ export function moduleToDom(css) {
             let base64_result = file.get_base64();
             match base64_result {
                 Ok(base64) => {
-                    // TODO: why add "" wrapper here?
-                    // should have better way to handle this
                     if inject_public_path {
                         Ok(format!("\"{}\"", base64))
                     } else {
@@ -293,7 +288,6 @@ export function moduleToDom(css) {
     }
 }
 
-// TODO: move to separate module
 pub struct FileSystem {}
 
 impl FileSystem {

--- a/crates/mako/src/build/mod.rs
+++ b/crates/mako/src/build/mod.rs
@@ -94,8 +94,7 @@ impl Compiler {
             let resolved_deps = info.deps.resolved_deps.clone();
             let m = module_graph.get_module_mut(&module.id);
             if let Some(m) = m {
-                // TODO: add_info > set_info
-                m.add_info(module.info);
+                m.set_info(module.info);
             } else {
                 module_ids.insert(module.id.clone());
                 module_graph.add_module(module);
@@ -186,12 +185,9 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
         let info = ModuleInfo {
             file,
             ast,
-            // TODO: update
             external: Some(external_name),
             is_async,
             resolved_resource: Some(resolved_resource.clone()),
-            // TODO: remove
-            path,
             raw,
             ..Default::default()
         };
@@ -213,7 +209,6 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
         let info = ModuleInfo {
             file,
             ast,
-            path,
             raw,
             ..Default::default()
         };
@@ -244,7 +239,7 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
             }
         };
 
-        module.add_info(Some(info));
+        module.set_info(Some(info));
 
         module
     }
@@ -314,14 +309,11 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
             file,
             deps,
             ast,
-            // TODO: rename
             resolved_resource: parent_resource,
             source_map_chain,
             top_level_await,
             is_async,
             raw_hash,
-            // TODO: remove
-            path,
             raw,
             ..Default::default()
         };

--- a/crates/mako/src/build/parse.rs
+++ b/crates/mako/src/build/parse.rs
@@ -95,7 +95,6 @@ impl Parse {
                     // transform
                     Transform::transform(&mut ast, &file, context.clone())?;
                     // analyze_deps
-                    // TODO: do not need to resolve here
                     let deps = AnalyzeDeps::analyze_deps(&ast, &file, context.clone())?;
                     if !deps.missing_deps.is_empty() {
                         return Err(anyhow!(ParseError::InlineCSSMissingDeps {
@@ -112,7 +111,6 @@ impl Parse {
                         .join("\n");
                     let ast = ast.as_css_mut();
                     // transform (remove @imports)
-                    // TODO: Render::transform(&mut ast, &file, context.clone())?;
                     let mut css_handler = CSSImports {};
                     ast.ast.visit_mut_with(&mut css_handler);
                     // ast to code

--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -151,7 +151,6 @@ impl Transform {
                         emit_metadata: false,
                         ..Default::default()
                     })));
-                    // TODO: is it a problem to clone comments?
                     let comments = origin_comments.get_swc_comments().clone();
                     let assumptions = context.assumptions_for(file);
 

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -155,7 +155,6 @@ pub struct ModuleInfo {
     pub ast: ModuleAst,
     pub file: File,
     pub deps: AnalyzeDepsResult,
-    pub path: String,
     pub external: Option<String>,
     pub raw: String,
     pub raw_hash: u64,
@@ -176,7 +175,6 @@ impl Default for ModuleInfo {
             ast: ModuleAst::None,
             file: Default::default(),
             deps: Default::default(),
-            path: "".to_string(),
             external: None,
             raw: "".to_string(),
             raw_hash: 0,
@@ -371,7 +369,7 @@ impl Module {
         self.info.as_mut().and_then(|i| i.ast.script_mut())
     }
 
-    pub fn add_info(&mut self, info: Option<ModuleInfo>) {
+    pub fn set_info(&mut self, info: Option<ModuleInfo>) {
         self.info = info;
     }
 

--- a/crates/mako/src/plugins/farm_tree_shake/module_side_effects_flag.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/module_side_effects_flag.rs
@@ -19,7 +19,11 @@ impl ModuleInfo {
                     let root: PathBuf = root.into();
 
                     side_effects.map(|side_effect| {
-                        Self::match_flag(side_effect, relative_to_root(&self.path, &root).as_str())
+                        Self::match_flag(
+                            side_effect,
+                            relative_to_root(&self.file.path.to_string_lossy().to_string(), &root)
+                                .as_str(),
+                        )
                     })
                 }
                 None => None,
@@ -48,7 +52,11 @@ impl ModuleInfo {
 
                             Self::match_flag(
                                 side_effect,
-                                relative_to_root(&self.path, &root).as_str(),
+                                relative_to_root(
+                                    &self.file.path.to_string_lossy().to_string(),
+                                    &root,
+                                )
+                                .as_str(),
                             )
                         }
                         None => true,

--- a/crates/mako/src/plugins/farm_tree_shake/shake/find_export_source.rs
+++ b/crates/mako/src/plugins/farm_tree_shake/shake/find_export_source.rs
@@ -472,7 +472,6 @@ mod tests {
             is_entry: false,
             info: Some(ModuleInfo {
                 ast: ModuleAst::Script(ast),
-                path: "test".to_string(),
                 file,
                 ..Default::default()
             }),

--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -377,7 +377,7 @@ pub fn create_stats_info(compile_time: u128, compiler: &Compiler) -> StatsJsonMa
                                     .unwrap()
                                     .info
                                     .clone()
-                                    .map(|info| info.path)
+                                    .map(|info| info.file.path.to_string_lossy().to_string())
                                     .unwrap_or("".to_string()),
                                 // -> "lo-hi"
                                 loc: dep

--- a/e2e/fixtures/loaders/expect.js
+++ b/e2e/fixtures/loaders/expect.js
@@ -8,7 +8,7 @@ const index_css_content = files["index.css"];
 
 assert(index_js_content.includes('"foo": "json"'), "json loader");
 assert(index_js_content.includes("var _default = MDXContent;"), "md loader");
-assert(index_js_content.includes('"foo": "json5"'), "json5 loader");
+assert(index_js_content.includes('unquoted: \'and you can quote me on that\''), "json5 loader");
 assert(index_js_content.includes('"foo": "toml"'), "toml loader");
 assert(index_js_content.includes('"$value": "foo"'), "xml loader");
 assert(index_js_content.includes('"foo": "yaml"'), "yaml loader");

--- a/e2e/fixtures/loaders/src/foo.json5
+++ b/e2e/fixtures/loaders/src/foo.json5
@@ -1,4 +1,17 @@
 {
-    // foo
-    "foo": "json5"
+  // comments
+  unquoted: 'and you can quote me on that',
+  singleQuotes: 'I can use "double quotes" here',
+  lineBreaks: "Look, Mom! \
+No \\n's!",
+  hexadecimal: 0xdecaf,
+  leadingDecimalPoint: .8675309, andTrailing: 8675309.,
+  positiveSign: +1,
+  trailingComma: 'in objects', andIn: ['arrays',],
+  "backwardsCompatible": "with JSON",
+  to: Infinity,
+  to2: -Infinity,
+  "null": null,
+  "NaN" : NaN,
+  foo: '\u2028\u2029'
 }


### PR DESCRIPTION
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **功能更新**
    - 在应用程序中修改了某些输出消息的打印方式，根据`watch`标志将`eprint`函数调用更改为`eprintln`，确保当设置了watch标志时，消息会打印到错误流中并跟随一个换行符。
    - 在`build/load.rs`中删除了与nonce支持、JSON复杂性、base64包装处理和将一个结构移动到单独模块有关的TODO注释。
    - 在`build/mod.rs`文件中，为`Compiler`实现中的模块替换了`add_info`方法为`set_info`，直接在`ModuleInfo`实例化中设置了某些字段，同时移除了`path`字段。
    - 在`build/parse.rs`中，删除了与解析依赖项和转换CSS导入相关的注释行，影响了依赖项和CSS导入的控制流和处理逻辑。
    - 在`transform.rs`中，删除了与克隆注释相关的TODO注释。
    - 在`module.rs`中，移除了`ModuleInfo`结构中的`path`字段，初始化方式有所不同，还将`Module`结构中的`add_info`方法重命名为`set_info`。
    - 在`plugins/farm_tree_shake/module_side_effects_flag.rs`中，更新了传递给`ModuleInfo`实现中`match_flag`函数的参数，其中修改了`Some`和`None`情况下的参数结构。
    - 在`stats.rs`中，修改了`create_stats_info`函数中将路径映射为字符串表示的方式。
    - 在`expect.js`中更新了JSON5加载器的断言。
    - 在`foo.json5`中对JSON5文件的结构和内容进行了修改。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->