### PR TITLE
fix: double value lose

### DIFF
--- a/crates/mako/src/visitors/css_px2rem.rs
+++ b/crates/mako/src/visitors/css_px2rem.rs
@@ -128,10 +128,10 @@ impl VisitMut for Px2Rem {
         if let Token::Dimension(dimension) = t {
             if dimension.unit.to_string() == "px" && self.should_transform(dimension.value) {
                 let mut rem_val = dimension.value / self.config.root;
-                dimension.raw_value = rem_val.to_string().into();
                 if self.is_any_in_doublelist() {
                     rem_val *= 2.0;
                 }
+                dimension.raw_value = rem_val.to_string().into();
                 dimension.value = rem_val;
                 dimension.raw_unit = "rem".into();
                 dimension.unit = "rem".into();
@@ -644,6 +644,26 @@ mod tests {
                 }
             ),
             r#".a{width:2rem}"#
+        );
+        assert_eq!(
+            run(
+                r#".a-x{width:100px;}"#,
+                Px2RemConfig {
+                    selector_doublelist: vec!["^.a-".to_string()],
+                    ..Default::default()
+                }
+            ),
+            r#".a-x{width:2rem}"#
+        );
+        assert_eq!(
+            run(
+                r#":root{width:100px;}"#,
+                Px2RemConfig {
+                    selector_doublelist: vec!["^:root".to_string()],
+                    ..Default::default()
+                }
+            ),
+            r#":root{width:2rem}"#
         );
     }
 


### PR DESCRIPTION
修复 变更后的值没有传递给 raw_value 
（不理解这里为什么会有 raw_value 和 value 两个值，望懂得大神指导一下😊）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进了像素到rem单位的转换逻辑，确保转换结果的一致性和准确性。
  
- **测试**
  - 新增测试用例，以验证在特定条件下的像素到rem的转换行为，提高功能的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->