### PR TITLE
[WIP] test: add more complicated cases for css merge

### DIFF
--- a/e2e/fixtures/css.css-merge-deep-level/expect.js
+++ b/e2e/fixtures/css.css-merge-deep-level/expect.js
@@ -1,0 +1,30 @@
+const assert = require("assert");
+const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const names = Object.keys(files).join(",");
+const content = files["index.css"];
+
+assert(
+  content.includes(`
+.a {
+  color: red;
+}
+.b {
+  color: blue;
+}
+.c {
+  color: green;
+}
+.b1 {
+  color: blue;
+}
+.c1 {
+  color: green;
+}
+.a1 {
+  color: red;
+}
+  `.trim()),
+  "css merge in js should work"
+);

--- a/e2e/fixtures/css.css-merge-deep-level/mako.config.json
+++ b/e2e/fixtures/css.css-merge-deep-level/mako.config.json
@@ -1,0 +1,1 @@
+{"minify": false}

--- a/e2e/fixtures/css.css-merge-deep-level/src/a.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/a.css
@@ -1,0 +1,6 @@
+@import "c.css";
+@import "a1.css";
+
+.a {
+  color: red;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/a1.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/a1.css
@@ -1,0 +1,5 @@
+@import "c1.css";
+
+.a1 {
+  color: red;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/b.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/b.css
@@ -1,0 +1,6 @@
+@import "c.css";
+@import "b1.css";
+
+.b {
+  color: blue;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/b1.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/b1.css
@@ -1,0 +1,5 @@
+@import "c1.css";
+
+.b1 {
+  color: blue;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/c.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/c.css
@@ -1,0 +1,4 @@
+@import "c1.css";
+.c {
+  color: green;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/c1.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/c1.css
@@ -1,0 +1,3 @@
+.c1 {
+  color: green;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/index.ts
+++ b/e2e/fixtures/css.css-merge-deep-level/src/index.ts
@@ -1,0 +1,6 @@
+import './a.css';
+import './c1.css';
+import './b.css';
+import './c.css';
+import './b1.css';
+import './a1.css';

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/expect.js
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/expect.js
@@ -1,0 +1,21 @@
+const assert = require("assert");
+const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const names = Object.keys(files).join(",");
+const content = files["index.css"];
+
+assert(
+  content.includes(`
+.a {
+  color: red;
+}
+.c {
+  color: green;
+}
+.b {
+  color: blue;
+}
+  `.trim()),
+  "css merge in css should work"
+);

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/mako.config.json
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/mako.config.json
@@ -1,0 +1,1 @@
+{"minify": false}

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/a.css
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/a.css
@@ -1,0 +1,6 @@
+@import "b.css";
+@import "c.css";
+
+.a {
+  color: red;
+}

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/b.css
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/b.css
@@ -1,0 +1,3 @@
+@import 'c.css';
+
+.b { color: blue }

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/c.css
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/c.css
@@ -1,0 +1,1 @@
+.c { color: green }

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/index.css
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/index.css
@@ -1,0 +1,2 @@
+@import 'a.css';
+@import 'b.css';

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/index.ts
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/index.ts
@@ -1,0 +1,1 @@
+import './index.css';

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/expect.js
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/expect.js
@@ -1,0 +1,23 @@
+const assert = require("assert");
+const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const names = Object.keys(files).join(",");
+const content = files["index.css"];
+
+assert(
+  content.includes(`
+.b {
+  color: blue;
+}
+.c {
+  color: green;
+}
+.a {
+  color: red;
+}
+.d {
+  color: black;
+}`.trim()),
+  "css merge in js should work"
+);

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/mako.config.json
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/mako.config.json
@@ -1,0 +1,1 @@
+{"minify": false}

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/a.css
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/a.css
@@ -1,0 +1,3 @@
+@import 'c.css';
+
+.a { color: red }

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/b.css
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/b.css
@@ -1,0 +1,3 @@
+@import 'c.css';
+
+.b { color: blue }

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/c.css
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/c.css
@@ -1,0 +1,1 @@
+.c { color: green }

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/d.css
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/d.css
@@ -1,0 +1,7 @@
+@import "c.css";
+@import "b.css";
+@import "a.css";
+
+.d {
+  color: black;
+}

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/index.ts
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/index.ts
@@ -1,0 +1,4 @@
+import './a.css';
+import './b.css';
+import './c.css';
+import './d.css';


### PR DESCRIPTION
As title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 新增 CSS 文件 `d.css`，定义了新的 CSS 类 `.d`，文本颜色设置为黑色。
	- 新增 CSS 文件 `a.css`、`b.css`、`c.css`，分别定义了文本颜色为红色、蓝色和绿色的类。
	- 新增测试脚本以验证 CSS 合并功能，确保样式正确应用。
- **样式**
	- 改进了多个 CSS 文件的格式，提高了可读性和模块化。
- **文档**
	- 在 `index.ts` 中新增了对所有新 CSS 文件的导入，扩展了模块的样式功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->