### PR TITLE
fix: Change notify features to macos_fsevent

### DIFF
--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -89,7 +89,7 @@ md5                   = "0.7.0"
 mdxjs                 = "0.1.14"
 merge-source-map      = "1.2.0"
 mime_guess            = "2.0.4"
-notify                = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
+notify                = { version = "6.1.1", default-features = false, features = ["macos_fsevent"] }
 notify-debouncer-full = { version = "0.3.1", default-features = false }
 path-clean            = "1.0.1"
 pathdiff              = "0.2.1"


### PR DESCRIPTION
fix #1428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了 macOS 的文件系统事件监控机制，以提升兼容性和性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->