### PR TITLE
fix: should inspect  reserved_words after preset_env

### DIFF
--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -10,6 +10,7 @@ use swc_core::ecma::preset_env::{self as swc_preset_env};
 use swc_core::ecma::transforms::base::feature::FeatureFlag;
 use swc_core::ecma::transforms::base::fixer::paren_remover;
 use swc_core::ecma::transforms::base::{resolver, Assumptions};
+use swc_core::ecma::transforms::compat::reserved_words;
 use swc_core::ecma::transforms::optimization::simplifier;
 use swc_core::ecma::transforms::optimization::simplify::{dce, Config as SimpilifyConfig};
 use swc_core::ecma::transforms::proposal::decorators;
@@ -177,6 +178,7 @@ impl Transform {
                         assumptions,
                         &mut FeatureFlag::default(),
                     )));
+                    folders.push(Box::new(reserved_words::reserved_words()));
                     folders.push(Box::new(paren_remover(Default::default())));
                     // simplify, but keep top level dead code
                     // e.g. import x from 'foo'; but x is not used

--- a/e2e/fixtures/config.targets/expect.js
+++ b/e2e/fixtures/config.targets/expect.js
@@ -1,6 +1,12 @@
 const assert = require("assert");
-const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
+const { parseBuildResult, moduleReg, injectSimpleJest } = require("../../../scripts/test-utils");
 const { files } = parseBuildResult(__dirname);
+const { distDir } = parseBuildResult(__dirname);
+
+
+injectSimpleJest();
+
+require(path.join(distDir, 'index.js'));
 
 const content = files["index.js"];
 

--- a/e2e/fixtures/config.targets/expect.js
+++ b/e2e/fixtures/config.targets/expect.js
@@ -9,6 +9,11 @@ assert.doesNotMatch(
   moduleReg("src/index.tsx", "const f = \\("),
   "should not have `const f`"
 );
+assert.doesNotMatch(
+  content,
+  moduleReg("src/index.tsx", "function default\\("),
+  "should not have `function default`"
+);
 assert.match(
   content,
   moduleReg("src/index.tsx", "var f = function\\("),

--- a/e2e/fixtures/config.targets/src/index.tsx
+++ b/e2e/fixtures/config.targets/src/index.tsx
@@ -4,6 +4,11 @@ console.log(f);
 
 const a =  {
   default : class {
-    
+
   }
 }
+it('class with obj.default should work ',()=>{
+  const b = new a.default()
+  console.log(b)
+})
+

--- a/e2e/fixtures/config.targets/src/index.tsx
+++ b/e2e/fixtures/config.targets/src/index.tsx
@@ -1,2 +1,9 @@
 const f = () => {};
 console.log(f);
+
+
+const a =  {
+  default : class {
+    
+  }
+}


### PR DESCRIPTION
在 preset_env 后执行了 swc 的保留字检查

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在应用程序中添加了一个新的对象 `a`，它包含一个默认类定义。
- **测试**
  - 添加了检查，确保内容不包含字符串“function default”。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->