### PR TITLE
feat: add regexes from node_modules watch

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -168,6 +168,7 @@ pub struct BuildParams {
     };
     watch?: {
         ignoredPaths?: string[];
+        nodeModulesRegexes?: string[];
     };
 }"#)]
     pub config: serde_json::Value,

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -446,6 +446,7 @@ pub struct ExperimentalConfig {
 #[serde(rename_all = "camelCase")]
 pub struct WatchConfig {
     pub ignore_paths: Vec<String>,
+    pub node_modules_regexes: Vec<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -719,7 +720,7 @@ const DEFAULT_CONFIG: &str = r#"
     },
     "useDefineForClassFields": true,
     "emitDecoratorMetadata": false,
-    "watch": { "ignorePaths": [] },
+    "watch": { "ignorePaths": [], "nodeModulesRegexes": [] },
     "devServer": { "host": "127.0.0.1", "port": 3000 }
 }
 "#;

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -445,8 +445,8 @@ pub struct ExperimentalConfig {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct WatchConfig {
-    pub ignore_paths: Vec<String>,
-    pub node_modules_regexes: Vec<String>,
+    pub ignore_paths: Option<Vec<String>>,
+    pub node_modules_regexes: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/crates/mako/src/dev/watch.rs
+++ b/crates/mako/src/dev/watch.rs
@@ -39,6 +39,8 @@ impl<'a> Watcher<'a> {
                 .config
                 .watch
                 .node_modules_regexes
+                .clone()
+                .unwrap_or_default()
                 .iter()
                 .map(|s| Regex::new(s).unwrap())
                 .collect::<Vec<Regex>>(),
@@ -125,6 +127,8 @@ impl<'a> Watcher<'a> {
                 .config
                 .watch
                 .ignore_paths
+                .as_deref()
+                .unwrap_or(&[])
                 .iter()
                 .map(|p| p.as_str()),
         );

--- a/crates/mako/src/dev/watch.rs
+++ b/crates/mako/src/dev/watch.rs
@@ -70,10 +70,12 @@ impl<'a> Watcher<'a> {
                     }
                 }
                 if !self.node_modules_regexes.is_empty() {
-                    let is_match = self
-                        .node_modules_regexes
-                        .iter()
-                        .any(|regex| regex.is_match(resource.0.path().to_str().unwrap()));
+                    let file_path = resource.0.path().to_str().unwrap();
+                    let is_match = file_path.contains("node_modules")
+                        && self
+                            .node_modules_regexes
+                            .iter()
+                            .any(|regex| regex.is_match(file_path));
                     if is_match {
                         let _ = self.watcher.watch(
                             resource.0.path().to_path_buf().as_path(),

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -183,6 +183,7 @@ export interface BuildParams {
     };
     watch?: {
       ignoredPaths?: string[];
+      nodeModulesRegexes?: string[];
     };
   };
   plugins: Array<JsHooks>;


### PR DESCRIPTION
watch module  in node_modules directly make too many files os error

add config node_modules_regexes to watch node_modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
	- 增加了对 `node_modules` 目录中路径的正则表达式匹配功能，用户可以在配置中指定要忽略的文件和目录，从而提高文件监视的性能和相关性。
	- 更新了 `BuildParams` 结构，新增可选属性 `nodeModulesRegexes`，允许用户定义路径匹配模式以优化构建过程。
	- 更新了默认配置以包含新的正则表达式选项，确保用户在使用默认设置时能够利用这一新功能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->