### PR TITLE
fix: hmr static server not response correct content-type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,10 +2094,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-staticfile"
-version = "0.9.5"
+name = "hyper-staticfile-jsutf8"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318ca89e4827e7fe4ddd2824f52337239796ae8ecc761a663324407dc3d8d7e7"
+checksum = "8898514e9a3bbf3f8dfe272e527e0742871fabf45359b897e3cfd1d7feb09e89"
 dependencies = [
  "futures-util",
  "http",
@@ -2629,7 +2629,7 @@ dependencies = [
  "glob-match",
  "heck",
  "hyper",
- "hyper-staticfile",
+ "hyper-staticfile-jsutf8",
  "hyper-tungstenite",
  "indexmap 2.2.6",
  "insta",

--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -71,45 +71,45 @@ swc_emotion         = "0.51.0"
 swc_error_reporters = "0.16.1"
 swc_node_comments   = "0.19.1"
 
-anyhow                = "1.0.71"
-base64                = "0.21.2"
-clap                  = { version = "4.3.11", features = ["derive"] }
-colored               = "2"
-config                = "0.13.3"
-convert_case          = "0.6.0"
-eframe                = { version = "0.22.0", optional = true }
-fs_extra              = "1.3.0"
-futures               = "0.3.28"
-glob                  = "0.3.1"
-hyper                 = { version = "0.14.27", features = ["full"] }
-hyper-staticfile      = "0.9.5"
-hyper-tungstenite     = "0.10.0"
-indexmap              = "2.0.0"
-md5                   = "0.7.0"
-mdxjs                 = "0.1.14"
-merge-source-map      = "1.2.0"
-mime_guess            = "2.0.4"
-notify                = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
-notify-debouncer-full = { version = "0.3.1", default-features = false }
-path-clean            = "1.0.1"
-pathdiff              = "0.2.1"
-petgraph              = "0.6.3"
-puffin                = { version = "0.16.0", optional = true }
-puffin_egui           = { version = "0.22.0", optional = true }
-rayon                 = "1.7.0"
-regex                 = "1.9.3"
-sailfish              = "0.8.3"
-serde-xml-rs          = "0.6.0"
-serde_yaml            = "0.9.22"
-svgr-rs               = "0.1.3"
-thiserror             = "1.0.43"
-tokio                 = { version = "1", features = ["rt-multi-thread", "sync"] }
-tokio-tungstenite     = "0.19.0"
-toml                  = "0.7.6"
-tracing               = "0.1.37"
-tracing-subscriber    = { version = "0.3.17", features = ["env-filter"] }
-tungstenite           = "0.19.0"
-twox-hash             = "1.6.3"
+anyhow                  = "1.0.71"
+base64                  = "0.21.2"
+clap                    = { version = "4.3.11", features = ["derive"] }
+colored                 = "2"
+config                  = "0.13.3"
+convert_case            = "0.6.0"
+eframe                  = { version = "0.22.0", optional = true }
+fs_extra                = "1.3.0"
+futures                 = "0.3.28"
+glob                    = "0.3.1"
+hyper                   = { version = "0.14.27", features = ["full"] }
+hyper-staticfile-jsutf8 = "0.0.1"
+hyper-tungstenite       = "0.10.0"
+indexmap                = "2.0.0"
+md5                     = "0.7.0"
+mdxjs                   = "0.1.14"
+merge-source-map        = "1.2.0"
+mime_guess              = "2.0.4"
+notify                  = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
+notify-debouncer-full   = { version = "0.3.1", default-features = false }
+path-clean              = "1.0.1"
+pathdiff                = "0.2.1"
+petgraph                = "0.6.3"
+puffin                  = { version = "0.16.0", optional = true }
+puffin_egui             = { version = "0.22.0", optional = true }
+rayon                   = "1.7.0"
+regex                   = "1.9.3"
+sailfish                = "0.8.3"
+serde-xml-rs            = "0.6.0"
+serde_yaml              = "0.9.22"
+svgr-rs                 = "0.1.3"
+thiserror               = "1.0.43"
+tokio                   = { version = "1", features = ["rt-multi-thread", "sync"] }
+tokio-tungstenite       = "0.19.0"
+toml                    = "0.7.6"
+tracing                 = "0.1.37"
+tracing-subscriber      = { version = "0.3.17", features = ["env-filter"] }
+tungstenite             = "0.19.0"
+twox-hash               = "1.6.3"
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 mimalloc-rust = { workspace = true }

--- a/crates/mako/src/dev/mod.rs
+++ b/crates/mako/src/dev/mod.rs
@@ -17,7 +17,7 @@ use notify_debouncer_full::new_debouncer;
 use tokio::sync::broadcast;
 use tracing::debug;
 use tungstenite::Message;
-use {hyper, hyper_staticfile, hyper_tungstenite, open};
+use {hyper, hyper_staticfile_jsutf8, hyper_tungstenite, open};
 
 use crate::compiler::{Compiler, Context};
 use crate::plugin::{PluginGenerateEndParams, PluginGenerateStats};
@@ -75,8 +75,9 @@ impl DevServer {
                     Ok::<_, hyper::Error>(service_fn(move |req| {
                         let context = context.clone();
                         let txws = txws.clone();
-                        let staticfile =
-                            hyper_staticfile::Static::new(context.config.output.path.clone());
+                        let staticfile = hyper_staticfile_jsutf8::Static::new(
+                            context.config.output.path.clone(),
+                        );
                         async move { Self::handle_requests(req, context, staticfile, txws).await }
                     }))
                 }
@@ -121,7 +122,7 @@ impl DevServer {
     async fn handle_requests(
         req: Request<Body>,
         context: Arc<Context>,
-        staticfile: hyper_staticfile::Static,
+        staticfile: hyper_staticfile_jsutf8::Static,
         txws: broadcast::Sender<WsMessage>,
     ) -> Result<hyper::Response<Body>> {
         let path = req.uri().path();

--- a/examples/normal/app.tsx
+++ b/examples/normal/app.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const Test = () => {
+  return (
+    <div>
+      <h1>中文中文</h1>
+      <h1>Hello World!</h1>
+    </div>
+  );
+};

--- a/examples/normal/index.tsx
+++ b/examples/normal/index.tsx
@@ -6,11 +6,13 @@ import Person, { ReactComponent as PersonComponent } from './assets/person.svg';
 import UmiLogo from './assets/umi-logo.png';
 import { foo } from './foo';
 import './index.css';
+import { Test } from './app';
 import styles from './style.module.css';
 
 function App() {
   return (
     <div>
+      <Test></Test>
       <h1 className={styles.title}>Hello {foo}!</h1>
       <PersonComponent width="40px" height="40px" />
       <img src={Person} />

--- a/examples/normal/mako.config.json
+++ b/examples/normal/mako.config.json
@@ -1,5 +1,6 @@
 {
-  "devtool": "source-map",
-  "stats": true,
-  "hash": true
+  "devServer": {
+    "host": "127.0.0.1",
+    "port": 3000
+  }
 }


### PR DESCRIPTION
Fix the garbled text issue caused by the missing "charset=utf-8" in the Content-Type response header of JS files by the HMR static server.

- replace hyper-staticfile to hyper-staticfile-jsutf8
- add hmr test case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 更新了`mako`包的依赖版本，包括`hyper-staticfile`、`colored`和`hyper`等。新增了一个名为`hyper-staticfile-jsutf8`的依赖项。
    - 引入了React组件`Test`，在`app.tsx`文件中渲染两个`<h1>`元素，一个展示“中文中文”，另一个展示“Hello World!”。
    - 将配置设置从顶层键移到嵌套的`devServer`对象中，特别是将`devtool`、`stats`和`hash`设置移到`devServer`中的`host`和`port`设置中。
- **修复问题**
    - 修复了`scripts/test-hmr.mjs`中JavaScript文件响应的内容类型检查问题，确保在热更新场景下匹配预期值。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->