### PR TITLE
perf: use arcstr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,6 +2622,7 @@ name = "mako"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "base64 0.21.2",
  "bitflags 2.4.2",
  "cached",

--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -72,6 +72,7 @@ swc_error_reporters = "0.16.1"
 swc_node_comments   = "0.19.1"
 
 anyhow                = "1.0.71"
+arcstr                = { version = "1.2.0", features = ["serde"] }
 base64                = "0.21.2"
 chrono                = "0.4.38"
 clap                  = { version = "4.3.11", features = ["derive"] }

--- a/crates/mako/src/ast/js_ast.rs
+++ b/crates/mako/src/ast/js_ast.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use arcstr::ArcStr;
 use swc_core::base::try_with_handler;
 use swc_core::common::errors::HANDLER;
 use swc_core::common::util::take::Take;
@@ -32,7 +33,7 @@ pub struct JsAst {
     pub ast: Module,
     pub unresolved_mark: Mark,
     pub top_level_mark: Mark,
-    pub path: String,
+    pub path: ArcStr,
     pub contains_top_level_await: bool,
 }
 
@@ -109,7 +110,7 @@ impl JsAst {
                 ast,
                 unresolved_mark,
                 top_level_mark,
-                path: file.relative_path.to_string_lossy().to_string(),
+                path: file.relative_path.to_string_lossy().into(),
                 contains_top_level_await,
             })
         })

--- a/crates/mako/src/ast/utils.rs
+++ b/crates/mako/src/ast/utils.rs
@@ -143,7 +143,7 @@ pub fn member_call(obj: Expr, member_prop: MemberProp, args: Vec<ExprOrSpread>) 
     })
 }
 
