### PR TITLE
fix: clickToComponent don't work

### DIFF
--- a/crates/mako/src/ast/js_ast.rs
+++ b/crates/mako/src/ast/js_ast.rs
@@ -42,7 +42,7 @@ impl fmt::Debug for JsAst {
 impl JsAst {
     pub fn new(file: &File, context: Arc<Context>) -> Result<Self> {
         let fm = context.meta.script.cm.new_source_file(
-            FileName::Real(file.relative_path.to_path_buf()),
+            FileName::Real(file.path.to_path_buf()),
             file.get_content_raw(),
         );
         let comments = context.meta.script.origin_comments.read().unwrap();

--- a/examples/dead-simple/app.tsx
+++ b/examples/dead-simple/app.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function App() {
+  return <div>Hello, world!</div>;
+}

--- a/examples/dead-simple/index.ts
+++ b/examples/dead-simple/index.ts
@@ -1,6 +1,9 @@
-import { foo } from './foo';
-import './foo/foo';
+// import { foo } from './foo';
+// import './foo/foo';
+
+import App from './app';
+
 /**
  * abcd
  */
-console.log(foo);
+console.log(App);


### PR DESCRIPTION
Close https://github.com/umijs/umi/issues/12725

Before:

```
(0, _jsxdevruntime.jsxDEV)("h1", {
            className: _indexlessasmodule.default.title,
            children: "Page index"
        }, void 0, false, {
            fileName: "pages/index.tsx",
            lineNumber: 7,
            columnNumber: 7
        }, this)
```

After:

```
(0, _jsxdevruntime.jsxDEV)("h1", {
            className: _indexlessasmodule.default.title,
            children: "Page index"
        }, void 0, false, {
            fileName: "/full/path/to/pages/index.tsx",
            lineNumber: 7,
            columnNumber: 7
        }, this)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 引入了新的 React 组件 `App`，在界面上显示“Hello, world!”。
- **改进**
	- 增强了 JavaScript 和 TypeScript 内容的解析能力，改进了错误处理和路径管理。
	- 更新了源映射生成逻辑，以更好地符合上下文配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->