### PR TITLE
fix: parse_path failed under windows

### DIFF
--- a/crates/mako/src/ast/file.rs
+++ b/crates/mako/src/ast/file.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::hash::{Hash, Hasher};
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
@@ -332,13 +331,14 @@ type Params = Vec<(String, String)>;
 type Fragment = Option<String>;
 
 pub fn parse_path(path: &str) -> Result<(PathName, Search, Params, Fragment)> {
-    let path = if env::consts::OS == "windows" {
+    #[cfg(target_os = "windows")]
+    let path = {
         let prefix = "\\\\?\\";
         let path = path.trim_start_matches(prefix);
         path.replace('\\', "/")
-    } else {
-        path.to_string()
     };
+    #[cfg(not(target_os = "windows"))]
+    let path = path.to_string();
     if path.contains('?') {
         let (path, search) = path.split_once('?').unwrap();
         let base = "http://a.com/";

--- a/crates/mako/src/ast/file.rs
+++ b/crates/mako/src/ast/file.rs
@@ -330,6 +330,15 @@ type Search = String;
 type Params = Vec<(String, String)>;
 type Fragment = Option<String>;
 
+fn has_hash_without_dot(input: &str) -> bool {
+    if let Some(pos) = input.find('#') {
+        let after_hash = &input[pos + 1..];
+        !after_hash.contains('.')
+    } else {
+        false
+    }
+}
+
 pub fn parse_path(path: &str) -> Result<(PathName, Search, Params, Fragment)> {
     #[cfg(target_os = "windows")]
     let path = {
@@ -339,8 +348,12 @@ pub fn parse_path(path: &str) -> Result<(PathName, Search, Params, Fragment)> {
     };
     #[cfg(not(target_os = "windows"))]
     let path = path.to_string();
-    if path.contains('?') {
-        let (path, search) = path.split_once('?').unwrap();
+    if path.contains('?') || has_hash_without_dot(path.as_str()) {
+        let (path, search) = if path.contains('?') {
+            path.split_once('?').unwrap_or((path.as_str(), ""))
+        } else {
+            path.split_once('#').unwrap_or((path.as_str(), ""))
+        };
         let base = "http://a.com/";
         let base_url = Url::parse(base)?;
         let full_url = base_url.join(format!("?{}", search).as_str())?;
@@ -393,5 +406,20 @@ mod tests {
         assert_eq!(search, "foo");
         assert_eq!(params, vec![("foo".to_string(), "".to_string())]);
         assert_eq!(fragment, None);
+    }
+
+    #[test]
+    fn test_parse_path_with_fragment() {
+        assert_eq!(parse_path("foo.ts#bar").unwrap().0, "foo.ts");
+        assert_eq!(parse_path("foo#bar.ts").unwrap().0, "foo#bar.ts");
+    }
+
+    #[test]
+    fn test_has_hash_without_dot() {
+        assert_eq!(has_hash_without_dot("foo.ts#world"), true);
+        assert_eq!(has_hash_without_dot("foo#bar.ts"), false);
+        assert_eq!(has_hash_without_dot("#no_dot"), true);
+        assert_eq!(has_hash_without_dot("no_hash"), false);
+        assert_eq!(has_hash_without_dot("#.dot_after_hash"), false);
     }
 }


### PR DESCRIPTION

e.g. builld with-antd

<img width="887" alt="image" src="https://github.com/user-attachments/assets/a5d70bce-0fc0-4004-8a55-f615ea4ef682">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 更新了路径解析功能，以支持Windows文件路径处理，增强了跨平台兼容性。
  
- **测试**
  - 新增测试用例以验证Windows路径的解析功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->