### PR TITLE
perf: group chunks with post order dfs

### DIFF
--- a/crates/mako/src/generate/chunk_graph.rs
+++ b/crates/mako/src/generate/chunk_graph.rs
@@ -118,7 +118,7 @@ impl ChunkGraph {
             .map(|idx| self.graph[idx].id.clone())
             .collect::<Vec<ChunkId>>();
         // The neighbors ordering is reversed, see https://github.com/petgraph/petgraph/issues/116,
-        // so need to add edges by reversed order
+        // so need to collect by reversed order
         ret.into_iter().rev().collect()
     }
 

--- a/crates/mako/src/generate/chunk_graph.rs
+++ b/crates/mako/src/generate/chunk_graph.rs
@@ -111,11 +111,15 @@ impl ChunkGraph {
 
     pub fn sync_dependencies_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {
         let idx = self.id_index_map.get(chunk_id).unwrap();
-        self.graph
+        let ret = self
+            .graph
             .neighbors_directed(*idx, Direction::Outgoing)
             .filter(|idx| matches!(self.graph[*idx].chunk_type, ChunkType::Sync))
             .map(|idx| self.graph[idx].id.clone())
-            .collect::<Vec<ChunkId>>()
+            .collect::<Vec<ChunkId>>();
+        // The neighbors ordering is reversed, see https://github.com/petgraph/petgraph/issues/116,
+        // so need to add edges by reversed order
+        ret.into_iter().rev().collect()
     }
 
     pub fn entry_dependencies_chunk(&self, chunk_id: &ChunkId) -> Vec<ChunkId> {

--- a/crates/mako/src/generate/group_chunk.rs
+++ b/crates/mako/src/generate/group_chunk.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::fmt::Display;
 use std::hash::Hash;
 use std::vec;
 
@@ -486,7 +485,7 @@ impl Compiler {
 fn visit_modules<F, T>(mut queue: Vec<T>, visited: Option<HashSet<T>>, mut callback: F) -> Vec<T>
 where
     F: FnMut(&T) -> Vec<T>,
-    T: Hash + Eq + Clone + Display,
+    T: Hash + Eq + Clone,
 {
     let mut post_order_dfs_ret: Vec<T> = Vec::new();
 

--- a/crates/mako/src/generate/group_chunk.rs
+++ b/crates/mako/src/generate/group_chunk.rs
@@ -482,6 +482,30 @@ impl Compiler {
     }
 }
 
+/*
+*  Visit dependencies by post order DFS. The reason for this is that
+*  the rightmost and deepest css dependence should have the highest priority.
+*  For example, the dependencies graph is:
+*
+*  ----------
+*  index.css
+*   -> a.css
+*       -> b.css
+*           -> c.css
+*       -> c.css
+*   -> b.css
+*       -> c.css
+* ----------
+* the final dependencies orders in chunk should be:
+*
+* ----------
+* a.css
+* c.css
+* b.css
+* index.css
+* ----------
+* note that c.css, b.css, c.css before a.css will be deduplicated.
+*/
 fn visit_modules<F, T>(mut queue: Vec<T>, visited: Option<HashSet<T>>, mut callback: F) -> Vec<T>
 where
     F: FnMut(&T) -> Vec<T>,

--- a/crates/mako/src/generate/group_chunk.rs
+++ b/crates/mako/src/generate/group_chunk.rs
@@ -496,7 +496,9 @@ where
         if visited.contains(&id) {
             continue;
         }
+
         post_order_dfs_ret.push(id.clone());
+
         visited.insert(id.clone());
 
         queue.extend(callback(&id));

--- a/crates/mako/src/generate/optimize_chunk.rs
+++ b/crates/mako/src/generate/optimize_chunk.rs
@@ -469,12 +469,16 @@ impl Compiler {
         }
 
         // add edge to original chunks
-        for (from, to) in edges_map
+        edges_map
             .iter()
-            .flat_map(|(from, tos)| tos.iter().map(move |to| (from, to)))
-        {
-            chunk_graph.add_edge(from, to);
-        }
+            .flat_map(|(from, tos)| {
+                // The neighbors ordering is reversed, see https://github.com/petgraph/petgraph/issues/116,
+                // so need to add edges by reversed order
+                tos.iter().rev().map(move |to| (from, to))
+            })
+            .for_each(|(from, to)| {
+                chunk_graph.add_edge(from, to);
+            });
     }
 
     fn apply_hot_update_optimize_infos(&self, optimize_chunks_infos: &Vec<OptimizeChunksInfo>) {
@@ -506,9 +510,9 @@ impl Compiler {
             }
 
             // add edge to original chunks
-            for (from, to) in edges.iter() {
+            edges.iter().for_each(|(from, to)| {
                 chunk_graph.add_edge(from, to);
-            }
+            });
         }
     }
 

--- a/crates/mako/src/generate/optimize_chunk.rs
+++ b/crates/mako/src/generate/optimize_chunk.rs
@@ -471,11 +471,7 @@ impl Compiler {
         // add edge to original chunks
         edges_map
             .iter()
-            .flat_map(|(from, tos)| {
-                // The neighbors ordering is reversed, see https://github.com/petgraph/petgraph/issues/116,
-                // so need to add edges by reversed order
-                tos.iter().rev().map(move |to| (from, to))
-            })
+            .flat_map(|(from, tos)| tos.iter().map(move |to| (from, to)))
             .for_each(|(from, to)| {
                 chunk_graph.add_edge(from, to);
             });

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -247,6 +247,12 @@ impl Ord for ModuleId {
 impl PartialOrd for ModuleId {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Display for ModuleId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id)
     }
 }
 

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -247,12 +247,6 @@ impl Ord for ModuleId {
 impl PartialOrd for ModuleId {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl Display for ModuleId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.id)
     }
 }
 

