### PR TITLE
fix: css order lost after chunk dependencies sorted by alphabet

### DIFF
--- a/crates/mako/src/generate/chunk_graph.rs
+++ b/crates/mako/src/generate/chunk_graph.rs
@@ -111,15 +111,11 @@ impl ChunkGraph {
 
     pub fn sync_dependencies_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
         let idx = self.id_index_map.get(chunk_id).unwrap();
-        let mut chunk_ids = self
-            .graph
+        self.graph
             .neighbors_directed(*idx, Direction::Outgoing)
             .filter(|idx| matches!(self.graph[*idx].chunk_type, ChunkType::Sync))
             .map(|idx| self.graph[idx].id.clone())
-            .collect::<Vec<ChunkId>>();
-
-        chunk_ids.sort_by(|id1, id2| id1.id.cmp(&id2.id));
-        chunk_ids
+            .collect::<Vec<ChunkId>>()
     }
 
     pub fn entry_dependencies_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {


### PR DESCRIPTION
As the title described. Should revert https://github.com/umijs/mako/pull/1117 and re-open https://github.com/umijs/mako/issues/1116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
  - 修改了 `sync_dependencies_chunk` 方法，取消了返回之前对 `chunk_ids` 的排序。提高了性能表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->