### PR TITLE
feat: upgrade hyper-staticfile, which fix the js file charset problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,10 +2094,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-staticfile-jsutf8"
-version = "0.0.1"
+name = "hyper-staticfile"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8898514e9a3bbf3f8dfe272e527e0742871fabf45359b897e3cfd1d7feb09e89"
+checksum = "0cae01e93c7c6172c525c8bd3e06c42bd8189b4f1db28caae20c4c749a583041"
 dependencies = [
  "futures-util",
  "http",
@@ -2629,7 +2629,7 @@ dependencies = [
  "glob-match",
  "heck",
  "hyper",
- "hyper-staticfile-jsutf8",
+ "hyper-staticfile",
  "hyper-tungstenite",
  "indexmap 2.2.6",
  "insta",

--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -71,45 +71,45 @@ swc_emotion         = "0.51.0"
 swc_error_reporters = "0.16.1"
 swc_node_comments   = "0.19.1"
 
-anyhow                  = "1.0.71"
-base64                  = "0.21.2"
-clap                    = { version = "4.3.11", features = ["derive"] }
-colored                 = "2"
-config                  = "0.13.3"
-convert_case            = "0.6.0"
-eframe                  = { version = "0.22.0", optional = true }
-fs_extra                = "1.3.0"
-futures                 = "0.3.28"
-glob                    = "0.3.1"
-hyper                   = { version = "0.14.27", features = ["full"] }
-hyper-staticfile-jsutf8 = "0.0.1"
-hyper-tungstenite       = "0.10.0"
-indexmap                = "2.0.0"
-md5                     = "0.7.0"
-mdxjs                   = "0.1.14"
-merge-source-map        = "1.2.0"
-mime_guess              = "2.0.4"
-notify                  = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
-notify-debouncer-full   = { version = "0.3.1", default-features = false }
-path-clean              = "1.0.1"
-pathdiff                = "0.2.1"
-petgraph                = "0.6.3"
-puffin                  = { version = "0.16.0", optional = true }
-puffin_egui             = { version = "0.22.0", optional = true }
-rayon                   = "1.7.0"
-regex                   = "1.9.3"
-sailfish                = "0.8.3"
-serde-xml-rs            = "0.6.0"
-serde_yaml              = "0.9.22"
-svgr-rs                 = "0.1.3"
-thiserror               = "1.0.43"
-tokio                   = { version = "1", features = ["rt-multi-thread", "sync"] }
-tokio-tungstenite       = "0.19.0"
-toml                    = "0.7.6"
-tracing                 = "0.1.37"
-tracing-subscriber      = { version = "0.3.17", features = ["env-filter"] }
-tungstenite             = "0.19.0"
-twox-hash               = "1.6.3"
+anyhow                = "1.0.71"
+base64                = "0.21.2"
+clap                  = { version = "4.3.11", features = ["derive"] }
+colored               = "2"
+config                = "0.13.3"
+convert_case          = "0.6.0"
+eframe                = { version = "0.22.0", optional = true }
+fs_extra              = "1.3.0"
+futures               = "0.3.28"
+glob                  = "0.3.1"
+hyper                 = { version = "0.14.27", features = ["full"] }
+hyper-staticfile      = "0.9.6"
+hyper-tungstenite     = "0.10.0"
+indexmap              = "2.0.0"
+md5                   = "0.7.0"
+mdxjs                 = "0.1.14"
+merge-source-map      = "1.2.0"
+mime_guess            = "2.0.4"
+notify                = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
+notify-debouncer-full = { version = "0.3.1", default-features = false }
+path-clean            = "1.0.1"
+pathdiff              = "0.2.1"
+petgraph              = "0.6.3"
+puffin                = { version = "0.16.0", optional = true }
+puffin_egui           = { version = "0.22.0", optional = true }
+rayon                 = "1.7.0"
+regex                 = "1.9.3"
+sailfish              = "0.8.3"
+serde-xml-rs          = "0.6.0"
+serde_yaml            = "0.9.22"
+svgr-rs               = "0.1.3"
+thiserror             = "1.0.43"
+tokio                 = { version = "1", features = ["rt-multi-thread", "sync"] }
+tokio-tungstenite     = "0.19.0"
+toml                  = "0.7.6"
+tracing               = "0.1.37"
+tracing-subscriber    = { version = "0.3.17", features = ["env-filter"] }
+tungstenite           = "0.19.0"
+twox-hash             = "1.6.3"
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 mimalloc-rust = { workspace = true }

--- a/crates/mako/src/dev/mod.rs
+++ b/crates/mako/src/dev/mod.rs
@@ -17,7 +17,7 @@ use notify_debouncer_full::new_debouncer;
 use tokio::sync::broadcast;
 use tracing::debug;
 use tungstenite::Message;
-use {hyper, hyper_staticfile_jsutf8, hyper_tungstenite, open};
+use {hyper, hyper_staticfile, hyper_tungstenite, open};
 
 use crate::compiler::{Compiler, Context};
 use crate::plugin::{PluginGenerateEndParams, PluginGenerateStats};
@@ -75,9 +75,8 @@ impl DevServer {
                     Ok::<_, hyper::Error>(service_fn(move |req| {
                         let context = context.clone();
                         let txws = txws.clone();
-                        let staticfile = hyper_staticfile_jsutf8::Static::new(
-                            context.config.output.path.clone(),
-                        );
+                        let staticfile =
+                            hyper_staticfile::Static::new(context.config.output.path.clone());
                         async move { Self::handle_requests(req, context, staticfile, txws).await }
                     }))
                 }
@@ -122,7 +121,7 @@ impl DevServer {
     async fn handle_requests(
         req: Request<Body>,
         context: Arc<Context>,
-        staticfile: hyper_staticfile_jsutf8::Static,
+        staticfile: hyper_staticfile::Static,
         txws: broadcast::Sender<WsMessage>,
     ) -> Result<hyper::Response<Body>> {
         let path = req.uri().path();


### PR DESCRIPTION
The hyper_staticfile has been fixed according to our issue and is now compatible with both application/javascript and text/javascript content types that may be returned by mime_guess.

> Ref: https://github.com/stephank/hyper-staticfile/releases/tag/v0.9.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 替换了 `hyper-staticfile-jsutf8` 依赖为 `hyper-staticfile`，改进了静态文件处理功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->