### PR TITLE
Revert "refactor: define env (#1499)"

### DIFF
--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -4,11 +4,15 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use serde_json::Value;
+use swc_core::common::collections::AHashMap;
+use swc_core::common::sync::Lrc;
 use swc_core::common::{Mark, DUMMY_SP};
 use swc_core::ecma::ast::{
     ArrayLit, Bool, ComputedPropName, Expr, ExprOrSpread, Ident, KeyValueProp, Lit, MemberExpr,
-    MemberProp, ModuleItem, Null, Number, ObjectLit, Prop, PropOrSpread, Stmt, Str,
+    MemberProp, MetaPropExpr, MetaPropKind, ModuleItem, Null, Number, ObjectLit, Prop, PropName,
+    PropOrSpread, Stmt, Str,
 };
+use swc_core::ecma::atoms::{js_word, JsWord};
 use swc_core::ecma::utils::{quote_ident, ExprExt};
 use swc_core::ecma::visit::{VisitMut, VisitMutWith};
 
@@ -16,110 +20,156 @@ use crate::ast::js_ast::JsAst;
 use crate::compiler::Context;
 use crate::config::ConfigError;
 
+enum EnvsType {
+    Node(Lrc<AHashMap<JsWord, Expr>>),
+    Browser(Lrc<AHashMap<String, Expr>>),
+}
+
 #[derive(Debug)]
 pub struct EnvReplacer {
     unresolved_mark: Mark,
-    define: HashMap<String, Expr>,
+    envs: Lrc<AHashMap<JsWord, Expr>>,
+    meta_envs: Lrc<AHashMap<String, Expr>>,
 }
 
 impl EnvReplacer {
-    pub fn new(define: HashMap<String, Expr>, unresolved_mark: Mark) -> Self {
+    pub fn new(envs: Lrc<AHashMap<JsWord, Expr>>, unresolved_mark: Mark) -> Self {
+        let mut meta_env_map = AHashMap::default();
+
+        // generate meta_envs from envs
+        for (k, v) in envs.iter() {
+            // convert NODE_ENV to MODE
+            let key: String = if k.eq(&js_word!("NODE_ENV")) {
+                "MODE".into()
+            } else {
+                k.to_string()
+            };
+
+            meta_env_map.insert(key, v.clone());
+        }
+
         Self {
             unresolved_mark,
-            define,
+            envs,
+            meta_envs: Lrc::new(meta_env_map),
         }
     }
 
-    fn get_define_env(&self, key: &str) -> Option<Expr> {
-        self.define.get(key).cloned()
+    fn get_env(envs: &EnvsType, sym: &JsWord) -> Option<Expr> {
+        match envs {
+            EnvsType::Node(envs) => envs.get(sym).cloned(),
+            EnvsType::Browser(envs) => envs.get(&sym.to_string()).cloned(),
+        }
     }
 }
 impl VisitMut for EnvReplacer {
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
-        if let Expr::Ident(Ident { span, .. }) = expr {
+        if let Expr::Ident(Ident { ref sym, span, .. }) = expr {
+            let envs = EnvsType::Node(self.envs.clone());
+
             // 先判断 env 中的变量名称，是否是上下文中已经存在的变量名称
             if span.ctxt.outer() != self.unresolved_mark {
                 expr.visit_mut_children_with(self);
                 return;
             }
+
+            if let Some(env) = EnvReplacer::get_env(&envs, sym) {
+                // replace with real value if env found
+                *expr = env;
+                return;
+            }
         }
 
-        match expr {
-            Expr::Member(MemberExpr {
-                obj,
-                prop: MemberProp::Ident(Ident { sym, .. }),
+        if let Expr::Member(MemberExpr { obj, prop, .. }) = expr {
+            if let Expr::Member(MemberExpr {
+                obj: first_obj,
+                prop:
+                    MemberProp::Ident(Ident {
+                        sym: js_word!("env"),
+                        ..
+                    }),
                 ..
-            }) => {
-                let mut member_visit_path = sym.to_string();
-                let mut current_member_obj = obj.as_ref();
+            }) = &**obj
+            {
+                // handle `env.XX`
+                let mut envs = EnvsType::Node(self.envs.clone());
 
-                while let Expr::Member(MemberExpr { obj, prop, .. }) = current_member_obj {
+                if match &**first_obj {
+                    Expr::Ident(Ident {
+                        sym: js_word!("process"),
+                        ..
+                    }) => true,
+                    Expr::MetaProp(MetaPropExpr {
+                        kind: MetaPropKind::ImportMeta,
+                        ..
+                    }) => {
+                        envs = EnvsType::Browser(self.meta_envs.clone());
+                        true
+                    }
+                    _ => false,
+                } {
+                    // handle `process.env.XX` and `import.meta.env.XX`
                     match prop {
-                        MemberProp::Ident(Ident { sym, .. }) => {
-                            member_visit_path.push('.');
-                            member_visit_path.push_str(sym.as_ref());
+                        MemberProp::Computed(ComputedPropName { expr: c, .. }) => {
+                            if let Expr::Lit(Lit::Str(Str { value: sym, .. })) = &**c {
+                                if let Some(env) = EnvReplacer::get_env(&envs, sym) {
+                                    // replace with real value if env found
+                                    *expr = env;
+                                } else {
+                                    // replace with `undefined` if env not found
+                                    *expr = *Box::new(Expr::Ident(Ident::new(
+                                        js_word!("undefined"),
+                                        DUMMY_SP,
+                                    )));
+                                }
+                            }
                         }
-                        MemberProp::Computed(ComputedPropName { expr, .. }) => {
-                            match expr.as_ref() {
-                                Expr::Lit(Lit::Str(Str { value, .. })) => {
-                                    member_visit_path.push('.');
-                                    member_visit_path.push_str(value.as_ref());
-                                }
 
-                                Expr::Lit(Lit::Num(Number { value, .. })) => {
-                                    member_visit_path.push('.');
-                                    member_visit_path.push_str(&value.to_string());
-                                }
-                                _ => (),
+                        MemberProp::Ident(Ident { sym, .. }) => {
+                            if let Some(env) = EnvReplacer::get_env(&envs, sym) {
+                                // replace with real value if env found
+                                *expr = env;
+                            } else {
+                                // replace with `undefined` if env not found
+                                *expr = *Box::new(Expr::Ident(Ident::new(
+                                    js_word!("undefined"),
+                                    DUMMY_SP,
+                                )));
                             }
                         }
                         _ => {}
                     }
-                    current_member_obj = obj.as_ref();
                 }
-
-                if let Expr::Ident(Ident { sym, .. }) = current_member_obj {
-                    member_visit_path.push('.');
-                    member_visit_path.push_str(sym.as_ref());
-                }
-                let member_visit_path = member_visit_path
-                    .split('.')
-                    .rev()
-                    .collect::<Vec<&str>>()
-                    .join(".");
-
-                if let Some(env) = self.get_define_env(&member_visit_path) {
-                    *expr = env
-                }
-            }
-            Expr::Member(MemberExpr {
-                obj: box Expr::Ident(Ident { sym, .. }),
+            } else if let Expr::Member(MemberExpr {
+                obj:
+                    box Expr::MetaProp(MetaPropExpr {
+                        kind: MetaPropKind::ImportMeta,
+                        ..
+                    }),
                 prop:
-                    MemberProp::Computed(ComputedPropName {
-                        expr: expr_computed,
+                    MemberProp::Ident(Ident {
+                        sym: js_word!("env"),
                         ..
                     }),
                 ..
-            }) => match expr_computed.as_ref() {
-                Expr::Lit(Lit::Str(Str { value, .. })) => {
-                    if let Some(env) = self.get_define_env(&format!("{}.{}", sym, value)) {
-                        *expr = env
-                    }
+            }) = *expr
+            {
+                // replace independent `import.meta.env` to json object
+                let mut props = Vec::new();
+
+                // convert envs to object properties
+                for (k, v) in self.meta_envs.iter() {
+                    props.push(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                        key: PropName::Ident(Ident::new(k.clone().into(), DUMMY_SP)),
+                        value: Box::new(v.clone()),
+                    }))));
                 }
 
-                Expr::Lit(Lit::Num(Number { value, .. })) => {
-                    if let Some(env) = self.get_define_env(&format!("{}.{}", sym, value)) {
-                        *expr = env
-                    }
-                }
-                _ => (),
-            },
-            Expr::Ident(Ident { sym, .. }) => {
-                if let Some(env) = self.get_define_env(sym.as_ref()) {
-                    *expr = env
-                }
+                *expr = Expr::Object(ObjectLit {
+                    span: DUMMY_SP,
+                    props,
+                });
             }
-            _ => (),
         }
 
         expr.visit_mut_children_with(self);
@@ -129,11 +179,11 @@ impl VisitMut for EnvReplacer {
 pub fn build_env_map(
     env_map: HashMap<String, Value>,
     context: &Arc<Context>,
-) -> Result<HashMap<String, Expr>> {
-    let mut map = HashMap::new();
+) -> Result<AHashMap<JsWord, Expr>> {
+    let mut map = AHashMap::default();
     for (k, v) in env_map.into_iter() {
         let expr = get_env_expr(v, context)?;
-        map.insert(k, expr);
+        map.insert(k.into(), expr);
     }
     Ok(map)
 }
@@ -214,6 +264,7 @@ mod tests {
 
     use maplit::hashmap;
     use serde_json::{json, Value};
+    use swc_core::common::sync::Lrc;
     use swc_core::common::GLOBALS;
     use swc_core::ecma::visit::VisitMutWith;
 
@@ -308,6 +359,17 @@ log([
     }
 
     #[test]
+    fn test_undefined_env() {
+        assert_eq!(
+            run(
+                r#"if (process.env.UNDEFINED_ENV === "true") {}"#,
+                Default::default()
+            ),
+            r#"if (undefined === "true") {}"#
+        );
+    }
+
+    #[test]
     fn test_stringified_env() {
         assert_eq!(
             run(
@@ -322,64 +384,12 @@ log([
         );
     }
 
-    #[test]
-    fn test_dot_key() {
-        assert_eq!(
-            run(
-                r#"log(x.y)"#,
-                hashmap! {
-                    "x.y".to_string() => json!(true)
-                }
-            ),
-            r#"log(true);"#
-        );
-    }
-
-    #[test]
-    fn test_deep_dot_key() {
-        assert_eq!(
-            run(
-                r#"log(process.env.A)"#,
-                hashmap! {
-                    "process.env.A".to_string() => json!(true)
-                }
-            ),
-            r#"log(true);"#
-        );
-    }
-
-    #[test]
-    fn test_computed() {
-        assert_eq!(
-            run(
-                r#"log(A["B"])"#,
-                hashmap! {
-                    "A.B".to_string() => json!(1)
-                }
-            ),
-            r#"log(1);"#
-        );
-    }
-
-    #[test]
-    fn test_computed_number() {
-        assert_eq!(
-            run(
-                r#"log(A[1])"#,
-                hashmap! {
-                    "A.1".to_string() => json!(1)
-                }
-            ),
-            r#"log(1);"#
-        );
-    }
-
     fn run(js_code: &str, envs: HashMap<String, Value>) -> String {
         let mut test_utils = TestUtils::gen_js_ast(js_code);
         let envs = build_env_map(envs, &test_utils.context).unwrap();
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
-            let mut visitor = EnvReplacer::new(envs, ast.unresolved_mark);
+            let mut visitor = EnvReplacer::new(Lrc::new(envs), ast.unresolved_mark);
             ast.ast.visit_mut_with(&mut visitor);
         });
         test_utils.js_ast_to_code()


### PR DESCRIPTION
This reverts commit 845ce1ea2a3be7417b0328ab57beaaafa5f1b3c5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改善了环境变量的处理方式，提升了内存效率并允许共享引用。
  - 提供了更通用的环境变量访问方法，支持在Node和浏览器环境之间区分。

- **修复**
  - 更新了测试用例，确保未定义环境变量的处理正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->