### PR TITLE
feat: reapply 1499 and fix import meta env

### DIFF
--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use swc_core::common::sync::Lrc;
 use swc_core::common::GLOBALS;
 use swc_core::css::ast::{AtRule, AtRulePrelude, ImportHref, Rule, Str, Stylesheet, UrlValue};
 use swc_core::css::compat::compiler::{self, Compiler};
@@ -114,18 +113,14 @@ impl Transform {
                             &unresolved_mark,
                         ));
                     }
-                    // TODO: refact env replacer
                     {
                         let mut define = context.config.define.clone();
                         let mode = context.config.mode.to_string();
                         define
-                            .entry("NODE_ENV".to_string())
+                            .entry("process.env.NODE_ENV".to_string())
                             .or_insert_with(|| format!("\"{}\"", mode).into());
                         let env_map = build_env_map(define, &context)?;
-                        visitors.push(Box::new(EnvReplacer::new(
-                            Lrc::new(env_map),
-                            unresolved_mark,
-                        )));
+                        visitors.push(Box::new(EnvReplacer::new(env_map, unresolved_mark)));
                     }
                     visitors.push(Box::new(TryResolve {
                         path: file.path.to_string_lossy().to_string(),

--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -32,6 +32,7 @@ use crate::visitors::dynamic_import_to_require::DynamicImportToRequire;
 use crate::visitors::env_replacer::{build_env_map, EnvReplacer};
 use crate::visitors::fix_helper_inject_position::FixHelperInjectPosition;
 use crate::visitors::fix_symbol_conflict::FixSymbolConflict;
+use crate::visitors::import_meta_env_replacer::ImportMetaEnvReplacer;
 use crate::visitors::import_template_to_string_literal::ImportTemplateToStringLiteral;
 use crate::visitors::new_url_assets::NewUrlAssets;
 use crate::visitors::provide::Provide;
@@ -121,6 +122,7 @@ impl Transform {
                             .or_insert_with(|| format!("\"{}\"", mode).into());
                         let env_map = build_env_map(define, &context)?;
                         visitors.push(Box::new(EnvReplacer::new(env_map, unresolved_mark)));
+                        visitors.push(Box::new(ImportMetaEnvReplacer::new(mode)));
                     }
                     visitors.push(Box::new(TryResolve {
                         path: file.path.to_string_lossy().to_string(),

--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -4,15 +4,11 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use serde_json::Value;
-use swc_core::common::collections::AHashMap;
-use swc_core::common::sync::Lrc;
 use swc_core::common::{Mark, DUMMY_SP};
 use swc_core::ecma::ast::{
     ArrayLit, Bool, ComputedPropName, Expr, ExprOrSpread, Ident, KeyValueProp, Lit, MemberExpr,
-    MemberProp, MetaPropExpr, MetaPropKind, ModuleItem, Null, Number, ObjectLit, Prop, PropName,
-    PropOrSpread, Stmt, Str,
+    MemberProp, ModuleItem, Null, Number, ObjectLit, Prop, PropOrSpread, Stmt, Str,
 };
-use swc_core::ecma::atoms::{js_word, JsWord};
 use swc_core::ecma::utils::{quote_ident, ExprExt};
 use swc_core::ecma::visit::{VisitMut, VisitMutWith};
 
@@ -20,156 +16,110 @@ use crate::ast::js_ast::JsAst;
 use crate::compiler::Context;
 use crate::config::ConfigError;
 
-enum EnvsType {
-    Node(Lrc<AHashMap<JsWord, Expr>>),
-    Browser(Lrc<AHashMap<String, Expr>>),
-}
-
 #[derive(Debug)]
 pub struct EnvReplacer {
     unresolved_mark: Mark,
-    envs: Lrc<AHashMap<JsWord, Expr>>,
-    meta_envs: Lrc<AHashMap<String, Expr>>,
+    define: HashMap<String, Expr>,
 }
 
 impl EnvReplacer {
-    pub fn new(envs: Lrc<AHashMap<JsWord, Expr>>, unresolved_mark: Mark) -> Self {
-        let mut meta_env_map = AHashMap::default();
-
-        // generate meta_envs from envs
-        for (k, v) in envs.iter() {
-            // convert NODE_ENV to MODE
-            let key: String = if k.eq(&js_word!("NODE_ENV")) {
-                "MODE".into()
-            } else {
-                k.to_string()
-            };
-
-            meta_env_map.insert(key, v.clone());
-        }
-
+    pub fn new(define: HashMap<String, Expr>, unresolved_mark: Mark) -> Self {
         Self {
             unresolved_mark,
-            envs,
-            meta_envs: Lrc::new(meta_env_map),
+            define,
         }
     }
 
-    fn get_env(envs: &EnvsType, sym: &JsWord) -> Option<Expr> {
-        match envs {
-            EnvsType::Node(envs) => envs.get(sym).cloned(),
-            EnvsType::Browser(envs) => envs.get(&sym.to_string()).cloned(),
-        }
+    fn get_define_env(&self, key: &str) -> Option<Expr> {
+        self.define.get(key).cloned()
     }
 }
 impl VisitMut for EnvReplacer {
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
-        if let Expr::Ident(Ident { ref sym, span, .. }) = expr {
-            let envs = EnvsType::Node(self.envs.clone());
-
+        if let Expr::Ident(Ident { span, .. }) = expr {
             // 先判断 env 中的变量名称，是否是上下文中已经存在的变量名称
             if span.ctxt.outer() != self.unresolved_mark {
                 expr.visit_mut_children_with(self);
                 return;
             }
-
-            if let Some(env) = EnvReplacer::get_env(&envs, sym) {
-                // replace with real value if env found
-                *expr = env;
-                return;
-            }
         }
 
-        if let Expr::Member(MemberExpr { obj, prop, .. }) = expr {
-            if let Expr::Member(MemberExpr {
-                obj: first_obj,
-                prop:
-                    MemberProp::Ident(Ident {
-                        sym: js_word!("env"),
-                        ..
-                    }),
+        match expr {
+            Expr::Member(MemberExpr {
+                obj,
+                prop: MemberProp::Ident(Ident { sym, .. }),
                 ..
-            }) = &**obj
-            {
-                // handle `env.XX`
-                let mut envs = EnvsType::Node(self.envs.clone());
+            }) => {
+                let mut member_visit_path = sym.to_string();
+                let mut current_member_obj = obj.as_ref();
 
-                if match &**first_obj {
-                    Expr::Ident(Ident {
-                        sym: js_word!("process"),
-                        ..
-                    }) => true,
-                    Expr::MetaProp(MetaPropExpr {
-                        kind: MetaPropKind::ImportMeta,
-                        ..
-                    }) => {
-                        envs = EnvsType::Browser(self.meta_envs.clone());
-                        true
-                    }
-                    _ => false,
-                } {
-                    // handle `process.env.XX` and `import.meta.env.XX`
+                while let Expr::Member(MemberExpr { obj, prop, .. }) = current_member_obj {
                     match prop {
-                        MemberProp::Computed(ComputedPropName { expr: c, .. }) => {
-                            if let Expr::Lit(Lit::Str(Str { value: sym, .. })) = &**c {
-                                if let Some(env) = EnvReplacer::get_env(&envs, sym) {
-                                    // replace with real value if env found
-                                    *expr = env;
-                                } else {
-                                    // replace with `undefined` if env not found
-                                    *expr = *Box::new(Expr::Ident(Ident::new(
-                                        js_word!("undefined"),
-                                        DUMMY_SP,
-                                    )));
-                                }
-                            }
-                        }
-
                         MemberProp::Ident(Ident { sym, .. }) => {
-                            if let Some(env) = EnvReplacer::get_env(&envs, sym) {
-                                // replace with real value if env found
-                                *expr = env;
-                            } else {
-                                // replace with `undefined` if env not found
-                                *expr = *Box::new(Expr::Ident(Ident::new(
-                                    js_word!("undefined"),
-                                    DUMMY_SP,
-                                )));
+                            member_visit_path.push('.');
+                            member_visit_path.push_str(sym.as_ref());
+                        }
+                        MemberProp::Computed(ComputedPropName { expr, .. }) => {
+                            match expr.as_ref() {
+                                Expr::Lit(Lit::Str(Str { value, .. })) => {
+                                    member_visit_path.push('.');
+                                    member_visit_path.push_str(value.as_ref());
+                                }
+
+                                Expr::Lit(Lit::Num(Number { value, .. })) => {
+                                    member_visit_path.push('.');
+                                    member_visit_path.push_str(&value.to_string());
+                                }
+                                _ => (),
                             }
                         }
                         _ => {}
                     }
+                    current_member_obj = obj.as_ref();
                 }
-            } else if let Expr::Member(MemberExpr {
-                obj:
-                    box Expr::MetaProp(MetaPropExpr {
-                        kind: MetaPropKind::ImportMeta,
-                        ..
-                    }),
+
+                if let Expr::Ident(Ident { sym, .. }) = current_member_obj {
+                    member_visit_path.push('.');
+                    member_visit_path.push_str(sym.as_ref());
+                }
+                let member_visit_path = member_visit_path
+                    .split('.')
+                    .rev()
+                    .collect::<Vec<&str>>()
+                    .join(".");
+
+                if let Some(env) = self.get_define_env(&member_visit_path) {
+                    *expr = env
+                }
+            }
+            Expr::Member(MemberExpr {
+                obj: box Expr::Ident(Ident { sym, .. }),
                 prop:
-                    MemberProp::Ident(Ident {
-                        sym: js_word!("env"),
+                    MemberProp::Computed(ComputedPropName {
+                        expr: expr_computed,
                         ..
                     }),
                 ..
-            }) = *expr
-            {
-                // replace independent `import.meta.env` to json object
-                let mut props = Vec::new();
-
-                // convert envs to object properties
-                for (k, v) in self.meta_envs.iter() {
-                    props.push(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
-                        key: PropName::Ident(Ident::new(k.clone().into(), DUMMY_SP)),
-                        value: Box::new(v.clone()),
-                    }))));
+            }) => match expr_computed.as_ref() {
+                Expr::Lit(Lit::Str(Str { value, .. })) => {
+                    if let Some(env) = self.get_define_env(&format!("{}.{}", sym, value)) {
+                        *expr = env
+                    }
                 }
 
-                *expr = Expr::Object(ObjectLit {
-                    span: DUMMY_SP,
-                    props,
-                });
+                Expr::Lit(Lit::Num(Number { value, .. })) => {
+                    if let Some(env) = self.get_define_env(&format!("{}.{}", sym, value)) {
+                        *expr = env
+                    }
+                }
+                _ => (),
+            },
+            Expr::Ident(Ident { sym, .. }) => {
+                if let Some(env) = self.get_define_env(sym.as_ref()) {
+                    *expr = env
+                }
             }
+            _ => (),
         }
 
         expr.visit_mut_children_with(self);
@@ -179,11 +129,11 @@ impl VisitMut for EnvReplacer {
 pub fn build_env_map(
     env_map: HashMap<String, Value>,
     context: &Arc<Context>,
-) -> Result<AHashMap<JsWord, Expr>> {
-    let mut map = AHashMap::default();
+) -> Result<HashMap<String, Expr>> {
+    let mut map = HashMap::new();
     for (k, v) in env_map.into_iter() {
         let expr = get_env_expr(v, context)?;
-        map.insert(k.into(), expr);
+        map.insert(k, expr);
     }
     Ok(map)
 }
@@ -264,7 +214,6 @@ mod tests {
 
     use maplit::hashmap;
     use serde_json::{json, Value};
-    use swc_core::common::sync::Lrc;
     use swc_core::common::GLOBALS;
     use swc_core::ecma::visit::VisitMutWith;
 
@@ -359,17 +308,6 @@ log([
     }
 
     #[test]
-    fn test_undefined_env() {
-        assert_eq!(
-            run(
-                r#"if (process.env.UNDEFINED_ENV === "true") {}"#,
-                Default::default()
-            ),
-            r#"if (undefined === "true") {}"#
-        );
-    }
-
-    #[test]
     fn test_stringified_env() {
         assert_eq!(
             run(
@@ -384,12 +322,64 @@ log([
         );
     }
 
+    #[test]
+    fn test_dot_key() {
+        assert_eq!(
+            run(
+                r#"log(x.y)"#,
+                hashmap! {
+                    "x.y".to_string() => json!(true)
+                }
+            ),
+            r#"log(true);"#
+        );
+    }
+
+    #[test]
+    fn test_deep_dot_key() {
+        assert_eq!(
+            run(
+                r#"log(process.env.A)"#,
+                hashmap! {
+                    "process.env.A".to_string() => json!(true)
+                }
+            ),
+            r#"log(true);"#
+        );
+    }
+
+    #[test]
+    fn test_computed() {
+        assert_eq!(
+            run(
+                r#"log(A["B"])"#,
+                hashmap! {
+                    "A.B".to_string() => json!(1)
+                }
+            ),
+            r#"log(1);"#
+        );
+    }
+
+    #[test]
+    fn test_computed_number() {
+        assert_eq!(
+            run(
+                r#"log(A[1])"#,
+                hashmap! {
+                    "A.1".to_string() => json!(1)
+                }
+            ),
+            r#"log(1);"#
+        );
+    }
+
     fn run(js_code: &str, envs: HashMap<String, Value>) -> String {
         let mut test_utils = TestUtils::gen_js_ast(js_code);
         let envs = build_env_map(envs, &test_utils.context).unwrap();
         let ast = test_utils.ast.js_mut();
         GLOBALS.set(&test_utils.context.meta.script.globals, || {
-            let mut visitor = EnvReplacer::new(Lrc::new(envs), ast.unresolved_mark);
+            let mut visitor = EnvReplacer::new(envs, ast.unresolved_mark);
             ast.ast.visit_mut_with(&mut visitor);
         });
         test_utils.js_ast_to_code()

--- a/crates/mako/src/visitors/import_meta_env_replacer.rs
+++ b/crates/mako/src/visitors/import_meta_env_replacer.rs
@@ -1,0 +1,126 @@
+use swc_core::common::DUMMY_SP;
+use swc_core::ecma::ast::{
+    Expr, Ident, KeyValueProp, MemberExpr, MemberProp, MetaPropExpr, MetaPropKind, ObjectLit, Prop,
+    PropOrSpread,
+};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::utils::{quote_ident, quote_str};
+use swc_core::ecma::visit::{VisitMut, VisitMutWith};
+
+#[derive(Debug)]
+pub(crate) struct ImportMetaEnvReplacer {
+    pub(crate) mode: String,
+}
+
+impl ImportMetaEnvReplacer {
+    pub(crate) fn new(mode: String) -> Self {
+        Self { mode }
+    }
+}
+
+impl VisitMut for ImportMetaEnvReplacer {
+    fn visit_mut_member_expr(&mut self, member_expr: &mut MemberExpr) {
+        match member_expr {
+            MemberExpr {
+                obj:
+                    box Expr::Member(MemberExpr {
+                        obj:
+                            box Expr::MetaProp(MetaPropExpr {
+                                kind: MetaPropKind::ImportMeta,
+                                ..
+                            }),
+                        prop:
+                            MemberProp::Ident(Ident {
+                                sym: js_word!("env"),
+                                ..
+                            }),
+                        ..
+                    }),
+                ..
+            } => {
+                // replace import.meta.env.MODE with "({ MODE: 'production' }).MODE"
+                *member_expr.obj = Expr::Paren(swc_core::ecma::ast::ParenExpr {
+                    span: DUMMY_SP,
+                    expr: ObjectLit {
+                        props: vec![PropOrSpread::Prop(
+                            Prop::KeyValue(KeyValueProp {
+                                key: quote_ident!("MODE").into(),
+                                value: quote_str!(self.mode.clone()).into(),
+                            })
+                            .into(),
+                        )],
+                        span: DUMMY_SP,
+                    }
+                    .into(),
+                });
+            }
+
+            _ => member_expr.visit_mut_children_with(self),
+        }
+    }
+
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        match expr {
+            Expr::Member(MemberExpr {
+                obj:
+                    box Expr::MetaProp(MetaPropExpr {
+                        kind: MetaPropKind::ImportMeta,
+                        ..
+                    }),
+                prop:
+                    MemberProp::Ident(Ident {
+                        sym: js_word!("env"),
+                        ..
+                    }),
+                ..
+            }) => {
+                // replace import.meta.env with "({ MODE: 'production' })"
+                *expr = Expr::Object(ObjectLit {
+                    props: vec![PropOrSpread::Prop(
+                        Prop::KeyValue(KeyValueProp {
+                            key: quote_ident!("MODE").into(),
+                            value: quote_str!(self.mode.clone()).into(),
+                        })
+                        .into(),
+                    )],
+                    span: DUMMY_SP,
+                });
+            }
+            _ => expr.visit_mut_children_with(self),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use swc_core::common::GLOBALS;
+    use swc_core::ecma::visit::VisitMutWith;
+
+    use super::ImportMetaEnvReplacer;
+    use crate::ast::tests::TestUtils;
+
+    #[test]
+    fn test_import_meta_env() {
+        assert_eq!(
+            run(
+                r#"typeof import.meta.env === "object" ? import.meta.env.MODE : process.env.NODE_ENV"#
+            ),
+            r#"typeof {
+    MODE: "development"
+} === "object" ? ({
+    MODE: "development"
+}).MODE : process.env.NODE_ENV;"#
+        );
+    }
+
+    fn run(js_code: &str) -> String {
+        let mut test_utils = TestUtils::gen_js_ast(js_code);
+        let ast = test_utils.ast.js_mut();
+        GLOBALS.set(&test_utils.context.meta.script.globals, || {
+            let mut visitor = ImportMetaEnvReplacer::new("development".to_string());
+            ast.ast.visit_mut_with(&mut visitor);
+        });
+        test_utils.js_ast_to_code()
+    }
+}

--- a/crates/mako/src/visitors/mod.rs
+++ b/crates/mako/src/visitors/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod dynamic_import_to_require;
 pub(crate) mod env_replacer;
 pub(crate) mod fix_helper_inject_position;
 pub(crate) mod fix_symbol_conflict;
+pub(crate) mod import_meta_env_replacer;
 pub(crate) mod import_template_to_string_literal;
 pub(crate) mod mako_require;
 pub(crate) mod meta_url_replacer;

--- a/e2e/fixtures/import.meta.env/expect.js
+++ b/e2e/fixtures/import.meta.env/expect.js
@@ -1,0 +1,7 @@
+const { parseBuildResult, injectSimpleJest } = require("../../../scripts/test-utils");
+const { distDir } = parseBuildResult(__dirname);
+
+injectSimpleJest()
+require(path.join(distDir, 'index.js'));
+
+

--- a/e2e/fixtures/import.meta.env/src/index.tsx
+++ b/e2e/fixtures/import.meta.env/src/index.tsx
@@ -1,0 +1,4 @@
+it("should replace import.meta.env", () => {
+  expect(import.meta.env).toEqual({MODE: "development"})
+  expect(import.meta.env.MODE).toEqual("development")
+});


### PR DESCRIPTION
Reapply https://github.com/umijs/mako/pull/1499.
Fix import.meta.env transpiling. The import.meta.env is a static global variable, should not be treated as a defined env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
  - 引入了对 `import.meta.env` 的处理，增强了环境变量管理功能。
  - 新增了测试用例，确保 `import.meta.env` 的属性和值正确。
  
- **bug 修复**
  - 精简了环境变量处理逻辑，提高了代码的可维护性和性能。
  
- **文档**
  - 新增了测试环境配置文件，优化了测试流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->