### PR TITLE
feat: moduleIdStrategy support numberous

### DIFF
--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -13,14 +13,16 @@ use swc_core::ecma::ast::Ident;
 use tracing::debug;
 
 use crate::ast::comments::Comments;
-use crate::config::{Config, OutputMode};
+use crate::config::{Config, ModuleIdStrategy, OutputMode};
 use crate::generate::chunk_graph::ChunkGraph;
 use crate::generate::optimize_chunk::OptimizeChunksInfo;
 use crate::module_graph::ModuleGraph;
 use crate::plugin::{Plugin, PluginDriver, PluginGenerateEndParams};
 use crate::plugins;
 use crate::resolve::{get_resolvers, Resolvers};
+use crate::share::helpers::SWC_HELPERS;
 use crate::stats::StatsInfo;
+use crate::utils::id_helper::{assign_numberous_ids, compare_modules_by_incomming_edges};
 use crate::utils::{thread_pool, ParseRegex};
 
 pub struct Context {
@@ -29,6 +31,7 @@ pub struct Context {
     pub assets_info: Mutex<HashMap<String, String>>,
     pub modules_with_missing_deps: RwLock<Vec<String>>,
     pub config: Config,
+    pub numberous_ids_map: RwLock<HashMap<String, usize>>,
     pub args: Args,
     pub root: PathBuf,
     pub meta: Meta,
@@ -107,6 +110,10 @@ impl Context {
 
 impl Default for Context {
     fn default() -> Self {
+        let mut numberous_ids_map = HashMap::new();
+        SWC_HELPERS.iter().enumerate().for_each(|(i, item)| {
+            numberous_ids_map.insert(item.to_string(), i);
+        });
         let config: Config = Default::default();
         let resolvers = get_resolvers(&config);
         Self {
@@ -123,6 +130,7 @@ impl Default for Context {
             resolvers,
             optimize_infos: Mutex::new(None),
             static_cache: Default::default(),
+            numberous_ids_map: RwLock::new(numberous_ids_map),
         }
     }
 }
@@ -330,6 +338,10 @@ impl Compiler {
         plugin_driver.modify_config(&mut config, &root, &args)?;
 
         let resolvers = get_resolvers(&config);
+        let mut numberous_ids_map = HashMap::new();
+        SWC_HELPERS.iter().enumerate().for_each(|(i, item)| {
+            numberous_ids_map.insert(item.to_string(), i);
+        });
         Ok(Self {
             context: Arc::new(Context {
                 static_cache: if config.write_to_disk {
@@ -346,6 +358,7 @@ impl Compiler {
                 modules_with_missing_deps: RwLock::new(Vec::new()),
                 meta: Meta::new(),
                 plugin_driver,
+                numberous_ids_map: RwLock::new(numberous_ids_map),
                 stats_info: StatsInfo::new(),
                 resolvers,
                 optimize_infos: Mutex::new(None),
@@ -401,6 +414,19 @@ impl Compiler {
         }
 
         self.context.plugin_driver.before_generate(&self.context)?;
+
+        if let ModuleIdStrategy::Numberous = self.context.config.module_id_strategy {
+            let module_graph = self.context.module_graph.read().unwrap();
+            assign_numberous_ids(
+                module_graph.modules(),
+                |a, b| compare_modules_by_incomming_edges(&module_graph, &a.id, &b.id),
+                |module, id| {
+                    let mut numberous_ids_map = self.context.numberous_ids_map.write().unwrap();
+                    // reserved ten indexes for swc helper and others runtime module
+                    numberous_ids_map.insert(module.id.id.clone(), id + 10);
+                },
+            )
+        }
 
         let result = {
             crate::mako_profile_scope!("Generate Stage");

--- a/crates/mako/src/config/config.rs
+++ b/crates/mako/src/config/config.rs
@@ -210,6 +210,8 @@ pub enum ModuleIdStrategy {
     Hashed,
     #[serde(rename = "named")]
     Named,
+    #[serde(rename = "numberous")]
+    Numberous,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/crates/mako/src/generate/swc_helpers.rs
+++ b/crates/mako/src/generate/swc_helpers.rs
@@ -1,5 +1,7 @@
 use indexmap::IndexSet;
 
+use crate::share::helpers::SWC_HELPERS;
+
 pub struct SwcHelpers {
     pub helpers: IndexSet<String>,
 }
@@ -16,9 +18,9 @@ impl SwcHelpers {
 
     pub fn full_helpers() -> IndexSet<String> {
         let mut helpers = IndexSet::new();
-        helpers.insert("@swc/helpers/_/_interop_require_default".into());
-        helpers.insert("@swc/helpers/_/_interop_require_wildcard".into());
-        helpers.insert("@swc/helpers/_/_export_star".into());
+        SWC_HELPERS.iter().for_each(|h| {
+            helpers.insert(h.to_string());
+        });
         helpers
     }
 }

--- a/crates/mako/src/generate/transform.rs
+++ b/crates/mako/src/generate/transform.rs
@@ -22,6 +22,7 @@ use tracing::debug;
 use crate::ast::js_ast::JsAst;
 use crate::compiler::{Compiler, Context};
 use crate::module::{Dependency, ModuleAst, ModuleId, ModuleType, ResolveType};
+use crate::share::helpers::SWC_HELPERS;
 use crate::utils::thread_pool;
 use crate::visitors::async_module::{mark_async, AsyncModule};
 use crate::visitors::common_js::common_js;
@@ -147,13 +148,7 @@ pub fn transform_modules_in_thread(
 }
 
 fn insert_swc_helper_replace(map: &mut HashMap<String, (String, String)>, context: &Arc<Context>) {
-    let helpers = vec![
-        "@swc/helpers/_/_interop_require_default",
-        "@swc/helpers/_/_interop_require_wildcard",
-        "@swc/helpers/_/_export_star",
-    ];
-
-    helpers.into_iter().for_each(|h| {
+    SWC_HELPERS.into_iter().for_each(|h| {
         let m_id: ModuleId = h.to_string().into();
         map.insert(m_id.id.clone(), (m_id.generate(context), h.to_string()));
     });

--- a/crates/mako/src/lib.rs
+++ b/crates/mako/src/lib.rs
@@ -16,6 +16,7 @@ mod module_graph;
 pub mod plugin;
 mod plugins;
 mod resolve;
+pub mod share;
 pub mod stats;
 pub mod utils;
 mod visitors;

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -216,6 +216,14 @@ pub fn generate_module_id(origin_module_id: String, context: &Arc<Context>) -> S
             let relative_path = diff_paths(&absolute_path, &context.root).unwrap_or(absolute_path);
             relative_path.to_string_lossy().to_string()
         }
+        ModuleIdStrategy::Numberous => {
+            let numberous_ids_map = context.numberous_ids_map.read().unwrap();
+            if let Some(numberous_id) = numberous_ids_map.get(&origin_module_id) {
+                numberous_id.to_string()
+            } else {
+                md5_hash(&origin_module_id, 8)
+            }
+        }
     }
 }
 

--- a/crates/mako/src/module_graph.rs
+++ b/crates/mako/src/module_graph.rs
@@ -13,7 +13,7 @@ use crate::module::{Dependencies, Dependency, Module, ModuleId, ResolveType};
 
 #[derive(Debug)]
 pub struct ModuleGraph {
-    id_index_map: HashMap<ModuleId, NodeIndex<DefaultIx>>,
+    pub id_index_map: HashMap<ModuleId, NodeIndex<DefaultIx>>,
     pub graph: StableDiGraph<Module, Dependencies>,
     entries: HashSet<ModuleId>,
 }
@@ -181,7 +181,7 @@ impl ModuleGraph {
     }
 
     // 公共方法抽出, InComing 找 targets, Outing 找 dependencies
-    fn get_edges(&self, module_id: &ModuleId, direction: Direction) -> WalkNeighbors<u32> {
+    pub fn get_edges(&self, module_id: &ModuleId, direction: Direction) -> WalkNeighbors<u32> {
         let i = self
             .id_index_map
             .get(module_id)

--- a/crates/mako/src/share/helpers.rs
+++ b/crates/mako/src/share/helpers.rs
@@ -1,0 +1,5 @@
+pub static SWC_HELPERS: [&str; 3] = [
+    "@swc/helpers/_/_interop_require_default",
+    "@swc/helpers/_/_interop_require_wildcard",
+    "@swc/helpers/_/_export_star",
+];

--- a/crates/mako/src/share/mod.rs
+++ b/crates/mako/src/share/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod helpers;

--- a/crates/mako/src/utils.rs
+++ b/crates/mako/src/utils.rs
@@ -1,3 +1,4 @@
+pub(crate) mod id_helper;
 pub mod logger;
 #[cfg(feature = "profile")]
 pub mod profile_gui;

--- a/crates/mako/src/utils/id_helper.rs
+++ b/crates/mako/src/utils/id_helper.rs
@@ -1,0 +1,37 @@
+use std::cmp::Ordering;
+
+use petgraph::Direction::Incoming;
+
+use crate::module::ModuleId;
+use crate::module_graph::ModuleGraph;
+
+fn get_edges_count(graph: &ModuleGraph, module_id: &ModuleId) -> usize {
+    let node_index = graph.id_index_map.get(module_id).unwrap_or_else(|| {
+        panic!(
+            r#"from node "{}" does not exist in the module graph when remove edge"#,
+            module_id.id
+        )
+    });
+    graph.graph.edges_directed(*node_index, Incoming).count()
+}
+
+pub fn compare_modules_by_incomming_edges(
+    module_graph: &ModuleGraph,
+    a: &ModuleId,
+    b: &ModuleId,
+) -> std::cmp::Ordering {
+    get_edges_count(module_graph, b).cmp(&get_edges_count(module_graph, a))
+}
+
+pub fn assign_numberous_ids<T>(
+    mut items: Vec<T>,
+    comparator: impl Fn(&T, &T) -> Ordering,
+    mut assign_id: impl FnMut(&T, usize),
+) {
+    items.sort_unstable_by(comparator);
+
+    items
+        .iter()
+        .enumerate()
+        .for_each(|(i, item)| assign_id(item, i))
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -457,7 +457,7 @@ Specify the build mode, `"development"` or `"production"`.
 
 ### moduleIdStrategy
 
-- Type: `"named" | "hashed"`
+- Type: `"named" | "hashed" | "numberous"`
 - Default: `"named"` when mode is development, `"hashed"` when mode is production
 
 Specify the strategy for generating moduleId.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了新的模块ID策略“Numberous”，允许用户在配置中选择不同的模块ID生成方式。
	- 新增公共模块`share`，提供了共享资源和功能的访问。
	- 添加了`SWC_HELPERS`静态数组，方便在代码中使用特定的助手函数。
	- 新增`id_helper`模块，提供了管理和比较模块的实用函数。

- **文档**
	- 更新了配置文档，增加了对“numberous”模块ID策略的说明。 

- **修复**
	- 改进了模块ID的分配逻辑，增强了模块标识符的管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->