### PR TITLE
Revert "refactor: Unify the static server in bundler-mako and devServer"

### DIFF
--- a/crates/mako/src/dev.rs
+++ b/crates/mako/src/dev.rs
@@ -121,8 +121,6 @@ impl DevServer {
         staticfile: hyper_staticfile::Static,
         txws: broadcast::Sender<WsMessage>,
     ) -> Result<hyper::Response<Body>> {
-        debug!("> {} {}", req.method().to_string(), req.uri().path());
-
         let mut path = req.uri().path().to_string();
         let public_path = &context.config.public_path;
         if !public_path.is_empty() && public_path.starts_with('/') && public_path != "/" {
@@ -173,16 +171,14 @@ impl DevServer {
                 // staticfile has 302 problems when modify tooooo fast in 1 second
                 // it will response 302 and we will get the old file
                 // TODO: fix the 302 problem?
-                if !context.config.write_to_disk {
-                    if let Some(res) = context.get_static_content(path_without_slash_start) {
-                        debug!("serve with context.get_static_content: {}", path);
+                if let Some(res) = context.get_static_content(path_without_slash_start) {
+                    debug!("serve with context.get_static_content: {}", path);
 
-                        return Ok(hyper::Response::builder()
-                            .status(hyper::StatusCode::OK)
-                            .header(CONTENT_TYPE, content_type)
-                            .body(hyper::Body::from(res))
-                            .unwrap());
-                    }
+                    return Ok(hyper::Response::builder()
+                        .status(hyper::StatusCode::OK)
+                        .header(CONTENT_TYPE, content_type)
+                        .body(hyper::Body::from(res))
+                        .unwrap());
                 }
                 // for cached dep
                 let abs_path = context
@@ -200,11 +196,7 @@ impl DevServer {
                 }
 
                 // for hmr files
-                debug!("< static file serve: {}", path);
-                let req = hyper::Request::builder()
-                    .uri(path)
-                    .body(hyper::Body::empty())
-                    .unwrap();
+                debug!("serve with staticfile server: {}", path);
                 let res = staticfile.serve(req).await;
                 res.map_err(anyhow::Error::from)
             }

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -111,17 +111,27 @@ exports.dev = async function (opts) {
     logLevel: 'silent',
   });
   app.use('/__/hmr-ws', wsProxy);
-  app.use((req, res, next) => {
-    if (req.method !== 'GET' && req.method !== 'HEAD') {
-      return next();
+
+  const outputPath = path.resolve(opts.cwd, opts.config.outputPath || 'dist');
+
+  function processReqURL(publicPath, reqURL) {
+    if (!publicPath.startsWith('/')) {
+      publicPath = '/' + publicPath;
     }
-    if (req.accepts().join('').includes('html')) {
-      return next();
-    }
-    wsProxy(req, res, () => {
+    return reqURL.startsWith(publicPath)
+      ? reqURL.slice(publicPath.length - 1)
+      : reqURL;
+  }
+
+  if (opts.config.publicPath) {
+    app.use((req, _res, next) => {
+      req.url = processReqURL(opts.config.publicPath, req.url);
       next();
     });
-  });
+  }
+
+  // serve dist files
+  app.use(express.static(outputPath));
 
   if (process.env.SSU === 'true') {
     // for ssu cache chunks

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,7 +848,7 @@ packages:
       '@ant-design/pro-skeleton': 2.1.3(antd@5.18.0)(react-dom@18.2.0)(react@18.2.0)
       '@ant-design/pro-table': 3.6.11(antd@5.18.0)(prop-types@15.8.1)(rc-field-form@1.41.0)(react-dom@18.2.0)(react@18.2.0)
       '@ant-design/pro-utils': 2.10.0(antd@5.18.0)(react-dom@18.2.0)(react@18.2.0)
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.24.7
       antd: 5.18.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
Reverts umijs/mako#1468
it will break proxy feature in umi 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了请求处理逻辑，增强了对请求 URL 的灵活处理。
	- 引入了新的函数以标准化请求 URL 处理，支持可配置的 `publicPath`。

- **性能提升**
	- 精简了静态内容服务的逻辑，减少了不必要的检查，可能提高了性能。

- **日志改进**
	- 更新了调试日志消息，提供了更清晰的上下文。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->