### PR TITLE
feat: pass umi config mako

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -243,7 +243,6 @@ function checkConfig(opts) {
     'px2rem',
     'experimental',
     'flexBugs',
-    'moduleIdStrategy',
     'optimization',
   ];
   // umi mako config

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -254,22 +254,6 @@ function checkConfig(opts) {
       `umi config mako.${key} is not supported`,
     );
   });
-  // 支持透传给 mako 的配置
-  const supportMakoConfigKeys = [
-    'px2rem',
-    'experimental',
-    'flexBugs',
-    'moduleIdStrategy',
-    'optimization',
-  ];
-  // umi mako config
-  const { mako } = opts.config;
-  Object.keys(mako).forEach((key) => {
-    assert(
-      supportMakoConfigKeys.includes(key),
-      `umi config mako.${key} is not supported`,
-    );
-  });
   // 暂不支持 { from, to } 格式
   const { copy } = opts.config;
   if (copy) {
@@ -331,7 +315,6 @@ function checkConfig(opts) {
   // 不支持但对构建影响不明确的配置项，会统一警告
   const riskyKeys = [
     'config.autoprefixer',
-    'config.analyze',
     'config.cssPublicPath',
     'config.cssLoader',
     'config.cssLoaderModules',

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -254,6 +254,22 @@ function checkConfig(opts) {
       `umi config mako.${key} is not supported`,
     );
   });
+  // 支持透传给 mako 的配置
+  const supportMakoConfigKeys = [
+    'px2rem',
+    'experimental',
+    'flexBugs',
+    'moduleIdStrategy',
+    'optimization',
+  ];
+  // umi mako config
+  const { mako } = opts.config;
+  Object.keys(mako).forEach((key) => {
+    assert(
+      supportMakoConfigKeys.includes(key),
+      `umi config mako.${key} is not supported`,
+    );
+  });
   // 暂不支持 { from, to } 格式
   const { copy } = opts.config;
   if (copy) {
@@ -457,7 +473,7 @@ async function getMakoConfig(opts) {
     forkTSChecker,
     inlineCSS,
     makoPlugins,
-    // umi config mako
+    analyze,
     mako,
   } = opts.config;
 
@@ -625,6 +641,7 @@ async function getMakoConfig(opts) {
       plugins: opts.config.lessLoader?.plugins,
     },
     plugins: makoPlugins || [],
+    analyze: analyze || process.env.ANALYZE ? {} : undefined,
     ...mako,
   };
 

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -238,6 +238,22 @@ function checkConfig(opts) {
     assert(!opts.config[key], `${key} is not supported in Mako bundler`);
   });
 
+  // 支持透传给 mako 的配置
+  const supportMakoConfigKeys = [
+    'px2rem',
+    'experimental',
+    'flexBugs',
+    'moduleIdStrategy',
+    'optimization',
+  ];
+  // umi mako config
+  const { mako } = opts.config;
+  Object.keys(mako).forEach((key) => {
+    assert(
+      supportMakoConfigKeys.includes(key),
+      `umi config mako.${key} is not supported`,
+    );
+  });
   // 暂不支持 { from, to } 格式
   const { copy } = opts.config;
   if (copy) {
@@ -299,6 +315,7 @@ function checkConfig(opts) {
   // 不支持但对构建影响不明确的配置项，会统一警告
   const riskyKeys = [
     'config.autoprefixer',
+    'config.analyze',
     'config.cssPublicPath',
     'config.cssLoader',
     'config.cssLoaderModules',
@@ -440,8 +457,10 @@ async function getMakoConfig(opts) {
     forkTSChecker,
     inlineCSS,
     makoPlugins,
-    analyze,
+    // umi config mako
+    mako,
   } = opts.config;
+
   let { codeSplitting } = opts.config;
   // TODO:
   // 暂不支持 $ 结尾，等 resolve 支持后可以把这段去掉
@@ -606,7 +625,7 @@ async function getMakoConfig(opts) {
       plugins: opts.config.lessLoader?.plugins,
     },
     plugins: makoPlugins || [],
-    analyze: analyze || process.env.ANALYZE ? {} : undefined,
+    ...mako,
   };
 
   return makoConfig;


### PR DESCRIPTION
支持从 umi 配置透传给 mako

https://github.com/umijs/mako/issues/1389

## 关联 PR

[在 umi 那边增加 mako 配置的类型](https://github.com/umijs/umi/pull/12553)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加了对 `mako` 配置键的支持。
  - 调整了 `mako` 配置处理方式，确保支持特定配置键并正确集成到最终配置中。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->