### PR TITLE
perf(tree-shaking): parallelize tree shaking module map init

### DIFF
--- a/crates/mako/src/plugins/tree_shaking/module.rs
+++ b/crates/mako/src/plugins/tree_shaking/module.rs
@@ -4,7 +4,6 @@ use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{Module as SwcModule, ModuleItem};
 
 use crate::module::{Module, ModuleId};
-use crate::module_graph::ModuleGraph;
 use crate::plugins::tree_shaking::statement_graph::{
     ExportInfo, ExportInfoMatch, ExportSource, ExportSpecifierInfo, ImportInfo, StatementGraph,
     StatementId,
@@ -278,7 +277,7 @@ impl TreeShakeModule {
         self.used_exports.is_empty()
     }
 
-    pub fn new(module: &Module, order: usize, _module_graph: &ModuleGraph) -> Self {
+    pub fn new(module: &Module, order: usize) -> Self {
         let module_info = module.info.as_ref().unwrap();
 
         let mut unresolved_ctxt = SyntaxContext::empty();

--- a/crates/mako/src/plugins/tree_shaking/shake.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake.rs
@@ -45,7 +45,7 @@ pub fn optimize_modules(module_graph: &mut ModuleGraph, context: &Arc<Context>) 
                         let dep_module_type = dep_module.get_module_type();
 
                         if dep_module_type != ModuleType::Script {
-                            return false;
+                            return true;
                         }
 
                         dep_module.side_effects = true;

--- a/crates/mako/src/plugins/tree_shaking/shake/find_export_source.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/find_export_source.rs
@@ -181,7 +181,7 @@ impl TreeShakeModule {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Deref;
+
     use std::sync::Arc;
 
     use swc_core::common::GLOBALS;
@@ -455,7 +455,7 @@ mod tests {
     fn tsm_with_code(code: &str) -> TreeShakeModule {
         let context: Arc<Context> = Default::default();
 
-        let module_graph = context.module_graph.write().unwrap();
+        let _module_graph = context.module_graph.write().unwrap();
 
         let file = File::with_content(
             "test.js".to_string(),
@@ -478,10 +478,8 @@ mod tests {
             side_effects: false,
         };
 
-        let tsm = GLOBALS.set(&context.meta.script.globals, || {
-            TreeShakeModule::new(&mako_module, 0, module_graph.deref())
-        });
-
-        tsm
+        GLOBALS.set(&context.meta.script.globals, || {
+            TreeShakeModule::new(&mako_module, 0)
+        })
     }
 }


### PR DESCRIPTION
performance: with-antd 

(disable `skipModules` and `concatenateModules` )

```txt
branch:  190.0ms
master:  265.1ms 
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
  - 引入了并行处理的树摇逻辑，提升模块优化性能。
  - 新增 `shake_module` 函数，提高代码可读性和可维护性。

- **bug 修复**
  - 简化了 `TreeShakeModule` 的实例化过程，消除了不必要的参数和导入。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->