### PR TITLE
perf: use hashlink, speed up 300% when building big project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,6 +1974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2639,7 @@ dependencies = [
  "get_if_addrs",
  "glob",
  "glob-match",
+ "hashlink",
  "heck",
  "hyper",
  "hyper-staticfile",

--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -82,6 +82,7 @@ eframe                = { version = "0.22.0", optional = true }
 fs_extra              = "1.3.0"
 futures               = "0.3.28"
 glob                  = "0.3.1"
+hashlink              = "0.9.1"
 hyper                 = { version = "0.14.27", features = ["full"] }
 hyper-staticfile      = "0.9.6"
 hyper-tungstenite     = "0.10.0"

--- a/crates/mako/src/generate/chunk.rs
+++ b/crates/mako/src/generate/chunk.rs
@@ -4,7 +4,7 @@ use std::path::{Component, Path};
 
 use base64::engine::general_purpose;
 use base64::Engine;
-use indexmap::IndexSet;
+use hashlink::LinkedHashSet;
 use twox_hash::XxHash64;
 
 use crate::ast::file::parse_path;
@@ -31,7 +31,7 @@ pub enum ChunkType {
 pub struct Chunk {
     pub id: ChunkId,
     pub chunk_type: ChunkType,
-    pub modules: IndexSet<ModuleId>,
+    pub modules: LinkedHashSet<ModuleId>,
     pub content: Option<String>,
     pub source_map: Option<String>,
 }
@@ -52,7 +52,7 @@ impl Debug for Chunk {
 impl Chunk {
     pub fn new(id: ChunkId, chunk_type: ChunkType) -> Self {
         Self {
-            modules: IndexSet::new(),
+            modules: LinkedHashSet::new(),
             id,
             chunk_type,
             content: None,
@@ -105,24 +105,15 @@ impl Chunk {
     }
 
     pub fn add_module(&mut self, module_id: ModuleId) {
-        if let (pos, false) = self.modules.insert_full(module_id.clone()) {
-            // module already exists, move it to the back
-            self.modules.shift_remove_index(pos);
-            self.modules.insert(module_id);
-        }
+        self.modules.insert(module_id);
     }
 
-    pub fn get_modules(&self) -> &IndexSet<ModuleId> {
+    pub fn get_modules(&self) -> &LinkedHashSet<ModuleId> {
         &self.modules
     }
 
-    #[allow(dead_code)]
-    pub fn mut_modules(&mut self) -> &mut IndexSet<ModuleId> {
-        &mut self.modules
-    }
-
     pub fn remove_module(&mut self, module_id: &ModuleId) {
-        self.modules.shift_remove(module_id);
+        self.modules.remove(module_id);
     }
 
     pub fn has_module(&self, module_id: &ModuleId) -> bool {

--- a/crates/mako/src/generate/chunk_pot/mod.rs
+++ b/crates/mako/src/generate/chunk_pot/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::vec;
 
 use anyhow::Result;
-use indexmap::IndexSet;
+use hashlink::LinkedHashSet;
 use swc_core::css::ast::Stylesheet;
 
 use crate::compiler::Context;
@@ -144,7 +144,7 @@ impl<'cp> ChunkPot<'cp> {
     }
 
     fn split_modules<'a>(
-        module_ids: &'a IndexSet<ModuleId>,
+        module_ids: &LinkedHashSet<ModuleId>,
         module_graph: &'a ModuleGraph,
         context: &'a Arc<Context>,
     ) -> (JsModules<'a>, Option<CssModules<'a>>) {
@@ -155,13 +155,11 @@ impl<'cp> ChunkPot<'cp> {
         let mut module_raw_hash_map: HashMap<String, u64> = Default::default();
         let mut css_raw_hashes = vec![];
 
-        let module_ids: Vec<_> = module_ids.iter().collect();
-
-        for module_id in module_ids {
+        module_ids.iter().for_each(|module_id| {
             let module = module_graph.get_module(module_id).unwrap();
 
             if module.info.is_none() {
-                continue;
+                return;
             }
 
             let module_info = module.info.as_ref().unwrap();
@@ -173,22 +171,13 @@ impl<'cp> ChunkPot<'cp> {
             }
 
             if let ModuleAst::Css(ast) = ast {
-                // only apply the last css module if chunk depend on it multiple times
-                // make sure the rules order is correct
-                if let Some(index) = merged_css_modules
-                    .iter()
-                    .position(|(id, _)| id.eq(&module.id.id))
-                {
-                    merged_css_modules.remove(index);
-                }
-
                 // not add empty css to chunk
                 if !ast.ast.rules.is_empty() {
                     merged_css_modules.push((module.id.id.clone(), &ast.ast));
                     css_raw_hashes.push(module_info.raw_hash);
                 }
             }
-        }
+        });
 
         let raw_hash = hash_hashmap(&module_raw_hash_map);
 

--- a/crates/mako/src/generate/group_chunk.rs
+++ b/crates/mako/src/generate/group_chunk.rs
@@ -388,7 +388,7 @@ impl Compiler {
 
         let chunk_id = entry_module_id.generate(&self.context);
         let mut chunk = Chunk::new(chunk_id.into(), chunk_type.clone());
-        let mut visited_modules: Vec<ModuleId> = vec![entry_module_id.clone()];
+        let mut visited_modules: Vec<&ModuleId> = vec![entry_module_id];
 
         let module_graph = self.context.module_graph.read().unwrap();
 
@@ -418,7 +418,7 @@ impl Compiler {
                     {
                         next_module_ids.push(dep_module_id.clone());
                         // collect normal deps for current head
-                        normal_deps.push(dep_module_id.clone());
+                        normal_deps.push(dep_module_id);
                     }
                     _ => {}
                 }
@@ -432,7 +432,7 @@ impl Compiler {
 
         // add modules to chunk as dfs order
         for module_id in visited_modules {
-            chunk.add_module(module_id);
+            chunk.add_module(module_id.clone());
         }
 
         (chunk, dynamic_entries, worker_entries)

--- a/crates/mako/src/generate/optimize_chunk.rs
+++ b/crates/mako/src/generate/optimize_chunk.rs
@@ -3,6 +3,7 @@ use std::string::String;
 
 use base64::engine::general_purpose;
 use base64::Engine;
+use hashlink::LinkedHashSet;
 use indexmap::{IndexMap, IndexSet};
 use regex::Regex;
 use tracing::debug;
@@ -124,7 +125,7 @@ impl Compiler {
         let async_chunk_root_modules = chunks
             .iter()
             .filter_map(|chunk| match chunk.chunk_type {
-                ChunkType::Async => chunk.modules.last(),
+                ChunkType::Async => chunk.modules.iter().last(),
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -212,7 +213,7 @@ impl Compiler {
                         .module_to_chunks
                         .keys()
                         .cloned()
-                        .collect::<IndexSet<_>>(),
+                        .collect::<LinkedHashSet<_>>(),
                     id: ChunkId { id: "".to_string() },
                     chunk_type: ChunkType::Sync,
                     content: None,
@@ -437,7 +438,7 @@ impl Compiler {
                     .module_to_chunks
                     .keys()
                     .cloned()
-                    .collect::<IndexSet<_>>(),
+                    .collect::<LinkedHashSet<_>>(),
                 id: info_chunk_id.clone(),
                 chunk_type: info_chunk_type,
                 content: None,

--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -126,9 +126,11 @@ impl Compiler {
                     ChunkType::Sync => chunk_graph
                         .dependents_chunk(&chunk.id)
                         .iter()
-                        .filter_map(|chunk_id| chunk_graph.chunk(chunk_id).unwrap().modules.last())
+                        .filter_map(|chunk_id| {
+                            chunk_graph.chunk(chunk_id).unwrap().modules.iter().last()
+                        })
                         .collect::<Vec<_>>(),
-                    _ => vec![chunk.modules.last().unwrap()],
+                    _ => vec![chunk.modules.iter().last().unwrap()],
                 };
                 let mut origins_set = IndexMap::new();
                 for origin_chunk_module in origin_chunk_modules {


### PR DESCRIPTION
Improve group_chunk and optimize_chunk

Before:
<img width="601" alt="image" src="https://github.com/user-attachments/assets/6246d237-af7e-4cde-a207-5b8cb8157b6b">

After:
<img width="610" alt="image" src="https://github.com/user-attachments/assets/2c922d58-a791-4b8b-a89b-9f3d426a6789">

The reason why group_chunk and optimize_chunk are slow ?

[IndexMap::shift_remove_index](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html#method.shift_remove_index)
[IndexMap::shift_remove](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html#method.shift_remove)

and in fn [create_chunk
](https://github.com/umijs/mako/blob/0ebed32a34bd94c50c3d7d488215e97fde258cc7/crates/mako/src/generate/group_chunk.rs#L378)
[Iter::position](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.position)
[Vec::splice](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.splice)

computes in O(n) time (average).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 添加了对 `hashlink` 库的支持，提升了模块管理和性能。

- **更改**
	- 在多个模块中更改了数据结构，使用 `LinkedHashSet` 和 `LinkedHashMap` 代替 `IndexSet` 和 `IndexMap`，以改善模块的插入顺序和去重能力。

- **修复**
	- 更新了访问模块集合中最后一个模块的方法，增强了代码可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->