### PR TITLE
fix: 🐛 turn off express-http-proxy's keep alive

### DIFF
--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -120,15 +120,12 @@ exports.dev = async function (opts) {
 
   app.use(
     proxy(`http://127.0.0.1:${hmrPort}`, {
-      proxyTimeout: 50000,
-
       proxyReqOptDecorator: function (proxyReqOpts) {
         // keep alive is on by default https://nodejs.org/docs/latest/api/http.html#httpglobalagent
         // 禁用 keep-alive
         proxyReqOpts.agent = false;
         return proxyReqOpts;
       },
-
       filter: function (req, res) {
         return req.method == 'GET' || req.method == 'HEAD';
       },

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -120,6 +120,15 @@ exports.dev = async function (opts) {
 
   app.use(
     proxy(`http://127.0.0.1:${hmrPort}`, {
+      proxyTimeout: 50000,
+
+      proxyReqOptDecorator: function (proxyReqOpts) {
+        // keep alive is on by default https://nodejs.org/docs/latest/api/http.html#httpglobalagent
+        // 禁用 keep-alive
+        proxyReqOpts.agent = false;
+        return proxyReqOpts;
+      },
+
       filter: function (req, res) {
         return req.method == 'GET' || req.method == 'HEAD';
       },


### PR DESCRIPTION
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在代理配置中添加了 `proxyTimeout` 属性，设置为 50000 毫秒。
	- 引入了 `proxyReqOptDecorator` 方法，用于修改代理的请求选项，禁用保持活动功能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->