### PR TITLE
refactor: avoid underscore prefix for chunk file name

### DIFF
--- a/crates/mako/src/generate/chunk.rs
+++ b/crates/mako/src/generate/chunk.rs
@@ -74,8 +74,8 @@ impl Chunk {
                     .components()
                     .filter(|c| !matches!(c, Component::RootDir | Component::CurDir))
                     .map(|c| match c {
-                        Component::ParentDir => "_pd_".to_string(),
-                        Component::Prefix(_) => "_ps_".to_string(),
+                        Component::ParentDir => "pd_".to_string(),
+                        Component::Prefix(_) => "ps_".to_string(),
                         Component::RootDir => "".to_string(),
                         Component::CurDir => "".to_string(),
                         Component::Normal(seg) => {


### PR DESCRIPTION
避免产出 `_` 开头的 chunk 文件名，因为 GitHub Pages 之类的平台默认会忽略 `_` 开头的文件，这会导致使用 Umi/dumi 部署 GitHub Pages 的项目出现资源 404 的问题

ref: https://github.com/ant-design/ant-design/issues/50232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 修改了某些组件的字符串表示，更新了组件前缀以简化输出格式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->