### PR TITLE
fix: chunk_loading_global 

### DIFF
--- a/crates/mako/src/generate/chunk_pot/util.rs
+++ b/crates/mako/src/generate/chunk_pot/util.rs
@@ -102,7 +102,8 @@ pub(crate) fn runtime_code(context: &Arc<Context>) -> Result<String> {
         umd,
         is_browser: matches!(context.config.platform, crate::config::Platform::Browser),
         cjs: context.config.cjs,
-        chunk_loading_global: context.config.output.chunk_loading_global.clone(),
+        chunk_loading_global: serde_json::to_string(&context.config.output.chunk_loading_global)
+            .unwrap(),
         cross_origin_loading: context
             .config
             .output

--- a/crates/mako/templates/app_runtime.stpl
+++ b/crates/mako/templates/app_runtime.stpl
@@ -377,7 +377,7 @@ function createRuntime(makoModules, entryModuleId, global) {
       installedChunks[id] = 0;
     }
   };
-  var chunkLoadingGlobal = global['<%= chunk_loading_global.clone() %>'] = global['<%= chunk_loading_global.clone() %>'] || [];
+  var chunkLoadingGlobal = global[<%- chunk_loading_global.clone() %>] = global[<%- chunk_loading_global.clone() %>] || [];
 	chunkLoadingGlobal.forEach(jsonpCallback.bind(null));
   chunkLoadingGlobal.push = (function(push, data) {
     push(data);

--- a/e2e/fixtures/config.output.chunk_loading_global/expect.js
+++ b/e2e/fixtures/config.output.chunk_loading_global/expect.js
@@ -1,0 +1,16 @@
+const assert = require("assert");
+const { parseBuildResult, string2RegExp } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+assert(
+  files['index.js'].includes(`global["foo' oo"]`),
+  "chunk loading should work in entry"
+);
+
+assert(
+  files['src_a_ts-async.js'].includes(
+    `(typeof globalThis !== "undefined" ? globalThis : self)["foo' oo"]`
+  ),
+  "chunk loading should work in async chunk"
+);
+

--- a/e2e/fixtures/config.output.chunk_loading_global/mako.config.json
+++ b/e2e/fixtures/config.output.chunk_loading_global/mako.config.json
@@ -1,0 +1,5 @@
+{
+  "output": {
+    "chunkLoadingGlobal": "foo' oo"
+  }
+}

--- a/e2e/fixtures/config.output.chunk_loading_global/src/a.ts
+++ b/e2e/fixtures/config.output.chunk_loading_global/src/a.ts
@@ -1,0 +1,1 @@
+export default 'a';

--- a/e2e/fixtures/config.output.chunk_loading_global/src/index.tsx
+++ b/e2e/fixtures/config.output.chunk_loading_global/src/index.tsx
@@ -1,0 +1,2 @@
+import('./a');
+console.log(1);


### PR DESCRIPTION
If the chunk_loading_global String contains a single quote, it will be  sanitized to `&#039;` see https://github.com/rust-sailfish/sailfish/issues/145#issuecomment-2030721853. This behavior is not matched with async chunk register.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了全局变量 `chunkLoadingGlobal` 的处理方式，采用 JSON 字符串表示。
	- 引入新的配置文件 `mako.config.json`，允许自定义全局上下文的 chunk 加载设置。
	- 新增文件 `a.ts`，导出简单字符串值 'a'。
	- 在 `index.tsx` 中实现动态导入模块，优化性能。

- **测试**
	- 新增文件 `expect.js`，验证全局变量在构建文件中的存在性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->