### PR TITLE
feat: 完成 analyze-watch 功能

### DIFF
--- a/client/index.tsx
+++ b/client/index.tsx
@@ -14,7 +14,6 @@ function App() {
   // ref 用于保存Treemap实例
   const treeMapRef = useRef(null);
   const [chartData, setChartData] = useState('');
-
   // toolTip展示使用
   const [tooltipContent, setToolTipContent] = useState('');
   const createModulesTree = (modules) => {

--- a/client/mako.config.json
+++ b/client/mako.config.json
@@ -1,3 +1,8 @@
 {
-  "devtool": false
+  "devtool": "source-map",
+  "stats": { "modules": true },
+  "hash": true,
+  "analyze": {
+    "watch": true
+  }
 }

--- a/client/mako.config.json
+++ b/client/mako.config.json
@@ -1,8 +1,3 @@
 {
-  "devtool": "source-map",
-  "stats": { "modules": true },
-  "hash": true,
-  "analyze": {
-    "watch": true
-  }
+  "devtool": false
 }

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -200,7 +200,9 @@ pub struct StatsConfig {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct AnalyzeConfig {}
+pub struct AnalyzeConfig {
+    pub watch: Option<bool>,
+}
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum CodeSplittingStrategy {

--- a/crates/mako/src/dev/mod.rs
+++ b/crates/mako/src/dev/mod.rs
@@ -77,7 +77,6 @@ impl DevServer {
                         let context = context.clone();
                         let txws = txws.clone();
                         let compile = compiler.clone();
-
                         let staticfile = hyper_staticfile_jsutf8::Static::new(
                             context.config.output.path.clone(),
                         );

--- a/crates/mako/src/generate/analyze.rs
+++ b/crates/mako/src/generate/analyze.rs
@@ -10,6 +10,12 @@ pub struct Analyze {}
 
 impl Analyze {
     pub fn write_analyze(stats: &StatsJsonMap, context: Arc<Context>) -> Result<()> {
+        let analyze = context.config.analyze.clone().unwrap();
+        let mut is_watch = false;
+        if analyze.watch.is_some() && analyze.watch.unwrap() {
+            is_watch = true;
+        }
+
         let stats_json = serde_json::to_string_pretty(&stats).unwrap();
         let html_str = format!(
             r#"<!DOCTYPE html>
@@ -23,12 +29,14 @@ impl Analyze {
     <div id="root"></div>
     <script>
       window.chartData = {};
+      window.hmrWatch = {}
     </script>
     <script>{}</script>
   </body>
 </html>"#,
             include_str!("../../../../client/dist/index.css"),
             stats_json,
+            is_watch,
             include_str!("../../../../client/dist/index.js").replace("</script>", "<\\/script>")
         );
         let report_path = context.config.output.path.join("report.html");


### PR DESCRIPTION
feat: 完成 analyze-watch 功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **新功能**
    - 为FoamTree添加了一个新函数`getFoamTreeData`来处理`chartData`。
    - 添加了处理WebSocket消息更新`chartData`的条件。
    - 添加了用于故障排除的调试器。
    - 更新了处理图表数据更新和重新渲染的逻辑。

- **导出或公共实体声明的变更**
    - 在`client/index.tsx`中的`function getFoamTreeData(chartData: any)`中添加了`getFoamTreeData`函数来处理FoamTree的`chartData`。

- **配置更改**
    - 在`crates/mako/src/config/config.rs`的`AnalyzeConfig`结构中添加了一个类型为`Option<bool>`的新字段`watch`。

- **开发工具**
    - 在`crates/mako/src/dev/mod.rs`的`DevServer`模块中进行了以下更改：
        - 从`crate::stats`中添加了一个新的导入语句`create_stats_info`。
        - 在`handle_requests`方法中添加了一个新的`compiler`声明。
        - 添加了用于处理WebSocket统计数据的新方法`handle_websocket_stats_data`。
        - 添加了在代码的各个部分创建并发送统计数据到WebSocket的逻辑。

- **生成分析**
    - 在`crates/mako/src/generate/analyze.rs`中，`Analyze`结构体内的`write_analyze`方法已更新，包括处理基于`analyze.watch`配置的布尔标志`is_watch`的逻辑。此外，`html_str`生成现在在模板中包含`is_watch`。
    - 在`crates/mako/src/generate/analyze.rs`的`struct Analyze`中的`pub fn write_analyze(stats: &StatsJsonMap, context: Arc<Context>) -> Result<()>`中：
        - 添加了处理`analyze.watch`配置的`is_watch`的逻辑。
        - 更新了`html_str`生成以在模板中包含`is_watch`。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->