### PR TITLE
fix: define stringified object value will cause panic

### DIFF
--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -191,7 +191,12 @@ fn get_env_expr(v: Value, context: &Arc<Context>) -> Result<Expr> {
     match v {
         Value::String(v) => {
             // the string content is treat as expression, so it has to be parsed
-            let ast = JsAst::build("_mako_internal/_define_.js", &v, context.clone()).unwrap();
+            let ast = JsAst::build(
+                "_mako_internal/_define_.js",
+                &format!("({})", v),
+                context.clone(),
+            )
+            .unwrap();
             let module = ast.ast.body.first().unwrap();
 
             match module {

--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -196,6 +196,7 @@ fn get_env_expr(v: Value, context: &Arc<Context>) -> Result<Expr> {
                 &format!("({})", v),
                 context.clone(),
             )
+            .map_err(|_| anyhow!(ConfigError::InvalidateDefineConfig(v.clone())))
             .unwrap();
             let module = ast.ast.body.first().unwrap();
 
@@ -331,7 +332,7 @@ mod tests {
                     "A".to_string() => json!("\"foo\"")
                 }
             ),
-            r#"log("foo");"#
+            r#"log(("foo"));"#
         );
     }
 
@@ -348,7 +349,7 @@ mod tests {
 log([
     1,
     true,
-    "foo"
+    ("foo")
 ]);
             "#
             .trim()

--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -190,14 +191,15 @@ pub fn build_env_map(
 fn get_env_expr(v: Value, context: &Arc<Context>) -> Result<Expr> {
     match v {
         Value::String(v) => {
+            let safe_value = if Value::from_str(&v).map_or(false, |t| t.is_object()) {
+                format!("({})", v)
+            } else {
+                v.clone()
+            };
+
             // the string content is treat as expression, so it has to be parsed
-            let ast = JsAst::build(
-                "_mako_internal/_define_.js",
-                &format!("({})", v),
-                context.clone(),
-            )
-            .map_err(|_| anyhow!(ConfigError::InvalidateDefineConfig(v.clone())))
-            .unwrap();
+            let ast =
+                JsAst::build("_mako_internal/_define_.js", &safe_value, context.clone()).unwrap();
             let module = ast.ast.body.first().unwrap();
 
             match module {
@@ -332,7 +334,7 @@ mod tests {
                     "A".to_string() => json!("\"foo\"")
                 }
             ),
-            r#"log(("foo"));"#
+            r#"log("foo");"#
         );
     }
 
@@ -349,7 +351,7 @@ mod tests {
 log([
     1,
     true,
-    ("foo")
+    "foo"
 ]);
             "#
             .trim()
@@ -364,6 +366,21 @@ log([
                 Default::default()
             ),
             r#"if (undefined === "true") {}"#
+        );
+    }
+
+    #[test]
+    fn test_stringified_env() {
+        assert_eq!(
+            run(
+                r#"log(A)"#,
+                hashmap! {
+                    "A".to_string() => json!("{\"v\": 1}")
+                }
+            ),
+            r#"log(({
+    "v": 1
+}));"#
         );
     }
 

--- a/e2e/fixtures/config.define/expect.js
+++ b/e2e/fixtures/config.define/expect.js
@@ -1,16 +1,7 @@
-const assert = require("assert");
-const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
-const { files } = parseBuildResult(__dirname);
+const { parseBuildResult, injectSimpleJest } = require("../../../scripts/test-utils");
+const { distDir } = parseBuildResult(__dirname);
 
-let content = files["index.js"];
-content = content.replace(/\s/g, "");
+injectSimpleJest()
+require(path.join(distDir, 'index.js'));
 
-assert(content.includes("\"development\";"), "support process.env.NODE_ENV");
-assert(content.includes("\"aaa\""), "support String");
-assert(content.includes("value:\"bbb\"") && content.includes("ccc:{"), "support Object");
-assert(content.includes("[\"a\",1]"), "support Array");
-assert(content.includes("console.log(1);"), "support Number");
-assert(content.includes("console.log(true);"), "support Boolean");
-assert(content.includes("console.log(false);"), "support Boolean");
-assert(content.includes("console.log(null);"), "support Null");
-assert(content.includes("console.log(2);"), "support expression");
+

--- a/e2e/fixtures/config.define/mako.config.json
+++ b/e2e/fixtures/config.define/mako.config.json
@@ -2,19 +2,27 @@
   "minify": false,
   "define": {
     "AAA": "\"aaa\"",
-    "BBB": {
+    "BBB": 1,
+    "CCC": true,
+    "DDD": false,
+    "EEE": null,
+    "FFF": [
+      "\"a\"",
+      1
+    ],
+    "GGG": "1+1",
+    "HHH": {
       "value": "\"bbb\"",
       "ccc": {
         "d": 1,
         "e": "\"2\"",
-        "c": [1, "\"2\"", true]
+        "c": [
+          1,
+          "\"2\"",
+          true
+        ]
       }
     },
-    "CCC": 1,
-    "DDD": true,
-    "EEE": false,
-    "FFF": null,
-    "GGG": ["\"a\"", 1],
-    "HHH": "1+1"
+    "III": "{\"v\": 1}"
   }
 }

--- a/e2e/fixtures/config.define/src/index.tsx
+++ b/e2e/fixtures/config.define/src/index.tsx
@@ -1,9 +1,41 @@
 process.env.NODE_ENV;
-console.log(AAA);
-console.log(BBB);
-console.log(CCC);
-console.log(DDD);
-console.log(EEE);
-console.log(FFF);
-console.log(GGG);
-console.log(HHH);
+
+it("defined string value should be right", () => {
+  expect(AAA).toEqual("aaa")
+});
+it("defined number value should be right", () => {
+  expect(BBB).toEqual(1)
+});
+it("defined boolean true value should be right", () => {
+  expect(CCC).toEqual(true)
+});
+it("defined boolean false value should be right", () => {
+  expect(DDD).toEqual(false)
+});
+it("defined null value should be right", () => {
+  expect(EEE).toEqual(null)
+});
+it("defined array value should be right", () => {
+  expect(FFF).toEqual(["a", 1])
+});
+it("defined caculcation value should be right", () => {
+  expect(GGG).toEqual(2)
+});
+it("defined complex object value should be right", () => {
+  expect(HHH).toEqual({
+    "value": "bbb",
+    "ccc": {
+      "d": 1,
+      "e": "2",
+      "c": [
+        1,
+        "2",
+        true
+      ]
+    }
+  })
+});
+it("defined stringified object value should be right", () => {
+  expect(III).toEqual({ v: 1 })
+});
+


### PR DESCRIPTION
close https://github.com/umijs/mako/issues/1347
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 修改了字符串内容作为表达式的解析方式，在特定上下文中进行解析。
  - 增加了新的测试函数 `test_stringified_env`，用于测试字符串化的环境值。

- **改进**
  - 更新了 `get_env_expr` 方法中的解析逻辑，通过在解析前将字符串内容用括号包裹。
  - 在 `mako.config.json` 文件中修改了 `define` 对象的结构和键值。
  - 在 `index.tsx` 文件中添加了多种测试用例，确保不同类型值的正确性。

- **重构**
  - `expect.js` 文件的功能重构，移除了与内容检查相关的断言，专注于注入 Jest 并引入 `index.js` 文件。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->