### PR TITLE
fix(update): async module update miss async deps

### DIFF
--- a/crates/mako/src/dev/update.rs
+++ b/crates/mako/src/dev/update.rs
@@ -475,7 +475,7 @@ impl Diff {
 
 // 比较两个依赖列表的差异
 // 未变化的模块算作 modified，因为依赖数据必然发生了变化；eg: order，span
-fn diff(origin: &Vec<(ModuleId, Dependency)>, new_deps: &Vec<(ModuleId, Dependency)>) -> Diff {
+fn diff(origin: &[(ModuleId, Dependency)], new_deps: &[(ModuleId, Dependency)]) -> Diff {
     let origin_module_ids = origin
         .iter()
         .map(|(module_id, _dep)| module_id.clone())

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -36,6 +36,12 @@ pub struct Dependency {
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Default)]
+    pub struct ResolveTypeFlags: u16 {
+        const Sync  = 1;
+        const Async = 1<<2;
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Default)]
     pub struct ImportType: u16 {
         const Default = 1;
         const Named = 1<<2;
@@ -48,6 +54,15 @@ bitflags! {
         const Named = 1;
         const Default = 1<<2;
         const Namespace = 1<<3;
+    }
+}
+
+impl From<&ResolveType> for ResolveTypeFlags {
+    fn from(value: &ResolveType) -> Self {
+        match value {
+            ResolveType::DynamicImport | ResolveType::Worker => Self::Async,
+            _ => Self::Sync,
+        }
     }
 }
 

--- a/crates/mako/src/module_graph.rs
+++ b/crates/mako/src/module_graph.rs
@@ -105,6 +105,29 @@ impl ModuleGraph {
         self.graph.node_weights_mut().collect()
     }
 
+    pub fn clear_dependency(&mut self, from: &ModuleId, to: &ModuleId) {
+        let from_index = self.id_index_map.get(from).unwrap_or_else(|| {
+            panic!(
+                r#"from node "{}" does not exist in the module graph when remove edge"#,
+                from.id
+            )
+        });
+
+        let to_index = self.id_index_map.get(to).unwrap_or_else(|| {
+            panic!(
+                r#"to node "{}" does not exist in the module graph when remove edge"#,
+                to.id
+            )
+        });
+
+        self.graph
+            .find_edge(*from_index, *to_index)
+            .and_then(|edge| {
+                self.graph.remove_edge(edge);
+                None::<()>
+            });
+    }
+
     pub fn remove_dependency(&mut self, from: &ModuleId, to: &ModuleId, dep: &Dependency) {
         let from_index = self.id_index_map.get(from).unwrap_or_else(|| {
             panic!(


### PR DESCRIPTION
## Problem

1. `Dependence` 数据需要记录 import source 的 span，用来给 aysnc module  定位需要转换哪句 import 语句；
2. 原来的 update 逻辑在 import source 和 resolve type 不变的情况下，不会更新 span 信息；
3. 当 async module 更新后，模块的 import 的 span 是新的, 无法命中老的 Dependence 记录，那么热更后 ，就漏掉了 await async 依赖的运行时语句，导致取到的是 Promise<Module>。

## Solution 

update 时更新 modified module 所有 edge 上的 Dependence 信息 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了依赖管理逻辑，简化了依赖跟踪机制。
	- 新增 `ResolveTypeFlags` 结构，增强同步与异步状态标记功能。
	- 增加了 `clear_dependency` 方法，以便更方便地移除模块之间的依赖关系。

- **测试**
	- 新增“异步模块更新”测试用例，验证 `@antv/g2` 库的异步导入行为及版本更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->