### PR TITLE
fix: env_replacer should not replace user defined variable in scope

### DIFF
--- a/crates/mako/src/ast/file.rs
+++ b/crates/mako/src/ast/file.rs
@@ -416,10 +416,10 @@ mod tests {
 
     #[test]
     fn test_has_hash_without_dot() {
-        assert_eq!(has_hash_without_dot("foo.ts#world"), true);
-        assert_eq!(has_hash_without_dot("foo#bar.ts"), false);
-        assert_eq!(has_hash_without_dot("#no_dot"), true);
-        assert_eq!(has_hash_without_dot("no_hash"), false);
-        assert_eq!(has_hash_without_dot("#.dot_after_hash"), false);
+        assert!(has_hash_without_dot("foo.ts#world"));
+        assert!(!has_hash_without_dot("foo#bar.ts"));
+        assert!(has_hash_without_dot("#no_dot"));
+        assert!(!has_hash_without_dot("no_hash"));
+        assert!(!has_hash_without_dot("#.dot_after_hash"));
     }
 }

--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -451,7 +451,7 @@ mod tests {
             run(
                 r#"let A = {};log(A.v, A[X.Y])"#,
                 hashmap! {
-                    "A".to_string() => json!("{\"v\": 1}"),
+                    "A".to_string() => json!(r#"{"v": 1}"#),
                     "X.Y".to_string() => json!(r#""xy""#)
                 }
             ),

--- a/crates/mako/src/visitors/env_replacer.rs
+++ b/crates/mako/src/visitors/env_replacer.rs
@@ -96,7 +96,6 @@ impl VisitMut for EnvReplacer {
 
                 if let Expr::Ident(Ident { sym, span, .. }) = current_member_obj {
                     if span.ctxt.outer() != self.unresolved_mark {
-                        expr.visit_mut_children_with(self);
                         return;
                     }
                     member_visit_path.push('.');
@@ -450,12 +449,13 @@ mod tests {
     fn test_should_not_replace_existed_as_member_prop() {
         assert_eq!(
             run(
-                r#"let A = {};log(A.v)"#,
+                r#"let A = {};log(A.v, A[X.Y])"#,
                 hashmap! {
-                    "A".to_string() => json!("{\"v\": 1}")
+                    "A".to_string() => json!("{\"v\": 1}"),
+                    "X.Y".to_string() => json!(r#""xy""#)
                 }
             ),
-            "let A = {};log(A.v);"
+            r#"let A = {};log(A.v, A["xy"]);"#
         );
     }
 


### PR DESCRIPTION
As title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 扩展了对标识符的处理逻辑，使其在上下文中更具灵活性。
  - 新增测试用例，以确保现有属性在日志操作中不会被替换。

- **错误修复**
  - 修正了测试函数名称，提高了清晰度和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->