### PR TITLE
wip: fix: add context nanoid to avoid confusion in mutiply build in one process

### DIFF
--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -38,7 +38,7 @@ pub struct Context {
     pub resolvers: Resolvers,
     pub static_cache: RwLock<MemoryChunkFileCache>,
     pub optimize_infos: Mutex<Option<Vec<OptimizeChunksInfo>>>,
-    pub nanoid: String,
+    pub id: String,
 }
 
 #[derive(Default)]
@@ -125,7 +125,7 @@ impl Default for Context {
             resolvers,
             optimize_infos: Mutex::new(None),
             static_cache: Default::default(),
-            nanoid: nanoid!(6),
+            id: nanoid!(6),
         }
     }
 }
@@ -323,7 +323,7 @@ impl Compiler {
                 stats_info: StatsInfo::new(),
                 resolvers,
                 optimize_infos: Mutex::new(None),
-                nanoid: nanoid!(6),
+                id: nanoid!(6),
             }),
         })
     }

--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -11,6 +11,7 @@ use mako_core::swc_common::sync::Lrc;
 use mako_core::swc_common::{Globals, SourceMap, DUMMY_SP};
 use mako_core::swc_ecma_ast::Ident;
 use mako_core::tracing::debug;
+use nanoid::nanoid;
 
 use crate::ast::comments::Comments;
 use crate::config::{Config, OutputMode};
@@ -37,6 +38,7 @@ pub struct Context {
     pub resolvers: Resolvers,
     pub static_cache: RwLock<MemoryChunkFileCache>,
     pub optimize_infos: Mutex<Option<Vec<OptimizeChunksInfo>>>,
+    pub nanoid: String,
 }
 
 #[derive(Default)]
@@ -123,6 +125,7 @@ impl Default for Context {
             resolvers,
             optimize_infos: Mutex::new(None),
             static_cache: Default::default(),
+            nanoid: nanoid!(6),
         }
     }
 }
@@ -320,6 +323,7 @@ impl Compiler {
                 stats_info: StatsInfo::new(),
                 resolvers,
                 optimize_infos: Mutex::new(None),
+                nanoid: nanoid!(6),
             }),
         })
     }

--- a/crates/mako/src/generate/chunk_pot/ast_impl.rs
+++ b/crates/mako/src/generate/chunk_pot/ast_impl.rs
@@ -33,7 +33,7 @@ use crate::generate::transform::transform_css_generate;
     type = "SizedCache<String , ChunkFile>",
     create = "{ SizedCache::with_size(500) }",
     key = "String",
