### PR TITLE
fix(win): copy don't work under windows

### DIFF
--- a/crates/mako/src/ast/file.rs
+++ b/crates/mako/src/ast/file.rs
@@ -339,7 +339,7 @@ fn has_hash_without_dot(input: &str) -> bool {
     }
 }
 
-pub fn parse_path(path: &str) -> Result<(PathName, Search, Params, Fragment)> {
+pub fn win_path(path: &str) -> String {
     #[cfg(target_os = "windows")]
     let path = {
         let prefix = "\\\\?\\";
@@ -348,6 +348,11 @@ pub fn parse_path(path: &str) -> Result<(PathName, Search, Params, Fragment)> {
     };
     #[cfg(not(target_os = "windows"))]
     let path = path.to_string();
+    path
+}
+
+pub fn parse_path(path: &str) -> Result<(PathName, Search, Params, Fragment)> {
+    let path = win_path(path);
     if path.contains('?') || has_hash_without_dot(path.as_str()) {
         let (path, search) = if path.contains('?') {
             path.split_once('?').unwrap_or((path.as_str(), ""))

--- a/crates/mako/src/plugins/copy.rs
+++ b/crates/mako/src/plugins/copy.rs
@@ -9,6 +9,7 @@ use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::sync::mpsc::channel;
 use tracing::debug;
 
+use crate::ast::file::win_path;
 use crate::compiler::Context;
 use crate::plugin::Plugin;
 use crate::stats::StatsJsonMap;
@@ -85,7 +86,8 @@ impl Plugin for CopyPlugin {
 }
 
 fn copy(src: &Path, dest: &Path) -> Result<()> {
-    let paths = glob(src.to_str().unwrap())?;
+    let src = win_path(src.to_str().unwrap());
+    let paths = glob(&src)?;
 
     for entry in paths {
         let entry = entry.unwrap();


### PR DESCRIPTION
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了 `win_path` 函数，专门处理 Windows 操作系统的路径字符串，确保长路径的兼容性。
  - 更新了 `parse_path` 函数，以调用 `win_path`，增强了 Windows 的路径解析能力。
  - 修改了 `CopyPlugin` 中的 `copy` 函数，以确保源路径在 Windows 系统上的正确格式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->