### PR TITLE
feat(bundler-mako): generate dynamicImportToRequire from babel and webpack config

### DIFF
--- a/e2e/fixtures.umi/config.babel-plugin-dynamic-import-node/.umirc.ts
+++ b/e2e/fixtures.umi/config.babel-plugin-dynamic-import-node/.umirc.ts
@@ -1,0 +1,4 @@
+export default {
+  mako: {},
+  extraBabelPlugins: ['babel-plugin-dynamic-import-node'],
+};

--- a/e2e/fixtures.umi/config.babel-plugin-dynamic-import-node/async.ts
+++ b/e2e/fixtures.umi/config.babel-plugin-dynamic-import-node/async.ts
@@ -1,0 +1,1 @@
+export default 'a';

--- a/e2e/fixtures.umi/config.babel-plugin-dynamic-import-node/expect.js
+++ b/e2e/fixtures.umi/config.babel-plugin-dynamic-import-node/expect.js
@@ -1,0 +1,11 @@
+const assert = require("assert");
+const { parseBuildResult } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const jsFilesCount = Object.keys(files).filter(f => f.endsWith('.js')).length;
+
+assert.equal(
+  jsFilesCount,
+  1,
+  'should output one js file',
+);

--- a/e2e/fixtures.umi/config.babel-plugin-dynamic-import-node/pages/index.tsx
+++ b/e2e/fixtures.umi/config.babel-plugin-dynamic-import-node/pages/index.tsx
@@ -1,0 +1,3 @@
+console.log('single file');
+
+import('../async');

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -388,7 +388,10 @@ function checkConfig(opts) {
     .some((p) => {
       const isImportPlugin = /^import$|babel-plugin-import/.test(p[0]);
       const isEmotionPlugin = p === '@emotion' || p === '@emotion/babel-plugin';
-      if (!isImportPlugin && !isEmotionPlugin) {
+      const isDynamicImportNode = /^(babel-plugin-)?dynamic-import-node$/.test(
+        p,
+      );
+      if (!isImportPlugin && !isEmotionPlugin && !isDynamicImportNode) {
         warningKeys.push('extraBabelPlugins');
         return true;
       }
@@ -446,12 +449,20 @@ async function getMakoConfig(opts) {
   }
   const webpackConfig = webpackChainConfig.toConfig();
   let umd = false;
-  if (
-    webpackConfig.output &&
-    webpackConfig.output.libraryTarget === 'umd' &&
-    webpackConfig.output.library
-  ) {
-    umd = webpackConfig.output.library;
+  let { dynamicImportToRequire } = opts.config;
+  if (webpackConfig.output) {
+    // handle asyncChunks config
+    if (webpackConfig.output.asyncChunks === false) {
+      dynamicImportToRequire = true;
+    }
+
+    // handle umd output config
+    if (
+      webpackConfig.output.libraryTarget === 'umd' &&
+      webpackConfig.output.library
+    ) {
+      umd = webpackConfig.output.library;
+    }
   }
 
   let platform = 'browser';
@@ -466,7 +477,6 @@ async function getMakoConfig(opts) {
     mdx,
     devtool,
     cjs,
-    dynamicImportToRequire,
     jsMinifier,
     externals,
     copy = [],
@@ -516,11 +526,19 @@ async function getMakoConfig(opts) {
   if (process.env.COMPRESS === 'none') {
     minify = false;
   }
-  // transform babel-plugin-import plugins to transformImport
   const extraBabelPlugins = [
     ...(opts.extraBabelPlugins || []),
     ...(opts.config.extraBabelPlugins || []),
   ];
+
+  // transform babel-plugin-dynamic-import-node to dynamicImportToRequire
+  dynamicImportToRequire ??= Boolean(
+    extraBabelPlugins.find((p) =>
+      /^(babel-plugin-)?dynamic-import-node$/.test(p),
+    ),
+  );
+
+  // transform babel-plugin-import plugins to transformImport
   const transformImport = extraBabelPlugins
     .filter((p) => /^import$|babel-plugin-import/.test(p[0]))
     .map(([_, v]) => {


### PR DESCRIPTION
支持将 Webpack 的 `output.asyncChunks` 配置以及 Umi 此前在用的 `babel-plugin-dynamic-import-node` 转成 Mako 的 `dynamicImportToRequire` 配置项

Close #1470 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了对动态导入的支持，提升了构建过程中的灵活性。
	- 增加了一个简单的模块，能够异步导入其他模块，从而优化应用性能。
  
- **修复**
	- 增强了插件处理和配置管理的逻辑，以便更好地支持动态导入插件。

- **测试**
	- 引入了测试脚本，以验证构建过程中生成的 JavaScript 文件数量是否正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->