### PR TITLE
fix: aci

### DIFF
--- a/e2e/fixtures.umi/config.babel-plugin-import/.umirc.ts
+++ b/e2e/fixtures.umi/config.babel-plugin-import/.umirc.ts
@@ -1,5 +1,6 @@
 export default {
   mfsu: false,
+  mako: {},
   extraBabelPlugins: [
     [
       require.resolve('babel-plugin-import'),

--- a/e2e/fixtures.umi/config.define/.umirc.ts
+++ b/e2e/fixtures.umi/config.define/.umirc.ts
@@ -1,5 +1,6 @@
 export default {
   mfsu: false,
+  mako: {},
   define: {
     AAA: "aaa",
     BBB: {

--- a/e2e/fixtures.umi/config.externals/.umirc.ts
+++ b/e2e/fixtures.umi/config.externals/.umirc.ts
@@ -1,5 +1,6 @@
 export default {
   mfsu: false,
+  mako: {},
   externals: {
     antd1: 'window antd1',
     antd2: 'window.antd2',

--- a/e2e/fixtures.umi/config.flex-bugs.default.true/.umirc.ts
+++ b/e2e/fixtures.umi/config.flex-bugs.default.true/.umirc.ts
@@ -1,1 +1,1 @@
-export default { mfsu: false };
+export default { mfsu: false, mako: {} };

--- a/e2e/fixtures.umi/config.less.math/.umirc.ts
+++ b/e2e/fixtures.umi/config.less.math/.umirc.ts
@@ -1,5 +1,6 @@
 export default {
   mfsu: false,
+  mako: {},
   lessLoader: {
     math: 'always',
   },

--- a/e2e/fixtures.umi/config.less.modifyVars/.umirc.ts
+++ b/e2e/fixtures.umi/config.less.modifyVars/.umirc.ts
@@ -1,5 +1,6 @@
 export default {
   mfsu: false,
+  mako: {},
   theme: {
     '@primary-color': 'red',
   },

--- a/e2e/fixtures.umi/config.less.plugins/.umirc.ts
+++ b/e2e/fixtures.umi/config.less.plugins/.umirc.ts
@@ -1,5 +1,6 @@
 export default {
   mfsu: false,
+  mako: {},
   lessLoader: {
     plugins: [
       [require.resolve("less-plugin-clean-css"), { roundingPrecision: 1 }]

--- a/e2e/fixtures.umi/emotion/.umirc.ts
+++ b/e2e/fixtures.umi/emotion/.umirc.ts
@@ -1,5 +1,6 @@
 export default {
   mfsu: false,
+  mako: {},
   extraBabelPlugins: [
     '@emotion',
   ],

--- a/e2e/fixtures.umi/plugin.api.on-dev-compile-done/.umirc.ts
+++ b/e2e/fixtures.umi/plugin.api.on-dev-compile-done/.umirc.ts
@@ -1,4 +1,5 @@
 
 export default {
+  mako: {},
   mfsu: false,
 }

--- a/e2e/fixtures.umi/react-16/.umirc.ts
+++ b/e2e/fixtures.umi/react-16/.umirc.ts
@@ -1,3 +1,4 @@
 export default {
+  mako: {},
   mfsu: false,
 };


### PR DESCRIPTION
umi 4.3.0 需要主动开启 mako 配置才会读取环境变量

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
    - 在配置文件中添加了一个空对象`mako`，并将`mfsu`设置为`false`。
    - 向导出的配置对象中添加了`mako`键下的空对象。
    - 在配置文件的`externals`部分中添加了一个空对象`mako`，同时将`mfsu`设置为`false`。
    - 在导出的配置对象中添加了一个空对象`mako`。
    - 在配置中添加了一个空对象`mako`，同时将`mfsu`设置为`false`。
    - 向导出的配置对象中添加了一个空对象`mako`。
    - 在配置中添加了一个空对象`mako`，将`mfsu`设置为`false`，并配置了`lessLoader`。
    - 向默认导出对象中添加了一个空对象`mako`。
    - 向默认导出对象中添加了一个空对象`mako`，同时增加了一项`@emotion`配置。
    - 向默认导出对象中添加了一个空对象`mako`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->