### PR TITLE
feat: build all platform by ci

### DIFF
--- a/.github/workflows/node-bind-build.yml
+++ b/.github/workflows/node-bind-build.yml
@@ -6,7 +6,7 @@ env:
 'on':
   push:
     branches:
-      - feat-build-all-platform-by-ci
+      - master
     tags-ignore:
       - '**'
     paths-ignore:
@@ -170,9 +170,15 @@ jobs:
       - name: List packages
         run: ls -R ./packages/mako/npm
         shell: bash
+
       - name: Publish
         run: |
-          echo "Not a release, skipping publish"
+          if git log -1 --pretty=%B | grep "^release: [0-9]\+\.[0-9]\+\.[0-9]\+"; then
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            pnpm --filter @umijs/mako publish --access public
+          else
+            echo "Not a release, skipping publish"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node-bind-build.yml
+++ b/.github/workflows/node-bind-build.yml
@@ -170,7 +170,6 @@ jobs:
       - name: List packages
         run: ls -R ./packages/mako/npm
         shell: bash
-
       - name: Publish
         run: |
           if git log -1 --pretty=%B | grep "^Release [0-9]\+\.[0-9]\+\.[0-9]\+"; then

--- a/.github/workflows/node-bind-build.yml
+++ b/.github/workflows/node-bind-build.yml
@@ -6,7 +6,7 @@ env:
 'on':
   push:
     branches:
-      - master
+      - feat-build-all-platform-by-ci
     tags-ignore:
       - '**'
     paths-ignore:
@@ -172,9 +172,9 @@ jobs:
         shell: bash
       - name: Publish
         run: |
-          if git log -1 --pretty=%B | grep "^Release [0-9]\+\.[0-9]\+\.[0-9]\+"; then
+          if git log -1 --pretty=%B | grep "^release: [0-9]\+\.[0-9]\+\.[0-9]\+"; then
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            pnpm --filter @okamjs/okam publish --access public
+            pnpm --filter @umijs/mako publish --access public
           else
             echo "Not a release, skipping publish"
           fi

--- a/.github/workflows/node-bind-build.yml
+++ b/.github/workflows/node-bind-build.yml
@@ -1,7 +1,7 @@
 name: node-bind-build
 env:
   DEBUG: napi:*
-  APP_NAME: okam
+  APP_NAME: mako
   MACOSX_DEPLOYMENT_TARGET: '10.13'
 'on':
   push:
@@ -20,14 +20,14 @@ env:
 jobs:
   pre-check:
     name: Check Is Release node-binding
