### PR TITLE
fix: duplicate_package_checker panic when no package.json is supplied

### DIFF
--- a/crates/mako/src/plugins/duplicate_package_checker.rs
+++ b/crates/mako/src/plugins/duplicate_package_checker.rs
@@ -99,17 +99,19 @@ impl DuplicatePackageCheckerPlugin {
                     .as_ref()
                     .and_then(|info| info.resolved_resource.as_ref())
                 {
-                    let package_json = resource.0.package_json().unwrap();
-                    let raw_json = package_json.raw_json();
-                    if let Some(name) = package_json.name.clone() {
-                        if let Some(version) = raw_json.as_object().unwrap().get("version") {
-                            let package_info = PackageInfo {
-                                name,
-                                version: semver::Version::parse(version.as_str().unwrap()).unwrap(),
-                                path: package_json.path.clone(),
-                            };
+                    if let Some(package_json) = resource.0.package_json() {
+                        let raw_json = package_json.raw_json();
+                        if let Some(name) = package_json.name.clone() {
+                            if let Some(version) = raw_json.as_object().unwrap().get("version") {
+                                let package_info = PackageInfo {
+                                    name,
+                                    version: semver::Version::parse(version.as_str().unwrap())
+                                        .unwrap(),
+                                    path: package_json.path.clone(),
+                                };
 
-                            packages.push(package_info);
+                                packages.push(package_info);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Before.

```
Building with mako for production...
● Mako ▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨ (28%) transform_js transform_js                                                                thread 'Mako thread 10' panicked at crates/mako/src/plugins/duplicate_package_checker.rs:102:66:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Rayon: detected unexpected panic; aborting
[1]    53972 abort      OKAM=  build
```

How to reproduce? 

```
umi g page index
umi config set mako {}
umi build
```
