### PR TITLE
fix: 🐛 concatenated module exported namespace should sort key 

### DIFF
--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer.rs
@@ -351,17 +351,21 @@ impl<'a> ConcatenatedTransform<'a> {
             .into_var_decl(VarDeclKind::Var, ns_ident.clone().into())
             .into();
 
-        let mut key_value_props: Vec<PropOrSpread> = vec![];
+        let mut key_value_props: Vec<KeyValueProp> = vec![];
 
         for (k, module_ref) in &mut *export_ref_map {
-            key_value_props.push(
-                Prop::KeyValue(KeyValueProp {
-                    key: quote_ident!(k.clone()).into(),
-                    value: module_ref_to_expr(module_ref).into_lazy_fn(vec![]).into(),
-                })
-                .into(),
-            )
+            key_value_props.push(KeyValueProp {
+                key: quote_ident!(k.clone()).into(),
+                value: module_ref_to_expr(module_ref).into_lazy_fn(vec![]).into(),
+            });
         }
+
+        key_value_props.sort_by_key(|prop| prop.key.as_ident().unwrap().sym.to_string());
+        let key_value_props = key_value_props
+            .into_iter()
+            .map(Prop::KeyValue)
+            .map(Into::into)
+            .collect::<Vec<PropOrSpread>>();
 
         let define_exports: Stmt = member_expr!(DUMMY_SP, __mako_require__.e)
             .as_call(

--- a/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer/tests.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/module_concatenate/concatenated_transformer/tests.rs
@@ -12,7 +12,7 @@ use super::ConcatenatedTransform;
 use crate::ast::js_ast::JsAst;
 use crate::compiler::Context;
 use crate::config::{Config, Mode, OptimizationConfig};
-use crate::module::ModuleId;
+use crate::module::{ImportType, ModuleId};
 
 #[test]
 fn test_import_default_from_inner() {
@@ -639,6 +639,54 @@ fn test_export_from_default() {
     assert_eq!(ccn_ctx.top_level_vars, expected_top_vars);
 }
 
+#[test]
+fn test_export_decl_vars_import_as_namespace() {
+    let mut ccn_ctx = ConcatenateContext::default();
+    let mut imported_type = ImportType::empty();
+    imported_type.insert(ImportType::Namespace);
+
+    let code = inner_trans_code_imported_as(
+        "export const a =1;export const b = 1",
+        &mut ccn_ctx,
+        imported_type,
+    );
+
+    assert_eq!(
+        code,
+        r#"
+const a = 1;
+const b = 1;
+var __$m_mut_js_ns = {};
+__mako_require__.e(__$m_mut_js_ns, {
+    a: function() {
+        return a;
+    },
+    b: function() {
+        return b;
+    }
+});
+    "#
+        .trim()
+    );
+    assert_eq!(
+        ccn_ctx.top_level_vars,
+        hashset!(
+            "a".to_string(),
+            "b".to_string(),
+            "__$m_mut_js_ns".to_string()
+        )
+    );
+    assert_eq!(
+        describe_export_map(&ccn_ctx),
+        r#"
+* => __$m_mut_js_ns
+a => a
+b => b
+"#
+        .trim()
+    );
+}
+
 fn concatenate_context_fixture_with_inner_module() -> ConcatenateContext {
     ConcatenateContext {
         top_level_vars: hashset! {
@@ -666,7 +714,11 @@ fn concatenate_context_fixture_with_inner_module() -> ConcatenateContext {
     }
 }
 
-fn inner_trans_code(code: &str, concatenate_context: &mut ConcatenateContext) -> String {
+fn inner_trans_code_imported_as(
+    code: &str,
+    concatenate_context: &mut ConcatenateContext,
+    imported_type: ImportType,
+) -> String {
     let context = Arc::new(Context {
         config: Config {
             devtool: None,
@@ -698,6 +750,7 @@ fn inner_trans_code(code: &str, concatenate_context: &mut ConcatenateContext) ->
             &context,
             ast.top_level_mark,
         );
+        inner.imported(imported_type);
 
         ast.ast.visit_mut_with(&mut resolver(
             ast.unresolved_mark,
@@ -718,4 +771,8 @@ fn inner_trans_code(code: &str, concatenate_context: &mut ConcatenateContext) ->
             .trim()
             .to_string()
     })
+}
+
+fn inner_trans_code(code: &str, concatenate_context: &mut ConcatenateContext) -> String {
+    inner_trans_code_imported_as(code, concatenate_context, ImportType::empty())
 }


### PR DESCRIPTION
make dist js more stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了模块的连接转换功能，允许更灵活地处理导入和导出，特别是在命名空间导入的上下文中。
	- 添加了新的测试功能，以验证导出声明变量作为命名空间时的行为。

- **修复**
	- 优化了代码结构，简化了关键值属性的处理，提升了代码的清晰度和效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->