### PR TITLE
fix: hmr static server not response correct content-type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,10 +2094,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-staticfile"
-version = "0.9.5"
+name = "hyper-staticfile-jsutf8"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318ca89e4827e7fe4ddd2824f52337239796ae8ecc761a663324407dc3d8d7e7"
+checksum = "8898514e9a3bbf3f8dfe272e527e0742871fabf45359b897e3cfd1d7feb09e89"
 dependencies = [
  "futures-util",
  "http",
@@ -2667,7 +2667,7 @@ dependencies = [
  "futures",
  "glob",
  "hyper",
- "hyper-staticfile",
+ "hyper-staticfile-jsutf8",
  "hyper-tungstenite",
  "indexmap 2.2.6",
  "md5",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -47,48 +47,48 @@ swc_emotion         = "0.51.0"
 swc_error_reporters = "0.16.1"
 swc_node_comments   = "0.19.1"
 
-anyhow                = "1.0.71"
-base64                = "0.21.2"
-cached                = { workspace = true }
-clap                  = { version = "4.3.11", features = ["derive"] }
-colored               = "2"
-config                = "0.13.3"
-convert_case          = "0.6.0"
-eframe                = { version = "0.22.0", optional = true }
-fs_extra              = "1.3.0"
-futures               = "0.3.28"
-glob                  = "0.3.1"
-hyper                 = { version = "0.14.27", features = ["full"] }
-hyper-staticfile      = "0.9.5"
-hyper-tungstenite     = "0.10.0"
-indexmap              = "2.0.0"
-md5                   = "0.7.0"
-mdxjs                 = "0.1.14"
-merge-source-map      = "1.2.0"
-mime_guess            = "2.0.4"
-notify                = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
-notify-debouncer-full = { version = "0.3.1", default-features = false }
-path-clean            = "1.0.1"
-pathdiff              = "0.2.1"
-petgraph              = "0.6.3"
-puffin                = { version = "0.16.0", optional = true }
-puffin_egui           = { version = "0.22.0", optional = true }
-rayon                 = "1.7.0"
-regex                 = "1.9.3"
-sailfish              = "0.8.3"
-serde                 = { workspace = true }
-serde-xml-rs          = "0.6.0"
-serde_json            = { workspace = true }
-serde_yaml            = "0.9.22"
-svgr-rs               = "0.1.3"
-thiserror             = "1.0.43"
-tokio                 = { version = "1", features = ["rt-multi-thread", "sync"] }
-tokio-tungstenite     = "0.19.0"
-toml                  = "0.7.6"
-tracing               = "0.1.37"
-tracing-subscriber    = { version = "0.3.17", features = ["env-filter"] }
-tungstenite           = "0.19.0"
-twox-hash             = "1.6.3"
+anyhow                  = "1.0.71"
+base64                  = "0.21.2"
+cached                  = { workspace = true }
+clap                    = { version = "4.3.11", features = ["derive"] }
+colored                 = "2"
+config                  = "0.13.3"
+convert_case            = "0.6.0"
+eframe                  = { version = "0.22.0", optional = true }
+fs_extra                = "1.3.0"
+futures                 = "0.3.28"
+glob                    = "0.3.1"
+hyper                   = { version = "0.14.27", features = ["full"] }
+hyper-staticfile-jsutf8 = "0.0.1"
+hyper-tungstenite       = "0.10.0"
+indexmap                = "2.0.0"
+md5                     = "0.7.0"
+mdxjs                   = "0.1.14"
+merge-source-map        = "1.2.0"
+mime_guess              = "2.0.4"
+notify                  = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
+notify-debouncer-full   = { version = "0.3.1", default-features = false }
+path-clean              = "1.0.1"
+pathdiff                = "0.2.1"
+petgraph                = "0.6.3"
+puffin                  = { version = "0.16.0", optional = true }
+puffin_egui             = { version = "0.22.0", optional = true }
+rayon                   = "1.7.0"
+regex                   = "1.9.3"
+sailfish                = "0.8.3"
+serde                   = { workspace = true }
+serde-xml-rs            = "0.6.0"
+serde_json              = { workspace = true }
+serde_yaml              = "0.9.22"
+svgr-rs                 = "0.1.3"
+thiserror               = "1.0.43"
+tokio                   = { version = "1", features = ["rt-multi-thread", "sync"] }
+tokio-tungstenite       = "0.19.0"
+toml                    = "0.7.6"
+tracing                 = "0.1.37"
+tracing-subscriber      = { version = "0.3.17", features = ["env-filter"] }
+tungstenite             = "0.19.0"
+twox-hash               = "1.6.3"
 
 [features]
 profile = ["dep:eframe", "dep:puffin", "dep:puffin_egui"]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,7 +22,7 @@ pub use swc_core::ecma::{
 };
 pub use {
     anyhow, base64, cached, clap, colored, config, convert_case, fs_extra, futures, glob, hyper,
-    hyper_staticfile, hyper_tungstenite, indexmap, md5, mdxjs, merge_source_map, mime_guess,
+    hyper_staticfile_jsutf8, hyper_tungstenite, indexmap, md5, mdxjs, merge_source_map, mime_guess,
     notify, notify_debouncer_full, path_clean, pathdiff, petgraph, rayon, regex, sailfish, serde,
     serde_json, serde_xml_rs, serde_yaml, svgr_rs, swc_emotion, swc_error_reporters,
     swc_node_comments, thiserror, tokio, tokio_tungstenite, toml, tracing, tracing_subscriber,

--- a/crates/mako/src/dev/mod.rs
+++ b/crates/mako/src/dev/mod.rs
@@ -17,7 +17,7 @@ use mako_core::notify_debouncer_full::new_debouncer;
 use mako_core::tokio::sync::broadcast;
 use mako_core::tracing::debug;
 use mako_core::tungstenite::Message;
-use mako_core::{hyper, hyper_staticfile, hyper_tungstenite};
+use mako_core::{hyper, hyper_staticfile_jsutf8, hyper_tungstenite};
 use open;
 
 use crate::compiler::{Compiler, Context};
@@ -76,8 +76,9 @@ impl DevServer {
                     Ok::<_, hyper::Error>(service_fn(move |req| {
                         let context = context.clone();
                         let txws = txws.clone();
-                        let staticfile =
-                            hyper_staticfile::Static::new(context.config.output.path.clone());
+                        let staticfile = hyper_staticfile_jsutf8::Static::new(
+                            context.config.output.path.clone(),
+                        );
                         async move { Self::handle_requests(req, context, staticfile, txws).await }
                     }))
                 }
@@ -122,7 +123,7 @@ impl DevServer {
     async fn handle_requests(
         req: Request<Body>,
         context: Arc<Context>,
-        staticfile: hyper_staticfile::Static,
+        staticfile: hyper_staticfile_jsutf8::Static,
         txws: broadcast::Sender<WsMessage>,
     ) -> Result<hyper::Response<Body>> {
         let path = req.uri().path();


### PR DESCRIPTION
Fix the garbled text issue caused by the missing "charset=utf-8" in the Content-Type response header of JS files by the HMR static server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 在应用程序中添加了一个新的依赖项 `hyper-staticfile-jsutf8`。
    - 在 `crates/mako` 包中更新了 `hyper_staticfile` 为 `hyper_staticfile_jsutf8`。
- **更改的导出或公共实体声明**
    - `hyper_staticfile` → `hyper_staticfile_jsutf8`


<!-- end of auto-generated comment: release notes by coderabbit.ai -->