### PR TITLE
fix: should not re-group when span changed

### DIFF
--- a/crates/mako/src/dev/update.rs
+++ b/crates/mako/src/dev/update.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 use crate::build::BuildError;
 use crate::compiler::Compiler;
 use crate::generate::transform::transform_modules;
-use crate::module::{Dependency, Module, ModuleId};
+use crate::module::{Dependency, Module, ModuleId, ResolveType};
 use crate::module_graph::ModuleGraph;
 use crate::resolve::{self, clear_resolver_cache};
 
@@ -466,14 +466,15 @@ impl Diff {
             return true;
         }
 
-        let new_deps: HashMap<&ModuleId, &Dependency> = new_dependencies
+        let new_deps: HashMap<&ModuleId, &ResolveType> = new_dependencies
             .iter()
-            .map(|(module_id, dep)| (module_id, dep))
+            .map(|(module_id, dep)| (module_id, &dep.resolve_type))
             .collect();
 
-        let original: HashMap<&ModuleId, &Dependency> = module_graph
+        let original: HashMap<&ModuleId, &ResolveType> = module_graph
             .get_dependencies(module_id)
             .into_iter()
+            .map(|(module_id, dep)| (module_id, &dep.resolve_type))
             .collect();
 
         !new_deps.eq(&original)


### PR DESCRIPTION
https://github.com/umijs/mako/pull/1628/files#diff-808f33e09a3d19b8da5481b9bd5bde583b2ce3fb6893f56f0d70545c7c619b82

中将 Dependency 整个结构题参与了 dep_change 的 diff. Dependency 结构体里有 span 信息，简单的 span 变化不应该触发 re group.

不过，热更时如果发生了 re-group, 可能还是会存在问题。https://github.com/umijs/mako/issues/1091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 引入了更精细的依赖解析机制，以增强模块更新处理。
	- 新增了 `ResolveType` 类型，以改善依赖关系的管理和跟踪。

- **文档**
	- 更新了代码注释，已翻译为英语，以提高代码段的清晰度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->