### PR TITLE
feat: legacy interop

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -175,6 +175,8 @@ pub struct Config {
     pub clean: bool,
     pub node_polyfill: bool,
     pub ignores: Vec<String>,
+    #[serde(rename = "legacyInterop")]
+    pub legacy_interop: bool,
     #[serde(
         rename = "_minifish",
         deserialize_with = "deserialize_minifish",

--- a/crates/mako/src/config/mako.config.default.json
+++ b/crates/mako/src/config/mako.config.default.json
@@ -72,6 +72,7 @@
       "graphviz": false
     }
   },
+  "legacyInterop": false,
   "useDefineForClassFields": true,
   "emitDecoratorMetadata": false,
   "watch": { "ignorePaths": [], "_nodeModulesRegexes": [] },

--- a/e2e/fixtures/config.legacy_interop/expect.js
+++ b/e2e/fixtures/config.legacy_interop/expect.js
@@ -1,0 +1,6 @@
+const { injectSimpleJest } = require("../../../scripts/test-utils");
+
+injectSimpleJest()
+
+require("./dist/index.js");
+

--- a/e2e/fixtures/config.legacy_interop/mako.config.json
+++ b/e2e/fixtures/config.legacy_interop/mako.config.json
@@ -1,0 +1,3 @@
+{
+  "legacyInterop": true
+}

--- a/e2e/fixtures/config.legacy_interop/src/a.ts
+++ b/e2e/fixtures/config.legacy_interop/src/a.ts
@@ -1,0 +1,1 @@
+module.exports = () => 1

--- a/e2e/fixtures/config.legacy_interop/src/index.ts
+++ b/e2e/fixtures/config.legacy_interop/src/index.ts
@@ -1,0 +1,10 @@
+// @ts-ignore
+import * as a from './a'
+
+
+
+
+it('should work when config legacyInterop',()=>{
+  expect(a()).toBe(1)
+});
+


### PR DESCRIPTION
增加 `legacy` 开关配置, 修改 `swc_helper_interop_require_wildcard`的逻辑 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在配置模块中添加了 `legacy_interop` 字段，扩展了用户的配置选项。
	- 新增方法 `modify_legacy_code`，根据 `legacy_interop` 标志修改代码。
	- 创建了用于遗留互操作性的测试目录，包含新的配置文件和测试用例。
	- 在默认配置文件中添加了 `"legacyInterop": false` 属性。

- **变更**
	- 更新了 `get_swc_helper_code` 方法以接受 `legacy_interop` 参数。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->