### PR TITLE
feat: support webpackIgnore and makoIgnore magic comment

### DIFF
--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -328,14 +328,12 @@ impl Compiler {
             );
         }
 
-        if !config.ignores.is_empty() {
-            let ignores = config
-                .ignores
-                .iter()
-                .map(|ignore| Regex::new(ignore).map_err(Error::new))
-                .collect::<Result<Vec<Regex>>>()?;
-            plugins.push(Arc::new(plugins::ignore::IgnorePlugin { ignores }))
-        }
+        let ignores = config
+            .ignores
+            .iter()
+            .map(|ignore| Regex::new(ignore).map_err(Error::new))
+            .collect::<Result<Vec<Regex>>>()?;
+        plugins.push(Arc::new(plugins::ignore::IgnorePlugin { ignores }));
 
         let plugin_driver = PluginDriver::new(plugins);
 

--- a/crates/mako/src/config/experimental.rs
+++ b/crates/mako/src/config/experimental.rs
@@ -7,7 +7,7 @@ use crate::create_deserialize_fn;
 pub struct ExperimentalConfig {
     pub webpack_syntax_validate: Vec<String>,
     pub require_context: bool,
-    pub magic_comment_chunk_name: bool,
+    pub magic_comment: bool,
     #[serde(deserialize_with = "deserialize_detect_loop")]
     pub detect_circular_dependence: Option<DetectCircularDependence>,
 }

