### PR TITLE
chore: ✨ strip span when parsing define's expression

### DIFF
--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use serde_json::Value;
-use swc_core::common::{Mark, DUMMY_SP};
+use swc_core::common::{Mark, Span, DUMMY_SP};
 use swc_core::ecma::ast::{
     ArrayLit, Bool, ComputedPropName, Expr, ExprOrSpread, Ident, KeyValueProp, Lit, MemberExpr,
     MemberProp, ModuleItem, Null, Number, ObjectLit, Prop, PropOrSpread, Stmt, Str,
@@ -135,10 +135,14 @@ fn get_env_expr(v: Value, context: &Arc<Context>) -> Result<Expr> {
                 v.clone()
             };
 
-            // the string content is treat as expression, so it has to be parsed
-            let ast =
-                JsAst::build("_mako_internal/_define_.js", &safe_value, context.clone()).unwrap();
-            let module = ast.ast.body.first().unwrap();
+            let module = {
+                // the string content is treat as expression, so it has to be parsed
+                let mut ast = JsAst::build("_mako_internal/_define_.js", &safe_value, context
+                    .clone())
+                    .unwrap();
+                ast.ast.visit_mut_with(&mut strip_span());
+                ast.ast.body.pop().unwrap()
+            };
 
             match module {
                 ModuleItem::Stmt(Stmt::Expr(stmt_expr)) => {
@@ -193,6 +197,17 @@ fn get_env_expr(v: Value, context: &Arc<Context>) -> Result<Expr> {
             .into())
         }
     }
+}
+
+struct SpanStrip {}
+impl VisitMut for SpanStrip {
+    fn visit_mut_span(&mut self, span: &mut Span) {
+        *span = DUMMY_SP;
+    }
+}
+
+fn strip_span() -> impl VisitMut {
+    SpanStrip {}
 }
 
 #[cfg(test)]

--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -137,9 +137,9 @@ fn get_env_expr(v: Value, context: &Arc<Context>) -> Result<Expr> {
 
             let module = {
                 // the string content is treat as expression, so it has to be parsed
-                let mut ast = JsAst::build("_mako_internal/_define_.js", &safe_value, context
-                    .clone())
-                    .unwrap();
+                let mut ast =
+                    JsAst::build("_mako_internal/_define_.js", &safe_value, context.clone())
+                        .unwrap();
                 ast.ast.visit_mut_with(&mut strip_span());
                 ast.ast.body.pop().unwrap()
             };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6052d197-8afb-41c4-b5dd-003faf8306e2)
remove the noise file in source map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 改进了JavaScript抽象语法树（AST）的处理逻辑，增强了节点的跨度一致性。
  - 引入了新的结构体`SpanStrip`，用于简化和组织跨度修改逻辑。

- **修复**
  - 通过新的访问者模式，确保AST节点的跨度信息被标准化，提升后续处理或分析的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->