### PR TITLE
fix(bundler-mako): analyze don't work in umi

### DIFF
--- a/crates/mako/src/generate/analyze.rs
+++ b/crates/mako/src/generate/analyze.rs
@@ -31,8 +31,12 @@ impl Analyze {
             stats_json,
             include_str!("../../../../client/dist/index.js").replace("</script>", "<\\/script>")
         );
-        let report_path = context.config.output.path.join("report.html");
-        fs::write(report_path, html_str).unwrap();
+        let report_path = context.config.output.path.join("analyze-report.html");
+        fs::write(&report_path, html_str).unwrap();
+        println!(
+            "Analyze report generated at: {}",
+            report_path.to_string_lossy()
+        );
         Ok(())
     }
 }

--- a/crates/mako/src/generate/mod.rs
+++ b/crates/mako/src/generate/mod.rs
@@ -182,10 +182,6 @@ impl Compiler {
         // generate stats
         let stats = create_stats_info(0, self);
 
-        if self.context.config.analyze.is_some() {
-            Analyze::write_analyze(&stats, self.context.clone())?;
-        }
-
         if self.context.config.stats.is_some() {
             write_stats(&stats, self);
         }
@@ -198,6 +194,10 @@ impl Compiler {
         // print stats
         if !self.context.args.watch {
             print_stats(self);
+        }
+
+        if self.context.config.analyze.is_some() {
+            Analyze::write_analyze(&stats, self.context.clone())?;
         }
 
         debug!("generate done in {}ms", t_generate.elapsed().as_millis());

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -299,7 +299,6 @@ function checkConfig(opts) {
   // 不支持但对构建影响不明确的配置项，会统一警告
   const riskyKeys = [
     'config.autoprefixer',
-    'config.analyze',
     'config.cssPublicPath',
     'config.cssLoader',
     'config.cssLoaderModules',
@@ -441,6 +440,7 @@ async function getMakoConfig(opts) {
     forkTSChecker,
     inlineCSS,
     makoPlugins,
+    analyze,
   } = opts.config;
   let { codeSplitting } = opts.config;
   // TODO:
@@ -606,6 +606,7 @@ async function getMakoConfig(opts) {
       plugins: opts.config.lessLoader?.plugins,
     },
     plugins: makoPlugins || [],
+    analyze: analyze || process.env.ANALYZE ? {} : undefined,
   };
 
   return makoConfig;


### PR DESCRIPTION
Close #1364 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 生成的分析报告文件名更改为 `analyze-report.html`，更加清晰明了。
  - 增加生成分析报告路径的打印信息，方便用户查看报告文件位置。

- **改进**
  - 在编译器实现中，分析信息写入操作不再依赖配置条件，确保在特定操作后无条件执行。

- **配置管理**
  - `checkConfig` 函数中删除了 `config.analyze` 的风险检查。
  - `getMakoConfig` 函数中增加了 `analyze` 配置项，支持基于环境变量 `ANALYZE` 设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->