### PR TITLE
fix: async module in circular dependence

### DIFF
--- a/crates/mako/src/generate/transform.rs
+++ b/crates/mako/src/generate/transform.rs
@@ -78,8 +78,9 @@ pub fn transform_modules_in_thread(
         let module_id = module_id.clone();
         let async_deps = async_deps_by_module_id
             .get(&module_id)
-            .expect(&module_id.id)
-            .clone();
+            .cloned()
+            .unwrap_or(vec![]);
+
         thread_pool::spawn(move || {
             let module_graph = context.module_graph.read().unwrap();
             let deps = module_graph.get_dependencies(&module_id);

--- a/e2e/fixtures/javascript.async_module_in_loop/async.js
+++ b/e2e/fixtures/javascript.async_module_in_loop/async.js
@@ -1,0 +1,11 @@
+let x = await new Promise((resolve)=>{
+    resolve("default")
+})
+
+let named = await new Promise((resolve)=>{
+    resolve("named")
+})
+
+export default x;
+
+export {named}

--- a/e2e/fixtures/javascript.async_module_in_loop/component.js
+++ b/e2e/fixtures/javascript.async_module_in_loop/component.js
@@ -1,0 +1,11 @@
+import { listKeys } from "./utils"
+
+import { named } from "./async"
+
+export const config = {
+    key: "value"
+}
+
+export function displayConfig() {
+    return listKeys()
+}

--- a/e2e/fixtures/javascript.async_module_in_loop/expect.js
+++ b/e2e/fixtures/javascript.async_module_in_loop/expect.js
@@ -1,0 +1,9 @@
+const {
+  injectSimpleJest,
+  parseBuildResult,
+  moduleDefinitionOf,
+} = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+injectSimpleJest();
+
+require("./dist/index.js");

--- a/e2e/fixtures/javascript.async_module_in_loop/index.js
+++ b/e2e/fixtures/javascript.async_module_in_loop/index.js
@@ -1,0 +1,6 @@
+import {displayConfig} from "./component";
+
+it("should require looped async moule", () => {
+    expect(displayConfig()).toStrictEqual(["key"])
+})
+

--- a/e2e/fixtures/javascript.async_module_in_loop/mako.config.json
+++ b/e2e/fixtures/javascript.async_module_in_loop/mako.config.json
@@ -1,0 +1,5 @@
+{
+  "entry": {
+    "index": "./index.js"
+  }
+}

--- a/e2e/fixtures/javascript.async_module_in_loop/utils.js
+++ b/e2e/fixtures/javascript.async_module_in_loop/utils.js
@@ -1,0 +1,9 @@
+import {config} from "./component"
+
+export function listKeys() {
+    if(config){
+        
+    return Object.keys(config)
+    }
+    return ["oops"]
+}


### PR DESCRIPTION
close #1656 

1. mark modules by traversaling from all known async module sto its syns esm dependants
2. records only async modules' dep, to save memory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了异步模块处理的新逻辑，支持异步依赖的动态创建和导出。
	- 新增了多个测试用例，增强了异步模块行为的测试覆盖率。
	- 添加了新的配置文件以指定模块的入口点。

- **文档**
	- 新增了多个 JavaScript 文件以支持异步行为和模块测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->