--- a/e2e/fixtures/code-splitting.complex/expect.js
+++ b/e2e/fixtures/code-splitting.complex/expect.js
@@ -32,9 +32,9 @@ assert.match(
   files["index.js"].replace(/\s/g, ""),
   new RegExp(`Promise.all\\(\\[${
     [
-      "vendors_0",
-      "common",
       "vendors_1",
+      "common",
+      "vendors_0",
       "src/should-be-split.ts",
     ].map((f) => `__mako_require__.ensure\\("${f}"\\)`).join(",")
   }\\]\\)`),
@@ -45,8 +45,8 @@ assert.match(
   files["index.js"].replace(/\s/g, ""),
   new RegExp(`Promise.all\\(\\[${
     [
-      "vendors_0",
       "common",
+      "vendors_0",
       "src/other-dynamic.ts",
     ].map((f) => `__mako_require__.ensure\\("${f}"\\)`).join(",")
   }\\]\\)`),

--- a/e2e/fixtures/code-splitting.complex/expect.js
+++ b/e2e/fixtures/code-splitting.complex/expect.js
@@ -45,8 +45,8 @@ assert.match(
   files["index.js"].replace(/\s/g, ""),
   new RegExp(`Promise.all\\(\\[${
     [
+      "vendors_0",
       "common",
-      "vendors_1",
       "src/other-dynamic.ts",
     ].map((f) => `__mako_require__.ensure\\("${f}"\\)`).join(",")
   }\\]\\)`),

--- a/e2e/fixtures/css.css-merge-deep-level/expect.js
+++ b/e2e/fixtures/css.css-merge-deep-level/expect.js
@@ -1,0 +1,30 @@
+const assert = require("assert");
+const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const names = Object.keys(files).join(",");
+const content = files["index.css"];
+
+assert(
+  content.includes(`
+.a {
+  color: red;
+}
+.b {
+  color: blue;
+}
+.c {
+  color: green;
+}
+.b1 {
+  color: blue;
+}
+.c1 {
+  color: green;
+}
+.a1 {
+  color: red;
+}
+  `.trim()),
+  "css merge in js should work"
+);

--- a/e2e/fixtures/css.css-merge-deep-level/expect.js
+++ b/e2e/fixtures/css.css-merge-deep-level/expect.js
@@ -26,5 +26,5 @@ assert(
   color: red;
 }
   `.trim()),
-  "css merge in js should work"
+  "css merge deep level should work"
 );

--- a/e2e/fixtures/css.css-merge-deep-level/mako.config.json
+++ b/e2e/fixtures/css.css-merge-deep-level/mako.config.json
@@ -1,0 +1,1 @@
+{"minify": false}

--- a/e2e/fixtures/css.css-merge-deep-level/src/a.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/a.css
@@ -1,0 +1,6 @@
+@import "c.css";
+@import "a1.css";
+
+.a {
+  color: red;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/a1.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/a1.css
@@ -1,0 +1,5 @@
+@import "c1.css";
+
+.a1 {
+  color: red;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/b.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/b.css
@@ -1,0 +1,6 @@
+@import "c.css";
+@import "b1.css";
+
+.b {
+  color: blue;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/b1.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/b1.css
@@ -1,0 +1,5 @@
+@import "c1.css";
+
+.b1 {
+  color: blue;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/c.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/c.css
@@ -1,0 +1,4 @@
+@import "c1.css";
+.c {
+  color: green;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/c1.css
+++ b/e2e/fixtures/css.css-merge-deep-level/src/c1.css
@@ -1,0 +1,3 @@
+.c1 {
+  color: green;
+}

--- a/e2e/fixtures/css.css-merge-deep-level/src/index.ts
+++ b/e2e/fixtures/css.css-merge-deep-level/src/index.ts
@@ -1,0 +1,6 @@
+import './a.css';
+import './c1.css';
+import './b.css';
+import './c.css';
+import './b1.css';
+import './a1.css';

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/expect.js
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/expect.js
@@ -1,0 +1,21 @@
+const assert = require("assert");
+const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const names = Object.keys(files).join(",");
+const content = files["index.css"];
+
+assert(
+  content.includes(`
+.a {
+  color: red;
+}
+.c {
+  color: green;
+}
+.b {
+  color: blue;
+}
+  `.trim()),
+  "css merge in css should work"
+);

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/expect.js
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/expect.js
@@ -17,5 +17,5 @@ assert(
   color: blue;
 }
   `.trim()),
-  "css merge in css should work"
+  "css merge in css multi imports should work"
 );

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/mako.config.json
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/mako.config.json
@@ -1,0 +1,1 @@
+{"minify": false}

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/a.css
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/a.css
@@ -1,0 +1,6 @@
+@import "b.css";
+@import "c.css";
+
+.a {
+  color: red;
+}

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/b.css
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/b.css
@@ -1,0 +1,3 @@
+@import 'c.css';
+
+.b { color: blue }

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/c.css
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/c.css
@@ -1,0 +1,1 @@
+.c { color: green }

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/index.css
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/index.css
@@ -1,0 +1,2 @@
+@import 'a.css';
+@import 'b.css';

--- a/e2e/fixtures/css.css-merge-in-css-multi-imports/src/index.ts
+++ b/e2e/fixtures/css.css-merge-in-css-multi-imports/src/index.ts
@@ -1,0 +1,1 @@
+import './index.css';

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/expect.js
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/expect.js
@@ -19,5 +19,5 @@ assert(
 .d {
   color: black;
 }`.trim()),
-  "css merge in js should work"
+  "css merge reverse by descent should work"
 );

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/expect.js
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/expect.js
@@ -1,0 +1,23 @@
+const assert = require("assert");
+const { parseBuildResult, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const names = Object.keys(files).join(",");
+const content = files["index.css"];
+
+assert(
+  content.includes(`
+.b {
+  color: blue;
+}
+.c {
+  color: green;
+}
+.a {
+  color: red;
+}
+.d {
+  color: black;
+}`.trim()),
+  "css merge in js should work"
+);

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/mako.config.json
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/mako.config.json
@@ -1,0 +1,1 @@
+{"minify": false}

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/a.css
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/a.css
@@ -1,0 +1,3 @@
+@import 'c.css';
+
+.a { color: red }

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/b.css
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/b.css
@@ -1,0 +1,3 @@
+@import 'c.css';
+
+.b { color: blue }

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/c.css
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/c.css
@@ -1,0 +1,1 @@
+.c { color: green }

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/d.css
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/d.css
@@ -1,0 +1,7 @@
+@import "c.css";
+@import "b.css";
+@import "a.css";
+
+.d {
+  color: black;
+}

--- a/e2e/fixtures/css.css-merge-reverse-by-descent/src/index.ts
+++ b/e2e/fixtures/css.css-merge-reverse-by-descent/src/index.ts
@@ -1,0 +1,4 @@
+import './a.css';
+import './b.css';
+import './c.css';
+import './d.css';

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -198,7 +198,11 @@ exports.dev = async function (opts) {
   // mako dev
   const { build } = require('@umijs/mako');
   const makoConfig = await getMakoConfig(opts);
-  makoConfig.hmr = {};
+  if (process.env.HMR === 'none') {
+    makoConfig.hmr = false;
+  } else {
+    makoConfig.hmr = {};
+  }
   makoConfig.devServer = { port: hmrPort, host: opts.host };
   makoConfig.plugins = makoConfig.plugins || [];
   makoConfig.plugins.push({


### PR DESCRIPTION
The previous impl of chunk dependencies by BFS is not right, and in that way, must use Iter::position (compute as O(n)) api to insert depencies before parent. Just change the way by post order DFS, and remove calls of Iter::position.

Why before impl it not right? With below files:

### a.css
```css
@import "b.css";
@import "c.css";

.demo {
 color: red
}
```
### b.css
```css
@import "c.css";

.test {
 color: blue
}
```
### c.css
```css
@import "c.css";

.demo {
 color: yellow
}
```
### index.css
```css
@import "a.css";
@import "b.css";
```

By BFS impl, the ordered modules will be 
```
c.ss
b.css
c.ss
a.css
b.css
index.css
```
And after deduplicating, the modules order will be
```
c.ss
a.css
b.css
index.css
```
 the result css chunk is
```
.demo {
 color: yellow
}
.demo {
 color: red
}
.test {
 color: blue
}
```
Because in index.css, b.css is been imported after a.css, and b.css also import c.css, so c.css will overwrite a.css again. So that this result is not correct.

By post order DFS, the ordered modules will be 
```
c.ss
b.css
c.ss
a.css
c.css
b.css
index.css
```
That result is correct.
Coincidely, in parcel-bundler, these is a same case, https://github.com/parcel-bundler/lightningcss/blob/ad2ec9f10309ac27261a996210023b8e8ad3c793/src/bundler.rs#L1632, also see the same discussion https://github.com/parcel-bundler/parcel/issues/5840.

When building big project, this impl is 8x faster than before:
Before:
![image](https://github.com/user-attachments/assets/4d9bd62d-1d75-4de4-b21a-7bffcb5ae44c)

After:
<img width="760" alt="image" src="https://github.com/user-attachments/assets/01e512b8-ec58-4f2f-b531-5713e9f851d9">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新功能**
	- 改进了模块依赖处理逻辑，增强了模块访问的灵活性和效率。
	- 优化了图结构中的边添加逻辑，提高了代码可读性和准确性。
	- 引入了多个测试脚本，以验证CSS合并功能在不同场景下的正确性。
- **修复**
	- 解决了与 `petgraph` 库相关的邻接模块顺序问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->