--- a/crates/mako/src/config/mako.config.default.json
+++ b/crates/mako/src/config/mako.config.default.json
@@ -67,7 +67,7 @@
   "experimental": {
     "webpackSyntaxValidate": [],
     "requireContext": true,
-    "magicCommentChunkName": false,
+    "magicComment": false,
     "detectCircularDependence": {
       "ignores": ["node_modules"],
       "graphviz": false

--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -129,6 +129,7 @@ impl From<&NamedExport> for NamedExportType {
 #[derive(Eq, Hash, PartialEq, Serialize, Debug, Clone, Default)]
 pub struct ImportOptions {
     pub chunk_name: Option<String>,
+    pub ignore: bool,
 }
 
 impl ImportOptions {

--- a/crates/mako/src/visitors/dep_analyzer.rs
+++ b/crates/mako/src/visitors/dep_analyzer.rs
@@ -135,7 +135,7 @@ impl Visit for DepAnalyzer {
                     }
                 };
 
-                let import_options = if self.context.config.experimental.magic_comment_chunk_name {
+                let import_options = if self.context.config.experimental.magic_comment {
                     maybe_magic_comments_pos
                         .map_or(ImportOptions::default(), |magic_comments_pos| {
                             self.analyze_import_options(magic_comments_pos)
@@ -171,7 +171,7 @@ impl Visit for DepAnalyzer {
                 }
             });
 
-            let import_options = if self.context.config.experimental.magic_comment_chunk_name {
+            let import_options = if self.context.config.experimental.magic_comment {
                 maybe_magic_comments_pos.map_or(ImportOptions::default(), |magic_comments_pos| {
                     self.analyze_import_options(magic_comments_pos)
                 })

--- a/crates/mako/src/visitors/dep_analyzer.rs
+++ b/crates/mako/src/visitors/dep_analyzer.rs
@@ -58,7 +58,15 @@ impl DepAnalyzer {
                 .and_then(|matched| matched.get(2).map(|m| m.as_str().to_string()))
         });
 
-        ImportOptions { chunk_name }
+        let ignore = comments_texts.iter().any(|t| {
+            get_magic_comment_ignore_regex()
+                .captures(t.trim())
+                .map_or(false, |cap| {
+                    cap.get(2).map_or(false, |m| m.as_str() == "true")
+                })
+        });
+
+        ImportOptions { chunk_name, ignore }
     }
 }
 
@@ -227,6 +235,10 @@ fn resolve_web_worker(expr: &NewExpr, unresolved_mark: Mark) -> Option<&Str> {
 
 fn get_magic_comment_chunk_name_regex() -> Regex {
     create_cached_regex(r#"(makoChunkName|webpackChunkName):\s*['"`](\w+)['"`]"#)
+}
+
+fn get_magic_comment_ignore_regex() -> Regex {
+    create_cached_regex(r#"(makoIgnore|webpackIgnore):\s*(true|false)"#)
 }
 
 #[cfg(test)]

--- a/crates/mako/src/visitors/dynamic_import.rs
+++ b/crates/mako/src/visitors/dynamic_import.rs
@@ -92,10 +92,7 @@ impl<'a> VisitMut for DynamicImport<'a> {
                         return;
                     }
 
-                    let resolved_info = self
-                        .dep_to_replace
-                        .resolved
-                        .get(source.value.as_ref());
+                    let resolved_info = self.dep_to_replace.resolved.get(source.value.as_ref());
 
                     // e.g.
                     // import(/* webpackIgnore: true */ "foo")

--- a/crates/mako/src/visitors/dynamic_import.rs
+++ b/crates/mako/src/visitors/dynamic_import.rs
@@ -95,7 +95,16 @@ impl<'a> VisitMut for DynamicImport<'a> {
                     let resolved_info = self
                         .dep_to_replace
                         .resolved
-                        .get(source.value.as_ref())
+                        .get(source.value.as_ref());
+
+                    // e.g.
+                    // import(/* webpackIgnore: true */ "foo")
+                    // will be ignored
+                    if resolved_info.is_none() {
+                        return;
+                    }
+
+                    let resolved_info = resolved_info
                         // If the identifier is not in dep_to_replace.missing,
                         // it must be resolved, so unwrap is safe here.
                         .unwrap();

--- a/docs/config.md
+++ b/docs/config.md
@@ -295,19 +295,19 @@ e.g.
 }
 ```
 
-### experimental.magicCommentChunkName
+### experimental.magicComment
 
 - Type: boolean
 - Default: false
 
-Experimental configuration, whether to support grouping chunk by magic comment chunk name like webpack.
+Experimental configuration, whether to support magic comments like webpack.
 
 e.g.
 
 ```ts
 {
   experimental: {
-    magicCommentChunkName: true,
+    magicComment: true,
   },
 }
 ```
@@ -316,12 +316,11 @@ the magic comment is like below:
 
 ```ts
 import(/* makoChunkName: 'myChunk' */ "./lazy");
-
 import(/* webpackChunkName: 'myChunk' */ "./lazy");
-
 new Worker(/* makoChunkName: 'myWorker' */ new URL("./worker", import.meta.url));
-
 new Worker(/* webpackChunkName: 'myWorker' */ new URL("./worker", import.meta.url));
+import(/* makoIgnore: true */ "./foo");
+import(/* webpackIgnore: true */ "./foo");
 ```
 
 ### externals

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -296,31 +296,30 @@ e.g.
 }
 ```
 
-### experimental.magicCommentChunkName
+### experimental.magicComment
 
 - 类型: boolean
 - 默认值: false
 
-实验性配置, 是否支持通过类似 webpack 的魔法注释控制 chunk 拆分.
+实验性配置，是否支持通过类似 webpack 的魔法注释。
 
 e.g.
 
 ```ts
 {
   experimental: {
-    magicCommentChunkName: true,
+    magicComment: true,
   },
 }
 ```
 魔法注释如下：
 ```ts
 import(/* makoChunkName: 'myChunk' */  "./lazy");
-
 import(/* webpackChunkName: 'myChunk' */  "./lazy");
-
 new Worker(/* makoChunkName: 'myWorker' */  new URL("./worker", import.meta.url));
-
 new Worker(/* webpackChunkName: 'myWorker' */  new URL("./worker", import.meta.url));
+import(/* makoIgnore: true */ "./foo");
+import(/* webpackIgnore: true */ "./foo");
 ```
 
 ### externals

--- a/e2e/fixtures.umi/config.babel-plugin-import/mako.config.json
+++ b/e2e/fixtures.umi/config.babel-plugin-import/mako.config.json
@@ -1,6 +1,6 @@
 {
 	"optimization": { "skipModules": true, "concatenateModules": false },
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures.umi/config.define/mako.config.json
+++ b/e2e/fixtures.umi/config.define/mako.config.json
@@ -1,5 +1,5 @@
 {
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures.umi/config.flex-bugs.default.true/mako.config.json
+++ b/e2e/fixtures.umi/config.flex-bugs.default.true/mako.config.json
@@ -1,5 +1,5 @@
 {
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures.umi/config.less.globalVars/mako.config.json
+++ b/e2e/fixtures.umi/config.less.globalVars/mako.config.json
@@ -1,5 +1,5 @@
 {
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures.umi/config.less.math/mako.config.json
+++ b/e2e/fixtures.umi/config.less.math/mako.config.json
@@ -1,5 +1,5 @@
 {
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures.umi/config.less.modifyVars/mako.config.json
+++ b/e2e/fixtures.umi/config.less.modifyVars/mako.config.json
@@ -1,5 +1,5 @@
 {
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures.umi/config.less.plugins/mako.config.json
+++ b/e2e/fixtures.umi/config.less.plugins/mako.config.json
@@ -1,5 +1,5 @@
 {
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures.umi/config.sassLoader/mako.config.json
+++ b/e2e/fixtures.umi/config.sassLoader/mako.config.json
@@ -1,5 +1,5 @@
 {
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures/magic-comments.chunk-name/mako.config.json
+++ b/e2e/fixtures/magic-comments.chunk-name/mako.config.json
@@ -3,6 +3,6 @@
     "strategy": "auto"
   },
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures/magic-comments.ignore/expect.js
+++ b/e2e/fixtures/magic-comments.ignore/expect.js
@@ -1,0 +1,7 @@
+const assert = require("assert");
+const { parseBuildResult } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+let index = files["index.js"];
+assert(index.includes(`import(/* webpackIgnore: true */ "./foo");`), "should include foo");
+assert(index.includes(`import(/* makoIgnore: true */ "./bar");`), "should include bar");

--- a/e2e/fixtures/magic-comments.ignore/mako.config.json
+++ b/e2e/fixtures/magic-comments.ignore/mako.config.json
@@ -1,0 +1,8 @@
+{
+  "codeSplitting": {
+    "strategy": "auto"
+  },
+  "experimental": {
+    "magicCommentChunkName": true
+  }
+}

--- a/e2e/fixtures/magic-comments.ignore/mako.config.json
+++ b/e2e/fixtures/magic-comments.ignore/mako.config.json
@@ -3,6 +3,6 @@
     "strategy": "auto"
   },
   "experimental": {
-    "magicCommentChunkName": true
+    "magicComment": true
   }
 }

--- a/e2e/fixtures/magic-comments.ignore/src/index.ts
+++ b/e2e/fixtures/magic-comments.ignore/src/index.ts
@@ -1,0 +1,2 @@
+import(/* webpackIgnore: true */  "./foo");
+import(/* makoIgnore: true */ "./bar");

--- a/scripts/test-hmr.mjs
+++ b/scripts/test-hmr.mjs
@@ -1869,7 +1869,7 @@ runTest('change async import magic comment chunk name', async () => {
           `,
       './mako.config.json': JSON.stringify({
         experimental: {
-          magicCommentChunkName: true,
+          magicComment: true,
         },
       }),
     }),


### PR DESCRIPTION
Close #1622


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了一个新的 `ignore` 字段到 `ImportOptions` 结构，允许用户指示是否忽略特定的导入选项。
	- 引入了新的配置文件 `mako.config.json`，包含代码拆分和实验性功能的设置。
	- 在 `src/index.ts` 中添加了动态导入语句，以支持条件加载模块。

- **测试**
	- 新增测试文件 `expect.js`，用于验证使用魔法注释的导入语句。

- **改进**
	- 通过更新 `IgnorePlugin` 和 `DepAnalyzer` 的逻辑，增强了对动态导入的处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->