### PR TITLE
chore(SSU):  add process.env.SOCKET_SERVER define to prevent process polyfill require too early

### DIFF
--- a/crates/mako/src/plugins/ssu.rs
+++ b/crates/mako/src/plugins/ssu.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use dashmap::DashSet;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tracing::debug;
 
 use crate::ast::file::{Content, File, JsContent};
@@ -189,6 +190,11 @@ impl Plugin for SUPlus {
                 },
             )),
         });
+
+        config
+            .define
+            .entry("process.env.SOCKET_SERVER".to_owned())
+            .or_insert(Value::Null);
 
         Ok(())
     }


### PR DESCRIPTION
https://github.com/umijs/mako/blob/9346dafbe6337f1ede61af3251ed624a94b33636/crates/mako/src/runtime/runtime_hmr_entry.js#L40-L42

防止 runtime 中的 process 未被 define 替换，导致过早的引入 process pollyfill，引起 SSU 二次启动运行时报错



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了对环境变量的支持，允许动态定义配置中的新条目。
	- 改进了模块依赖和缓存机制的处理。
- **改进**
	- 更新了配置管理方法，以更好地处理特定路径和依赖状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->