### PR TITLE
fix: file size unit

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -447,7 +447,7 @@ pub fn write_stats(stats: &StatsJsonMap, compiler: &Compiler) {
 
 // 文件大小转换
 pub fn human_readable_size(size: u64) -> String {
-    let units = ["kB", "mB", "gB"];
+    let units = ["kB", "MB", "GB"];
     // 把 B 转为 KB
     let mut size = (size as f64) / 1000.0;
     let mut i = 0;

--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -447,7 +447,7 @@ pub fn write_stats(stats: &StatsJsonMap, compiler: &Compiler) {
 
 // 文件大小转换
 pub fn human_readable_size(size: u64) -> String {
-    let units = ["kB", "MB", "GB"];
+    let units = ["kB", "mB", "gB"];
     // 把 B 转为 KB
     let mut size = (size as f64) / 1000.0;
     let mut i = 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **功能更新**
    - 更新了`human_readable_size`函数中用于人类可读大小转换的单位，从"kB"、"mB"、"gB"调整为"kB"、"MB"、"GB"。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->