### PR TITLE
fix: support dynamic import with template string

### DIFF
--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -33,6 +33,7 @@ use crate::visitors::dynamic_import_to_require::DynamicImportToRequire;
 use crate::visitors::env_replacer::{build_env_map, EnvReplacer};
 use crate::visitors::fix_helper_inject_position::FixHelperInjectPosition;
 use crate::visitors::fix_symbol_conflict::FixSymbolConflict;
+use crate::visitors::import_template_to_string_literal::ImportTemplateToStringLiteral;
 use crate::visitors::new_url_assets::NewUrlAssets;
 use crate::visitors::provide::Provide;
 use crate::visitors::react::react;
@@ -141,6 +142,7 @@ impl Transform {
                     }));
                     // TODO: move ContextModuleVisitor out of plugin
                     visitors.push(Box::new(ContextModuleVisitor { unresolved_mark }));
+                    visitors.push(Box::new(ImportTemplateToStringLiteral {}));
                     // DynamicImportToRequire must be after ContextModuleVisitor
                     // since ContextModuleVisitor will add extra dynamic imports
                     if context.config.dynamic_import_to_require {

--- a/crates/mako/src/visitors/import_template_to_string_literal.rs
+++ b/crates/mako/src/visitors/import_template_to_string_literal.rs
@@ -1,0 +1,40 @@
+use swc_core::ecma::ast::{CallExpr, Callee, Expr, Lit};
+use swc_core::ecma::visit::VisitMut;
+
+pub struct ImportTemplateToStringLiteral {}
+
+impl VisitMut for ImportTemplateToStringLiteral {
+    fn visit_mut_call_expr(&mut self, n: &mut CallExpr) {
+        if matches!(n.callee, Callee::Import(_)) && n.args.len() == 1 {
+            if let box Expr::Tpl(tpl) = &n.args[0].expr {
+                if tpl.exprs.is_empty() && tpl.quasis.len() == 1 {
+                    let s: String = tpl.quasis[0].raw.clone().to_string();
+                    n.args[0].expr = Expr::Lit(Lit::Str(s.into())).into();
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_core::common::GLOBALS;
+    use swc_core::ecma::visit::VisitMutWith;
+
+    use crate::ast::tests::TestUtils;
+
+    #[test]
+    fn test_normal() {
+        assert_eq!(run(r#"import(`a`)"#), r#"import("a");"#);
+    }
+
+    fn run(js_code: &str) -> String {
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
+        let ast = test_utils.ast.js_mut();
+        GLOBALS.set(&test_utils.context.meta.script.globals, || {
+            let mut visitor = super::ImportTemplateToStringLiteral {};
+            ast.ast.visit_mut_with(&mut visitor);
+        });
+        test_utils.js_ast_to_code()
+    }
+}

--- a/crates/mako/src/visitors/mod.rs
+++ b/crates/mako/src/visitors/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod dynamic_import_to_require;
 pub(crate) mod env_replacer;
 pub(crate) mod fix_helper_inject_position;
 pub(crate) mod fix_symbol_conflict;
+pub(crate) mod import_template_to_string_literal;
 pub(crate) mod mako_require;
 pub(crate) mod meta_url_replacer;
 pub(crate) mod new_url_assets;

--- a/e2e/fixtures/javascript.dynamic-import.template-string/expect.js
+++ b/e2e/fixtures/javascript.dynamic-import.template-string/expect.js
@@ -1,0 +1,8 @@
+const {
+  parseBuildResult,
+} = require("../../../scripts/test-utils");
+const assert = require("assert");
+const { files } = parseBuildResult(__dirname);
+const content = files["index.js"];
+
+assert(content.includes(`"foo.js": "foo_js-async.js"`), "template string replace works");

--- a/e2e/fixtures/javascript.dynamic-import.template-string/foo.js
+++ b/e2e/fixtures/javascript.dynamic-import.template-string/foo.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/e2e/fixtures/javascript.dynamic-import.template-string/index.js
+++ b/e2e/fixtures/javascript.dynamic-import.template-string/index.js
@@ -1,0 +1,1 @@
+import(`./foo`)

--- a/e2e/fixtures/javascript.dynamic-import.template-string/mako.config.json
+++ b/e2e/fixtures/javascript.dynamic-import.template-string/mako.config.json
@@ -1,0 +1,11 @@
+{
+  "entry": {
+    "index": "./index.js"
+  },
+  "optimization": {
+    "skipModules": false,
+    "concatenateModules": false
+  },
+  "platform": "node",
+  "chunkLoadingGlobal": "dynamic_import_async_module"
+}


### PR DESCRIPTION
Close #1225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 添加了一种新的转换访客`ImportTemplateToStringLiteral`，用于将特定的导入模板表达式转换为字符串字面量。
  - 在JavaScript中引入了使用模板字符串动态导入模块的功能。

- **测试**
  - 添加了新的端到端测试，验证导入模板字符串的功能。
  
- **配置**
  - 引入新的配置文件`mako.config.json`，用于指定JavaScript项目的入口点、优化选项、平台目标和动态导入相关的全局变量。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->