### PR TITLE
feat: add console warning for hmr if react was externalized

### DIFF
--- a/crates/mako/src/visitors/react.rs
+++ b/crates/mako/src/visitors/react.rs
@@ -138,7 +138,7 @@ self.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
         code = format!(
             r#"
 if (!(typeof window !== 'undefined' ? window : globalThis).__REACT_DEVTOOLS_GLOBAL_HOOK__) {{
-  console.warn('HMR is not available for React currently! Because React was externalized, please install the React Developers Tools extension to enable React Refresh feature. https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#externalising-react');
+  console.warn('HMR is not available for React currently! Because React was externalized, please install the React Developer Tools extension to enable React Refresh feature. https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#externalising-react');
 }}
 {}
         "#,


### PR DESCRIPTION
当 React 被 external 且运行时无法热更时，打印警告提示开发者安装 React Developer Tools

close #1352 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->