### PR TITLE
fix(tree-shaking): object spread transform should go before deconstructing

### DIFF
--- a/e2e/fixtures/tree-shaking.import_namespace/src/index.tsx
+++ b/e2e/fixtures/tree-shaking.import_namespace/src/index.tsx
@@ -5,3 +5,17 @@ const { shouldKeep2 } = mod
 console.log(mod.shouldKeep1(42));
 console.log(shouldKeep2(42))
 
+// Guardian don't remove
+let array= [1,2,3,]
+console.log(array)
+let [first, ...rest]  = array
+console.log(first,rest)
+let copiedArray = [...array]
+console.log(copiedArray)
+
+let object = {a: 1,b: 2,c: 3}
+console.log(object)
+let {a, ...restObject} = object
+console.log(a,restObject)
+let copiedObject = {...object}
+console.log(copiedObject)


### PR DESCRIPTION
```js
import * as ns from "./ns"

let {x, ..rest} = ns

console.log(x,rest)
```

will panic with 
```txt
internal error: entered unreachable code: Object rest pattern should be removed by es2018::object_rest_spread pass
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 引入了对象 rest/spread 语法的支持，增强了模块的树摇能力。
	- 添加了与数组和对象操作相关的新变量声明和控制台日志，展示了 JavaScript 的数组和对象处理特性。

- **无变化**
	- 未对导出或公共实体的声明进行更改。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->