### PR TITLE
fix: bad output when chunk_loading_global containing quotation mark

### DIFF
--- a/crates/mako/src/generate/chunk_pot/str_impl.rs
+++ b/crates/mako/src/generate/chunk_pot/str_impl.rs
@@ -112,12 +112,14 @@ pub(super) fn render_normal_js_chunk(
 ) -> Result<ChunkFile> {
     let (content_buf, source_map_buf) = {
         let pot = chunk_pot;
+
+        // to avoid ' or " been included in chunk_loading_global
+        let safe_prop = serde_json::to_string(&context.config.output.chunk_loading_global).unwrap();
+
         let chunk_prefix_code = format!(
-            r#"((typeof globalThis !== 'undefined' ? globalThis : self)['{}'] = (typeof globalThis !== 'undefined' ? globalThis : self)['{}'] || []).push([
-['{}'],"#,
-            context.config.output.chunk_loading_global,
-            context.config.output.chunk_loading_global,
-            pot.chunk_id,
+            r#"((typeof globalThis !== 'undefined' ? globalThis : self)[{}] = (typeof globalThis !== 'undefined' ? globalThis : self)[{}] || []).push([
+        ['{}'],"#,
+            safe_prop, safe_prop, pot.chunk_id,
         );
 
         let (chunk_content, chunk_raw_sourcemap) = pot_to_chunk_module_object_string(


### PR DESCRIPTION
If chunk_loading_global contains single quote, the output will be broken.

```js
((typeof globalThis !== 'undefined' ? globalThis : self)['makoChunk_application's name'] 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 改进了对 `chunk_loading_global` 属性的处理，增强了生成的 JavaScript 代码的安全性和可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->