-    if: "contains(github.event.head_commit.message, 'Release')"
+    if: startsWith(github.event.head_commit.message, 'release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: is Release Commit
         run: |
           echo Start Release
-          if git log -1 --pretty=%B | grep "^Release [0-9]\+\.[0-9]\+\.[0-9]\+"; then
+          if git log -1 --pretty=%B | grep "^release: [0-9]\+\.[0-9]\+\.[0-9]\+"; then
             echo "start Release"
           else
             gh run cancel ${{ github.run_id }}
@@ -45,21 +45,35 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             build: |
-              pnpm --filter @okamjs/okam build --target x86_64-apple-darwin
+              rustup target add x86_64-apple-darwin
+              pnpm --filter @umijs/mako build --target x86_64-apple-darwin
               strip -x ./packages/mako/*.node
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |-
               set -e &&
-              pnpm --filter @okamjs/okam build --target x86_64-unknown-linux-gnu &&
+              rustup target add x86_64-unknown-linux-gnu &&
+              pnpm --filter @umijs/mako build --target x86_64-unknown-linux-gnu &&
               strip ./packages/mako/*.node
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
               rustup target add aarch64-apple-darwin
-              pnpm --filter @okamjs/okam build --target aarch64-apple-darwin
+              pnpm --filter @umijs/mako build --target aarch64-apple-darwin
               strip -x ./packages/mako/*.node
+          - host: windows-latest
+            build: |
+              rustup target add x86_64-pc-windows-msvc
+              pnpm --filter @umijs/mako build --target x86_64-pc-windows-msvc
+              strip -x ./packages/mako/*.node
+            target: x86_64-pc-windows-msvc
+          - host: windows-latest
+            build: |
+              rustup target add i686-pc-windows-msvc
+              pnpm --filter @umijs/mako build --target i686-pc-windows-msvc
+              strip -x ./packages/mako/*.node
+            target: i686-pc-windows-msvc
     name: stable - ${{ matrix.settings.target }} - node@18
     runs-on: ${{ matrix.settings.host }}
     steps:
@@ -100,10 +114,6 @@ jobs:
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}
         shell: bash
-      - name: Setup node x86
-        if: matrix.settings.target == 'i686-pc-windows-msvc'
-        run: yarn config set supportedArchitectures.cpu "ia32"
-        shell: bash
       - name: Install dependencies
         run: pnpm install
       - name: Setup node x86
@@ -129,7 +139,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: bindings-${{ matrix.settings.target }}
-          path: ./packaegs/mako/${{ env.APP_NAME }}.*.node
+          path: ./packages/mako/${{ env.APP_NAME }}.*.node
           if-no-files-found: error
   publish:
     name: Publish
@@ -154,11 +164,11 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v3
         with:
-          path: packaegs/mako/artifacts
+          path: packages/mako/artifacts
       - name: Move artifacts
-        run: pnpm --filter @okamjs/okam artifacts
+        run: pnpm --filter @umijs/mako artifacts
       - name: List packages
-        run: ls -R ./packaegs/mako/npm
+        run: ls -R ./packages/mako/npm
         shell: bash
 
       - name: Publish

--- a/.github/workflows/node-bind-build.yml
+++ b/.github/workflows/node-bind-build.yml
@@ -174,8 +174,8 @@ jobs:
       - name: Publish
         run: |
           if git log -1 --pretty=%B | grep "^release: [0-9]\+\.[0-9]\+\.[0-9]\+"; then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            pnpm --filter @umijs/mako publish --access public
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            pnpm --filter @umijs/mako publish --access public --no-git-checks
           else
             echo "Not a release, skipping publish"
           fi

--- a/.github/workflows/node-bind-build.yml
+++ b/.github/workflows/node-bind-build.yml
@@ -172,12 +172,7 @@ jobs:
         shell: bash
       - name: Publish
         run: |
-          if git log -1 --pretty=%B | grep "^release: [0-9]\+\.[0-9]\+\.[0-9]\+"; then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            pnpm --filter @umijs/mako publish --access public
-          else
-            echo "Not a release, skipping publish"
-          fi
+          echo "Not a release, skipping publish"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/mako/package.json
+++ b/packages/mako/package.json
@@ -12,7 +12,9 @@
       "defaults": false,
       "additional": [
         "aarch64-apple-darwin",
+        "i686-pc-windows-msvc",
         "x86_64-apple-darwin",
+        "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
         "x86_64-unknown-linux-musl"
       ]


### PR DESCRIPTION
主要是支持 window

触发条件改成提交日志是 "release:"

如果能正确发包的话，可以 Close: https://github.com/umijs/mako/issues/1343

在 [fork](https://github.com/xiaohuoni/mako/actions/runs/10468516257/job/28991036830) 的仓库，可以看到有对应包生成，发包都走通了，（发了别名包测试）https://www.npmjs.com/package/@alita/mako-win32-x64-msvc?activeTab=code
![image](https://github.com/user-attachments/assets/270945e8-1754-4180-8386-0cf7265f1150)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新特性**
  - 更新应用名称为“mako”，并增强跨平台构建流程，现支持Windows平台（i686和x86_64架构）。
  
- **修复**
  - 修正了构建过程中包路径的错误，确保文件管理的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->