### PR TITLE
refactor: code splitting config

### DIFF
--- a/crates/mako/src/build/transform.rs
+++ b/crates/mako/src/build/transform.rs
@@ -14,7 +14,7 @@ use swc_core::ecma::transforms::base::helpers::{Helpers, HELPERS};
 use swc_core::ecma::transforms::base::{resolver, Assumptions};
 use swc_core::ecma::transforms::compat::reserved_words;
 use swc_core::ecma::transforms::optimization::simplifier;
-use swc_core::ecma::transforms::optimization::simplify::{dce, Config as SimpilifyConfig};
+use swc_core::ecma::transforms::optimization::simplify::{dce, Config as SimplifyConfig};
 use swc_core::ecma::transforms::proposal::decorators;
 use swc_core::ecma::visit::{Fold, VisitMut};
 
@@ -236,7 +236,7 @@ impl Transform {
                                     // this must be kept for tree shaking to work
                                     Box::new(simplifier(
                                         unresolved_mark,
-                                        SimpilifyConfig {
+                                        SimplifyConfig {
                                             dce: dce::Config {
                                                 top_level: false,
                                                 ..Default::default()

--- a/crates/mako/src/plugins/ssu.rs
+++ b/crates/mako/src/plugins/ssu.rs
@@ -8,15 +8,14 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use dashmap::DashSet;
 use rayon::prelude::*;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::ast::file::{Content, File, JsContent};
 use crate::compiler::{Args, Compiler, Context};
 use crate::config::{
-    CodeSplitting, CodeSplittingAdvancedOptions, CodeSplittingStrategy,
-    CodeSplittingStrategyOptions, Config, OptimizeAllowChunks, OptimizeChunkGroup,
+    AllowChunks, ChunkGroup, CodeSplitting, CodeSplittingAdvancedOptions, CodeSplittingStrategy,
+    CodeSplittingStrategyOptions, Config,
 };
 use crate::generate::chunk::ChunkType;
 use crate::generate::chunk_pot::util::{hash_hashmap, hash_vec};
@@ -164,18 +163,18 @@ impl Plugin for SUPlus {
                 CodeSplittingAdvancedOptions {
                     min_size: 0,
                     groups: vec![
-                        OptimizeChunkGroup {
+                        ChunkGroup {
                             name: "node_modules".to_string(),
                             name_suffix: None,
-                            allow_chunks: OptimizeAllowChunks::All,
+                            allow_chunks: AllowChunks::All,
                             min_chunks: 0,
                             min_size: 0,
                             max_size: usize::MAX,
                             min_module_size: None,
                             priority: 10,
-                            test: Regex::new(r"[/\\]node_modules[/\\]").ok(),
+                            test: Some(r"[/\\]node_modules[/\\]".to_string()),
                         },
-                        OptimizeChunkGroup {
+                        ChunkGroup {
                             name: "common".to_string(),
                             min_chunks: 0,
                             // always split, to avoid multi-instance risk

--- a/crates/mako/src/utils.rs
+++ b/crates/mako/src/utils.rs
@@ -72,6 +72,7 @@ pub(crate) fn get_pkg_name(root: &Path) -> Option<String> {
 pub fn create_cached_regex(re: &str) -> Regex {
     Regex::new(re).unwrap()
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Rename code splitting config structs,  is an equivalent with before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修正了配置类型名称中的拼写错误，确保功能正常。

- **新功能**
	- 引入了新的测试模块，增强了对 URL 处理功能的验证。

- **重构**
	- 多个枚举和结构体名称进行了重命名，以简化代码结构和配置机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->