### PR TITLE
perf: should not clone ast when create stats info

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -374,10 +374,11 @@ pub fn create_stats_info(compile_time: u128, compiler: &Compiler) -> StatsJsonMa
                                 module_identifier: id.id.clone(),
                                 module_name: module_graph
                                     .get_module(id)
-                                    .unwrap()
-                                    .info
-                                    .clone()
-                                    .map(|info| info.file.path.to_string_lossy().to_string())
+                                    .and_then(|module| {
+                                        module.info.as_ref().map(|info| {
+                                            info.file.path.to_string_lossy().to_string()
+                                        })
+                                    })
                                     .unwrap_or("".to_string()),
                                 // -> "lo-hi"
                                 loc: dep


### PR DESCRIPTION
create_stats_info 不需要 clone 整个 module， module 上  ast clone 开销巨大。
Close https://github.com/umijs/mako/issues/1331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 改进了统计信息创建功能，提高了模块名的检索准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->