### PR TITLE
feat: support __webpack_public_path and __mako_public_path assignment

### DIFF
--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -36,6 +36,7 @@ use crate::visitors::fix_symbol_conflict::FixSymbolConflict;
 use crate::visitors::import_template_to_string_literal::ImportTemplateToStringLiteral;
 use crate::visitors::new_url_assets::NewUrlAssets;
 use crate::visitors::provide::Provide;
+use crate::visitors::public_path_assignment::PublicPathAssignment;
 use crate::visitors::react::react;
 use crate::visitors::try_resolve::TryResolve;
 use crate::visitors::ts_strip::ts_strip;
@@ -131,6 +132,7 @@ impl Transform {
                         context: context.clone(),
                         unresolved_mark,
                     }));
+                    visitors.push(Box::new(PublicPathAssignment {}));
                     // TODO: refact provide
                     visitors.push(Box::new(Provide::new(
                         context.config.providers.clone(),

--- a/crates/mako/src/plugins/invalid_webpack_syntax.rs
+++ b/crates/mako/src/plugins/invalid_webpack_syntax.rs
@@ -62,7 +62,9 @@ impl<'a> Visit for InvalidSyntaxVisitor<'a> {
     }
     fn visit_ident(&mut self, n: &Ident) {
         // why keep __webpack_nonce__? since styled-components is using it
-        let is_webpack_prefix = n.sym.starts_with("__webpack_") && &n.sym != "__webpack_nonce__";
+        let is_webpack_prefix = n.sym.starts_with("__webpack_")
+            && &n.sym != "__webpack_nonce__"
+            && &n.sym != "__webpack_public_path__";
         let has_binding = n.span.ctxt.outer() != self.unresolved_mark;
         if is_webpack_prefix && !has_binding {
             self.handler

--- a/crates/mako/src/visitors/mod.rs
+++ b/crates/mako/src/visitors/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod meta_url_replacer;
 pub(crate) mod new_url_assets;
 pub(crate) mod optimize_define_utils;
 pub(crate) mod provide;
+pub(crate) mod public_path_assignment;
 pub(crate) mod react;
 pub(crate) mod try_resolve;
 pub(crate) mod ts_strip;

--- a/crates/mako/src/visitors/public_path_assignment.rs
+++ b/crates/mako/src/visitors/public_path_assignment.rs
@@ -1,0 +1,54 @@
+use swc_core::common::DUMMY_SP;
+use swc_core::ecma::ast::{AssignExpr, AssignOp, Pat, PatOrExpr};
+use swc_core::ecma::utils::member_expr;
+use swc_core::ecma::visit::{VisitMut, VisitMutWith};
+
+pub struct PublicPathAssignment {}
+
+impl VisitMut for PublicPathAssignment {
+    fn visit_mut_assign_expr(&mut self, n: &mut AssignExpr) {
+        if n.op == AssignOp::Assign {
+            if let PatOrExpr::Pat(box Pat::Ident(ident)) = &n.left {
+                let sym = ident.sym.as_ref();
+                if sym == "__webpack_public_path__" || sym == "__mako_public_path__" {
+                    *n = AssignExpr {
+                        left: PatOrExpr::Expr(member_expr!(DUMMY_SP, __mako_require__.publicPath)),
+                        ..n.clone()
+                    };
+                }
+            }
+        }
+        n.visit_mut_children_with(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_core::common::GLOBALS;
+    use swc_core::ecma::visit::VisitMutWith;
+
+    use super::PublicPathAssignment;
+    use crate::ast::tests::TestUtils;
+
+    #[test]
+    fn test_normal() {
+        assert_eq!(
+            run(r#"__webpack_public_path__ = '/foo/';"#),
+            r#"__mako_require__.publicPath = '/foo/';"#.trim()
+        );
+        assert_eq!(
+            run(r#"__mako_public_path__ = '/foo/';"#),
+            r#"__mako_require__.publicPath = '/foo/';"#.trim()
+        );
+    }
+
+    fn run(js_code: &str) -> String {
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
+        let ast = test_utils.ast.js_mut();
+        GLOBALS.set(&test_utils.context.meta.script.globals, || {
+            let mut visitor = PublicPathAssignment {};
+            ast.ast.visit_mut_with(&mut visitor);
+        });
+        test_utils.js_ast_to_code()
+    }
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -539,6 +539,12 @@ Buffer;
 
 publicPath configuration. Note: There is a special value `"runtime"`, which means that it will switch to runtime mode and use the runtime `window.publicPath` as publicPath.
 
+If you want to set the `publicPath` in the runtime, use `__mako_public_path__`. (Notice: `__webpack_public_path__` is also supported)
+
+```ts
+__mako_public_path__ = '/foo/';
+```
+
 ### px2rem
 
 - Type: `false | { root?: number, propBlackList?: string[], propWhiteList?: string[], selectorBlackList?: string[], selectorWhiteList?: string[], selectorDoubleList?: string[], minPixelValue?: number }`

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -540,6 +540,12 @@ Buffer;
 
 publicPath 配置。注意：有一个特殊值 `"runtime"`，这意味着它将切换到运行时模式并使用运行时的 `window.publicPath` 作为 publicPath。
 
+如果你想在运行时设置 `publicPath`，请使用 `__mako_public_path__`。（注：`__webpack_public_path__` 也是支持的）
+
+```ts
+__mako_public_path__ = '/foo/';
+```
+
 ### px2rem
 
 - 类型：`false | { root?: number, propBlackList?: string[], propWhiteList?: string[], selectorBlackList?: string[], selectorWhiteList?: string[], selectorDoubleList?: string[], minPixelValue?: number }`

--- a/e2e/fixtures/config.public_path.with-assignment/expect.js
+++ b/e2e/fixtures/config.public_path.with-assignment/expect.js
@@ -1,0 +1,8 @@
+const assert = require("assert");
+const { parseBuildResult, trim, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const content = files["index.js"];
+
+assert(content.includes(`__mako_require__.publicPath = '/foo/'`), `__webpack_public_path__ works`);
+assert(content.includes(`__mako_require__.publicPath = '/bar/'`), `__mako_public_path__ works`);

--- a/e2e/fixtures/config.public_path.with-assignment/mako.config.json
+++ b/e2e/fixtures/config.public_path.with-assignment/mako.config.json
@@ -1,0 +1,6 @@
+{
+  "publicPath": "/foooooo/",
+  "mode": "production",
+  "minify": false,
+  "hmr": false
+}

--- a/e2e/fixtures/config.public_path.with-assignment/src/index.tsx
+++ b/e2e/fixtures/config.public_path.with-assignment/src/index.tsx
@@ -1,0 +1,3 @@
+console.log(1);
+__webpack_public_path__ = '/foo/';
+__mako_public_path__ = '/bar/';


### PR DESCRIPTION
Close #1328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了公路径分配处理的新模块，改进了资产路径管理。
	- 添加了对 `__webpack_public_path__` 和 `__mako_public_path__` 的处理逻辑，以支持动态公共路径配置。

- **测试**
	- 增加了新的测试文件和配置，确保公路径分配在构建过程中的正确性。

- **文档**
	- 新增了配置文件，定义了公共路径及构建相关属性，用于前端应用程序的构建和部署。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->