### PR TITLE
refact: some confusing types and logic

### DIFF
--- a/crates/binding/src/js_plugin.rs
+++ b/crates/binding/src/js_plugin.rs
@@ -16,7 +16,7 @@ impl Plugin for JsPlugin {
         "js_plugin"
     }
 
-    fn build_start(&self, _context: &Arc<Context>) -> Result<Option<()>> {
+    fn build_start(&self, _context: &Arc<Context>) -> Result<()> {
         if let Some(hook) = &self.hooks.build_start {
             let (tx, rx) = mpsc::channel::<napi::Result<()>>();
             hook.call(
@@ -26,7 +26,7 @@ impl Plugin for JsPlugin {
             rx.recv()
                 .unwrap_or_else(|e| panic!("recv error: {:?}", e.to_string()))?;
         }
-        Ok(None)
+        Ok(())
     }
 
     fn load(&self, param: &PluginLoadParam, _context: &Arc<Context>) -> Result<Option<Content>> {
@@ -64,11 +64,7 @@ impl Plugin for JsPlugin {
         Ok(None)
     }
 
-    fn generate_end(
-        &self,
-        param: &PluginGenerateEndParams,
-        _context: &Arc<Context>,
-    ) -> Result<Option<()>> {
+    fn generate_end(&self, param: &PluginGenerateEndParams, _context: &Arc<Context>) -> Result<()> {
         if let Some(hook) = &self.hooks.generate_end {
             let (tx, rx) = mpsc::channel::<napi::Result<()>>();
             hook.call(
@@ -81,7 +77,7 @@ impl Plugin for JsPlugin {
             rx.recv()
                 .unwrap_or_else(|e| panic!("recv error: {:?}", e.to_string()))?;
         }
-        Ok(None)
+        Ok(())
     }
 
     fn before_write_fs(&self, path: &std::path::Path, content: &[u8]) -> Result<()> {

--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -247,7 +247,10 @@ impl Compiler {
         }
 
         if config.output.mode == OutputMode::Bundless {
-            plugins.insert(0, Arc::new(plugins::bundless_compiler::BundlessCompiler {}));
+            plugins.insert(
+                0,
+                Arc::new(plugins::bundless_compiler::BundlessCompilerPlugin {}),
+            );
         }
 
         if std::env::var("DEBUG_GRAPH").is_ok_and(|v| v == "true") {

--- a/crates/mako/src/generate/analyze.rs
+++ b/crates/mako/src/generate/analyze.rs
@@ -1,15 +1,14 @@
 use std::fs;
-use std::sync::Arc;
+use std::path::Path;
 
 use anyhow::Result;
 
-use crate::compiler::Context;
 use crate::stats::StatsJsonMap;
 
 pub struct Analyze {}
 
 impl Analyze {
-    pub fn write_analyze(stats: &StatsJsonMap, context: Arc<Context>) -> Result<()> {
+    pub fn write_analyze(stats: &StatsJsonMap, path: &Path) -> Result<()> {
         let stats_json = serde_json::to_string_pretty(&stats).unwrap();
         let html_str = format!(
             r#"<!DOCTYPE html>
@@ -31,7 +30,7 @@ impl Analyze {
             stats_json,
             include_str!("../../../../client/dist/index.js").replace("</script>", "<\\/script>")
         );
-        let report_path = context.config.output.path.join("analyze-report.html");
+        let report_path = path.join("analyze-report.html");
         fs::write(&report_path, html_str).unwrap();
         println!(
             "Analyze report generated at: {}",

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use swc_core::common::errors::Handler;
 use swc_core::common::Mark;
 use swc_core::ecma::ast::Module;
@@ -95,10 +95,6 @@ pub trait Plugin: Any + Send + Sync {
         Ok(())
     }
 
-    fn generate(&self, _context: &Arc<Context>) -> Result<Option<()>> {
-        Ok(None)
-    }
-
     fn after_generate_chunk_files(
         &self,
         _chunk_files: &[ChunkFile],
@@ -107,15 +103,15 @@ pub trait Plugin: Any + Send + Sync {
         Ok(())
     }
 
-    fn build_success(&self, _stats: &StatsJsonMap, _context: &Arc<Context>) -> Result<Option<()>> {
-        Ok(None)
+    fn build_success(&self, _stats: &StatsJsonMap, _context: &Arc<Context>) -> Result<()> {
+        Ok(())
     }
 
-    fn build_start(&self, _context: &Arc<Context>) -> Result<Option<()>> {
-        Ok(None)
+    fn build_start(&self, _context: &Arc<Context>) -> Result<()> {
+        Ok(())
     }
 
-    fn generate_beg(&self, _context: &Arc<Context>) -> Result<()> {
+    fn generate_begin(&self, _context: &Arc<Context>) -> Result<()> {
         Ok(())
     }
 
@@ -123,8 +119,8 @@ pub trait Plugin: Any + Send + Sync {
         &self,
         _params: &PluginGenerateEndParams,
         _context: &Arc<Context>,
-    ) -> Result<Option<()>> {
-        Ok(None)
+    ) -> Result<()> {
+        Ok(())
     }
 
     fn runtime_plugins(&self, _context: &Arc<Context>) -> Result<Vec<String>> {
@@ -255,19 +251,9 @@ impl PluginDriver {
 
     pub fn before_generate(&self, context: &Arc<Context>) -> Result<()> {
         for plugin in &self.plugins {
-            plugin.generate_beg(context)?;
+            plugin.generate_begin(context)?;
         }
         Ok(())
-    }
-
-    pub fn generate(&self, context: &Arc<Context>) -> Result<Option<()>> {
-        for plugin in &self.plugins {
-            let ret = plugin.generate(context)?;
-            if ret.is_some() {
-                return Ok(Some(()));
-            }
-        }
-        Err(anyhow!("None of the plugins generate content"))
     }
 
     pub(crate) fn after_generate_chunk_files(
@@ -282,40 +268,36 @@ impl PluginDriver {
         Ok(())
     }
 
-    pub fn build_start(&self, context: &Arc<Context>) -> Result<Option<()>> {
+    pub fn build_start(&self, context: &Arc<Context>) -> Result<()> {
         for plugin in &self.plugins {
             plugin.build_start(context)?;
         }
-        Ok(None)
+        Ok(())
     }
 
     pub fn generate_end(
         &self,
         param: &PluginGenerateEndParams,
         context: &Arc<Context>,
-    ) -> Result<Option<()>> {
+    ) -> Result<()> {
         for plugin in &self.plugins {
             plugin.generate_end(param, context)?;
         }
-        Ok(None)
+        Ok(())
     }
 
-    pub fn generate_beg(&self, context: &Arc<Context>) -> Result<Option<()>> {
+    pub fn generate_begin(&self, context: &Arc<Context>) -> Result<()> {
         for plugin in &self.plugins {
-            plugin.generate_beg(context)?;
+            plugin.generate_begin(context)?;
         }
-        Ok(None)
+        Ok(())
     }
 
-    pub fn build_success(
-        &self,
-        stats: &StatsJsonMap,
-        context: &Arc<Context>,
-    ) -> Result<Option<()>> {
+    pub fn build_success(&self, stats: &StatsJsonMap, context: &Arc<Context>) -> Result<()> {
         for plugin in &self.plugins {
             plugin.build_success(stats, context)?;
         }
-        Ok(None)
+        Ok(())
     }
 
     pub fn runtime_plugins_code(&self, context: &Arc<Context>) -> Result<String> {

--- a/crates/mako/src/plugins/copy.rs
+++ b/crates/mako/src/plugins/copy.rs
@@ -75,12 +75,12 @@ impl Plugin for CopyPlugin {
         "copy"
     }
 
-    fn build_success(&self, _stats: &StatsJsonMap, context: &Arc<Context>) -> Result<Option<()>> {
+    fn build_success(&self, _stats: &StatsJsonMap, context: &Arc<Context>) -> Result<()> {
         CopyPlugin::copy(context)?;
         if context.args.watch {
             CopyPlugin::watch(context);
         }
-        Ok(None)
+        Ok(())
     }
 }
 

--- a/crates/mako/src/plugins/graphviz.rs
+++ b/crates/mako/src/plugins/graphviz.rs
@@ -35,7 +35,7 @@ impl Plugin for Graphviz {
         "graphviz"
     }
 
-    fn generate_beg(&self, context: &Arc<Context>) -> Result<()> {
+    fn generate_begin(&self, context: &Arc<Context>) -> Result<()> {
         Graphviz::write_graph(
             context.root.join("_mako_module_graph_origin.dot"),
             &context.module_graph.read().unwrap().graph,
@@ -55,7 +55,7 @@ impl Plugin for Graphviz {
         &self,
         _params: &PluginGenerateEndParams,
         context: &Arc<Context>,
-    ) -> Result<Option<()>> {
+    ) -> Result<()> {
         Graphviz::write_graph(
             context.root.join("_mako_chunk_graph_finale.dot"),
             &context.chunk_graph.read().unwrap().graph,
@@ -66,6 +66,6 @@ impl Plugin for Graphviz {
             &context.module_graph.read().unwrap().graph,
         )?;
 
-        Ok(None)
+        Ok(())
     }
 }

--- a/crates/mako/src/plugins/manifest.rs
+++ b/crates/mako/src/plugins/manifest.rs
@@ -21,7 +21,7 @@ impl Plugin for ManifestPlugin {
         "manifest"
     }
 
-    fn build_success(&self, _stats: &StatsJsonMap, context: &Arc<Context>) -> Result<Option<()>> {
+    fn build_success(&self, _stats: &StatsJsonMap, context: &Arc<Context>) -> Result<()> {
         if let Some(manifest_config) = &context.config.manifest {
             let assets = &context.stats_info.get_assets();
             let mut manifest: BTreeMap<String, String> = BTreeMap::new();
@@ -41,7 +41,7 @@ impl Plugin for ManifestPlugin {
 
             fs::write(output_path, manifest_json).unwrap();
         }
-        Ok(None)
+        Ok(())
     }
 }
 

--- a/crates/mako/src/plugins/minifish.rs
+++ b/crates/mako/src/plugins/minifish.rs
@@ -172,7 +172,7 @@ impl Plugin for MinifishPlugin {
         Ok(())
     }
 
-    fn build_success(&self, _stats: &StatsJsonMap, context: &Arc<Context>) -> Result<Option<()>> {
+    fn build_success(&self, _stats: &StatsJsonMap, context: &Arc<Context>) -> Result<()> {
         if let Some(meta_path) = &self.meta_path {
             let mg = context.module_graph.read().unwrap();
 
@@ -217,7 +217,7 @@ impl Plugin for MinifishPlugin {
                 .map_err(|e| anyhow!("write meta file({}) error: {}", meta_path.display(), e))?;
         }
 
-        Ok(None)
+        Ok(())
     }
 }
 #[derive(Serialize)]

--- a/crates/mako/src/plugins/ssu.rs
+++ b/crates/mako/src/plugins/ssu.rs
@@ -453,7 +453,7 @@ module.export = Promise.all(
         Ok(())
     }
 
-    fn build_start(&self, context: &Arc<Context>) -> Result<Option<()>> {
+    fn build_start(&self, context: &Arc<Context>) -> Result<()> {
         if let Some(content) = self.load_cached_state(context) {
             let mut state = self.cached_state.lock().unwrap();
             *state = content;
@@ -461,7 +461,7 @@ module.export = Promise.all(
 
         self.current_state.lock().unwrap().config_hash = Self::config_hash(&context.config);
 
-        Ok(None)
+        Ok(())
     }
 
     fn runtime_plugins(&self, _context: &Arc<Context>) -> Result<Vec<String>> {


### PR DESCRIPTION
1. Type Result<Option<()>> is meaningless;
2. generate_beg should be generate_begin;
3. The compiler instance should not be spread if possible;
4. The bundless generation should not be defined as a plugin, it's an exclusive logic;
5. The Rc<RefCell> usage in stats.rs is meaningless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了 `BundlessCompilerPlugin` 结构体，实现了 `Plugin` 接口。
  
- **错误修复**
  - 修改了多个函数的返回类型，从 `Result<Option<()>>` 改为 `Result<()>`，简化了返回逻辑。
  
- **改进**
  - 函数参数改动：多个函数的参数从上下文（`context`）改为直接指定路径（`path`）。
  - 函数重命名：`generate_beg` 改为 `generate_begin`。
  
- **性能优化**
  - 用可变 `Vec` 替换了 `Rc<RefCell>`，提升了性能。

- **文档**
  - 更新了 `stats.rs` 的函数签名和导入结构。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->