### PR TITLE
feat: support to control crossorigin for async chunk scripts and links

### DIFF
--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -103,6 +103,7 @@ create_deserialize_fn!(deserialize_rsc_client, RscClientConfig);
 create_deserialize_fn!(deserialize_rsc_server, RscServerConfig);
 create_deserialize_fn!(deserialize_stats, StatsConfig);
 create_deserialize_fn!(deserialize_detect_loop, DetectCircularDependence);
+create_deserialize_fn!(deserialize_cross_origin_loading, CrossOriginLoading);
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -115,6 +116,25 @@ pub struct OutputConfig {
     pub preserve_modules: bool,
     pub preserve_modules_root: PathBuf,
     pub skip_write: bool,
+    #[serde(deserialize_with = "deserialize_cross_origin_loading")]
+    pub cross_origin_loading: Option<CrossOriginLoading>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum CrossOriginLoading {
+    #[serde(rename = "anonymous")]
+    Anonymous,
+    #[serde(rename = "use-credentials")]
+    UseCredentials,
+}
+
+impl fmt::Display for CrossOriginLoading {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CrossOriginLoading::Anonymous => write!(f, "anonymous"),
+            CrossOriginLoading::UseCredentials => write!(f, "use-credentials"),
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -681,7 +701,8 @@ const DEFAULT_CONFIG: &str = r#"
       "chunkLoadingGlobal": "",
       "preserveModules": false,
       "preserveModulesRoot": "",
-      "skipWrite": false
+      "skipWrite": false,
+      "crossOriginLoading": false
     },
     "resolve": { "alias": [], "extensions": ["js", "jsx", "ts", "tsx"] },
     "mode": "development",

--- a/crates/mako/src/generate/chunk_pot/util.rs
+++ b/crates/mako/src/generate/chunk_pot/util.rs
@@ -103,6 +103,12 @@ pub(crate) fn runtime_code(context: &Arc<Context>) -> Result<String> {
         is_browser: matches!(context.config.platform, crate::config::Platform::Browser),
         cjs: context.config.cjs,
         chunk_loading_global: context.config.output.chunk_loading_global.clone(),
+        cross_origin_loading: context
+            .config
+            .output
+            .cross_origin_loading
+            .clone()
+            .map(|s| s.to_string()),
         pkg_name: get_pkg_name(&context.root),
         concatenate_enabled: context
             .config

--- a/crates/mako/src/generate/runtime.rs
+++ b/crates/mako/src/generate/runtime.rs
@@ -11,4 +11,5 @@ pub struct AppRuntimeTemplate {
     pub chunk_loading_global: String,
     pub is_browser: bool,
     pub concatenate_enabled: bool,
+    pub cross_origin_loading: Option<String>,
 }

--- a/crates/mako/templates/app_runtime.stpl
+++ b/crates/mako/templates/app_runtime.stpl
@@ -207,6 +207,15 @@ function createRuntime(makoModules, entryModuleId, global) {
       link.rel = 'stylesheet';
       link.type = 'text/css';
       link.href = url;
+      <% if let Some(col_val) = cross_origin_loading.clone() { %>
+        <% if col_val == "use-credentials" { %>
+      link.crossOrigin = 'use-credentials';
+        <% } else { %>
+      if (link.href.indexOf(window.location.origin + '/') !== 0) {
+        link.crossOrigin = '<%= col_val %>';
+      }
+        <% } %>
+      <% } %>
       link.onerror = link.onload = function (event) {
         // avoid mem leaks, from webpack
         link.onerror = link.onload = null;
@@ -300,6 +309,15 @@ function createRuntime(makoModules, entryModuleId, global) {
         script = document.createElement('script');
         script.timeout = 120;
         script.src = url;
+        <% if let Some(col_val) = cross_origin_loading.clone() { %>
+          <% if col_val == "use-credentials" { %>
+        script.crossOrigin = 'use-credentials';
+          <% } else { %>
+        if (script.src.indexOf(window.location.origin + '/') !== 0) {
+          script.crossOrigin = '<%= col_val %>';
+        }
+          <% } %>
+        <% } %>
       }
 
       inProgress[url] = [done];

--- a/docs/config.md
+++ b/docs/config.md
@@ -446,8 +446,8 @@ Whether to enable node polyfill.
 
 ### output
 
-- Type: `{ path: string, mode: "bundle" | "bundless", esVersion: "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext", meta: boolean, chunkLoadingGlobal: string, preserveModules: boolean, preserveModulesRoot: string }`
-- Default: `{ path: "dist", mode: "bundle", esVersion: "es2022", meta: false, chunkLoadingGlobal: "", preserveModules: false, preserveModulesRoot: "" }`
+- Type: `{ path: string, mode: "bundle" | "bundless", esVersion: "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext", meta: boolean, chunkLoadingGlobal: string, preserveModules: boolean, preserveModulesRoot: string; crossOriginLoading: false | "anonymous" | "use-credentials" }`
+- Default: `{ path: "dist", mode: "bundle", esVersion: "es2022", meta: false, chunkLoadingGlobal: "", preserveModules: false, preserveModulesRoot: "", crossOriginLoading: false }`
 
 Output related configuration.
 
@@ -458,6 +458,7 @@ Output related configuration.
 - `chunkLoadingGlobal`, global variable name for `chunk loading`
 - `preserveModules`, whether to preserve the module directory structure (Bundless Only)
 - `preserveModulesRoot`, preserve the root directory of the module directory structure (Bundless Only)
+- `crossOriginLoading`, control the `crossorigin` attribute of the `script` tag and `link` tag for load async chunks
 
 ### optimization
 

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -447,8 +447,8 @@ e.g.
 
 ### output
 
-- 类型：`{ path: string, mode: "bundle" | "bundless", esVersion: "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext", meta: boolean, chunkLoadingGlobal: string, preserveModules: boolean, preserveModulesRoot: string }`
-- 默认值：`{ path: "dist", mode: "bundle", esVersion: "es2022", meta: false, chunkLoadingGlobal: "", preserveModules: false, preserveModulesRoot: "" }`
+- 类型：`{ path: string, mode: "bundle" | "bundless", esVersion: "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext", meta: boolean, chunkLoadingGlobal: string, preserveModules: boolean, preserveModulesRoot: string; crossOriginLoading: false | "anonymous" | "use-credentials" }`
+- 默认值：`{ path: "dist", mode: "bundle", esVersion: "es2022", meta: false, chunkLoadingGlobal: "", preserveModules: false, preserveModulesRoot: "", crossOriginLoading: false }`
 
 输出相关配置。
 
@@ -459,6 +459,7 @@ e.g.
 - `chunkLoadingGlobal`，`chunk loading` 的全局变量名称
 - `preserveModules`，是否保留模块目录结构（仅适用于 Bundless）
 - `preserveModulesRoot`，是否保留模块目录结构的根目录（仅限 Bundless）
+- `crossOriginLoading`，控制异步 chunk 加载时 `script` 及 `link` 标签的 `crossorigin` 属性值
 
 ### optimization
 

--- a/e2e/fixtures/config.crossOriginLoading/expect.js
+++ b/e2e/fixtures/config.crossOriginLoading/expect.js
@@ -1,0 +1,7 @@
+const assert = require("assert");
+const { parseBuildResult } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+const content = files["index.js"];
+
+assert(content.includes("script.crossOrigin = 'anonymous'"), 'should set crossOrigin to anonymous for loadScript function');
+assert(content.includes("link.crossOrigin = 'anonymous'"), 'should set crossOrigin to anonymous for createStylesheet function');

--- a/e2e/fixtures/config.crossOriginLoading/mako.config.json
+++ b/e2e/fixtures/config.crossOriginLoading/mako.config.json
@@ -1,0 +1,5 @@
+{
+  "output": {
+    "crossOriginLoading": "anonymous"
+  }
+}

--- a/e2e/fixtures/config.crossOriginLoading/src/async.ts
+++ b/e2e/fixtures/config.crossOriginLoading/src/async.ts
@@ -1,0 +1,3 @@
+console.log('async');
+
+export default 'async';

--- a/e2e/fixtures/config.crossOriginLoading/src/index.ts
+++ b/e2e/fixtures/config.crossOriginLoading/src/index.ts
@@ -1,0 +1,1 @@
+import('./async');

--- a/examples/dead-simple/mako.config.json
+++ b/examples/dead-simple/mako.config.json
@@ -1,4 +1,5 @@
 {
+  "output": { "crossOriginLoading": "anonymous" },
   "minify": false,
   "moduleIdStrategy": "hashed",
   "resolve": {

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -453,6 +453,7 @@ async function getMakoConfig(opts) {
   }
   const webpackConfig = webpackChainConfig.toConfig();
   let umd = false;
+  let crossOriginLoading = false;
   let { dynamicImportToRequire } = opts.config;
   if (webpackConfig.output) {
     // handle asyncChunks config
@@ -466,6 +467,11 @@ async function getMakoConfig(opts) {
       webpackConfig.output.library
     ) {
       umd = webpackConfig.output.library;
+    }
+
+    // handle crossOriginLoading config
+    if (webpackConfig.output.crossOriginLoading) {
+      crossOriginLoading = webpackConfig.output.crossOriginLoading;
     }
   }
 
@@ -611,7 +617,7 @@ async function getMakoConfig(opts) {
 
   const makoConfig = {
     entry: opts.entry,
-    output: { path: outputPath },
+    output: { path: outputPath, crossOriginLoading },
     resolve: {
       alias: generatorAlias,
     },


### PR DESCRIPTION
支持通过 `output.crossOriginLoading` 指定 async chunk 资源加载时的 `script` 及 `link` 标签的 `crossorigin` 值

Close #1511 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
  - 新增了 `crossOriginLoading` 配置选项，以便用户可以控制跨域资源加载的方式（如使用凭证或匿名）。
  - 更新了多个模板和配置文件，以支持新的跨域加载选项。
  
- **测试**
  - 引入了新的测试文件以验证跨域加载行为，确保应用遵循安全最佳实践。

- **文档**
  - 修改了输出配置文档，新增 `crossOriginLoading` 属性的说明和默认值。
  - 更新了中文文档以反映相同的配置变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->