### PR TITLE
feat: support select template from templates dir

### DIFF
--- a/packages/create-mako/mako-project/index.ts
+++ b/packages/create-mako/mako-project/index.ts
@@ -1,1 +1,0 @@
-console.log('Creating angular project...');

--- a/packages/create-mako/mako-project/index.ts
+++ b/packages/create-mako/mako-project/index.ts
@@ -1,0 +1,1 @@
+console.log('Creating angular project...');

--- a/packages/create-mako/src/cli.ts
+++ b/packages/create-mako/src/cli.ts
@@ -14,6 +14,10 @@ type InitOptions = {
 
 async function init({ projectName, template }: InitOptions) {
   let templatePath = path.join(baseTemplatesPath, template);
+  if (!fs.existsSync(templatePath)) {
+    console.error(`Template "${template}" does not exist.`);
+    process.exit(1);
+  }
   let files = globSync('**/*', { cwd: templatePath, nodir: true });
   let cwd = path.join(process.cwd(), projectName);
 

--- a/packages/create-mako/src/cli.ts
+++ b/packages/create-mako/src/cli.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { globSync } from 'glob';
-import { QuestionCollection } from 'inquirer';
+import type { QuestionCollection } from 'inquirer';
 import yargs from 'yargs-parser';
 
 const args = yargs(process.argv.slice(2));
@@ -54,7 +54,7 @@ type InitQuestion = {
 };
 async function main() {
   let name = args._[0];
-  let template = args.template;
+  let { template } = args;
   let questions: QuestionCollection[] = [];
   if (!name) {
     questions.push({


### PR DESCRIPTION
- Support select template from templates dir
  - `yarn create mako demo --template=vue3`
  - `yarn create mako ` 
    ![image](https://github.com/umijs/mako/assets/10286961/1078be92-52e9-41a0-9f25-1ab68e96b5d0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了一个新选项类型 `InitOptions`，`init` 函数现在接受包含 `projectName` 和 `template` 属性的对象。
  - 使用 `inquirer` 提示用户输入项目名称和模板选择。
  - 根据用户输入动态确定模板路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->