### PR TITLE
fix: 🐛 hased chunk file name starts with underscore

### DIFF
--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use base64::engine::{general_purpose, Engine};
 use bitflags::bitflags;
 use pathdiff::diff_paths;
 use serde::Serialize;
@@ -202,9 +201,10 @@ impl Default for ModuleInfo {
 }
 
 fn md5_hash(source_str: &str, lens: usize) -> String {
-    let digest = md5::compute(source_str);
-    let hash = general_purpose::URL_SAFE.encode(digest.0);
-    hash[..lens].to_string()
+    format!("{:x}", md5::compute(source_str))
+        .chars()
+        .take(lens)
+        .collect::<String>()
 }
 
 pub fn generate_module_id(origin_module_id: String, context: &Arc<Context>) -> String {


### PR DESCRIPTION
close https://github.com/umijs/mako/issues/1492 

Digest's hex string is url safe, url encode is unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 简化了 MD5 哈希计算的方法，直接以十六进制字符串格式化 MD5 摘要，提升了性能和可维护性。
- **Bug 修复**
	- 修复了上一个实现中可能引起的编码依赖问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->