### PR TITLE
feat: ✨ support mako cli using abbreviated mode value, like "prod"

### DIFF
--- a/crates/mako/src/cli.rs
+++ b/crates/mako/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap;
+use clap::builder::TypedValueParser;
 use clap::Parser;
 
 use crate::config::Mode;
@@ -10,6 +11,15 @@ pub struct Cli {
     #[arg(short, long)]
     pub watch: bool,
     pub root: PathBuf,
-    #[arg(long, default_value_t = Mode::Development, value_enum)]
+    #[arg(long, default_value_t = Mode::Development,
+        value_parser = clap::builder::PossibleValuesParser::new(["production", "prod", "p", "development","dev"])
+                .map(|s|{
+                    match s.as_str() {
+                        "production" | "prod" | "p" => Mode::Production,
+                        "development" | "dev" => Mode::Development,
+                        _ => unreachable!()
+                    }
+                })
+    )]
     pub mode: Mode,
 }


### PR DESCRIPTION
after this,  i will never bother with miss-spelling
```bash
cargo mako  . --mode dev
cargo mako  . --mode prod
cargo mako  . --mode p
```