### PR TITLE
feat: add writeBundle plugin hook

### DIFF
--- a/crates/binding/src/js_hook.rs
+++ b/crates/binding/src/js_hook.rs
@@ -57,6 +57,8 @@ pub struct JsHooks {
     };
   }) => void"#)]
     pub generate_end: Option<JsFunction>,
+    #[napi(ts_type = "() => Promise<void>;")]
+    pub write_bundle: Option<JsFunction>,
     #[napi(ts_type = "(path: string, content: Buffer) => Promise<void>;")]
     pub _on_generate_file: Option<JsFunction>,
     #[napi(ts_type = "() => Promise<void>;")]
@@ -78,6 +80,7 @@ pub struct JsHooks {
 pub struct TsFnHooks {
     pub build_start: Option<ThreadsafeFunction<(), ()>>,
     pub build_end: Option<ThreadsafeFunction<(), ()>>,
+    pub write_bundle: Option<ThreadsafeFunction<(), ()>>,
     pub generate_end: Option<ThreadsafeFunction<Value, ()>>,
     pub load: Option<ThreadsafeFunction<String, Option<LoadResult>>>,
     pub load_include: Option<ThreadsafeFunction<String, Option<bool>>>,
@@ -95,6 +98,9 @@ impl TsFnHooks {
                 ThreadsafeFunction::from_napi_value(env.raw(), hook.raw()).unwrap()
             }),
             build_end: hooks.build_end.as_ref().map(|hook| unsafe {
+                ThreadsafeFunction::from_napi_value(env.raw(), hook.raw()).unwrap()
+            }),
+            write_bundle: hooks.write_bundle.as_ref().map(|hook| unsafe {
                 ThreadsafeFunction::from_napi_value(env.raw(), hook.raw()).unwrap()
             }),
             generate_end: hooks.generate_end.as_ref().map(|hook| unsafe {

--- a/crates/binding/src/js_plugin.rs
+++ b/crates/binding/src/js_plugin.rs
@@ -121,6 +121,13 @@ impl Plugin for JsPlugin {
         Ok(())
     }
 
+    fn write_bundle(&self, _context: &Arc<Context>) -> Result<()> {
+        if let Some(hook) = &self.hooks.write_bundle {
+            hook.call(())?
+        }
+        Ok(())
+    }
+
     fn before_write_fs(&self, path: &std::path::Path, content: &[u8]) -> Result<()> {
         if let Some(hook) = &self.hooks._on_generate_file {
             hook.call(WriteFile {

--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -460,6 +460,7 @@ impl Compiler {
                 self.context
                     .plugin_driver
                     .generate_end(&params, &self.context)?;
+                self.context.plugin_driver.write_bundle(&self.context)?;
                 Ok(())
             }
             Err(e) => Err(e),

--- a/crates/mako/src/dev.rs
+++ b/crates/mako/src/dev.rs
@@ -402,6 +402,11 @@ impl DevServer {
                 .plugin_driver
                 .generate_end(&params, &compiler.context)
                 .unwrap();
+            compiler
+                .context
+                .plugin_driver
+                .write_bundle(&compiler.context)
+                .unwrap();
         }
 
         let receiver_count = txws.receiver_count();

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -147,6 +147,10 @@ pub trait Plugin: Any + Send + Sync {
         Ok(())
     }
 
+    fn write_bundle(&self, _context: &Arc<Context>) -> Result<()> {
+        Ok(())
+    }
+
     fn runtime_plugins(&self, _context: &Arc<Context>) -> Result<Vec<String>> {
         Ok(Vec::new())
     }
@@ -320,6 +324,13 @@ impl PluginDriver {
     ) -> Result<()> {
         for plugin in &self.plugins {
             plugin.generate_end(params, context)?;
+        }
+        Ok(())
+    }
+
+    pub fn write_bundle(&self, context: &Arc<Context>) -> Result<()> {
+        for plugin in &self.plugins {
+            plugin.write_bundle(context)?;
         }
         Ok(())
     }

--- a/docs/config.md
+++ b/docs/config.md
@@ -573,6 +573,7 @@ Specify the plugins to use.
       ...
     };
   }) => void;
+  writeBundle?: () => void;
   load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
   loadInclude?: (filePath: string) => boolean;
   resolveId?: (id: string, importer: string, { isEntry: bool }) => Promise<{ id: string, external: bool }>;

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -571,6 +571,7 @@ import(/* webpackIgnore: true */ "./foo");
       ...
     };
   }) => void;
+  writeBundle?: () => void;
   load?: (filePath: string) => Promise<{ content: string, type: 'css'|'js'|'jsx'|'ts'|'tsx' }>;
   loadInclude?: (filePath: string) => boolean;
   resolveId?: (id: string, importer: string, { isEntry: bool }) => Promise<{ id: string, external: bool }>;

--- a/e2e/fixtures/plugins/plugins.config.js
+++ b/e2e/fixtures/plugins/plugins.config.js
@@ -8,6 +8,9 @@ module.exports = [
         };
       }
     },
+    async writeBundle() {
+      console.log("writeBundle");
+    },
   },
   {
     async loadInclude(path) {

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -51,6 +51,7 @@ export interface JsHooks {
       endTime: number;
     };
   }) => void;
+  writeBundle?: () => Promise<void>;
   onGenerateFile?: (path: string, content: Buffer) => Promise<void>;
   buildStart?: () => Promise<void>;
   buildEnd?: () => Promise<void>;


### PR DESCRIPTION
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `JsHooks` 和 `TsFnHooks` 结构中添加了可选的 `write_bundle` 字段。
	- 在 `JsPlugin` 结构中新增 `write_bundle` 方法，支持插件处理捆绑写入。
	- 编译器现在在生成阶段后处理捆绑写入。
	- `DevServer` 的 `rebuild` 方法更新，重建后写入捆绑。
	- 新增多个配置选项，增强 Mako 框架的插件开发能力。

- **文档**
	- 更新了配置文档，增加了捆绑写入的回调函数示例及说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->