-pub fn require_ensure(source: String) -> Expr {
+pub fn require_ensure(source: &str) -> Expr {
     member_call(
         Expr::Ident(id("__mako_require__")),
         MemberProp::Ident(id("ensure")),

--- a/crates/mako/src/build/mod.rs
+++ b/crates/mako/src/build/mod.rs
@@ -102,7 +102,7 @@ impl Compiler {
             // handle deps
             for dep in resolved_deps {
                 let path = dep.resolver_resource.get_resolved_path();
-                let dep_module_id = ModuleId::new(path.clone());
+                let dep_module_id = ModuleId::new(&path);
                 if !module_graph.has_module(&dep_module_id) {
                     let module = match dep.resolver_resource {
                         ResolverResource::Virtual(_) | ResolverResource::Resolved(_) => {
@@ -190,7 +190,7 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
             raw,
             ..Default::default()
         };
-        let module_id = ModuleId::new(origin_path.to_string());
+        let module_id = ModuleId::new(&origin_path);
         Module::new(module_id, false, Some(info))
     }
 
@@ -203,7 +203,7 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
         }));
         let ast = parse::Parse::parse(&file, context.clone())?;
         let path = file.path.to_string_lossy().to_string();
-        let module_id = ModuleId::new(path.clone());
+        let module_id = ModuleId::new(&path);
         let raw = file.get_content_raw();
         let info = ModuleInfo {
             file,
@@ -215,7 +215,7 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
     }
 
     fn create_ignored_module(path: &str, context: Arc<Context>) -> Module {
-        let module_id = ModuleId::new(path.to_owned());
+        let module_id = ModuleId::new(path);
 
         let mut module = Module::new(module_id, false, None);
 
@@ -285,7 +285,7 @@ __mako_require__.loadScript('{}', (e) => e.type === 'load' ? resolve() : reject(
 
         // 5. create module
         let path = file.path.to_string_lossy().to_string();
-        let module_id = ModuleId::new(path.clone());
+        let module_id = ModuleId::new(&path);
         let raw = file.get_content_raw();
         let is_entry = file.is_entry;
         let source_map_chain = file.get_source_map_chain(context.clone());

--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
 use anyhow::{anyhow, Error, Result};
+use arcstr::ArcStr;
 use colored::Colorize;
 use regex::Regex;
 use swc_core::common::sync::Lrc;
@@ -27,7 +28,7 @@ pub struct Context {
     pub module_graph: RwLock<ModuleGraph>,
     pub chunk_graph: RwLock<ChunkGraph>,
     pub assets_info: Mutex<HashMap<String, String>>,
-    pub modules_with_missing_deps: RwLock<Vec<String>>,
+    pub modules_with_missing_deps: RwLock<Vec<ArcStr>>,
     pub config: Config,
     pub args: Args,
     pub root: PathBuf,

--- a/crates/mako/src/dev/update.rs
+++ b/crates/mako/src/dev/update.rs
@@ -128,7 +128,7 @@ impl Compiler {
                 self.context.modules_with_missing_deps.write().unwrap();
             let mut module_graph = self.context.module_graph.write().unwrap();
             for module_id in modules_with_missing_deps.clone().iter() {
-                let id = ModuleId::new(module_id.clone());
+                let id = ModuleId::new(module_id);
                 let module = module_graph.get_module_mut(&id).unwrap();
                 let missing_deps = module.info.clone().unwrap().deps.missing_deps;
                 for (_source, dep) in missing_deps {
@@ -139,7 +139,7 @@ impl Compiler {
                             "  > missing deps resolved {:?} from {:?}",
                             dep.source, module_id
                         );
-                        modified.push(PathBuf::from(module_id.clone()));
+                        modified.push(PathBuf::from(module_id.as_str()));
                         let info = module.info.as_mut().unwrap();
                         info.deps.missing_deps.remove(&dep.source);
                         if info.deps.missing_deps.is_empty() {
@@ -168,12 +168,14 @@ impl Compiler {
                     let id: ModuleId = format!("{}{}", path, search).into();
                     if module_graph.has_module(&id) {
                         debug!("  > {} is filtered", &id.id);
-                        new_paths.push((PathBuf::from(&id.id), update_type.clone()));
+                        new_paths.push((PathBuf::from(&id.id.as_str()), update_type.clone()));
                         let dependents = module_graph.get_dependents(&id);
                         for dependent in dependents {
                             debug!("  > {} is filtered", dependent.0.id);
-                            new_paths
-                                .push((PathBuf::from(dependent.0.id.clone()), update_type.clone()));
+                            new_paths.push((
+                                PathBuf::from(dependent.0.id.as_str()),
+                                update_type.clone(),
+                            ));
                         }
                     }
                 }
@@ -311,7 +313,7 @@ impl Compiler {
                 resolved_deps.iter().for_each(|dep| {
                     let resolved_path = dep.resolver_resource.get_resolved_path();
                     let is_external = dep.resolver_resource.get_external().is_some();
-                    let module_id = ModuleId::new(resolved_path.clone());
+                    let module_id = ModuleId::new(resolved_path.as_str());
                     let module = if is_external {
                         Self::create_external_module(&dep.resolver_resource, self.context.clone())
                     } else {
@@ -400,10 +402,7 @@ impl Compiler {
         let files = added
             .iter()
             .map(|path| {
-                crate::ast::file::File::new(
-                    path.to_string_lossy().to_string(),
-                    self.context.clone(),
-                )
+                crate::ast::file::File::new(path.to_string_lossy().into(), self.context.clone())
             })
             .collect();
         self.build(files)

--- a/crates/mako/src/features/rsc.rs
+++ b/crates/mako/src/features/rsc.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use arcstr::ArcStr;
 use serde::Serialize;
 use swc_core::ecma::ast::{Expr, ExprStmt, Lit, Module, ModuleItem, Stmt, Str};
 
@@ -16,14 +17,14 @@ use crate::module::{ModuleAst, ModuleId};
 #[serde(rename_all = "camelCase")]
 pub struct RscClientInfo {
     pub path: String,
-    pub module_id: String,
+    pub module_id: ArcStr,
 }
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RscCssModules {
     pub path: String,
-    pub module_id: String,
+    pub module_id: ArcStr,
     pub modules: bool,
 }
 
@@ -61,7 +62,7 @@ impl Rsc {
     }
 
     fn generate_client(file: &File, tpl: &str, context: Arc<Context>) -> ModuleAst {
-        let id = ModuleId::new(file.path.to_string_lossy().to_string()).generate(&context);
+        let id = ModuleId::new(file.path.to_string_lossy().as_ref()).generate(&context);
         let path = file.relative_path.to_string_lossy().to_string();
         let content = tpl
             .replace("{{path}}", path.as_str())

--- a/crates/mako/src/generate/chunk_graph.rs
+++ b/crates/mako/src/generate/chunk_graph.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hasher;
 
+use arcstr::ArcStr;
 use petgraph::stable_graph::{DefaultIx, NodeIndex, StableDiGraph};
 use petgraph::visit::Dfs;
 use petgraph::Direction;
@@ -55,7 +56,7 @@ impl ChunkGraph {
         self.graph.node_weights_mut().collect()
     }
 
-    pub fn get_chunk_by_name(&self, name: &String) -> Option<&Chunk> {
+    pub fn get_chunk_by_name(&self, name: &str) -> Option<&Chunk> {
         self.graph.node_weights().find(|c| c.filename().eq(name))
     }
 
@@ -94,7 +95,7 @@ impl ChunkGraph {
             .remove_edge(self.graph.find_edge(*from, *to).unwrap());
     }
 
-    pub fn chunk_names(&self) -> HashSet<String> {
+    pub fn chunk_names(&self) -> HashSet<ArcStr> {
         self.graph.node_weights().map(|c| c.filename()).collect()
     }
 

--- a/crates/mako/src/generate/chunk_pot/mod.rs
+++ b/crates/mako/src/generate/chunk_pot/mod.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::vec;
 
 use anyhow::Result;
+use arcstr::ArcStr;
 use indexmap::IndexSet;
 use swc_core::css::ast::Stylesheet;
 
@@ -21,10 +22,10 @@ use crate::module_graph::ModuleGraph;
 use crate::ternary;
 
 pub struct ChunkPot<'a> {
-    pub chunk_id: String,
+    pub chunk_id: ArcStr,
     pub chunk_type: ChunkType,
-    pub js_name: String,
-    pub module_map: HashMap<String, (&'a Module, u64)>,
+    pub js_name: ArcStr,
+    pub module_map: HashMap<ArcStr, (&'a Module, u64)>,
     pub js_hash: u64,
     pub stylesheet: Option<CssModules<'a>>,
 }
@@ -96,8 +97,8 @@ impl<'cp> ChunkPot<'cp> {
     pub fn to_entry_chunk_files(
         &self,
         context: &Arc<Context>,
-        js_map: &HashMap<String, String>,
-        css_map: &HashMap<String, String>,
+        js_map: &HashMap<ArcStr, ArcStr>,
+        css_map: &HashMap<ArcStr, ArcStr>,
         chunk: &Chunk,
         hmr_hash: u64,
     ) -> Result<Vec<ChunkFile>> {
@@ -149,10 +150,10 @@ impl<'cp> ChunkPot<'cp> {
         context: &'a Arc<Context>,
     ) -> (JsModules<'a>, Option<CssModules<'a>>) {
         crate::mako_profile_function!(module_ids.len().to_string());
-        let mut module_map: HashMap<String, (&Module, u64)> = Default::default();
-        let mut merged_css_modules: Vec<(String, &Stylesheet)> = vec![];
+        let mut module_map: HashMap<ArcStr, (&Module, u64)> = Default::default();
+        let mut merged_css_modules: Vec<(ArcStr, &Stylesheet)> = vec![];
 
-        let mut module_raw_hash_map: HashMap<String, u64> = Default::default();
+        let mut module_raw_hash_map: HashMap<ArcStr, u64> = Default::default();
         let mut css_raw_hashes = vec![];
 
         let module_ids: Vec<_> = module_ids.iter().collect();
@@ -226,7 +227,7 @@ impl<'cp> ChunkPot<'cp> {
 }
 
 struct JsModules<'a> {
-    pub module_map: HashMap<String, (&'a Module, u64)>,
+    pub module_map: HashMap<ArcStr, (&'a Module, u64)>,
     raw_hash: u64,
 }
 
@@ -235,9 +236,10 @@ pub struct CssModules<'a> {
     raw_hash: u64,
 }
 
-pub fn get_css_chunk_filename(js_chunk_filename: &str) -> String {
+pub fn get_css_chunk_filename(js_chunk_filename: &str) -> ArcStr {
     format!(
         "{}.css",
         js_chunk_filename.strip_suffix(".js").unwrap_or("")
     )
+    .into()
 }

--- a/crates/mako/src/generate/chunk_pot/str_impl.rs
+++ b/crates/mako/src/generate/chunk_pot/str_impl.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use arcstr::ArcStr;
 use cached::proc_macro::cached;
 use cached::SizedCache;
 use rayon::prelude::*;
@@ -22,8 +23,8 @@ use crate::ternary;
 
 pub(super) fn render_entry_js_chunk(
     pot: &ChunkPot,
-    js_map: &HashMap<String, String>,
-    css_map: &HashMap<String, String>,
+    js_map: &HashMap<ArcStr, ArcStr>,
+    css_map: &HashMap<ArcStr, ArcStr>,
     chunk: &Chunk,
     context: &Arc<Context>,
     hmr_hash: u64,

--- a/crates/mako/src/generate/chunk_pot/util.rs
+++ b/crates/mako/src/generate/chunk_pot/util.rs
@@ -188,7 +188,7 @@ pub(crate) fn pot_to_module_object(pot: &ChunkPot, context: &Arc<Context>) -> Re
                         },
                     );
                     let pv: PropOrSpread = Prop::KeyValue(KeyValueProp {
-                        key: quote_str!(span, module_id_str.clone()).into(),
+                        key: quote_str!(span, module_id_str.as_str()).into(),
                         value: fn_expr.into(),
                     })
                     .into();
@@ -248,7 +248,7 @@ pub(crate) fn pot_to_chunk_module(
             DUMMY_SP,
             // [[ "module id"], { module object }]
             vec![to_array_lit(vec![
-                to_array_lit(vec![quote_str!(pot.chunk_id.clone()).as_arg()]).as_arg(),
+                to_array_lit(vec![quote_str!(pot.chunk_id.as_str()).as_arg()]).as_arg(),
                 module_object.as_arg(),
             ])
             .as_arg()],

--- a/crates/mako/src/generate/generate_chunks.rs
+++ b/crates/mako/src/generate/generate_chunks.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use arcstr::ArcStr;
 use indexmap::IndexSet;
 use nanoid::nanoid;
 use rayon::prelude::*;
@@ -31,31 +32,31 @@ pub struct ChunkFile {
     pub content: Vec<u8>,
     pub source_map: Option<Vec<u8>>,
     pub hash: Option<String>,
-    pub file_name: String,
-    pub chunk_id: String,
+    pub file_name: ArcStr,
+    pub chunk_id: ArcStr,
     pub file_type: ChunkFileType,
 }
 
 impl ChunkFile {
-    pub fn disk_name(&self) -> String {
+    pub fn disk_name(&self) -> ArcStr {
         if let Some(hash) = &self.hash {
-            hash_file_name(&self.file_name, hash)
+            hash_file_name(self.file_name.as_str(), hash)
         } else {
             self.file_name.clone()
         }
     }
 
-    pub fn source_map_disk_name(&self) -> String {
-        format!("{}.map", self.disk_name())
+    pub fn source_map_disk_name(&self) -> ArcStr {
+        format!("{}.map", self.disk_name()).into()
     }
 
-    pub fn source_map_name(&self) -> String {
-        format!("{}.map", self.file_name)
+    pub fn source_map_name(&self) -> ArcStr {
+        format!("{}.map", self.file_name).into()
     }
 }
 
-type ChunksHashPlaceholder = HashMap<String, String>;
-type ChunksHashReplacer = HashMap<String, String>;
+type ChunksHashPlaceholder = HashMap<ArcStr, ArcStr>;
+type ChunksHashReplacer = HashMap<ArcStr, ArcStr>;
 
 impl Compiler {
     pub fn generate_chunk_files(&self, hmr_hash: u64) -> Result<Vec<ChunkFile>> {
@@ -335,7 +336,7 @@ pub fn modules_to_js_stmts(
     context: &Arc<Context>,
 ) -> Result<(Vec<PropOrSpread>, Option<Stylesheet>)> {
     let mut js_stmts = vec![];
-    let mut merged_css_modules: Vec<(String, Stylesheet)> = vec![];
+    let mut merged_css_modules: Vec<(ArcStr, Stylesheet)> = vec![];
 
     let module_ids: Vec<_> = module_ids.iter().collect();
 
@@ -380,10 +381,10 @@ pub fn modules_to_js_stmts(
     }
 }
 
-fn hash_file_name(file_name: &String, hash: &String) -> String {
+fn hash_file_name(file_name: &str, hash: &str) -> ArcStr {
     let path = Path::new(&file_name);
     let file_stem = path.file_stem().unwrap().to_str().unwrap();
     let file_extension = path.extension().unwrap().to_str().unwrap();
 
-    format!("{}.{}.{}", file_stem, hash, file_extension)
+    format!("{}.{}.{}", file_stem, hash, file_extension).into()
 }

--- a/crates/mako/src/generate/optimize_chunk.rs
+++ b/crates/mako/src/generate/optimize_chunk.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::string::String;
 
+use arcstr::ArcStr;
 use base64::engine::general_purpose;
 use base64::Engine;
 use indexmap::{IndexMap, IndexSet};
@@ -213,7 +214,7 @@ impl Compiler {
                         .keys()
                         .cloned()
                         .collect::<IndexSet<_>>(),
-                    id: ChunkId { id: "".to_string() },
+                    id: ChunkId { id: "".into() },
                     chunk_type: ChunkType::Sync,
                     content: None,
                     source_map: None,
@@ -243,7 +244,7 @@ impl Compiler {
             let mut package_size_map = chunk_modules.iter().fold(
                 IndexMap::<String, (usize, IndexMap<ModuleId, Vec<ChunkId>>)>::new(),
                 |mut size_map, mtc| {
-                    let pkg_name = self.get_package_name(mtc.0).unwrap_or(mtc.0.id.clone());
+                    let pkg_name = self.get_package_name(mtc.0).unwrap_or(mtc.0.id.to_string());
 
                     let module_size = module_graph.get_module(mtc.0).unwrap().get_module_size();
 
@@ -253,7 +254,7 @@ impl Compiler {
                         modules.insert(mtc.0.clone(), mtc.1.clone());
                     } else {
                         size_map.insert(
-                            pkg_name.to_string(),
+                            pkg_name,
                             (
                                 module_size,
                                 IndexMap::from([(mtc.0.clone(), mtc.1.clone())]),
@@ -423,14 +424,15 @@ impl Compiler {
 
         for info in optimize_chunks_infos {
             // create new chunk
+            let group_name: ArcStr = info.group_options.name.as_str().into();
             let info_chunk_id = ChunkId {
-                id: info.group_options.name.clone(),
+                id: group_name.clone(),
             };
             let info_chunk_type =
                 if matches!(info.group_options.allow_chunks, OptimizeAllowChunks::Async) {
                     ChunkType::Sync
                 } else {
-                    ChunkType::Entry(info_chunk_id.clone(), info.group_options.name.clone(), true)
+                    ChunkType::Entry(info_chunk_id.clone(), group_name.clone(), true)
                 };
             let info_chunk = Chunk {
                 modules: info
@@ -483,9 +485,10 @@ impl Compiler {
             // update group chunk
             for (module_id, chunk_ids) in &info.module_to_chunks {
                 // get chunk
+                let group_name: ArcStr = info.group_options.name.as_str().into();
                 let info_chunk = chunk_graph
                     .mut_chunk(&ChunkId {
-                        id: info.group_options.name.clone(),
+                        id: group_name.clone(),
                     })
                     .unwrap();
                 let info_chunk_id = info_chunk.id.clone();
@@ -553,7 +556,9 @@ impl Compiler {
                         ..
                     }),
                 ..
-            }) => resolution.package_json().and_then(|r| r.name.clone()),
+            }) => resolution
+                .package_json()
+                .and_then(|r| r.name.as_ref().map(|name| name.into())),
             _ => None,
         }
     }

--- a/crates/mako/src/generate/transform.rs
+++ b/crates/mako/src/generate/transform.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Error, Result};
+use arcstr::ArcStr;
 use regex::Regex;
 use swc_core::common::errors::HANDLER;
 use swc_core::common::GLOBALS;
@@ -82,7 +83,7 @@ pub fn transform_modules_in_thread(
         thread_pool::spawn(move || {
             let module_graph = context.module_graph.read().unwrap();
             let deps = module_graph.get_dependencies(&module_id);
-            let mut resolved_deps: HashMap<String, (String, String)> = deps
+            let mut resolved_deps: HashMap<String, (ArcStr, ArcStr)> = deps
                 .into_iter()
                 .map(|(id, dep)| {
                     (
@@ -146,7 +147,7 @@ pub fn transform_modules_in_thread(
     Ok(())
 }
 
-fn insert_swc_helper_replace(map: &mut HashMap<String, (String, String)>, context: &Arc<Context>) {
+fn insert_swc_helper_replace(map: &mut HashMap<String, (ArcStr, ArcStr)>, context: &Arc<Context>) {
     let helpers = vec![
         "@swc/helpers/_/_interop_require_default",
         "@swc/helpers/_/_interop_require_wildcard",
@@ -154,8 +155,8 @@ fn insert_swc_helper_replace(map: &mut HashMap<String, (String, String)>, contex
     ];
 
     helpers.into_iter().for_each(|h| {
-        let m_id: ModuleId = h.to_string().into();
-        map.insert(m_id.id.clone(), (m_id.generate(context), h.to_string()));
+        let m_id: ModuleId = ModuleId::from(h);
+        map.insert(m_id.id.to_string(), (m_id.generate(context), h.into()));
     });
 }
 

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use arcstr::ArcStr;
 use base64::engine::{general_purpose, Engine};
 use bitflags::bitflags;
 use pathdiff::diff_paths;
@@ -201,25 +202,25 @@ impl Default for ModuleInfo {
     }
 }
 
-fn md5_hash(source_str: &str, lens: usize) -> String {
+fn md5_hash(source_str: &str, lens: usize) -> ArcStr {
     let digest = md5::compute(source_str);
     let hash = general_purpose::URL_SAFE.encode(digest.0);
-    hash[..lens].to_string()
+    ArcStr::from(&hash[..lens])
 }
 
-pub fn generate_module_id(origin_module_id: String, context: &Arc<Context>) -> String {
+pub fn generate_module_id(origin_module_id: ArcStr, context: &Arc<Context>) -> ArcStr {
     match context.config.module_id_strategy {
-        ModuleIdStrategy::Hashed => md5_hash(&origin_module_id, 8),
+        ModuleIdStrategy::Hashed => md5_hash(origin_module_id.as_str(), 8),
         ModuleIdStrategy::Named => {
             // readable ids for debugging usage
-            let absolute_path = PathBuf::from(origin_module_id);
+            let absolute_path = PathBuf::from(origin_module_id.as_str());
             let relative_path = diff_paths(&absolute_path, &context.root).unwrap_or(absolute_path);
-            relative_path.to_string_lossy().to_string()
+            relative_path.to_string_lossy().into()
         }
     }
 }
 
-pub fn relative_to_root(module_path: &String, root: &PathBuf) -> String {
+pub fn relative_to_root(module_path: &str, root: &PathBuf) -> String {
     let absolute_path = PathBuf::from(module_path);
     let relative_path = diff_paths(&absolute_path, root).unwrap_or(absolute_path);
     // diff_paths result always starts with ".."/"." or not
@@ -235,7 +236,7 @@ pub fn relative_to_root(module_path: &String, root: &PathBuf) -> String {
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct ModuleId {
-    pub id: String,
+    pub id: ArcStr,
 }
 
 impl Ord for ModuleId {
@@ -252,43 +253,49 @@ impl PartialOrd for ModuleId {
 
 impl ModuleId {
     // we use absolute path as module id now
-    pub fn new(id: String) -> Self {
-        Self { id }
+    pub fn new(id: &str) -> Self {
+        Self { id: id.into() }
     }
 
-    pub fn generate(&self, context: &Arc<Context>) -> String {
+    pub fn generate(&self, context: &Arc<Context>) -> ArcStr {
         // TODO: 如果是 Hashed 的话，stats 拿不到原始的 chunk_id
         generate_module_id(self.id.clone(), context)
     }
 
     pub fn from_path(path_buf: PathBuf) -> Self {
         Self {
-            id: path_buf.to_string_lossy().to_string(),
+            id: path_buf.to_string_lossy().into(),
         }
     }
 
     // FIXME: 这里暂时直接通过 module_id 转换为 path，后续如果改了逻辑要记得改
     pub fn to_path(&self) -> PathBuf {
-        PathBuf::from(self.id.clone())
+        PathBuf::from(self.id.as_str())
     }
 }
 
 impl From<String> for ModuleId {
     fn from(id: String) -> Self {
+        Self { id: id.into() }
+    }
+}
+
+impl From<ArcStr> for ModuleId {
+    fn from(id: ArcStr) -> Self {
         Self { id }
     }
 }
 
 impl From<&str> for ModuleId {
     fn from(id: &str) -> Self {
-        Self { id: id.to_string() }
+        Self { id: id.into() }
     }
 }
 
 impl From<PathBuf> for ModuleId {
     fn from(path: PathBuf) -> Self {
         Self {
-            id: path.to_string_lossy().to_string(),
+            id: path.to_string_lossy().into(),
         }
     }
 }

--- a/crates/mako/src/module_graph.rs
+++ b/crates/mako/src/module_graph.rs
@@ -301,7 +301,7 @@ impl ModuleGraph {
     pub fn get_dependency_module_by_source(
         &self,
         module_id: &ModuleId,
-        source: &String,
+        source: &str,
     ) -> Option<&ModuleId> {
         let deps = self.get_dependencies(module_id);
         for (module_id, dep) in deps {

--- a/crates/mako/src/plugins/bundless_compiler.rs
+++ b/crates/mako/src/plugins/bundless_compiler.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use arcstr::ArcStr;
 use pathdiff::diff_paths;
 use rayon::prelude::*;
 use swc_core::common::errors::HANDLER;
@@ -80,11 +81,13 @@ impl BundlessCompiler {
                             }
                         };
 
+                        let replacement = ArcStr::from(replacement);
+
                         Ok((dep.source.clone(), (replacement.clone(), replacement)))
                     })
                     .collect::<Result<Vec<_>>>();
 
-                let resolved_deps: HashMap<String, (String, String)> =
+                let resolved_deps: HashMap<String, (ArcStr, ArcStr)> =
                     resolved_deps?.into_iter().collect();
 
                 drop(module_graph);

--- a/crates/mako/src/plugins/detect_circular_dependence.rs
+++ b/crates/mako/src/plugins/detect_circular_dependence.rs
@@ -49,7 +49,7 @@ impl Plugin for LoopDetector {
                         .iter()
                         .chain(std::iter::once(&loop_end))
                         .map(|id| {
-                            let absolute_path = PathBuf::from(id.id.clone());
+                            let absolute_path = PathBuf::from(id.id.as_str());
                             let relative_path =
                                 diff_paths(&absolute_path, &context.root).unwrap_or(absolute_path);
                             let relative_path = relative_path.to_string_lossy().to_string();

--- a/crates/mako/src/plugins/manifest.rs
+++ b/crates/mako/src/plugins/manifest.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::sync::Arc;
 
 use anyhow::Result;
+use arcstr::ArcStr;
 use regex::Regex;
 use serde_json;
 
@@ -24,7 +25,7 @@ impl Plugin for ManifestPlugin {
     fn build_success(&self, _stats: &StatsJsonMap, context: &Arc<Context>) -> Result<()> {
         if let Some(manifest_config) = &context.config.manifest {
             let assets = &context.stats_info.get_assets();
-            let mut manifest: BTreeMap<String, String> = BTreeMap::new();
+            let mut manifest: BTreeMap<String, ArcStr> = BTreeMap::new();
             let file_name = manifest_config.file_name.clone();
             let base_path = manifest_config.base_path.clone();
 

--- a/crates/mako/src/plugins/minifish.rs
+++ b/crates/mako/src/plugins/minifish.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use arcstr::ArcStr;
 pub(crate) use inject::Inject;
 use inject::MyInjector;
 use rayon::prelude::*;
@@ -163,7 +164,7 @@ impl Plugin for MinifishPlugin {
 
         for dep in deps.iter_mut() {
             if dep.source.starts_with('/') {
-                let mut resolve_as = dep.source.clone();
+                let mut resolve_as = dep.source.to_string();
                 resolve_as.replace_range(0..0, src_root);
                 dep.resolve_as = Some(resolve_as);
             }
@@ -196,7 +197,7 @@ impl Plugin for MinifishPlugin {
                         to_dist_path(&id.id, context)
                             .with_extension("js")
                             .to_string_lossy()
-                            .to_string()
+                            .into()
                     };
 
                     Module {
@@ -228,14 +229,14 @@ struct ModuleGraphOutput {
 #[derive(Serialize)]
 struct Module {
     filename: String,
-    id: String,
+    id: ArcStr,
     dependencies: Vec<Dependency>,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Dependency {
-    module: String,
+    module: ArcStr,
     import_type: ResolveType,
 }
 

--- a/crates/mako/src/plugins/minifish/inject.rs
+++ b/crates/mako/src/plugins/minifish/inject.rs
@@ -492,7 +492,7 @@ my.call("toast");
         };
         let context = Arc::new(context);
         let file = File::with_content(
-            "cut.js".to_string(),
+            "cut.js".into(),
             crate::ast::file::Content::Js(JsContent {
                 content: code.to_string(),
                 ..Default::default()

--- a/crates/mako/src/plugins/ssu.rs
+++ b/crates/mako/src/plugins/ssu.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
+use arcstr::ArcStr;
 use dashmap::DashSet;
 use rayon::prelude::*;
 use regex::Regex;
@@ -29,8 +30,8 @@ struct CacheState {
     config_hash: u64,
     reversed_required_files: HashSet<String>,
     cached_boundaries: HashMap<String, String>,
-    js_patch_map: HashMap<String, String>,
-    css_patch_map: HashMap<String, String>,
+    js_patch_map: HashMap<ArcStr, ArcStr>,
+    css_patch_map: HashMap<ArcStr, ArcStr>,
 }
 
 impl CacheState {
@@ -428,9 +429,13 @@ module.export = Promise.all(
             .par_iter()
             .filter(|&cf| cf.file_name.starts_with("node_modules"))
             .for_each(|cf| {
-                let p = cache_root.join(cf.disk_name());
+                let p = cache_root.join(cf.disk_name().as_str());
                 if let Some(source_map) = &cf.source_map {
-                    fs::write(cache_root.join(cf.source_map_disk_name()), source_map).unwrap();
+                    fs::write(
+                        cache_root.join(cf.source_map_disk_name().as_str()),
+                        source_map,
+                    )
+                    .unwrap();
 
                     let mut f = SysFile::create(&p).unwrap();
 

--- a/crates/mako/src/plugins/tree_shaking/module.rs
+++ b/crates/mako/src/plugins/tree_shaking/module.rs
@@ -210,7 +210,7 @@ impl TreeShakeModule {
                 .as_ref()
                 .and_then(|export_info| export_info.source.as_ref())
             {
-                if self.side_effect_dep_sources.contains(source) {
+                if self.side_effect_dep_sources.contains(source.as_str()) {
                     side_effect_stmts.push(s.id);
                 }
             }
@@ -221,7 +221,7 @@ impl TreeShakeModule {
                 .map(|import_info| &import_info.source)
                 .as_ref()
             {
-                if self.side_effect_dep_sources.contains(source) {
+                if self.side_effect_dep_sources.contains(source.as_str()) {
                     side_effect_stmts.push(s.id);
                 }
             }

--- a/crates/mako/src/plugins/tree_shaking/module_side_effects_flag.rs
+++ b/crates/mako/src/plugins/tree_shaking/module_side_effects_flag.rs
@@ -21,7 +21,7 @@ impl ModuleInfo {
                     side_effects.map(|side_effect| {
                         Self::match_flag(
                             side_effect,
-                            relative_to_root(&self.file.path.to_string_lossy().to_string(), &root)
+                            relative_to_root(self.file.path.to_string_lossy().as_ref(), &root)
                                 .as_str(),
                         )
                     })
@@ -52,11 +52,8 @@ impl ModuleInfo {
 
                             Self::match_flag(
                                 side_effect,
-                                relative_to_root(
-                                    &self.file.path.to_string_lossy().to_string(),
-                                    &root,
-                                )
-                                .as_str(),
+                                relative_to_root(self.file.path.to_string_lossy().as_ref(), &root)
+                                    .as_str(),
                             )
                         }
                         None => true,

--- a/crates/mako/src/plugins/tree_shaking/shake/find_export_source.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/find_export_source.rs
@@ -458,7 +458,7 @@ mod tests {
         let _module_graph = context.module_graph.write().unwrap();
 
         let file = File::with_content(
-            "test.js".to_string(),
+            "test.js".into(),
             Content::Js(JsContent {
                 content: code.to_string(),
                 ..Default::default()

--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate.rs
@@ -278,7 +278,7 @@ pub fn optimize_module_graph(
                             (cjs_name.clone(), cjs_name)
                         };
 
-                        let require_src = id.id.clone();
+                        let require_src = id.id.to_string();
                         module_items.extend(interop.inject_external_export_decl(
                             &require_src,
                             &exposed_names,

--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenate_context.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenate_context.rs
@@ -393,7 +393,7 @@ impl ConcatenateContext {
                 .into_iter()
                 .map(|(k, ref_expr)| {
                     Prop::KeyValue(KeyValueProp {
-                        key: quote_ident!(k).into(),
+                        key: quote_ident!(k.as_str()).into(),
                         value: ref_expr.into_lazy_fn(vec![]).into(),
                     })
                     .into()

--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer.rs
@@ -124,7 +124,7 @@ impl<'a> ConcatenatedTransform<'a> {
                             }
                             Symbol::Namespace => map.get("*").unwrap().clone(),
                             Symbol::Var(ident) => {
-                                if let Some(mf) = map.get(&ident.sym.to_string()) {
+                                if let Some(mf) = map.get(ident.sym.as_ref()) {
                                     mf.clone()
                                 } else {
                                     (quote_ident!("undefined"), None)
@@ -159,7 +159,7 @@ impl<'a> ConcatenatedTransform<'a> {
 
         var_map.iter().for_each(|(id, link)| match link {
             VarLink::Direct(direct_id) => {
-                ref_map.insert(id.0.to_string(), (direct_id.clone().into(), None));
+                ref_map.insert(id.0.as_ref().into(), (direct_id.clone().into(), None));
             }
             VarLink::InDirect(symbol, source) => {
                 let src_module_id = self.src_to_module.get(source).unwrap();
@@ -176,18 +176,18 @@ impl<'a> ConcatenatedTransform<'a> {
                             }
                             Symbol::Namespace => map.get("*").unwrap().clone(),
                             Symbol::Var(ident) => {
-                                if let Some(mf) = map.get(&ident.sym.to_string()) {
+                                if let Some(mf) = map.get(ident.sym.as_ref()) {
                                     mf.clone()
                                 } else {
                                     (quote_ident!("undefined"), None)
                                 }
                             }
                         };
-                        ref_map.insert(id.0.to_string(), module_ref);
+                        ref_map.insert(id.0.as_ref().into(), module_ref);
                     }
                     InnerOrExternal::External(external_names) => {
                         ref_map.insert(
-                            id.0.to_string(),
+                            id.0.as_ref().into(),
                             (quote_ident!(external_names.1.clone()), symbol.to_field()),
                         );
                     }
@@ -356,7 +356,7 @@ impl<'a> ConcatenatedTransform<'a> {
         for (k, module_ref) in &mut *export_ref_map {
             key_value_props.push(
                 Prop::KeyValue(KeyValueProp {
-                    key: quote_ident!(k.clone()).into(),
+                    key: quote_ident!(k.as_str()).into(),
                     value: module_ref_to_expr(module_ref).into_lazy_fn(vec![]).into(),
                 })
                 .into(),
@@ -377,7 +377,7 @@ impl<'a> ConcatenatedTransform<'a> {
             )
             .into_stmt();
 
-        export_ref_map.insert("*".to_string(), (quote_ident!(ns_name.clone()), None));
+        export_ref_map.insert("*".into(), (quote_ident!(ns_name.clone()), None));
         self.my_top_decls.insert(ns_name);
 
         n.body.push(init_stmt.into());

--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer/external_tests.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer/external_tests.rs
@@ -289,7 +289,7 @@ fn run_test(code: &str, ccn_ctx: &mut ConcatenateContext) -> String {
 
     let current_module_id = ModuleId::from("mut.js");
     let module_map = hashmap! {
-       "external".to_string() => ModuleId::from("external")
+       "external".into() => ModuleId::from("external")
     };
 
     GLOBALS.set(&context.meta.script.globals, || {

--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer/tests.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer/tests.rs
@@ -616,7 +616,7 @@ fn test_export_from_var() {
     let mut ccn_ctx = ConcatenateContext {
         modules_exports_map: hashmap! {
             ModuleId::from("src/index.js") => hashmap! {
-                "default".to_string() => (quote_ident!("src_index_default"), None)
+                "default".into() => (quote_ident!("src_index_default"), None)
             }
         },
         ..Default::default()
@@ -650,10 +650,10 @@ fn concatenate_context_fixture_with_inner_module() -> ConcatenateContext {
         },
         modules_exports_map: hashmap! {
             ModuleId::from("src/index.js") => hashmap!{
-                "*".to_string() => (quote_ident!("inner_namespace"), None),
-                "default".to_string() => ( quote_ident!("inner_default_export"), None),
-                "foo".to_string() => (quote_ident!("bar") ,None),
-                "named".to_string() => (quote_ident!("named"), None)
+                "*".into() => (quote_ident!("inner_namespace"), None),
+                "default".into() => ( quote_ident!("inner_default_export"), None),
+                "foo".into() => (quote_ident!("bar") ,None),
+                "named".into() => (quote_ident!("named"), None)
             },
             ModuleId::from("src/no_exports.js") => hashmap!{},
         },
@@ -685,9 +685,9 @@ fn inner_trans_code(code: &str, concatenate_context: &mut ConcatenateContext) ->
     let module_id = ModuleId::from("mut.js");
 
     let src_to_module = hashmap! {
-        "./src".to_string() => ModuleId::from("src/index.js"),
-        "./no_exports".to_string() => ModuleId::from("src/no_exports.js"),
-    "external".to_string() => ModuleId::from("external")
+        "./src".into() => ModuleId::from("src/index.js"),
+        "./no_exports".into() => ModuleId::from("src/no_exports.js"),
+    "external".into() => ModuleId::from("external")
     };
 
     GLOBALS.set(&context.meta.script.globals, || {

--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/utils.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/utils.rs
@@ -6,7 +6,7 @@ use heck::ToSnakeCase;
 use crate::module::ModuleId;
 
 pub fn uniq_module_prefix(module_id: &ModuleId) -> String {
-    let path = Path::new(&module_id.id);
+    let path = Path::new(module_id.id.as_str());
     let len = path.components().count() as i32;
     let mut skip = max(len - 3, 0);
     let mut p = path.components();

--- a/crates/mako/src/plugins/tree_shaking/shake/skip_module.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/skip_module.rs
@@ -33,26 +33,26 @@ impl ReExportReplace {
             ReExportType::Default => {
                 quote!("export { default as $ident } from \"$from\";" as ModuleItem,
                     ident: Ident = ident,
-                    from: Str = quote_str!(self.from_module_id.id.clone())
+                    from: Str = quote_str!(self.from_module_id.id.as_str())
                 )
             }
             ReExportType::Namespace => {
                 quote!("export * as $ident from \"$from\";" as ModuleItem,
                     ident: Ident = ident,
-                    from: Str = quote_str!(self.from_module_id.id.clone())
+                    from: Str = quote_str!(self.from_module_id.id.as_str())
                 )
             }
             ReExportType::Named(local) => {
                 if ident.sym.eq(local) {
                     quote!("export { $ident } from \"$from\";" as ModuleItem,
                         ident: Ident = ident,
-                        from: Str = quote_str!(self.from_module_id.id.clone())
+                        from: Str = quote_str!(self.from_module_id.id.as_str())
                     )
                 } else {
                     quote!("export { $local as $ident } from \"$from\";" as ModuleItem,
                         local: Ident = quote_ident!(local.clone()),
                         ident: Ident = ident,
-                        from: Str = quote_str!(self.from_module_id.id.clone())
+                        from: Str = quote_str!(self.from_module_id.id.as_str())
                     )
                 }
             }
@@ -63,7 +63,7 @@ impl ReExportReplace {
         let import_type: ImportType = (&self.re_export_source.re_export_type).into();
 
         Dependency {
-            source: self.from_module_id.id.clone(),
+            source: self.from_module_id.id.to_string(),
             span: Some(span),
             order: 0,
             resolve_as: None,
@@ -79,7 +79,7 @@ impl ReExportReplace {
         };
 
         Dependency {
-            source: self.from_module_id.id.clone(),
+            source: self.from_module_id.id.to_string(),
             resolve_as: None,
             resolve_type,
             order: 0,
@@ -92,27 +92,27 @@ impl ReExportReplace {
             ReExportType::Default => {
                 quote!("import $ident from \"$from\";" as ModuleItem,
                     ident: Ident = ident,
-                    from: Str = quote_str!(self.from_module_id.id.clone())
+                    from: Str = quote_str!(self.from_module_id.id.as_str())
                 )
             }
             ReExportType::Named(local) => {
                 if ident.sym.eq(local) {
                     quote!("import { $ident } from \"$from\";" as ModuleItem,
                         ident: Ident = ident,
-                        from: Str = quote_str!(self.from_module_id.id.clone())
+                        from: Str = quote_str!(self.from_module_id.id.as_str())
                     )
                 } else {
                     quote!("import { $local as $ident } from \"$from\";" as ModuleItem,
                         local: Ident = quote_ident!(local.clone()),
                         ident: Ident = ident,
-                        from: Str = quote_str!(self.from_module_id.id.clone())
+                        from: Str = quote_str!(self.from_module_id.id.as_str())
                     )
                 }
             }
             ReExportType::Namespace => {
                 quote!("import * as $ident from \"$from\";" as ModuleItem,
                     ident: Ident = ident,
-                    from: Str = quote_str!(self.from_module_id.id.clone())
+                    from: Str = quote_str!(self.from_module_id.id.as_str())
                 )
             }
         }
@@ -514,7 +514,7 @@ pub(super) fn skip_module_optimize(
 
 fn get_imported_tree_shake_module<'a>(
     from_module_id: &ModuleId,
-    source: &String,
+    source: &str,
     module_graph: &ModuleGraph,
     tree_shake_modules_map: &'a HashMap<ModuleId, RefCell<TreeShakeModule>>,
 ) -> Option<&'a RefCell<TreeShakeModule>> {

--- a/crates/mako/src/resolve/mod.rs
+++ b/crates/mako/src/resolve/mod.rs
@@ -50,7 +50,9 @@ pub fn resolve(
     crate::mako_profile_scope!("resolve", &dep.source);
 
     if dep.source.starts_with("virtual:") {
-        return Ok(ResolverResource::Virtual(PathBuf::from(&dep.source)));
+        return Ok(ResolverResource::Virtual(PathBuf::from(
+            dep.source.as_str(),
+        )));
     }
 
     let has_context_query = parse_path(&dep.source)?

--- a/crates/mako/src/visitors/async_module.rs
+++ b/crates/mako/src/visitors/async_module.rs
@@ -402,10 +402,10 @@ __mako_require__._async(module, async (handleAsyncDeps, asyncResult)=>{
     fn run(js_code: &str) -> String {
         let mut test_utils = TestUtils::gen_js_ast(js_code);
         let mut chunk = Chunk::new(
-            "./async".to_string().into(),
-            ChunkType::Entry("./async".to_string().into(), "async".to_string(), false),
+            "./async".into(),
+            ChunkType::Entry("./async".into(), "async".into(), false),
         );
-        chunk.add_module("./async".to_string().into());
+        chunk.add_module("./async".into());
         test_utils
             .context
             .chunk_graph

--- a/crates/mako/src/visitors/dep_analyzer.rs
+++ b/crates/mako/src/visitors/dep_analyzer.rs
@@ -97,7 +97,11 @@ impl Visit for DepAnalyzer {
         // e.g.
         // new Worker(new URL('a', import.meta.url));
         if let Some(str) = resolve_web_worker(expr, self.unresolved_mark) {
-            self.add_dependency(str.value.to_string(), ResolveType::Worker, Some(str.span));
+            self.add_dependency(
+                str.value.as_ref().into(),
+                ResolveType::Worker,
+                Some(str.span),
+            );
         }
         expr.visit_children_with(self);
     }

--- a/crates/mako/src/visitors/dynamic_import.rs
+++ b/crates/mako/src/visitors/dynamic_import.rs
@@ -56,7 +56,7 @@ impl<'a> VisitMut for DynamicImport<'a> {
                 .unwrap();
 
             let require_interop = quote_ident!("__mako_require__")
-                .as_call(DUMMY_SP, vec![quote_str!(id.clone()).as_arg()]);
+                .as_call(DUMMY_SP, vec![quote_str!(id.as_str()).as_arg()]);
 
             let stmt: Stmt = Expr::Member(MemberExpr {
                 span: DUMMY_SP,
@@ -125,7 +125,7 @@ impl<'a> VisitMut for DynamicImport<'a> {
                             .map(|c_id| {
                                 Some(ExprOrSpread {
                                     spread: None,
-                                    expr: Box::new(require_ensure(c_id.clone())),
+                                    expr: Box::new(require_ensure(c_id.as_str())),
                                 })
                             })
                             .collect::<Vec<_>>();
@@ -201,7 +201,7 @@ Promise.all([
         let dep_to_replace = DependenciesToReplace {
             resolved: maplit::hashmap! {
                 "@swc/helpers/_/_interop_require_wildcard".to_string() =>
-                ("hashed_helper".to_string(), "dummy".into())
+                ("hashed_helper".into(), "dummy".into())
             },
             missing: HashMap::new(),
         };


### PR DESCRIPTION
Use [arcstr](https://crates.io/crates/arcstr) to represent module id, avoid alloc when cloning. When building huge project, run   
faster about 10%.

Before:
<img width="504" alt="image" src="https://github.com/user-attachments/assets/e6c710f6-5637-4687-8721-4ca94d7e33e7">

After:
<img width="527" alt="image" src="https://github.com/user-attachments/assets/2a2923ee-fd7a-4ee8-9936-0be55cafa8dd">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 引入新依赖 `arcstr`，提升字符串处理和数据序列化能力。
  - 优化了多个结构和方法的字符串处理，改为使用 `ArcStr`，以提高内存效率和性能。

- **错误修复**
  - 调整了路径处理的方式，避免不必要的字符串克隆。

- **文档**
  - 更新了相关文档以反映新的依赖和字符串处理方式的变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->