### PR TITLE
perf(tree-shaking): ⚡️ use take instead of clone

### DIFF
--- a/crates/mako/src/plugins/tree_shaking/shake.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use swc_core::common::comments::{Comment, CommentKind};
+use swc_core::common::util::take::Take;
 use swc_core::common::{DUMMY_SP, GLOBALS};
 
 use self::skip_module::skip_module_optimize;
@@ -256,11 +257,11 @@ pub fn optimize_modules(module_graph: &mut ModuleGraph, context: &Arc<Context>) 
     }
 
     for (module_id, tsm) in &tree_shake_modules_map {
-        let tsm = tsm.borrow();
+        let mut tsm = tsm.borrow_mut();
 
         if tsm.not_used() {
             module_graph.remove_module(module_id);
-        } else if let Some(swc_module) = &tsm.updated_ast {
+        } else if let Some(swc_module) = &mut tsm.updated_ast {
             module_graph
                 .get_module_mut(module_id)
                 .unwrap()
@@ -269,7 +270,7 @@ pub fn optimize_modules(module_graph: &mut ModuleGraph, context: &Arc<Context>) 
                 .unwrap()
                 .ast
                 .as_script_ast_mut()
-                .body = swc_module.body.clone();
+                .body = swc_module.body.take();
         }
     }
 


### PR DESCRIPTION
benchmark with with-antd
```txt
clone: 494.0ms
 take: 454.3ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **性能优化**
	- 优化了模块处理逻辑，提高运行效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->