### PR TITLE
feat: add emitDecoratorMetadata config

### DIFF
--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -158,10 +158,12 @@ impl Transform {
 
                     // folders
                     let mut folders: Vec<Box<dyn Fold>> = vec![];
-                    // decorators should go before preset_env, when compile down to es5, classes become functions, then the decorators on the functions will be removed silently.
+                    // decorators should go before preset_env, when compile down to es5,
+                    // classes become functions, then the decorators on the functions
+                    // will be removed silently.
                     folders.push(Box::new(decorators(decorators::Config {
                         legacy: true,
-                        emit_metadata: false,
+                        emit_metadata: context.config.emit_decorator_metadata,
                         ..Default::default()
                     })));
                     let comments = origin_comments.get_swc_comments().clone();

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -545,6 +545,7 @@ pub struct Config {
     pub experimental: ExperimentalConfig,
     pub watch: WatchConfig,
     pub use_define_for_class_fields: bool,
+    pub emit_decorator_metadata: bool,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
@@ -717,6 +718,7 @@ const DEFAULT_CONFIG: &str = r#"
       "detectLoop": { "ignoreNodeModules": true, "graphviz": false }
     },
     "useDefineForClassFields": true,
+    "emitDecoratorMetadata": false,
     "watch": { "ignorePaths": [] },
     "devServer": { "host": "127.0.0.1", "port": 3000 }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -182,6 +182,13 @@ import("./a.js");
 
 Whether to output assets files. Usually set to `false` when building a pure server-side rendering project, because assets files are not needed at this time.
 
+### emitDecoratorMetadata
+
+- Type: `boolean`
+- Default: `false`
+
+Whether to emit decorator metadata.
+
 ### emotion
 
 - Type: `boolean`
@@ -691,7 +698,7 @@ Whether to output umd format.
 ### useDefineForClassFields
 
 - Type: `boolean`
-- Default: `false`
+- Default: `true`
 
 Whether to use `defineProperty` to define class fields.
 

--- a/e2e/fixtures/javascript.transform.emit_decorator_metadata/expect.js
+++ b/e2e/fixtures/javascript.transform.emit_decorator_metadata/expect.js
@@ -1,0 +1,9 @@
+const assert = require("assert");
+const { parseBuildResult, trim, moduleReg, injectSimpleJest } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const content = files["index.js"];
+assert(
+  content.includes(`_ts_metadata._("design:type", Function),`),
+  `emitDecoratorMetadata works`,
+);

--- a/e2e/fixtures/javascript.transform.emit_decorator_metadata/mako.config.json
+++ b/e2e/fixtures/javascript.transform.emit_decorator_metadata/mako.config.json
@@ -1,0 +1,3 @@
+{
+  "emitDecoratorMetadata": true
+}

--- a/e2e/fixtures/javascript.transform.emit_decorator_metadata/src/index.ts
+++ b/e2e/fixtures/javascript.transform.emit_decorator_metadata/src/index.ts
@@ -1,0 +1,13 @@
+@Decorate
+class MyClass {
+  constructor(
+    private generic: Generic<A>,
+    generic2: Generic<A, B>
+  ) {}
+
+  @Run
+  method(
+    generic: Inter<A>,
+    @Arg() generic2: InterGen<A, B>
+  ) {}
+}


### PR DESCRIPTION
Close #1173

用例来自 https://github.com/leonardfactory/babel-plugin-transform-typescript-metadata/blob/master/test/__fixtures__/generics/code.js

参考：
https://www.typescriptlang.org/docs/handbook/decorators.html#metadata
https://github.com/leonardfactory/babel-plugin-transform-typescript-metadata
https://babeljs.io/docs/babel-plugin-transform-typescript#typescript-compiler-options
