### PR TITLE
feat: add resolve_id plugin hook

### DIFF
--- a/crates/binding/src/js_hook.rs
+++ b/crates/binding/src/js_hook.rs
@@ -109,4 +109,5 @@ pub struct LoadResult {
 #[napi(object, use_nullable = true)]
 pub struct ResolveIdResult {
     pub id: String,
+    pub external: Option<bool>,
 }

--- a/crates/binding/src/js_hook.rs
+++ b/crates/binding/src/js_hook.rs
@@ -58,12 +58,15 @@ pub struct JsHooks {
     pub _on_generate_file: Option<JsFunction>,
     #[napi(ts_type = "() => Promise<void>;")]
     pub build_start: Option<JsFunction>,
+    #[napi(ts_type = "(source: string, importer: string) => Promise<{ id: string }>;")]
+    pub resolve_id: Option<JsFunction>,
 }
 
 pub struct TsFnHooks {
     pub build_start: Option<ThreadsafeFunction<(), ()>>,
     pub generate_end: Option<ThreadsafeFunction<Value, ()>>,
     pub load: Option<ThreadsafeFunction<String, Option<LoadResult>>>,
+    pub resolve_id: Option<ThreadsafeFunction<(String, String), Option<ResolveIdResult>>>,
     pub _on_generate_file: Option<ThreadsafeFunction<WriteFile, ()>>,
 }
 
@@ -77,6 +80,9 @@ impl TsFnHooks {
                 ThreadsafeFunction::from_napi_value(env.raw(), hook.raw()).unwrap()
             }),
             load: hooks.load.as_ref().map(|hook| unsafe {
+                ThreadsafeFunction::from_napi_value(env.raw(), hook.raw()).unwrap()
+            }),
+            resolve_id: hooks.resolve_id.as_ref().map(|hook| unsafe {
                 ThreadsafeFunction::from_napi_value(env.raw(), hook.raw()).unwrap()
             }),
             _on_generate_file: hooks._on_generate_file.as_ref().map(|hook| unsafe {
@@ -98,4 +104,9 @@ pub struct LoadResult {
     pub content: String,
     #[napi(js_name = "type")]
     pub content_type: String,
+}
+
+#[napi(object, use_nullable = true)]
+pub struct ResolveIdResult {
+    pub id: String,
 }

--- a/crates/binding/src/js_plugin.rs
+++ b/crates/binding/src/js_plugin.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::js_hook::{LoadResult, TsFnHooks, WriteFile};
+use crate::js_hook::{LoadResult, ResolveIdResult, TsFnHooks, WriteFile};
 
 pub struct JsPlugin {
     pub hooks: TsFnHooks,
@@ -9,6 +10,7 @@ use anyhow::{anyhow, Result};
 use mako::ast::file::{Content, JsContent};
 use mako::compiler::Context;
 use mako::plugin::{Plugin, PluginGenerateEndParams, PluginLoadParam};
+use mako::resolve::{Resolution, ResolvedResource, ResolverResource};
 
 impl Plugin for JsPlugin {
     fn name(&self) -> &str {
@@ -42,6 +44,29 @@ impl Plugin for JsPlugin {
                     "css" => return Ok(Some(Content::Css(x.content))),
                     _ => return Err(anyhow!("Unsupported content type: {}", x.content_type)),
                 }
+            }
+        }
+        Ok(None)
+    }
+
+    fn resolve_id(
+        &self,
+        source: &str,
+        importer: &str,
+        _context: &Arc<Context>,
+    ) -> Result<Option<ResolverResource>> {
+        if let Some(hook) = &self.hooks.resolve_id {
+            let x: Option<ResolveIdResult> =
+                hook.call((source.to_string(), importer.to_string()))?;
+            if let Some(x) = x {
+                return Ok(Some(ResolverResource::Resolved(ResolvedResource(
+                    Resolution {
+                        path: PathBuf::from(x.id),
+                        query: None,
+                        fragment: None,
+                        package_json: None,
+                    },
+                ))));
             }
         }
         Ok(None)

--- a/crates/binding/src/js_plugin.rs
+++ b/crates/binding/src/js_plugin.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Result};
 use mako::ast::file::{Content, JsContent};
 use mako::compiler::Context;
 use mako::plugin::{Plugin, PluginGenerateEndParams, PluginLoadParam};
-use mako::resolve::{Resolution, ResolvedResource, ResolverResource};
+use mako::resolve::{ExternalResource, Resolution, ResolvedResource, ResolverResource};
 
 impl Plugin for JsPlugin {
     fn name(&self) -> &str {
@@ -59,6 +59,13 @@ impl Plugin for JsPlugin {
             let x: Option<ResolveIdResult> =
                 hook.call((source.to_string(), importer.to_string()))?;
             if let Some(x) = x {
+                if let Some(true) = x.external {
+                    return Ok(Some(ResolverResource::External(ExternalResource {
+                        source: source.to_string(),
+                        external: source.to_string(),
+                        script: None,
+                    })));
+                }
                 return Ok(Some(ResolverResource::Resolved(ResolvedResource(
                     Resolution {
                         path: PathBuf::from(x.id),

--- a/crates/mako/src/lib.rs
+++ b/crates/mako/src/lib.rs
@@ -15,7 +15,7 @@ mod module;
 mod module_graph;
 pub mod plugin;
 mod plugins;
-mod resolve;
+pub mod resolve;
 pub mod share;
 pub mod stats;
 pub mod utils;

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -53,6 +53,15 @@ pub trait Plugin: Any + Send + Sync {
         Ok(None)
     }
 
+    fn resolve_id(
+        &self,
+        _source: &str,
+        _importer: &str,
+        _context: &Arc<Context>,
+    ) -> Result<Option<ResolverResource>> {
+        Ok(None)
+    }
+
     fn next_build(&self, _next_build_param: &NextBuildParam) -> bool {
         true
     }
@@ -208,7 +217,6 @@ impl PluginDriver {
         Ok(None)
     }
 
-    #[allow(dead_code)]
     pub fn transform_js(
         &self,
         param: &PluginTransformJsParam,
@@ -233,7 +241,6 @@ impl PluginDriver {
         Ok(())
     }
 
-    #[allow(dead_code)]
     pub fn before_resolve(
         &self,
         param: &mut Vec<Dependency>,
@@ -243,6 +250,21 @@ impl PluginDriver {
             plugin.before_resolve(param, context)?;
         }
         Ok(())
+    }
+
+    pub fn resolve_id(
+        &self,
+        source: &str,
+        importer: &str,
+        context: &Arc<Context>,
+    ) -> Result<Option<ResolverResource>> {
+        for plugin in &self.plugins {
+            let ret = plugin.resolve_id(source, importer, context)?;
+            if ret.is_some() {
+                return Ok(ret);
+            }
+        }
+        Ok(None)
     }
 
     pub fn before_generate(&self, context: &Arc<Context>) -> Result<()> {

--- a/crates/mako/src/resolve/resolution.rs
+++ b/crates/mako/src/resolve/resolution.rs
@@ -1,0 +1,63 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use oxc_resolver::PackageJson;
+
+#[derive(Clone)]
+pub struct Resolution {
+    pub path: PathBuf,
+    pub query: Option<String>,
+    pub fragment: Option<String>,
+    pub package_json: Option<Arc<PackageJson>>,
+}
+
+impl Resolution {
+    /// Returns the path without query and fragment
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the path without query and fragment
+    pub fn into_path_buf(self) -> PathBuf {
+        self.path
+    }
+
+    /// Returns the path query `?query`, contains the leading `?`
+    pub fn query(&self) -> Option<&str> {
+        self.query.as_deref()
+    }
+
+    /// Returns the path fragment `#fragment`, contains the leading `#`
+    pub fn fragment(&self) -> Option<&str> {
+        self.fragment.as_deref()
+    }
+
+    /// Returns serialized package_json
+    pub fn package_json(&self) -> Option<&Arc<PackageJson>> {
+        self.package_json.as_ref()
+    }
+
+    /// Returns the full path with query and fragment
+    pub fn full_path(&self) -> PathBuf {
+        let mut path = self.path.clone().into_os_string();
+        if let Some(query) = &self.query {
+            path.push(query);
+        }
+        if let Some(fragment) = &self.fragment {
+            path.push(fragment);
+        }
+        PathBuf::from(path)
+    }
+}
+
+impl fmt::Debug for Resolution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Resolution")
+            .field("path", &self.path)
+            .field("query", &self.query)
+            .field("fragment", &self.fragment)
+            .field("package_json", &self.package_json.as_ref().map(|p| &p.path))
+            .finish()
+    }
+}

--- a/crates/mako/src/resolve/resource.rs
+++ b/crates/mako/src/resolve/resource.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use oxc_resolver::Resolution;
+use crate::resolve::Resolution;
 
 #[derive(Debug, Clone)]
 pub struct ExternalResource {

--- a/docs/config.md
+++ b/docs/config.md
@@ -544,6 +544,7 @@ Specify the plugins to use.
     };
   }) => void;
   load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
+  resolveId?: (id: string, importer: string) => Promise<{ id: string }>;
 }
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -544,7 +544,7 @@ Specify the plugins to use.
     };
   }) => void;
   load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
-  resolveId?: (id: string, importer: string) => Promise<{ id: string }>;
+  resolveId?: (id: string, importer: string) => Promise<{ id: string, external: bool }>;
 }
 ```
 

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -544,6 +544,7 @@ e.g.
     };
   }) => void;
   load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
+  resolveId?: (id: string, importer: string) => Promise<{ id: string }>;
 }
 ```
 

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -544,7 +544,7 @@ e.g.
     };
   }) => void;
   load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
-  resolveId?: (id: string, importer: string) => Promise<{ id: string }>;
+  resolveId?: (id: string, importer: string) => Promise<{ id: string, external: bool }>;
 }
 ```
 

--- a/e2e/fixtures/plugins/expect.js
+++ b/e2e/fixtures/plugins/expect.js
@@ -8,3 +8,6 @@ assert(content.includes(`children: "foo.bar"`), `jsx in foo.bar works`);
 assert(content.includes(`children: ".bar"`), `jsx in hoo.bar works`);
 assert(content.includes(`children: ".haha"`), `plugin in node_modules works`);
 assert(content.includes(`children: ".hoo"`), `relative plugin works`);
+
+// resolve_id hook
+assert(content.includes(`resolve_id mocked`), `resolve_id hook works`);

--- a/e2e/fixtures/plugins/expect.js
+++ b/e2e/fixtures/plugins/expect.js
@@ -11,3 +11,4 @@ assert(content.includes(`children: ".hoo"`), `relative plugin works`);
 
 // resolve_id hook
 assert(content.includes(`resolve_id mocked`), `resolve_id hook works`);
+assert(content.includes(`module.exports = resolve_id_external;`), `resolve_id hook with external works`);

--- a/e2e/fixtures/plugins/plugins.config.js
+++ b/e2e/fixtures/plugins/plugins.config.js
@@ -22,9 +22,12 @@ module.exports = [
   },
   {
     async resolveId(source, importer) {
+      console.log('resolveId', source, importer);
       if (source === 'resolve_id') {
-        console.log('resolveId', source, importer);
-        return { id: require('path').join(__dirname, 'resolve_id_mock.js') };
+        return { id: require('path').join(__dirname, 'resolve_id_mock.js'), external: false };
+      }
+      if (source === 'resolve_id_external') {
+        return { id: 'resolve_id_external', external: true };
       }
       return null;
     }

--- a/e2e/fixtures/plugins/plugins.config.js
+++ b/e2e/fixtures/plugins/plugins.config.js
@@ -19,5 +19,14 @@ module.exports = [
         };
       }
     }
-  }
+  },
+  {
+    async resolveId(source, importer) {
+      if (source === 'resolve_id') {
+        console.log('resolveId', source, importer);
+        return { id: require('path').join(__dirname, 'resolve_id_mock.js') };
+      }
+      return null;
+    }
+  },
 ];

--- a/e2e/fixtures/plugins/resolve_id_mock.js
+++ b/e2e/fixtures/plugins/resolve_id_mock.js
@@ -1,0 +1,1 @@
+console.log('resolve_id mocked');

--- a/e2e/fixtures/plugins/src/index.tsx
+++ b/e2e/fixtures/plugins/src/index.tsx
@@ -2,3 +2,4 @@ console.log(require('./foo.bar'));
 console.log(require('./hoo.bar'));
 console.log(require('./foo.haha'));
 console.log(require('./foo.hoo'));
+console.log(require('resolve_id'));

--- a/e2e/fixtures/plugins/src/index.tsx
+++ b/e2e/fixtures/plugins/src/index.tsx
@@ -3,3 +3,4 @@ console.log(require('./hoo.bar'));
 console.log(require('./foo.haha'));
 console.log(require('./foo.hoo'));
 console.log(require('resolve_id'));
+console.log(require('resolve_id_external'));

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -51,6 +51,7 @@ export interface JsHooks {
   }) => void;
   onGenerateFile?: (path: string, content: Buffer) => Promise<void>;
   buildStart?: () => Promise<void>;
+  resolveId?: (source: string, importer: string) => Promise<{ id: string }>;
 }
 export interface WriteFile {
   path: string;
@@ -59,6 +60,9 @@ export interface WriteFile {
 export interface LoadResult {
   content: string;
   type: string;
+}
+export interface ResolveIdResult {
+  id: string;
 }
 export interface BuildParams {
   root: string;

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -63,6 +63,7 @@ export interface LoadResult {
 }
 export interface ResolveIdResult {
   id: string;
+  external: boolean | null;
 }
 export interface BuildParams {
   root: string;


### PR DESCRIPTION
part of https://github.com/umijs/mako/issues/1238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在 `JsHooks` 和 `TsFnHooks` 结构中添加了可选字段 `resolve_id`，支持基于源和导入者字符串解析标识符。
	- 新增 `Resolution` 结构体，封装文件路径及其相关信息。
	- `resolve_id` 方法被引入到 `JsPlugin` 结构，允许插件解析标识符。
	- `Plugin` 接口中新增 `resolve_id` 方法，增强插件功能。
	- `resolve` 模块的可见性更新为公共，便于外部访问。

- **文档**
	- 更新了 `binding.d.ts` 文件，增加了 `JsHooks` 接口的可选方法 `resolveId` 及新接口 `ResolveIdResult`。
	- 更新了 Mako 配置文档，增加了新的配置项和示例，提升了可读性和易用性。

- **测试**
	- 在测试用例中增加了对 `resolve_id` 钩子的验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->