### PR TITLE
fix: duplicate_package_checker panic when package.json has no version field

### DIFF
--- a/crates/mako/src/plugins/duplicate_package_checker.rs
+++ b/crates/mako/src/plugins/duplicate_package_checker.rs
@@ -103,14 +103,15 @@ impl DuplicatePackageCheckerPlugin {
                         let raw_json = package_json.raw_json();
                         if let Some(name) = package_json.name.clone() {
                             if let Some(version) = raw_json.as_object().unwrap().get("version") {
-                                let package_info = PackageInfo {
-                                    name,
-                                    version: semver::Version::parse(version.as_str().unwrap())
-                                        .unwrap(),
-                                    path: package_json.path.clone(),
-                                };
-
-                                packages.push(package_info);
+                                let version = semver::Version::parse(version.as_str().unwrap());
+                                if let Ok(version) = version {
+                                    let package_info = PackageInfo {
+                                        name,
+                                        version,
+                                        path: package_json.path.clone(),
+                                    };
+                                    packages.push(package_info);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Close https://github.com/umijs/mako/issues/1632


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 改进了重复包检查插件的版本解析，增强了代码的健壮性，避免了因解析失败导致的运行时错误。
  
- **Style**
	- 进行了轻微的格式调整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->