### PR TITLE
fix: typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,7 +174,7 @@
 * Turn on concatenate modules by default by [@stormslowly](https://github.com/stormslowly) in [#1126](https://github.com/umijs/mako/pull/1126)
 * Fix the potential instability of chunk id ordering by [@stormslowly](https://github.com/stormslowly) in [#1117](https://github.com/umijs/mako/pull/1117)
 * chore: add log for parallel generate by [@xusd320](https://github.com/xusd320) in [#1127](https://github.com/umijs/mako/pull/1127)
-* Fix the issue where re-grouping of chunk does not happen when dependancy types change in a hot update scenario by [@xusd320](https://github.com/xusd320) in [#1124](https://github.com/umijs/mako/pull/1124)
+* Fix the issue where re-grouping of chunk does not happen when dependency types change in a hot update scenario by [@xusd320](https://github.com/xusd320) in [#1124](https://github.com/umijs/mako/pull/1124)
 
 ## 0.4.13
 


### PR DESCRIPTION
<img width="1385" alt="image" src="https://github.com/umijs/mako/assets/10286961/7a4341f6-6f50-43a5-accd-8204eab87114">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 修复了在热更新场景下依赖类型变化时未进行块重新分组的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->