### PR TITLE
chore: chunk group by right-first DFS, not post order DFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 `2024-09-05`
 
-* perf: group chunks with post order dfs by [@xusd320](https://github.com/xusd320) in [#1554](https://github.com/umijs/mako/pull/1554)
+* perf: group chunks with right first dfs by [@xusd320](https://github.com/xusd320) in [#1554](https://github.com/umijs/mako/pull/1554)
 * refactor: unify base64 utils by [@xusd320](https://github.com/xusd320) in [#1557](https://github.com/umijs/mako/pull/1557)
 * Revert "refactor: Unify the static server in bundler-mako and devServer" by [@stormslowly](https://github.com/stormslowly) in [#1556](https://github.com/umijs/mako/pull/1556)
 * fix: define env by [@xusd320](https://github.com/xusd320) in [#1551](https://github.com/umijs/mako/pull/1551)

--- a/CHANGELOG_zh-CN.md
+++ b/CHANGELOG_zh-CN.md
@@ -2,7 +2,7 @@
 
 `2024-09-05`
 
-* 优化 group chunks 的性能，基于 post order dfs by [@xusd320](https://github.com/xusd320) in [#1554](https://github.com/umijs/mako/pull/1554)
+* 优化 group chunks 的性能，基于 right first dfs by [@xusd320](https://github.com/xusd320) in [#1554](https://github.com/umijs/mako/pull/1554)
 * 重构 base64 utils by [@xusd320](https://github.com/xusd320) in [#1557](https://github.com/umijs/mako/pull/1557)
 * 回滚 "refactor: Unify the static server in bundler-mako and devServer" by [@stormslowly](https://github.com/stormslowly) in [#1556](https://github.com/umijs/mako/pull/1556)
 * 修复 define env by [@xusd320](https://github.com/xusd320) in [#1551](https://github.com/umijs/mako/pull/1551)

--- a/crates/mako/src/generate/group_chunk.rs
+++ b/crates/mako/src/generate/group_chunk.rs
@@ -483,7 +483,7 @@ impl Compiler {
 }
 
 /*
-*  Visit dependencies by post order DFS. The reason for this is that
+*  Visit dependencies by right first DFS. The reason for this is that
 *  the rightmost and deepest css dependence should have the highest priority.
 *  For example, the dependencies graph is:
 *
@@ -499,19 +499,19 @@ impl Compiler {
 * the final dependencies orders in chunk should be:
 *
 * ----------
-* a.css
-* c.css
-* b.css
 * index.css
+* b.css
+* c.css
+* a.css
 * ----------
-* note that c.css, b.css, c.css before a.css will be deduplicated.
+* note that c.css, b.css, c.css after a.css will be deduplicated.
 */
 fn visit_modules<F, T>(mut queue: Vec<T>, visited: Option<HashSet<T>>, mut callback: F) -> Vec<T>
 where
     F: FnMut(&T) -> Vec<T>,
     T: Hash + Eq + Clone,
 {
-    let mut post_order_dfs_ret: Vec<T> = Vec::new();
+    let mut right_firtst_dfs_ret: Vec<T> = Vec::new();
 
     let mut visited = visited.unwrap_or_default();
 
@@ -520,12 +520,12 @@ where
             continue;
         }
 
-        post_order_dfs_ret.push(id.clone());
+        right_firtst_dfs_ret.push(id.clone());
 
         visited.insert(id.clone());
 
         queue.extend(callback(&id));
     }
 
-    post_order_dfs_ret
+    right_firtst_dfs_ret
 }


### PR DESCRIPTION
https://github.com/umijs/mako/pull/1554 impl is right-first DFS, not post order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
	- 更新了 `CHANGELOG.md` 和 `CHANGELOG_zh-CN.md` 文件中的性能优化和重构描述，以提高文档的清晰度和准确性。
  
- **功能改进**
	- 修改了 CSS 依赖的遍历策略，从“后序 DFS”更改为“右优先 DFS”，可能提高了依赖处理的效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->