### PR TITLE
feat: px2rem support selectorDoubleRemList

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -117,7 +117,7 @@ pub struct BuildParams {
         propWhiteList?: string[];
         selectorBlackList?: string[];
         selectorWhiteList?: string[];
-        selectorDoubleRemList?: string[];
+        selectorDoubleList?: string[];
     };
     stats?: boolean;
     hash?: boolean;

--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -117,6 +117,7 @@ pub struct BuildParams {
         propWhiteList?: string[];
         selectorBlackList?: string[];
         selectorWhiteList?: string[];
+        selectorDoubleRemList?: string[];
     };
     stats?: boolean;
     hash?: boolean;

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -245,8 +245,8 @@ pub struct Px2RemConfig {
     pub selector_blacklist: Vec<String>,
     #[serde(rename = "selectorWhiteList", default)]
     pub selector_whitelist: Vec<String>,
-    #[serde(rename = "selectorDoubleRemList", default)]
-    pub selector_doubleremlist: Vec<String>,
+    #[serde(rename = "selectorDoubleList", default)]
+    pub selector_doublelist: Vec<String>,
     #[serde(rename = "minPixelValue", default)]
     pub min_pixel_value: f64,
 }
@@ -259,7 +259,7 @@ impl Default for Px2RemConfig {
             prop_whitelist: vec![],
             selector_blacklist: vec![],
             selector_whitelist: vec![],
-            selector_doubleremlist: vec![],
+            selector_doublelist: vec![],
             min_pixel_value: 0.0,
         }
     }

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -245,6 +245,8 @@ pub struct Px2RemConfig {
     pub selector_blacklist: Vec<String>,
     #[serde(rename = "selectorWhiteList", default)]
     pub selector_whitelist: Vec<String>,
+    #[serde(rename = "selectorDoubleRemList", default)]
+    pub selector_doubleremlist: Vec<String>,
     #[serde(rename = "minPixelValue", default)]
     pub min_pixel_value: f64,
 }
@@ -257,6 +259,7 @@ impl Default for Px2RemConfig {
             prop_whitelist: vec![],
             selector_blacklist: vec![],
             selector_whitelist: vec![],
+            selector_doubleremlist: vec![],
             min_pixel_value: 0.0,
         }
     }

--- a/crates/mako/src/visitors/css_px2rem.rs
+++ b/crates/mako/src/visitors/css_px2rem.rs
@@ -618,16 +618,6 @@ mod tests {
             ),
             r#".a{width:2rem}"#
         );
-        assert_eq!(
-            run(
-                r#".a-a{width:100px;}"#,
-                Px2RemConfig {
-                    selector_doublelist: vec![r#"/\.a-/"#.to_string()],
-                    ..Default::default()
-                }
-            ),
-            r#".a-a{width:2rem}"#
-        );
     }
 
     fn run_with_default(css_code: &str) -> String {

--- a/docs/config.md
+++ b/docs/config.md
@@ -495,7 +495,7 @@ publicPath configuration. Note: There is a special value `"runtime"`, which mean
 
 ### px2rem
 
-- Type: `false | { root?: number, propBlackList?: string[], propWhiteList?: string[], selectorBlackList?: string[], selectorWhiteList?: string[], selectorDoubleRemList?: string[], minPixelValue?: number }`
+- Type: `false | { root?: number, propBlackList?: string[], propWhiteList?: string[], selectorBlackList?: string[], selectorWhiteList?: string[], selectorDoubleList?: string[], minPixelValue?: number }`
 - Default: `false`
 
 Whether to enable px2rem conversion.
@@ -505,7 +505,7 @@ Whether to enable px2rem conversion.
 - `propWhiteList`, property white list
 - `selectorBlackList`, selector black list
 - `selectorWhiteList`, selector white list
-- `selectorDoubleRemList`, selector double rem list
+- `selectorDoubleList`, selector double rem list
 - `minPixelValue`，minimum pixel value, default is `0`
 
 ### react

--- a/docs/config.md
+++ b/docs/config.md
@@ -495,7 +495,7 @@ publicPath configuration. Note: There is a special value `"runtime"`, which mean
 
 ### px2rem
 
-- Type: `false | { root?: number, propBlackList?: string[], propWhiteList?: string[], selectorBlackList?: string[], selectorWhiteList?: string[], minPixelValue?: number }`
+- Type: `false | { root?: number, propBlackList?: string[], propWhiteList?: string[], selectorBlackList?: string[], selectorWhiteList?: string[], selectorDoubleRemList?: string[], minPixelValue?: number }`
 - Default: `false`
 
 Whether to enable px2rem conversion.
@@ -505,6 +505,7 @@ Whether to enable px2rem conversion.
 - `propWhiteList`, property white list
 - `selectorBlackList`, selector black list
 - `selectorWhiteList`, selector white list
+- `selectorDoubleRemList`, selector double rem list
 - `minPixelValue`，minimum pixel value, default is `0`
 
 ### react

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -108,7 +108,7 @@ export interface BuildParams {
           propWhiteList?: string[];
           selectorBlackList?: string[];
           selectorWhiteList?: string[];
-          selectorDoubleRemList?: string[];
+          selectorDoubleList?: string[];
         };
     stats?: boolean;
     hash?: boolean;

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -108,6 +108,7 @@ export interface BuildParams {
           propWhiteList?: string[];
           selectorBlackList?: string[];
           selectorWhiteList?: string[];
+          selectorDoubleRemList?: string[];
         };
     stats?: boolean;
     hash?: boolean;


### PR DESCRIPTION
px2rem 支持配置双倍 rem 转换的选择器

## 什么时候需要

1、antd-mobile@5 的 2x 样式，在 antd-mobile/2x 目录，需要用别名转一手，不然默认是 1x 样式

可通过以下配置简化这个需求

```ts
px2rem: {
      selectorDoubleRemList: [/.adm-/, /\:root/],
},
```

2、当在移动端使用 antd 组件时，按钮会比预期的小

可通过以下配置实现

```ts
px2rem: {
      selectorDoubleRemList: [/.ant-/],
},
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了一个新的配置选项 `selectorDoubleRemList` 到 px2rem 的类型定义中。
  - 在 `Px2Rem` 结构中新增了 `selector_doublelist` 字段和 `is_any_in_doublelist` 方法。这些新增字段和方法用于检查选择器是否匹配 `selector_doublelist`。

- **文档**
  - 更新了文档以包含新的 `selectorDoubleRemList` 配置选项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->