### PR TITLE
fix: should not alias define XXX to process.env.XXX

### DIFF
--- a/e2e/fixtures.umi/config.define/.umirc.ts
+++ b/e2e/fixtures.umi/config.define/.umirc.ts
@@ -15,7 +15,6 @@ export default {
     DDD: true,
     EEE: false,
     FFF: null,
-    GGG: ["a", 1],
-    "process.env.HHH": false,
+    GGG: ["a", 1]
   },
 };

--- a/e2e/fixtures.umi/config.define/expect.js
+++ b/e2e/fixtures.umi/config.define/expect.js
@@ -13,7 +13,6 @@ assert(content.includes("console.log(1);"), "support Number");
 assert(content.includes("console.log(true);"), "support Boolean");
 assert(content.includes("console.log(false);"), "support Boolean");
 assert(content.includes("console.log(null);"), "support Null");
-assert(content.includes("console.log('process.env',false);"), "support normalize process.env.XXX");
 
 /**
 "production";

--- a/e2e/fixtures.umi/config.define/pages/index.tsx
+++ b/e2e/fixtures.umi/config.define/pages/index.tsx
@@ -7,5 +7,4 @@ console.log(DDD);
 console.log(EEE);
 console.log(FFF);
 console.log(GGG);
-console.log('process.env', HHH);
 export default () => <div>1</div>;

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -514,7 +514,9 @@ async function getMakoConfig(opts) {
   }
 
   if (process.env.SOCKET_SERVER) {
-    define.SOCKET_SERVER = normalizeDefineValue(process.env.SOCKET_SERVER);
+    define['process.env.SOCKET_SERVER'] = normalizeDefineValue(
+      process.env.SOCKET_SERVER,
+    );
   }
 
   let minify = jsMinifier === 'none' ? false : true;

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -509,16 +509,7 @@ async function getMakoConfig(opts) {
   const define = {};
   if (opts.config.define) {
     for (const key of Object.keys(opts.config.define)) {
-      // mako 的 define 会先去判断 process.env.xxx，再去判断 xxx
-      // 这里传 process.env.xxx 反而不会生效
-      // TODO: 待 mako 改成和 umi/webpack 的方式一致之后，可以把这段去掉
-      if (key.startsWith('process.env.')) {
-        define[key.replace(/^process\.env\./, '')] = normalizeDefineValue(
-          opts.config.define[key],
-        );
-      } else {
-        define[key] = normalizeDefineValue(opts.config.define[key]);
-      }
+      define[key] = normalizeDefineValue(opts.config.define[key]);
     }
   }
 


### PR DESCRIPTION
 Alias define XXX to process.env.XXX is a bad design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
	- 简化了环境变量的配置管理。
	- 减少了控制台输出，优化了调试过程。

- **修复**
	- 移除了对不再需要的日志断言的验证，简化了测试范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->