### PR TITLE
fix: dev server don't support publicPath (again)

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -111,6 +111,24 @@ exports.dev = async function (opts) {
 
   const outputPath = path.resolve(opts.cwd, opts.config.outputPath || 'dist');
 
+  function processReqURL(publicPath, reqURL) {
+    if (!publicPath.startsWith('/')) {
+      publicPath = '/' + publicPath;
+    }
+    if (reqURL.startsWith(publicPath)) {
+      return reqURL.slice(publicPath.length - 1);
+    } else {
+      return reqURL;
+    }
+  }
+
+  if (opts.config.publicPath) {
+    app.use((req, _res, next) => {
+      req.url = processReqURL(opts.config.publicPath, req.url);
+      next();
+    });
+  }
+
   // serve dist files
   app.use(express.static(outputPath));
 

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -115,11 +115,9 @@ exports.dev = async function (opts) {
     if (!publicPath.startsWith('/')) {
       publicPath = '/' + publicPath;
     }
-    if (reqURL.startsWith(publicPath)) {
-      return reqURL.slice(publicPath.length - 1);
-    } else {
-      return reqURL;
-    }
+    return reqURL.startsWith(publicPath)
+      ? reqURL.slice(publicPath.length - 1)
+      : reqURL;
   }
 
   if (opts.config.publicPath) {


### PR DESCRIPTION
#1398 的后续。

---

@whyer11 

你的逻辑应该是对的。

我之前以为的逻辑是静态资源会 proxy 到 mako(rust) 的 server，我昨天验也只验了 mako（rust） server 的逻辑。刚才看代码发现，我们是基于 express.static 的逻辑才生效的。。

我先把你之前的修改再加回去，但感觉终态应该要走 mako(rust) 的 server。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
  - 引入了动态处理请求URL的新功能，可以根据配置自定义公共路径，提高了URL处理的灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->