### PR TITLE
perf: reapply pr 1509 and sourcemap missing when chain_map is empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,16 +1224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "serde",
- "uuid",
-]
-
-[[package]]
 name = "delegate"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,7 +2654,6 @@ dependencies = [
  "maplit",
  "md5",
  "mdxjs",
- "merge-source-map",
  "miette 5.10.0",
  "mimalloc-rust",
  "mime_guess",
@@ -2811,15 +2800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "merge-source-map"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20543fa819b8d7b4f0fd51514aef9cfad3b1d746ad88c63d2f68b2b8cc034dd"
-dependencies = [
- "sourcemap 7.0.1",
 ]
 
 [[package]]
@@ -4485,22 +4465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sourcemap"
-version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10da010a590ed2fa9ca8467b00ce7e9c5a8017742c0c09c45450efc172208c4b"
-dependencies = [
- "data-encoding",
- "debugid",
- "if_chain",
- "rustc_version",
- "serde",
- "serde_json",
- "unicode-id",
- "url",
-]
-
-[[package]]
 name = "st-map"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,7 +4659,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "sourcemap 6.2.3",
+ "sourcemap",
  "swc_atoms 0.5.9",
  "swc_cached",
  "swc_common 0.32.1",
@@ -4886,7 +4850,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "siphasher",
- "sourcemap 6.2.3",
+ "sourcemap",
  "string_cache",
  "swc_atoms 0.5.9",
  "swc_eq_ignore_macros",
@@ -5236,7 +5200,7 @@ dependencies = [
  "once_cell",
  "rustc-hash",
  "serde",
- "sourcemap 6.2.3",
+ "sourcemap",
  "swc_atoms 0.4.43",
  "swc_common 0.30.5",
  "swc_ecma_ast 0.102.5",
@@ -5255,7 +5219,7 @@ dependencies = [
  "once_cell",
  "rustc-hash",
  "serde",
- "sourcemap 6.2.3",
+ "sourcemap",
  "swc_atoms 0.5.9",
  "swc_common 0.31.22",
  "swc_ecma_ast 0.107.8",
@@ -5274,7 +5238,7 @@ dependencies = [
  "once_cell",
  "rustc-hash",
  "serde",
- "sourcemap 6.2.3",
+ "sourcemap",
  "swc_atoms 0.5.9",
  "swc_common 0.32.1",
  "swc_ecma_ast 0.109.1",
@@ -5791,7 +5755,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha-1",
- "sourcemap 6.2.3",
+ "sourcemap",
  "swc_common 0.32.1",
  "swc_ecma_ast 0.109.1",
  "swc_ecma_codegen 0.145.5",
@@ -5948,7 +5912,7 @@ dependencies = [
  "radix_fmt",
  "regex",
  "serde",
- "sourcemap 6.2.3",
+ "sourcemap",
  "swc_atoms 0.5.9",
  "swc_common 0.32.1",
  "swc_ecma_ast 0.109.1",

--- a/crates/mako/Cargo.toml
+++ b/crates/mako/Cargo.toml
@@ -90,7 +90,6 @@ indexmap              = "2.0.0"
 indicatif             = "0.17.8"
 md5                   = "0.7.0"
 mdxjs                 = "0.1.14"
-merge-source-map      = "1.2.0"
 mime_guess            = "2.0.4"
 notify                = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
 notify-debouncer-full = { version = "0.3.1", default-features = false }

--- a/crates/mako/src/ast/sourcemap.rs
+++ b/crates/mako/src/ast/sourcemap.rs
@@ -77,6 +77,8 @@ impl From<RawSourceMap> for swc_sourcemap::SourceMap {
     }
 }
 
+// This is based on https://github.com/jiesia/merge-source-map/blob/main/src/lib.rs#L95,
+// just refactor it with a hash map to determinate which source should be searched accurately
 pub fn merge_source_map(
     target_source_map: swc_sourcemap::SourceMap,
     chain_map: HashMap<String, Vec<swc_sourcemap::SourceMap>>,
@@ -103,6 +105,7 @@ pub fn merge_source_map(
                 }
             }
 
+            // This maybe impossible ?
             if !searched_in_chain {
                 return;
             }

--- a/crates/mako/src/ast/sourcemap.rs
+++ b/crates/mako/src/ast/sourcemap.rs
@@ -1,9 +1,8 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
-use merge_source_map::sourcemap::SourceMap as MergeSourceMap;
-use merge_source_map::{merge, MergeOptions};
 use pathdiff::diff_paths;
-use swc_core::base::sourcemap;
+use swc_core::base::sourcemap as swc_sourcemap;
 use swc_core::common::source_map::SourceMapGenConfig;
 use swc_core::common::sync::Lrc;
 use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
@@ -34,7 +33,7 @@ pub fn build_source_map_to_buf(mappings: &[(BytePos, LineCol)], cm: &Lrc<SourceM
 pub fn build_source_map(
     mappings: &[(BytePos, LineCol)],
     cm: &Lrc<SourceMap>,
-) -> sourcemap::SourceMap {
+) -> swc_sourcemap::SourceMap {
     let config = SwcSourceMapGenConfig;
 
     cm.build_source_map_with_config(mappings, None, config)
@@ -45,14 +44,14 @@ pub fn build_source_map(
 #[derive(Clone, Default, Debug)]
 pub struct RawSourceMap {
     pub file: Option<String>,
-    pub tokens: Vec<sourcemap::RawToken>,
+    pub tokens: Vec<swc_sourcemap::RawToken>,
     pub names: Vec<String>,
     pub sources: Vec<String>,
     pub sources_content: Vec<Option<String>>,
 }
 
-impl From<sourcemap::SourceMap> for RawSourceMap {
-    fn from(sm: sourcemap::SourceMap) -> Self {
+impl From<swc_sourcemap::SourceMap> for RawSourceMap {
+    fn from(sm: swc_sourcemap::SourceMap) -> Self {
         Self {
             file: sm.get_file().map(|f| f.to_owned()),
             tokens: sm.tokens().map(|t| t.get_raw_token()).collect(),
@@ -66,7 +65,7 @@ impl From<sourcemap::SourceMap> for RawSourceMap {
     }
 }
 
-impl From<RawSourceMap> for sourcemap::SourceMap {
+impl From<RawSourceMap> for swc_sourcemap::SourceMap {
     fn from(rsm: RawSourceMap) -> Self {
         Self::new(
             rsm.file,
@@ -78,25 +77,124 @@ impl From<RawSourceMap> for sourcemap::SourceMap {
     }
 }
 
-pub fn merge_source_map(source_map_chain: Vec<Vec<u8>>, root: PathBuf) -> Vec<u8> {
-    let source_map_chain = source_map_chain
-        .iter()
-        .map(|s| MergeSourceMap::from_slice(s).unwrap())
-        .collect::<Vec<_>>();
+pub fn merge_source_map(
+    target_source_map: swc_sourcemap::SourceMap,
+    chain_map: HashMap<String, Vec<swc_sourcemap::SourceMap>>,
+    root: &PathBuf,
+) -> swc_sourcemap::SourceMap {
+    let mut builder = swc_sourcemap::SourceMapBuilder::new(None);
+    target_source_map.tokens().for_each(|token| {
+        if let Some(source) = token.get_source() {
+            let mut final_token = token;
+            let mut searched_in_chain = true;
 
-    let merged = merge(
-        source_map_chain,
-        MergeOptions {
-            source_replacer: Some(Box::new(move |src| {
-                diff_paths(src, &root)
-                    .unwrap_or(src.into())
-                    .to_string_lossy()
-                    .to_string()
-            })),
-        },
-    );
+            if let Some(source_map_chain) = chain_map.get(source)
+                && !source_map_chain.is_empty()
+            {
+                for map in source_map_chain.iter().rev() {
+                    if let Some(map_token) =
+                        map.lookup_token(token.get_src_line(), token.get_src_col())
+                    {
+                        final_token = map_token;
+                    } else {
+                        searched_in_chain = false;
+                        break;
+                    }
+                }
 
-    let mut buf = vec![];
-    merged.to_writer(&mut buf).unwrap();
-    buf
+                if !searched_in_chain {
+                    return;
+                }
+
+                // replace source
+                let replaced_source = final_token.get_source().map(|src| {
+                    diff_paths(src, root)
+                        .unwrap_or(src.into())
+                        .to_string_lossy()
+                        .to_string()
+                });
+
+                // add mapping
+                let added_token = builder.add(
+                    token.get_dst_line(),
+                    token.get_dst_col(),
+                    final_token.get_src_line(),
+                    final_token.get_src_col(),
+                    replaced_source.as_deref(),
+                    final_token.get_name(),
+                );
+
+                // add source centent
+                if !builder.has_source_contents(added_token.src_id) {
+                    let source_content = final_token.get_source_view().map(|view| view.source());
+
+                    builder.set_source_contents(added_token.src_id, source_content);
+                }
+            }
+        }
+    });
+
+    builder.into_sourcemap()
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use crate::ast::sourcemap::{merge_source_map, swc_sourcemap};
+
+    #[test]
+    fn test_merge() {
+        let sourcemap1 = r#"{
+            "version": 3,
+            "file": "index.js",
+            "sourceRoot": "",
+            "sources": [
+              "index.ts"
+            ],
+            "names": [],
+            "mappings": "AAAA,SAAS,QAAQ,CAAC,IAAY;IAC5B,OAAO,CAAC,GAAG,CAAC,iBAAU,IAAI,CAAE,CAAC,CAAC;AAChC,CAAC",
+            "sourcesContent": [
+              "function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"
+            ]
+        }"#;
+        let sourcemap2 = r#"{
+            "version": 3,
+            "file": "minify.js",
+            "sourceRoot": "",
+            "sources": [
+              "index.ts"
+            ],
+            "names": [
+              "sayHello",
+              "name",
+              "console",
+              "log",
+              "concat"
+            ],
+            "mappings": "AAAA,SAASA,SAASC,CAAI,EAClBC,QAAQC,GAAG,CAAC,UAAUC,MAAM,CAACH,GACjC",
+            "sourcesContent": [
+              "function sayHello(name) {\n    console.log(\"Hello, \".concat(name));\n}\n"
+            ]
+        }"#;
+
+        let merged_source_map = merge_source_map(
+            swc_sourcemap::SourceMap::from_reader(sourcemap2.as_bytes()).unwrap(),
+            HashMap::<String, Vec<swc_sourcemap::SourceMap>>::from([(
+                "index.ts".to_string(),
+                vec![swc_sourcemap::SourceMap::from_reader(sourcemap1.as_bytes()).unwrap()],
+            )]),
+            &PathBuf::from_str("./").unwrap(),
+        );
+
+        let mut buf = vec![];
+
+        merged_source_map.to_writer(&mut buf).unwrap();
+
+        let merged = String::from_utf8(buf).unwrap();
+
+        assert!(merged.eq(r#"{"version":3,"sources":["index.ts"],"sourcesContent":["function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"],"names":[],"mappings":"AAAA,SAAS,SAAS,CAAY,EAC5B,QAAQ,GAAG,CAAC,UAAA,MAAA,CAAU,GACxB"}"#));
+    }
 }

--- a/crates/mako/src/generate/chunk_pot/ast_impl.rs
+++ b/crates/mako/src/generate/chunk_pot/ast_impl.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use cached::proc_macro::cached;
 use cached::SizedCache;
+use pathdiff::diff_paths;
+use swc_core::base::sourcemap as swc_sourcemap;
 use swc_core::common::{Mark, DUMMY_SP, GLOBALS};
 use swc_core::css::ast::Stylesheet;
 use swc_core::css::codegen::writer::basic::{BasicCssWriter, BasicCssWriterConfig};
@@ -15,7 +17,7 @@ use swc_core::ecma::ast::{
 use swc_core::ecma::utils::{quote_ident, quote_str, ExprFactory};
 
 use crate::ast::js_ast::JsAst;
-use crate::ast::sourcemap::{build_source_map_to_buf, merge_source_map};
+use crate::ast::sourcemap::{build_source_map, merge_source_map};
 use crate::compiler::Context;
 use crate::config::Mode;
 use crate::generate::chunk::{Chunk, ChunkType};
@@ -82,22 +84,40 @@ pub(crate) fn render_css_chunk(
         None => None,
         _ => {
             mako_profile_scope!("build_source_map");
-            // source map chain
-            let mut source_map_chain: Vec<Vec<u8>> = vec![];
 
             let module_graph = context.module_graph.read().unwrap();
+            let chunk_source_map = build_source_map(&source_map, cm);
+
+            let mut chain_map = HashMap::<String, Vec<swc_sourcemap::SourceMap>>::new();
+
             chunk.get_modules().iter().for_each(|module_id| {
-                let module = module_graph.get_module(module_id).unwrap();
-                if let Some(info) = module.info.as_ref()
-                    && matches!(info.ast, crate::module::ModuleAst::Css(_))
-                {
-                    source_map_chain.append(&mut info.source_map_chain.clone());
+                if let Some(module) = module_graph.get_module(module_id) {
+                    if let Some(info) = module.info.as_ref()
+                        && matches!(info.ast, crate::module::ModuleAst::Css(_))
+                    {
+                        let relative_source = diff_paths(&module_id.id, &context.root)
+                            .unwrap_or((&module_id.id).into())
+                            .to_string_lossy()
+                            .to_string();
+
+                        chain_map.insert(
+                            relative_source,
+                            info.source_map_chain
+                                .iter()
+                                .map(|sc| swc_sourcemap::SourceMap::from_slice(sc).unwrap())
+                                .collect::<Vec<_>>(),
+                        );
+                    }
                 }
             });
 
-            source_map_chain.push(build_source_map_to_buf(&source_map, cm));
+            let merged_source_map = merge_source_map(chunk_source_map, chain_map, &context.root);
 
-            Some(merge_source_map(source_map_chain, context.root.clone()))
+            let mut buf = vec![];
+
+            merged_source_map.to_writer(&mut buf).unwrap();
+
+            Some(buf)
         }
     };
 


### PR DESCRIPTION
Reapply https://github.com/umijs/mako/pull/1509 and fix sourcemap missing when chain_map is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化了源映射的处理逻辑，提高了源映射管理的效率和可读性。
  - 引入了更结构化的方法来处理源映射，使用 `HashMap` 替代了原来的向量。

- **改进**
  - 更新了 `render_css_chunk` 函数的实现，改进了源映射的生成和处理方式。
  - 精简了源映射的返回类型，提升了输出的组织性和可维护性。

- **依赖管理**
  - 移除了对 `merge-source-map` 包的依赖，简化了依赖列表。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->