### PR TITLE
fix: dev server 504 with chunk loding

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -120,6 +120,34 @@ exports.dev = async function (opts) {
 
   // serve dist files
   app.use(express.static(makoConfig.output.path));
+  if (process.env.SSU === 'true') {
+    // for ssu cache chunks
+
+    app.use(function (req, res, next) {
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        return next();
+      }
+
+      let proxy = createProxyMiddleware({
+        target: `http://127.0.0.1:${hmrPort}`,
+        selfHandleResponse: true,
+        onProxyRes: (proxyRes, req, res) => {
+          if (proxyRes.statusCode !== 200) {
+            next();
+          } else {
+            proxyRes.pipe(res);
+          }
+        },
+        onError: (err, req, res) => {
+          next();
+        },
+      });
+
+      proxy(req, res, () => {
+        next();
+      });
+    });
+  }
 
   // after middlewares
   (opts.afterMiddlewares || []).forEach((m) => {

--- a/packages/bundler-mako/package.json
+++ b/packages/bundler-mako/package.json
@@ -9,7 +9,6 @@
     "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "express-http-proxy": "^2.1.1",
     "get-tsconfig": "4.7.5",
     "lodash": "^4.17.21",
     "rimraf": "5.0.1",


### PR DESCRIPTION
## problem 
when ensure  5 or more chunks in browser, all the requests are proxied to mako dev server hyper; but hyper will reset connect at tcp level  for some connection, at last results in some chunk's request gets 504 in browser.

## wordaround
serve chunk files at node side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入新的代理中间件，取代了之前的 `express-http-proxy`，增强了对响应处理的控制。
	- 现在应用可以根据配置异步提供静态文件。

- **依赖更新**
	- 移除了对 `express-http-proxy` 的依赖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->