### PR TITLE
fix(bundler-mako): assignment failure when plugins are undefined

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -191,6 +191,7 @@ exports.dev = async function (opts) {
   const makoConfig = await getMakoConfig(opts);
   makoConfig.hmr = {};
   makoConfig.devServer = { port: hmrPort, host: opts.host };
+  makoConfig.plugins = makoConfig.plugins || [];
   makoConfig.plugins.push({
     name: 'mako-dev',
     generateEnd: (args) => {


### PR DESCRIPTION
<img width="809" alt="image" src="https://github.com/umijs/mako/assets/7599351/9d877c81-983e-4f2d-b46f-dc20431eff42">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 修复了 `makoConfig.plugins` 未定义时导致的问题，确保它默认设置为空数组。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->