### PR TITLE
fix: checker failed when pkg don't have dependencies or devDependencies

### DIFF
--- a/packages/mako/src/checker.ts
+++ b/packages/mako/src/checker.ts
@@ -36,7 +36,7 @@ export function check(root: string) {
 }
 
 function depExists(pkg: any, name: string) {
-  return pkg.dependencies[name] || pkg.devDependencies[name];
+  return pkg.dependencies?.[name] || pkg.devDependencies?.[name];
 }
 
 function getDepVersion(root: string, name: string) {


### PR DESCRIPTION
来自用户反馈，![image](https://github.com/umijs/mako/assets/35128/157a7658-9e51-4a9e-8414-0a5455f0428f)