### PR TITLE
chore: 🎨 rayon is not friendly to js users

### DIFF
--- a/crates/mako/src/utils/thread_pool.rs
+++ b/crates/mako/src/utils/thread_pool.rs
@@ -6,9 +6,9 @@ static THREAD_POOL: OnceLock<ThreadPool> = OnceLock::new();
 
 fn build_rayon_thread_pool() -> ThreadPool {
     ThreadPoolBuilder::new()
-        .thread_name(|i| format!("rayon thread {}", i))
+        .thread_name(|i| format!("Mako thread {}", i))
         .build()
-        .expect("failed to create rayon thread pool.")
+        .expect("Mako failed to create thread pool.")
 }
 
 pub fn spawn<F>(func: F)

--- a/crates/mako/src/utils/tokio_runtime.rs
+++ b/crates/mako/src/utils/tokio_runtime.rs
@@ -9,9 +9,9 @@ fn build_tokio_runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .enable_io()
         .worker_threads(2)
-        .thread_name("tokio-worker")
+        .thread_name("Mako-tokio-worker")
         .build()
-        .expect("failed to create tokio runtime.")
+        .expect("Mako: failed to create tokio runtime.")
 }
 
 pub fn spawn<F>(future: F) -> tokio::task::JoinHandle<F::Output>


### PR DESCRIPTION
when unexpected panic happens,  node process aborts ,  the log does not show it's a error of mako 

```txt
thread 'rayon thread 5' panicked at crates/svgr-rs/src/hast_to_swc_ast/decode_xml.rs:60:21:
byte index 11 is not a char boundary; it is inside '文' (bytes 10..13) of `&yen;a&中文`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Rayon: detected unexpected panic; aborting
Abort trap: 6
```
Change `rayon thread x` -> `Mako thread x`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新线程池和Tokio运行时的线程命名，提升了品牌识别度。
- **错误修复**
	- 改进了线程池和Tokio运行时创建失败时的错误提示信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->