### PR TITLE
fix(plugin:emotion): panic when target to chrome 40

### DIFF
--- a/crates/mako/src/ast/js_ast.rs
+++ b/crates/mako/src/ast/js_ast.rs
@@ -23,7 +23,6 @@ use crate::ast::{error, utils};
 use crate::compiler::Context;
 use crate::config::{DevtoolConfig, Mode, OutputMode};
 use crate::module::Dependency;
-use crate::plugin::PluginTransformJsParam;
 use crate::utils::base64_encode;
 use crate::visitors::dep_analyzer::DepAnalyzer;
 
@@ -134,7 +133,6 @@ impl JsAst {
         &mut self,
         mut_visitors: &mut Vec<Box<dyn visit::VisitMut>>,
         folders: &mut Vec<Box<dyn visit::Fold>>,
-        file: &File,
         should_inject_helpers: bool,
         context: Arc<Context>,
     ) -> Result<()> {
@@ -151,28 +149,11 @@ impl JsAst {
                         }
 
                         // folders
-                        let body = ast.body.take();
-                        let mut module = Module {
-                            span: ast.span,
-                            shebang: ast.shebang.clone(),
-                            body,
-                        };
+                        let mut module = ast.take();
                         for folder in folders {
                             module = folder.as_mut().fold_module(module);
                         }
-                        ast.body = module.body;
-
-                        // transform with plugin
-                        context.plugin_driver.transform_js(
-                            &PluginTransformJsParam {
-                                handler,
-                                path: file.path.to_str().unwrap(),
-                                top_level_mark: self.top_level_mark,
-                                unresolved_mark: self.unresolved_mark,
-                            },
-                            ast,
-                            &context,
-                        )?;
+                        *ast = module;
 
                         // FIXME: remove this, it's special logic
                         // inject helpers

--- a/crates/mako/src/ast/js_ast.rs
+++ b/crates/mako/src/ast/js_ast.rs
@@ -2,8 +2,6 @@ use std::fmt;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use swc_core::base::try_with_handler;
-use swc_core::common::errors::HANDLER;
 use swc_core::common::util::take::Take;
 use swc_core::common::{FileName, Mark, Spanned, GLOBALS};
 use swc_core::ecma::ast::{EsVersion, Module};
@@ -12,7 +10,7 @@ use swc_core::ecma::codegen::{Config as JsCodegenConfig, Emitter};
 use swc_core::ecma::parser::error::SyntaxError;
 use swc_core::ecma::parser::lexer::Lexer;
 use swc_core::ecma::parser::{EsConfig, Parser, StringInput, Syntax, TsConfig};
-use swc_core::ecma::transforms::base::helpers::{inject_helpers, Helpers, HELPERS};
+use swc_core::ecma::transforms::base::helpers::inject_helpers;
 use swc_core::ecma::utils::contains_top_level_await;
 use swc_core::ecma::visit;
 use swc_core::ecma::visit::{VisitMutWith, VisitWith};
@@ -134,55 +132,45 @@ impl JsAst {
         mut_visitors: &mut Vec<Box<dyn visit::VisitMut>>,
         folders: &mut Vec<Box<dyn visit::Fold>>,
         should_inject_helpers: bool,
-        context: Arc<Context>,
+        _context: Arc<Context>,
     ) -> Result<()> {
-        let cm = context.meta.script.cm.clone();
-        GLOBALS.set(&context.meta.script.globals, || {
-            try_with_handler(cm, Default::default(), |handler| {
-                HELPERS.set(&Helpers::new(true), || {
-                    HANDLER.set(handler, || {
-                        let ast = &mut self.ast;
+        let ast = &mut self.ast;
 
-                        // visitors
-                        for visitor in mut_visitors {
-                            ast.visit_mut_with(visitor.as_mut());
-                        }
+        // visitors
+        for visitor in mut_visitors {
+            ast.visit_mut_with(visitor.as_mut());
+        }
 
-                        // folders
-                        let mut module = ast.take();
-                        for folder in folders {
-                            module = folder.as_mut().fold_module(module);
-                        }
-                        *ast = module;
+        // folders
+        let mut module = ast.take();
+        for folder in folders {
+            module = folder.as_mut().fold_module(module);
+        }
+        *ast = module;
 
-                        // FIXME: remove this, it's special logic
-                        // inject helpers
-                        // why need to handle cjs specially?
-                        // because the ast is currently a module, not a program
-                        // if not handled specially, the injected helpers will all be in esm format
-                        // which is not as expected in the cjs scenario
-                        // ref: https://github.com/umijs/mako/pull/831
-                        if should_inject_helpers {
-                            if utils::is_esm(ast) {
-                                ast.visit_mut_with(&mut inject_helpers(self.unresolved_mark));
-                            } else {
-                                let body = ast.body.take();
-                                let mut script_ast = swc_core::ecma::ast::Script {
-                                    span: ast.span,
-                                    shebang: ast.shebang.clone(),
-                                    body: body.into_iter().map(|i| i.stmt().unwrap()).collect(),
-                                };
-                                script_ast
-                                    .visit_mut_with(&mut inject_helpers(self.unresolved_mark));
-                                ast.body = script_ast.body.into_iter().map(|i| i.into()).collect();
-                            }
-                        }
+        // FIXME: remove this, it's special logic
+        // inject helpers
+        // why need to handle cjs specially?
+        // because the ast is currently a module, not a program
+        // if not handled specially, the injected helpers will all be in esm format
+        // which is not as expected in the cjs scenario
+        // ref: https://github.com/umijs/mako/pull/831
+        if should_inject_helpers {
+            if utils::is_esm(ast) {
+                ast.visit_mut_with(&mut inject_helpers(self.unresolved_mark));
+            } else {
+                let body = ast.body.take();
+                let mut script_ast = swc_core::ecma::ast::Script {
+                    span: ast.span,
+                    shebang: ast.shebang.clone(),
+                    body: body.into_iter().map(|i| i.stmt().unwrap()).collect(),
+                };
+                script_ast.visit_mut_with(&mut inject_helpers(self.unresolved_mark));
+                ast.body = script_ast.body.into_iter().map(|i| i.into()).collect();
+            }
+        }
 
-                        Ok(())
-                    })
-                })
-            })
-        })
+        Ok(())
     }
 
     pub fn analyze_deps(&self, context: Arc<Context>) -> Vec<Dependency> {

--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -55,139 +55,153 @@ impl Transform {
         crate::mako_profile_function!();
         match ast {
             ModuleAst::Script(ast) => {
+                let cm = context.meta.script.cm.clone();
                 GLOBALS.set(&context.meta.script.globals, || {
-                    let unresolved_mark = ast.unresolved_mark;
-                    let top_level_mark = ast.top_level_mark;
-                    let cm: Arc<swc_core::common::SourceMap> = context.meta.script.cm.clone();
-                    let origin_comments = context.meta.script.origin_comments.read().unwrap();
-                    let is_ts = file.extname == "ts";
-                    let is_tsx = file.extname == "tsx";
-                    let is_jsx = file.is_content_jsx()
-                        || file.extname == "jsx"
-                        || file.extname == "js"
-                        || file.extname == "ts"
-                        || file.extname == "tsx";
-
-                    // visitors
-                    let mut visitors: Vec<Box<dyn VisitMut>> = vec![
-                        Box::new(resolver(unresolved_mark, top_level_mark, is_ts || is_tsx)),
-                        // fix helper inject position
-                        // should be removed after upgrade to latest swc
-                        // ref: https://github.com/umijs/mako/issues/1193
-                        Box::new(FixHelperInjectPosition::new()),
-                        Box::new(FixSymbolConflict::new(top_level_mark)),
-                        Box::new(NewUrlAssets {
-                            context: context.clone(),
-                            path: file.path.clone(),
-                            unresolved_mark,
-                        }),
-                        Box::new(WorkerModule::new(unresolved_mark)),
-                    ];
-                    if is_tsx {
-                        visitors.push(Box::new(tsx_strip(
-                            cm.clone(),
-                            context.clone(),
-                            top_level_mark,
-                        )))
-                    }
-                    // strip should be ts only
-                    // since when use this in js, it will remove all unused imports
-                    // which is not expected as what webpack does
-                    if is_ts {
-                        visitors.push(Box::new(ts_strip(top_level_mark)))
-                    }
-                    // named default export
-                    if context.args.watch && !file.is_under_node_modules && is_jsx {
-                        visitors.push(Box::new(DefaultExportNamer::new()));
-                    }
-                    // react & react-refresh
-                    let is_dev = matches!(context.config.mode, Mode::Development);
-                    let is_browser =
-                        matches!(context.config.platform, crate::config::Platform::Browser);
-                    let use_refresh = is_dev
-                        && context.args.watch
-                        && context.config.hmr.is_some()
-                        && !file.is_under_node_modules
-                        && is_browser;
-                    if is_jsx {
-                        visitors.push(react(
-                            cm.clone(),
-                            context.clone(),
-                            use_refresh,
-                            &top_level_mark,
-                            &unresolved_mark,
-                        ));
-                    }
-                    {
-                        let mut define = context.config.define.clone();
-                        let mode = context.config.mode.to_string();
-                        define
-                            .entry("process.env.NODE_ENV".to_string())
-                            .or_insert_with(|| format!("\"{}\"", mode).into());
-                        let env_map = build_env_map(define, &context)?;
-                        visitors.push(Box::new(EnvReplacer::new(env_map, unresolved_mark)));
-                        visitors.push(Box::new(ImportMetaEnvReplacer::new(mode)));
-                    }
-                    visitors.push(Box::new(TryResolve {
-                        path: file.path.to_string_lossy().to_string(),
-                        context: context.clone(),
-                        unresolved_mark,
-                    }));
-                    visitors.push(Box::new(PublicPathAssignment { unresolved_mark }));
-                    // TODO: refact provide
-                    visitors.push(Box::new(Provide::new(
-                        context.config.providers.clone(),
-                        unresolved_mark,
-                        top_level_mark,
-                    )));
-                    visitors.push(Box::new(VirtualCSSModules {
-                        auto_css_modules: context.config.auto_css_modules,
-                        unresolved_mark,
-                    }));
-                    // TODO: move ContextModuleVisitor out of plugin
-                    visitors.push(Box::new(ContextModuleVisitor { unresolved_mark }));
-                    visitors.push(Box::new(ImportTemplateToStringLiteral {}));
-                    // DynamicImportToRequire must be after ContextModuleVisitor
-                    // since ContextModuleVisitor will add extra dynamic imports
-                    if context.config.dynamic_import_to_require {
-                        visitors.push(Box::new(DynamicImportToRequire::new(unresolved_mark)));
-                    }
-                    if matches!(context.config.platform, crate::config::Platform::Node) {
-                        visitors.push(Box::new(features::node::MockFilenameAndDirname {
-                            unresolved_mark,
-                            current_path: file.path.clone(),
-                            context: context.clone(),
-                        }));
-                    }
-
-                    // folders
-                    let mut folders: Vec<Box<dyn Fold>> = vec![];
-                    // decorators should go before preset_env, when compile down to es5,
-                    // classes become functions, then the decorators on the functions
-                    // will be removed silently.
-                    folders.push(Box::new(decorators(decorators::Config {
-                        legacy: true,
-                        emit_metadata: context.config.emit_decorator_metadata,
-                        ..Default::default()
-                    })));
-                    let comments = origin_comments.get_swc_comments().clone();
-                    let assumptions = context.assumptions_for(file);
-
-                    // NOTICE: remove optimize_package_imports temporarily
-                    // folders.push(Box::new(Optional {
-                    //     enabled: should_optimize(file.path.to_str().unwrap(), context.clone()),
-                    //     visitor: optimize_package_imports(
-                    //         file.path.to_string_lossy().to_string(),
-                    //         context.clone(),
-                    //     ),
-                    // }));
-
-                    ast.transform(&mut visitors, &mut folders, false, context.clone())?;
-
-                    // run transform js in plugins
-                    try_with_handler(cm.clone(), Default::default(), |handler| {
+                    try_with_handler(cm, Default::default(), |handler| {
                         HELPERS.set(&Helpers::new(true), || {
                             HANDLER.set(handler, || {
+                                let unresolved_mark = ast.unresolved_mark;
+                                let top_level_mark = ast.top_level_mark;
+                                let cm: Arc<swc_core::common::SourceMap> =
+                                    context.meta.script.cm.clone();
+                                let origin_comments =
+                                    context.meta.script.origin_comments.read().unwrap();
+                                let is_ts = file.extname == "ts";
+                                let is_tsx = file.extname == "tsx";
+                                let is_jsx = file.is_content_jsx()
+                                    || file.extname == "jsx"
+                                    || file.extname == "js"
+                                    || file.extname == "ts"
+                                    || file.extname == "tsx";
+
+                                // visitors
+                                let mut visitors: Vec<Box<dyn VisitMut>> = vec![
+                                    Box::new(resolver(
+                                        unresolved_mark,
+                                        top_level_mark,
+                                        is_ts || is_tsx,
+                                    )),
+                                    // fix helper inject position
+                                    // should be removed after upgrade to latest swc
+                                    // ref: https://github.com/umijs/mako/issues/1193
+                                    Box::new(FixHelperInjectPosition::new()),
+                                    Box::new(FixSymbolConflict::new(top_level_mark)),
+                                    Box::new(NewUrlAssets {
+                                        context: context.clone(),
+                                        path: file.path.clone(),
+                                        unresolved_mark,
+                                    }),
+                                    Box::new(WorkerModule::new(unresolved_mark)),
+                                ];
+                                if is_tsx {
+                                    visitors.push(Box::new(tsx_strip(
+                                        cm.clone(),
+                                        context.clone(),
+                                        top_level_mark,
+                                    )))
+                                }
+                                // strip should be ts only
+                                // since when use this in js, it will remove all unused imports
+                                // which is not expected as what webpack does
+                                if is_ts {
+                                    visitors.push(Box::new(ts_strip(top_level_mark)))
+                                }
+                                // named default export
+                                if context.args.watch && !file.is_under_node_modules && is_jsx {
+                                    visitors.push(Box::new(DefaultExportNamer::new()));
+                                }
+                                // react & react-refresh
+                                let is_dev = matches!(context.config.mode, Mode::Development);
+                                let is_browser = matches!(
+                                    context.config.platform,
+                                    crate::config::Platform::Browser
+                                );
+                                let use_refresh = is_dev
+                                    && context.args.watch
+                                    && context.config.hmr.is_some()
+                                    && !file.is_under_node_modules
+                                    && is_browser;
+                                if is_jsx {
+                                    visitors.push(react(
+                                        cm.clone(),
+                                        context.clone(),
+                                        use_refresh,
+                                        &top_level_mark,
+                                        &unresolved_mark,
+                                    ));
+                                }
+                                {
+                                    let mut define = context.config.define.clone();
+                                    let mode = context.config.mode.to_string();
+                                    define
+                                        .entry("process.env.NODE_ENV".to_string())
+                                        .or_insert_with(|| format!("\"{}\"", mode).into());
+                                    let env_map = build_env_map(define, &context)?;
+                                    visitors
+                                        .push(Box::new(EnvReplacer::new(env_map, unresolved_mark)));
+                                    visitors.push(Box::new(ImportMetaEnvReplacer::new(mode)));
+                                }
+                                visitors.push(Box::new(TryResolve {
+                                    path: file.path.to_string_lossy().to_string(),
+                                    context: context.clone(),
+                                    unresolved_mark,
+                                }));
+                                visitors.push(Box::new(PublicPathAssignment { unresolved_mark }));
+                                // TODO: refact provide
+                                visitors.push(Box::new(Provide::new(
+                                    context.config.providers.clone(),
+                                    unresolved_mark,
+                                    top_level_mark,
+                                )));
+                                visitors.push(Box::new(VirtualCSSModules {
+                                    auto_css_modules: context.config.auto_css_modules,
+                                    unresolved_mark,
+                                }));
+                                // TODO: move ContextModuleVisitor out of plugin
+                                visitors.push(Box::new(ContextModuleVisitor { unresolved_mark }));
+                                visitors.push(Box::new(ImportTemplateToStringLiteral {}));
+                                // DynamicImportToRequire must be after ContextModuleVisitor
+                                // since ContextModuleVisitor will add extra dynamic imports
+                                if context.config.dynamic_import_to_require {
+                                    visitors.push(Box::new(DynamicImportToRequire::new(
+                                        unresolved_mark,
+                                    )));
+                                }
+                                if matches!(context.config.platform, crate::config::Platform::Node)
+                                {
+                                    visitors.push(Box::new(
+                                        features::node::MockFilenameAndDirname {
+                                            unresolved_mark,
+                                            current_path: file.path.clone(),
+                                            context: context.clone(),
+                                        },
+                                    ));
+                                }
+
+                                // folders
+                                let mut folders: Vec<Box<dyn Fold>> = vec![];
+                                // decorators should go before preset_env, when compile down to es5,
+                                // classes become functions, then the decorators on the functions
+                                // will be removed silently.
+                                folders.push(Box::new(decorators(decorators::Config {
+                                    legacy: true,
+                                    emit_metadata: context.config.emit_decorator_metadata,
+                                    ..Default::default()
+                                })));
+                                let comments = origin_comments.get_swc_comments().clone();
+                                let assumptions = context.assumptions_for(file);
+
+                                // NOTICE: remove optimize_package_imports temporarily
+                                // folders.push(Box::new(Optional {
+                                //     enabled: should_optimize(file.path.to_str().unwrap(), context.clone()),
+                                //     visitor: optimize_package_imports(
+                                //         file.path.to_string_lossy().to_string(),
+                                //         context.clone(),
+                                //     ),
+                                // }));
+
+                                ast.transform(&mut visitors, &mut folders, false, context.clone())?;
+
                                 // transform with plugin
                                 context.plugin_driver.transform_js(
                                     &PluginTransformJsParam {
@@ -198,44 +212,48 @@ impl Transform {
                                     },
                                     &mut ast.ast,
                                     &context,
+                                )?;
+
+                                // preset_env should go last
+                                let mut preset_folders: Vec<Box<dyn Fold>> = vec![
+                                    Box::new(swc_preset_env::preset_env(
+                                        unresolved_mark,
+                                        Some(comments),
+                                        swc_preset_env::Config {
+                                            mode: Some(swc_preset_env::Mode::Entry),
+                                            targets: Some(swc_preset_env_targets_from_map(
+                                                context.config.targets.clone(),
+                                            )),
+                                            ..Default::default()
+                                        },
+                                        assumptions,
+                                        &mut FeatureFlag::default(),
+                                    )),
+                                    Box::new(reserved_words::reserved_words()),
+                                    Box::new(paren_remover(Default::default())),
+                                    // simplify, but keep top level dead code
+                                    // e.g. import x from 'foo'; but x is not used
+                                    // this must be kept for tree shaking to work
+                                    Box::new(simplifier(
+                                        unresolved_mark,
+                                        SimpilifyConfig {
+                                            dce: dce::Config {
+                                                top_level: false,
+                                                ..Default::default()
+                                            },
+                                            ..Default::default()
+                                        },
+                                    )),
+                                ];
+                                ast.transform(
+                                    &mut vec![],
+                                    &mut preset_folders,
+                                    true,
+                                    context.clone(),
                                 )
                             })
                         })
                     })?;
-
-                    // preset_env should go last
-                    let mut preset_folders: Vec<Box<dyn Fold>> = vec![
-                        Box::new(swc_preset_env::preset_env(
-                            unresolved_mark,
-                            Some(comments),
-                            swc_preset_env::Config {
-                                mode: Some(swc_preset_env::Mode::Entry),
-                                targets: Some(swc_preset_env_targets_from_map(
-                                    context.config.targets.clone(),
-                                )),
-                                ..Default::default()
-                            },
-                            assumptions,
-                            &mut FeatureFlag::default(),
-                        )),
-                        Box::new(reserved_words::reserved_words()),
-                        Box::new(paren_remover(Default::default())),
-                        // simplify, but keep top level dead code
-                        // e.g. import x from 'foo'; but x is not used
-                        // this must be kept for tree shaking to work
-                        Box::new(simplifier(
-                            unresolved_mark,
-                            SimpilifyConfig {
-                                dce: dce::Config {
-                                    top_level: false,
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            },
-                        )),
-                    ];
-                    ast.transform(&mut vec![], &mut preset_folders, true, context.clone())?;
-
                     Ok(())
                 })
             }

--- a/crates/mako/src/plugins/emotion.rs
+++ b/crates/mako/src/plugins/emotion.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::Ok;
 use swc_core::common::comments::NoopComments;
 use swc_core::common::sync::Lrc;
+use swc_core::common::util::take::Take;
 use swc_core::common::SourceMap;
 use swc_core::ecma::ast::Module;
 use swc_core::ecma::visit::{Fold, VisitMut, VisitMutWith};
@@ -77,8 +78,7 @@ impl VisitMut for Emotion {
             self.cm.clone(),
             NoopComments,
         );
-        module.body = folder.fold_module(module.clone()).body;
 
-        module.visit_mut_children_with(self);
+        *module = folder.fold_module(module.take());
     }
 }

--- a/crates/mako/src/visitors/fix_helper_inject_position.rs
+++ b/crates/mako/src/visitors/fix_helper_inject_position.rs
@@ -97,7 +97,6 @@ mod tests {
     use swc_core::ecma::visit::{Fold, VisitMut, VisitMutWith};
 
     use super::FixHelperInjectPosition;
-    use crate::ast::file::File;
     use crate::ast::tests::TestUtils;
     use crate::build::targets::swc_preset_env_targets_from_map;
 
@@ -190,8 +189,7 @@ export { foo };
             )));
             let mut visitors: Vec<Box<dyn VisitMut>> = vec![];
             let context = test_utils.context.clone();
-            let file = File::new("test.ts".to_string(), context.clone());
-            ast.transform(&mut visitors, &mut folders, &file, false, context)
+            ast.transform(&mut visitors, &mut folders, false, context)
                 .unwrap();
         });
         test_utils.js_ast_to_code()

--- a/e2e/fixtures/config.emotion/expect.js
+++ b/e2e/fixtures/config.emotion/expect.js
@@ -55,3 +55,7 @@ const test = async () => {
   }
 };
 module.exports = test;
+
+if (!module.parent) {
+  test();
+}

--- a/e2e/fixtures/config.emotion/mako.config.json
+++ b/e2e/fixtures/config.emotion/mako.config.json
@@ -1,3 +1,7 @@
 {
-  "emotion": true
+  "emotion": true,
+  "targets": {
+    "chrome": 40
+  },
+  "progress": false
 }


### PR DESCRIPTION
close. https://github.com/umijs/mako/issues/1484 

0.  move scoped value  outside of ast transform method, because we need to use the same scoped value in different method calling
1. make preset env to go last while transforming js
2. extract plugin in transform to transform mod


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
  - 改进了 JavaScript 转换过程，集成插件处理机制，增强了错误处理能力。
  - 添加了新配置属性，允许更细致的目标环境控制。

- **优化**
  - 精简了 AST 的处理逻辑，提高了性能和可读性。
  - 测试模块中移除了不必要的依赖，简化了函数签名。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->