-    convert = r#"{format!("{}.{}.{:x}",context.nanoid, chunk_pot.chunk_id,chunk_pot.stylesheet.as_ref().unwrap().raw_hash)}"#
+    convert = r#"{format!("{}.{}.{:x}",context.id, chunk_pot.chunk_id,chunk_pot.stylesheet.as_ref().unwrap().raw_hash)}"#
 )]
 pub(crate) fn render_css_chunk(
     chunk_pot: &ChunkPot,
@@ -123,7 +123,7 @@ pub(crate) fn render_css_chunk(
     type = "SizedCache<String , ChunkFile>",
     create = "{ SizedCache::with_size(500) }",
     key = "String",
-    convert = r#"{format!("{}.{}.{:x}", context.nanoid, chunk_pot.chunk_id, chunk_pot.js_hash)}"#
+    convert = r#"{format!("{}.{}.{:x}", context.id, chunk_pot.chunk_id, chunk_pot.js_hash)}"#
 )]
 pub(crate) fn render_normal_js_chunk(
     chunk_pot: &ChunkPot,
@@ -210,7 +210,7 @@ pub(crate) fn render_entry_js_chunk(
 #[cached(
     result = true,
     key = "String",
-    convert = r#"{format!("{}.{}", context.nanoid, pot.js_hash)}"#
+    convert = r#"{format!("{}.{}", context.id, pot.js_hash)}"#
 )]
 fn render_entry_chunk_js_without_full_hash(
     pot: &ChunkPot,

--- a/crates/mako/src/generate/chunk_pot/ast_impl.rs
+++ b/crates/mako/src/generate/chunk_pot/ast_impl.rs
@@ -33,7 +33,7 @@ use crate::generate::transform::transform_css_generate;
     type = "SizedCache<String , ChunkFile>",
     create = "{ SizedCache::with_size(500) }",
     key = "String",
-    convert = r#"{format!("{}.{:x}",chunk_pot.chunk_id,chunk_pot.stylesheet.as_ref().unwrap().raw_hash)}"#
+    convert = r#"{format!("{}.{}.{:x}",context.nanoid, chunk_pot.chunk_id,chunk_pot.stylesheet.as_ref().unwrap().raw_hash)}"#
 )]
 pub(crate) fn render_css_chunk(
     chunk_pot: &ChunkPot,
@@ -123,7 +123,7 @@ pub(crate) fn render_css_chunk(
     type = "SizedCache<String , ChunkFile>",
     create = "{ SizedCache::with_size(500) }",
     key = "String",
-    convert = r#"{format!("{}.{:x}", chunk_pot.chunk_id, chunk_pot.js_hash)}"#
+    convert = r#"{format!("{}.{}.{:x}", context.nanoid, chunk_pot.chunk_id, chunk_pot.js_hash)}"#
 )]
 pub(crate) fn render_normal_js_chunk(
     chunk_pot: &ChunkPot,
@@ -210,7 +210,7 @@ pub(crate) fn render_entry_js_chunk(
 #[cached(
     result = true,
     key = "String",
-    convert = r#"{format!("{}",pot.js_hash)}"#
+    convert = r#"{format!("{}.{}", context.nanoid, pot.js_hash)}"#
 )]
 fn render_entry_chunk_js_without_full_hash(
     pot: &ChunkPot,

--- a/crates/mako/src/generate/chunk_pot/str_impl.rs
+++ b/crates/mako/src/generate/chunk_pot/str_impl.rs
@@ -106,7 +106,7 @@ pub(super) fn render_entry_js_chunk(
     type = "SizedCache<String , ChunkFile>",
     create = "{ SizedCache::with_size(500) }",
     key = "String",
-    convert = r#"{format!("{}.{}.{:x}", context.nanoid, chunk_pot.chunk_id, chunk_pot.js_hash)}"#
+    convert = r#"{format!("{}.{}.{:x}", context.id, chunk_pot.chunk_id, chunk_pot.js_hash)}"#
 )]
 pub(super) fn render_normal_js_chunk(
     chunk_pot: &ChunkPot,
@@ -155,7 +155,7 @@ type EmittedWithMapping = (String, Option<Vec<(BytePos, LineCol)>>);
     key = "String",
     type = "SizedCache<String , EmittedWithMapping>",
     create = "{ SizedCache::with_size(20000) }",
-    convert = r#"{format!("{}-{}-{}", context.nanoid, _raw_hash, module_id)}"#
+    convert = r#"{format!("{}-{}-{}", context.id, _raw_hash, module_id)}"#
 )]
 fn emit_module_with_mapping(
     module_id: &str,

--- a/crates/mako/src/generate/chunk_pot/str_impl.rs
+++ b/crates/mako/src/generate/chunk_pot/str_impl.rs
@@ -106,7 +106,7 @@ pub(super) fn render_entry_js_chunk(
     type = "SizedCache<String , ChunkFile>",
     create = "{ SizedCache::with_size(500) }",
     key = "String",
-    convert = r#"{format!("{}.{:x}", chunk_pot.chunk_id, chunk_pot.js_hash)}"#
+    convert = r#"{format!("{}.{}.{:x}", context.nanoid, chunk_pot.chunk_id, chunk_pot.js_hash)}"#
 )]
 pub(super) fn render_normal_js_chunk(
     chunk_pot: &ChunkPot,
@@ -155,7 +155,7 @@ type EmittedWithMapping = (String, Option<Vec<(BytePos, LineCol)>>);
     key = "String",
     type = "SizedCache<String , EmittedWithMapping>",
     create = "{ SizedCache::with_size(20000) }",
-    convert = r#"{format!("{}-{}", _raw_hash, module_id)}"#
+    convert = r#"{format!("{}-{}-{}", context.nanoid, _raw_hash, module_id)}"#
 )]
 fn emit_module_with_mapping(
     module_id: &str,

--- a/crates/mako/src/visitors/optimize_package_imports.rs
+++ b/crates/mako/src/visitors/optimize_package_imports.rs
@@ -201,7 +201,7 @@ fn build_import_stmts(
 #[cached(
     result = true,
     key = "String",
-    convert = r#"{ format!("{:?}_{:}", resource.get_resolved_path(), exports_all) }"#
+    convert = r#"{ format!("{}_{:?}_{:}", context.nanoid, resource.get_resolved_path(), exports_all) }"#
 )]
 fn parse_barrel_file(
     resource: &ResolverResource,

--- a/crates/mako/src/visitors/optimize_package_imports.rs
+++ b/crates/mako/src/visitors/optimize_package_imports.rs
@@ -201,7 +201,7 @@ fn build_import_stmts(
 #[cached(
     result = true,
     key = "String",
-    convert = r#"{ format!("{}_{:?}_{:}", context.nanoid, resource.get_resolved_path(), exports_all) }"#
+    convert = r#"{ format!("{}_{:?}_{:}", context.id, resource.get_resolved_path(), exports_all) }"#
 )]
 fn parse_barrel_file(
     resource: &ResolverResource,


### PR DESCRIPTION
add context nanoid to avoid confusion in mutiply build in one process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能变更**
    - 在`compiler.rs`文件中增加了`nanoid::nanoid`的引入，并在`Context`和`Compiler`结构体中增加了类型为`String`的`nanoid`字段，初始化为`nanoid!(6)`。
    - 在`ast_impl.rs`文件的`render_css_chunk`、`render_normal_js_chunk`和`render_entry_chunk_js_without_full_hash`函数中更新了`convert`字段，包含了`context.id`在格式化中的应用。
    - 在`str_impl.rs`文件的`render_entry_js_chunk`和`emit_module_with_mapping`函数中，更新了`convert`函数，将`context.id`包含在格式化字符串中。
    - 在`optimize_package_imports.rs`文件的`build_import_stmts`函数中，修改了与构建导入语句相关的函数的缓存转换逻辑，现在在转换过程中包含了上下文标识符。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->