### PR TITLE
chore: use lto: thin in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tikv-jemallocator = { version = "=0.5.4", features = ["disable_initial_exec_tls"
 
 [profile.release]
 debug = false
-lto   = true
+lto   = "thin"
 strip = true
 
 # Use the `--profile release-debug` flag to show symbols in release mode.


### PR DESCRIPTION
The default lto strategy ("fat") is slow, and with debug: true, it may cause OOM.