### PR TITLE
fix(concatenate): nested named fn expr conflicted

### DIFF
--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenate_context.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenate_context.rs
@@ -499,6 +499,8 @@ impl Visit for FnExprIdentCollector {
         if let Some(fn_ident) = fn_expr.ident.as_ref() {
             self.idents.insert(fn_ident.to_id());
         }
+
+        fn_expr.visit_children_with(self);
     }
 }
 

--- a/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/expect.js
+++ b/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/expect.js
@@ -1,0 +1,8 @@
+const {
+	injectSimpleJest,
+	parseBuildResult
+} = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+injectSimpleJest();
+
+require("./dist/index.js");

--- a/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/file1.js
+++ b/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/file1.js
@@ -1,0 +1,3 @@
+export function addTarget() {
+  return "ok";
+}

--- a/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/index.js
+++ b/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/index.js
@@ -1,0 +1,7 @@
+const root = require("./module");
+
+it("should detect nested named fn expr ident", () => {
+  let target = root.c.addTarget();
+
+  expect(target).toBe("OK");
+});

--- a/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/mako.config.json
+++ b/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/mako.config.json
@@ -1,0 +1,9 @@
+{
+  "entry": {
+    "index": "./index.js"
+  },
+  "optimization": {
+    "skipModules": true,
+    "concatenateModules": true
+  }
+}

--- a/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/module.js
+++ b/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/module.js
@@ -6,7 +6,7 @@ const createC = function () {
       key: "addTarget",
       value: function addTarget() {
         _addTarget();
-        return "in key";
+        return "OK";
       },
     },
   ];

--- a/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/module.js
+++ b/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/module.js
@@ -1,0 +1,21 @@
+import { addTarget as _addTarget } from "./file1";
+
+const createC = function () {
+  const methods = [
+    {
+      key: "addTarget",
+      value: function addTarget() {
+        _addTarget();
+        return "in key";
+      },
+    },
+  ];
+
+  return {
+    [methods[0].key]: methods[0].value,
+  };
+};
+
+const c = createC();
+
+export { c };

--- a/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/module.js
+++ b/e2e/fixtures/mako.scope-hoisting.renaming_conflicted_with_nested_named_fn_expr_ident/module.js
@@ -4,6 +4,7 @@ const createC = function () {
   const methods = [
     {
       key: "addTarget",
+      // the nested function expression
       value: function addTarget() {
         _addTarget();
         return "OK";


### PR DESCRIPTION
## problem: 

nested named fn expr's ident is missed.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了一个模块 `module.js`，它导出一个函数 `createC`，该函数创建了一个包含方法 `addTarget` 的对象 `c`。此方法调用另一个模块中的 `_addTarget` 并返回 "OK"。

- **测试**
  - 添加了新的测试场景，用于检测嵌套命名函数表达式标识符冲突。
  - 更新了测试工具，包含 `injectSimpleJest` 和 `parseBuildResult` 功能。
  
- **配置**
  - 新增了 `mako.config.json` 配置文件，指定了项目的入口点和与模块处理相关的优化选项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->