### PR TITLE
fix: chunk file name should be url-friendly

### DIFF
--- a/crates/mako/src/generate/chunk.rs
+++ b/crates/mako/src/generate/chunk.rs
@@ -74,11 +74,13 @@ impl Chunk {
                     .components()
                     .filter(|c| !matches!(c, Component::RootDir | Component::CurDir))
                     .map(|c| match c {
-                        Component::ParentDir => "@".to_string(),
-                        Component::Prefix(_) => "@".to_string(),
+                        Component::ParentDir => "_pd_".to_string(),
+                        Component::Prefix(_) => "_ps_".to_string(),
                         Component::RootDir => "".to_string(),
                         Component::CurDir => "".to_string(),
-                        Component::Normal(seg) => seg.to_string_lossy().replace(['.', '?'], "_"),
+                        Component::Normal(seg) => {
+                            seg.to_string_lossy().replace(['.', '?', '@'], "_")
+                        }
                     })
                     .collect::<Vec<String>>()
                     .join("_");


### PR DESCRIPTION
修复配置 `moduleIdStrategy: 'named'` 时生成的 chunk 文件名可能包含 `@` 的问题，文件名被 encode 可能会导致 CDN 资源访问失败