### PR TITLE
Revert "fix: merge mako config"

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -677,9 +677,10 @@ async function getMakoConfig(opts) {
       },
     },
     sass: sassLoader,
+    ...mako,
   };
 
-  return lodash.merge(makoConfig, mako);
+  return makoConfig;
 }
 
 function getLessSourceMapConfig(devtool) {


### PR DESCRIPTION
Reverts umijs/mako#1578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 修改了配置检索的行为，确保返回的配置不再包含潜在的合并属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->