### PR TITLE
feat: add enforce plugin hook

### DIFF
--- a/crates/binding/src/js_hook.rs
+++ b/crates/binding/src/js_hook.rs
@@ -8,6 +8,7 @@ use crate::threadsafe_function::ThreadsafeFunction;
 #[napi(object)]
 pub struct JsHooks {
     pub name: Option<String>,
+    pub enforce: Option<String>,
     #[napi(
         ts_type = "(filePath: string) => Promise<{ content: string, type: 'css'|'js' } | void> | void;"
     )]

--- a/crates/binding/src/js_plugin.rs
+++ b/crates/binding/src/js_plugin.rs
@@ -28,11 +28,17 @@ fn content_from_result(result: TransformResult) -> Result<Content> {
 
 pub struct JsPlugin {
     pub hooks: TsFnHooks,
+    pub name: Option<String>,
+    pub enforce: Option<String>,
 }
 
 impl Plugin for JsPlugin {
     fn name(&self) -> &str {
-        "js_plugin"
+        self.name.as_deref().unwrap_or("js_plugin")
+    }
+
+    fn enforce(&self) -> Option<String> {
+        self.enforce.clone()
     }
 
     fn build_start(&self, _context: &Arc<Context>) -> Result<()> {

--- a/crates/binding/src/js_plugin.rs
+++ b/crates/binding/src/js_plugin.rs
@@ -37,8 +37,8 @@ impl Plugin for JsPlugin {
         self.name.as_deref().unwrap_or("js_plugin")
     }
 
-    fn enforce(&self) -> Option<String> {
-        self.enforce.clone()
+    fn enforce(&self) -> Option<&str> {
+        self.enforce.as_deref()
     }
 
     fn build_start(&self, _context: &Arc<Context>) -> Result<()> {

--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -193,7 +193,7 @@ pub fn build(env: Env, build_params: BuildParams) -> napi::Result<JsObject> {
     }
 
     // sort with enforce: pre / post
-    plugins.sort_by_key(|plugin| match plugin.enforce().as_deref() {
+    plugins.sort_by_key(|plugin| match plugin.enforce() {
         Some("pre") => 0,
         Some("post") => 2,
         _ => 1,

--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use std::cmp::Ordering;
 use std::sync::{Arc, Once};
 
 use js_hook::{JsHooks, TsFnHooks};
@@ -194,39 +193,10 @@ pub fn build(env: Env, build_params: BuildParams) -> napi::Result<JsObject> {
     }
 
     // sort with enforce: pre / post
-    plugins.sort_by(|a, b| {
-        let a_enforce = a.enforce();
-        let b_enforce = b.enforce();
-        match (a_enforce, b_enforce) {
-            (Some(a_enforce), Some(b_enforce)) => {
-                if a_enforce == "pre" || b_enforce == "post" {
-                    Ordering::Less
-                } else if a_enforce == "post" || b_enforce == "pre" {
-                    Ordering::Greater
-                } else {
-                    Ordering::Equal
-                }
-            }
-            (Some(a_enforce), None) => {
-                if a_enforce == "pre" {
-                    Ordering::Less
-                } else if a_enforce == "post" {
-                    Ordering::Greater
-                } else {
-                    Ordering::Equal
-                }
-            }
-            (None, Some(b_enforce)) => {
-                if b_enforce == "post" {
-                    Ordering::Greater
-                } else if b_enforce == "pre" {
-                    Ordering::Less
-                } else {
-                    Ordering::Equal
-                }
-            }
-            (None, None) => Ordering::Equal,
-        }
+    plugins.sort_by_key(|plugin| match plugin.enforce().as_deref() {
+        Some("pre") => 0,
+        Some("post") => 2,
+        _ => 1,
     });
 
     let root = std::path::PathBuf::from(&build_params.root);

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -50,7 +50,7 @@ pub struct PluginGenerateEndParams {
 pub trait Plugin: Any + Send + Sync {
     fn name(&self) -> &str;
 
-    fn enforce(&self) -> Option<String> {
+    fn enforce(&self) -> Option<&str> {
         None
     }
 

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -50,6 +50,10 @@ pub struct PluginGenerateEndParams {
 pub trait Plugin: Any + Send + Sync {
     fn name(&self) -> &str;
 
+    fn enforce(&self) -> Option<String> {
+        None
+    }
+
     fn modify_config(&self, _config: &mut Config, _root: &Path, _args: &Args) -> Result<()> {
         Ok(())
     }

--- a/docs/config.md
+++ b/docs/config.md
@@ -561,6 +561,7 @@ Specify the plugins to use.
 // JSHooks
 {
   name?: string;
+  enforce?: "pre" | "post";
   buildStart?: () => void;
   buildEnd?: () => void;
   generateEnd?: (data: {

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -559,6 +559,7 @@ import(/* webpackIgnore: true */ "./foo");
 // JSHooks
 {
   name?: string;
+  enforce?: "pre" | "post";
   buildStart?: () => void;
   buildEnd?: () => void;
   generateEnd?: (data: {

--- a/e2e/fixtures/plugins/expect.js
+++ b/e2e/fixtures/plugins/expect.js
@@ -14,4 +14,4 @@ assert(content.includes(`resolve_id mocked`), `resolve_id hook works`);
 assert(content.includes(`module.exports = resolve_id_external;`), `resolve_id hook with external works`);
 
 // transform hook
-assert(content.includes(`console.log('transform_2_1');`), `transform hook works`);
+assert(content.includes(`console.log('transform_1_2');`), `transform hook works`);

--- a/e2e/fixtures/plugins/plugins.config.js
+++ b/e2e/fixtures/plugins/plugins.config.js
@@ -47,6 +47,7 @@ module.exports = [
     },
   },
   {
+    enforce: "pre",
     async transform(code, id) {
       if (id.endsWith("transform.ts")) {
         console.log("transform", code, id);

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -5,6 +5,7 @@
 
 export interface JsHooks {
   name?: string;
+  enforce?: string;
   load?: (
     filePath: string,
   ) => Promise<{ content: string; type: 'css' | 'js' } | void> | void;
@@ -52,6 +53,7 @@ export interface JsHooks {
   }) => void;
   onGenerateFile?: (path: string, content: Buffer) => Promise<void>;
   buildStart?: () => Promise<void>;
+  buildEnd?: () => Promise<void>;
   resolveId?: (
     source: string,
     importer: string,


### PR DESCRIPTION
part of https://github.com/umijs/mako/issues/1238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `JsHooks` 和 `JsPlugin` 结构中添加了新的可选字段 `enforce` 和 `name`，增强了插件的灵活性。
	- 新增 `enforce` 方法到 `Plugin` 接口，允许实现类型指定强制机制。
	- 配置文档更新，新增 `enforce` 属性，支持插件作为 "pre" 或 "post" 钩子。

- **文档**
	- 更新了 Mako 的配置文档，详细说明了新的配置选项及其用法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->