### PR TITLE
chore: add windows shell support for just

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,6 @@
 #!/usr/bin/env -S just --justfile
+set windows-shell := ["powershell"]
+set shell := ["bash", "-cu"]
 
 _default:
   just --list -u


### PR DESCRIPTION
closes #1472 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 引入了新的 `set` 命令，以支持在 PowerShell 和 Bash 中运行脚本，增强跨平台兼容性和灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->