### PR TITLE
fix: typos

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -442,7 +442,7 @@ async function getMakoConfig(opts) {
     inlineCSS,
     makoPlugins,
   } = opts.config;
-  let { codeSplitting } = opts.config.codeSplitting;
+  let { codeSplitting } = opts.config;
   // TODO:
   // 暂不支持 $ 结尾，等 resolve 支持后可以把这段去掉
   Object.keys(alias).forEach((key) => {


### PR DESCRIPTION
低级错误...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **代码优化**
	- 简化了`getMakoConfig`函数中从`opts.config`中解构`codeSplitting`的过程，去除了不必要的嵌套解构，简化了代码逻辑。
	- 修改了`packages/bundler-mako/index.js`中导出或公共实体的声明。
		- `async function getMakoConfig(opts)`：
			- 修改前：`let { codeSplitting } = opts.config.codeSplitting;`
			- 修改后：`let { codeSplitting } = opts.config;`


<!-- end of auto-generated comment: release notes by coderabbit.ai -->