### PR TITLE
fix(win): module id should be win_pathed

### DIFF
--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -15,7 +15,7 @@ use swc_core::ecma::ast::{
 use swc_core::ecma::utils::quote_ident;
 
 use crate::ast::css_ast::CssAst;
-use crate::ast::file::File;
+use crate::ast::file::{win_path, File};
 use crate::ast::js_ast::JsAst;
 use crate::build::analyze_deps::AnalyzeDepsResult;
 use crate::compiler::Context;
@@ -214,7 +214,7 @@ pub fn generate_module_id(origin_module_id: String, context: &Arc<Context>) -> S
             // readable ids for debugging usage
             let absolute_path = PathBuf::from(origin_module_id);
             let relative_path = diff_paths(&absolute_path, &context.root).unwrap_or(absolute_path);
-            relative_path.to_string_lossy().to_string()
+            win_path(relative_path.to_str().unwrap())
         }
     }
 }


### PR DESCRIPTION
Close https://github.com/umijs/mako/issues/1580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了模块ID的生成逻辑，以更好地支持Windows文件路径格式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->