### PR TITLE
fix: __webpack_public_path__ and __mako_public_path__ should not be replaced when it's defined by user

### DIFF
--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -132,7 +132,7 @@ impl Transform {
                         context: context.clone(),
                         unresolved_mark,
                     }));
-                    visitors.push(Box::new(PublicPathAssignment {}));
+                    visitors.push(Box::new(PublicPathAssignment { unresolved_mark }));
                     // TODO: refact provide
                     visitors.push(Box::new(Provide::new(
                         context.config.providers.clone(),

--- a/crates/mako/src/visitors/public_path_assignment.rs
+++ b/crates/mako/src/visitors/public_path_assignment.rs
@@ -1,16 +1,20 @@
-use swc_core::common::DUMMY_SP;
+use swc_core::common::{Mark, DUMMY_SP};
 use swc_core::ecma::ast::{AssignExpr, AssignOp, Pat, PatOrExpr};
 use swc_core::ecma::utils::member_expr;
 use swc_core::ecma::visit::{VisitMut, VisitMutWith};
 
-pub struct PublicPathAssignment {}
+pub struct PublicPathAssignment {
+    pub unresolved_mark: Mark,
+}
 
 impl VisitMut for PublicPathAssignment {
     fn visit_mut_assign_expr(&mut self, n: &mut AssignExpr) {
         if n.op == AssignOp::Assign {
             if let PatOrExpr::Pat(box Pat::Ident(ident)) = &n.left {
                 let sym = ident.sym.as_ref();
-                if sym == "__webpack_public_path__" || sym == "__mako_public_path__" {
+                if ident.span.ctxt.outer() == self.unresolved_mark
+                    && (sym == "__webpack_public_path__" || sym == "__mako_public_path__")
+                {
                     *n = AssignExpr {
                         left: PatOrExpr::Expr(member_expr!(DUMMY_SP, __mako_require__.publicPath)),
                         ..n.clone()
@@ -42,11 +46,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_ident_defined() {
+        assert_eq!(
+            run(r#"let __webpack_public_path__ = 1; __webpack_public_path__ = '/foo/';"#),
+            r#"
+let __webpack_public_path__ = 1;
+__webpack_public_path__ = '/foo/';
+"#
+            .trim()
+        );
+        assert_eq!(
+            run(r#"let __mako_public_path__ = 1; __mako_public_path__ = '/foo/';"#),
+            r#"
+let __mako_public_path__ = 1;
+__mako_public_path__ = '/foo/';
+"#
+            .trim()
+        );
+    }
+
     fn run(js_code: &str) -> String {
         let mut test_utils = TestUtils::gen_js_ast(js_code);
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
-            let mut visitor = PublicPathAssignment {};
+            let mut visitor = PublicPathAssignment {
+                unresolved_mark: ast.unresolved_mark,
+            };
             ast.ast.visit_mut_with(&mut visitor);
         });
         test_utils.js_ast_to_code()


### PR DESCRIPTION
https://github.com/umijs/mako/pull/1441 的后续。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了 `PublicPathAssignment` 结构以包含新的 `unresolved_mark` 字段，增强了对特定赋值表达式的处理逻辑。
	- 改进了对 `__webpack_public_path__` 和 `__mako_public_path__` 的识别条件，提升了公共路径赋值的准确性。
	- 添加了新的测试用例 `test_ident_defined`，确保赋值表达式处理的正确性。
  
- **修复**
	- 改进了公共路径转换的控制流，确保在处理时考虑到 `unresolved_mark` 的上下文。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->