### PR TITLE
wip chore: targets default from chrome 80 to any-target

### DIFF
--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -683,7 +683,7 @@ const DEFAULT_CONFIG: &str = r#"
     "providers": {},
     "publicPath": "/",
     "inlineLimit": 10000,
-    "targets": { "chrome": 80 },
+    "targets": {},
     "less": { "theme": {}, "lesscPath": "", javascriptEnabled: true },
     "define": {},
     "mdx": false,

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -600,9 +600,7 @@ async function getMakoConfig(opts) {
     },
     mode: 'development',
     publicPath: runtimePublicPath ? 'runtime' : publicPath || '/',
-    targets: targets || {
-      chrome: 80,
-    },
+    targets: targets || {},
     manifest,
     mdx: !!mdx,
     codeSplitting:


### PR DESCRIPTION
use swc preset-env any_targets to align umi default targets(babel-preset-env options `{ targets: {} })`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了默认配置，以便更灵活地处理浏览器目标，通过将 Chrome 的特定版本目标移除，改为使用空对象，提供更广泛的兼容性。

- **变更**
	- 修改了配置对象中 `targets` 属性的默认值，简化了配置设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->