### PR TITLE
feat: px2rem supports custom 'unit'

### DIFF
--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -253,6 +253,8 @@ pub struct Px2RemConfig {
     pub min_pixel_value: f64,
     #[serde(rename = "mediaQuery", default)]
     pub media_query: bool,
+    #[serde(rename = "unit", default = "visitors::css_px2rem::default_unit")]
+    pub unit: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -272,6 +274,7 @@ impl Default for Px2RemConfig {
             selector_doublelist: vec![],
             min_pixel_value: 0.0,
             media_query: false,
+            unit: visitors::css_px2rem::default_unit(),
         }
     }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -573,6 +573,7 @@ Whether to enable px2rem conversion.
 - `selectorDoubleList`, selector double rem list
 - `minPixelValue`，minimum pixel value, default is `0`
 - `mediaQuery`，allow px to be converted in media queries, default is `false`
+- `unit`, the unit to be converted, default is `px`
 
 Among them, `selectorBlackList`, `selectorWhiteList` and `selectorDoubleList` all support passing regular expressions or strings, such as
 

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -573,6 +573,7 @@ __mako_public_path__ = '/foo/';
 - `selectorDoubleList`，选择器白名单，会被转换为两倍的值
 - `minPixelValue`，最小像素值，默认为 `0`
 - `mediaQuery`，是否转换媒体查询中的 px, 默认 `false`
+- `unit`，需要转换的单位，默认为 `px`
 
 其中 `selectorBlackList`、`selectorWhiteList`、`selectorDoubleList` 均支持传递正则表达式或者字符串，如
 

--- a/e2e/fixtures/config.px2rem.custom-unit/expect.js
+++ b/e2e/fixtures/config.px2rem.custom-unit/expect.js
@@ -1,9 +1,10 @@
 const assert = require("assert");
-const { parseBuildResult, string2RegExp } = require("../../../scripts/test-utils");
+const { parseBuildResult } = require("../../../scripts/test-utils");
 const { files } = parseBuildResult(__dirname);
 
 const content = files["index.css"];
 
+// only convert rpx to rem, px need to be kept
 assert.doesNotMatch(
   content,
   /width: 0.34rem;/,

--- a/e2e/fixtures/config.px2rem.custom-unit/expect.js
+++ b/e2e/fixtures/config.px2rem.custom-unit/expect.js
@@ -1,0 +1,64 @@
+const assert = require("assert");
+const { parseBuildResult, string2RegExp } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const content = files["index.css"];
+
+assert.doesNotMatch(
+  content,
+  /width: 0.34rem;/,
+  "should not have `width: 0.34rem;`"
+)
+
+assert.match(
+  content,
+  /margin: 0 0 0.2rem;/,
+  "should have `margin: 0 0 0.2rem;`"
+);
+assert.doesNotMatch(
+  content,
+  /content: 0.16rem;/,
+  "should not have `content: 0.16rem;`"
+);
+assert(
+  content.includes("@media (min-width: 5rem) {"),
+  "media query should be transformed"
+);
+assert(
+  content.includes(
+    "--border-radius: var(--adm-button-border-radius, 0.88rem);"
+  ),
+  "should convert rpx in var func"
+);
+assert(
+  content.includes(
+    "height: var(--state, var(--button-color, var(--brand-color, 0.88rem)));"
+  ),
+  "should convert rpx in nested var func "
+);
+assert(
+  content.includes("width: 0.88rem;"),
+  "should convert when surrounding by var func declaration"
+);
+assert(
+  content.includes(
+    "--my-height: var(--state, var(--button-color, var(--brand-color, calc(100% - 0.88rem))));"
+  ),
+  "should convert rpx in nested var func and other func call"
+);
+assert(
+  content.includes("--border-top: var(--adm-button-border-radius, 88em);"),
+  "em should not be converted in var func"
+);
+assert(
+  content.includes(
+    "min-height: var(--state, var(--button-color, var(--brand-color, 88em)));"
+  ),
+  "em should not be converted in nested var func"
+);
+assert(
+  content.includes(
+    "--your-height: var(--state, var(--button-color, var(--brand-color, calc(100% - 88em))));"
+  ),
+  "em should not be converted in nested var and other func"
+);

--- a/e2e/fixtures/config.px2rem.custom-unit/mako.config.json
+++ b/e2e/fixtures/config.px2rem.custom-unit/mako.config.json
@@ -1,0 +1,6 @@
+{
+  "px2rem": {
+    "mediaQuery": true,
+    "unit": "rpx"
+  }
+}

--- a/e2e/fixtures/config.px2rem.custom-unit/src/index.css
+++ b/e2e/fixtures/config.px2rem.custom-unit/src/index.css
@@ -9,7 +9,6 @@
   letter-spacing: 1rpx;
 }
 
-
 .b {
   font-size: 2em;
 }

--- a/e2e/fixtures/config.px2rem.custom-unit/src/index.css
+++ b/e2e/fixtures/config.px2rem.custom-unit/src/index.css
@@ -1,0 +1,41 @@
+.px {
+  width: 34px;
+}
+
+.a {
+  margin: 0 0 20rpx;
+  font-size: 32rpx;
+  line-height: 1.2;
+  letter-spacing: 1rpx;
+}
+
+
+.b {
+  font-size: 2em;
+}
+
+.c {
+  margin: 0.5rpx;
+}
+
+.d {
+  content: "16rpx";
+  font-family: "16rpx";
+  font-size: 16rpx;
+}
+
+@media (min-width: 500rpx) {
+  .rule {
+    font-size: 16rpx;
+  }
+}
+
+h1 {
+  --border-radius: var(--adm-button-border-radius, 88rpx);
+  --border-top: var(--adm-button-border-radius, 88em);
+  width: 88rpx;
+  height: var(--state, var(--button-color, var(--brand-color, 88rpx)));
+  min-height: var(--state, var(--button-color, var(--brand-color, 88em)));
+  --my-height: var(--state, var(--button-color, var(--brand-color, calc(100% - 88rpx))));
+  --your-height: var(--state, var(--button-color, var(--brand-color, calc(100% - 88em))));
+}

--- a/e2e/fixtures/config.px2rem.custom-unit/src/index.tsx
+++ b/e2e/fixtures/config.px2rem.custom-unit/src/index.tsx
@@ -1,0 +1,2 @@
+import "./index.css";
+console.log(1);


### PR DESCRIPTION
支持自定义需要转换的单位，默认为 `px`。

例如，当配置 unit 为 rpx 时：
```json
{
  "px2rem": {
    "unit": "rpx"
  }
}
```

以下样式：
```css
.a {
  width: 100rpx;
  height: 100px;
}
```
将生成：
```css
.a {
  width: 1rem;
  height: 100px;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增配置选项 `unit`，允许用户指定转换的单位，默认为 `px`。
  - 引入 `rpx` 单位的支持，增强了对响应式设计的灵活性。

- **文档**
  - 更新文档以包含 `unit` 配置选项，提供更明确的功能说明。
  
- **测试**
  - 新增测试用例，验证 `rpx` 到 `rem` 的转换是否正常。

- **样式**
  - 新增 CSS 文件，定义响应式设计的样式类。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->