### PR TITLE
fix: skip module should skip async module

### DIFF
--- a/crates/mako/src/plugins/tree_shaking/module.rs
+++ b/crates/mako/src/plugins/tree_shaking/module.rs
@@ -171,6 +171,7 @@ pub struct TreeShakeModule {
     used_exports: UsedExports,
     pub module_system: ModuleSystem,
     pub all_exports: AllExports,
+    pub is_async: bool,
     pub topo_order: usize,
     pub updated_ast: Option<SwcModule>,
     pub side_effect_dep_sources: HashSet<String>,
@@ -323,6 +324,7 @@ impl TreeShakeModule {
             described_side_effects: module.info.as_ref().unwrap().described_side_effect(),
             side_effects: module_system != ModuleSystem::ESModule,
             side_effect_dep_sources: Default::default(),
+            is_async: module.info.as_ref().unwrap().is_async,
             all_exports: match module_system {
                 ModuleSystem::ESModule => AllExports::Precise(Default::default()),
                 ModuleSystem::Custom | ModuleSystem::CommonJS => {

--- a/crates/mako/src/plugins/tree_shaking/shake/skip_module.rs
+++ b/crates/mako/src/plugins/tree_shaking/shake/skip_module.rs
@@ -491,13 +491,15 @@ pub(super) fn skip_module_optimize(
 
     for (module_id, replaces) in re_export_replace_map.iter() {
         if module_graph.has_module(module_id) {
+            let mut tsm = tree_shake_modules_map.get(module_id).unwrap().borrow_mut();
+            if tsm.is_async {
+                continue;
+            }
             // stmt_id is reversed order
             for to_replace in replaces.iter() {
                 // println!("{} apply with {:?}", module_id.id, to_replace.1);
                 apply_replace(to_replace, module_id, module_graph, context);
             }
-
-            let mut tsm = tree_shake_modules_map.get(module_id).unwrap().borrow_mut();
 
             let swc_module = module_graph
                 .get_module(module_id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `TreeShakeModule` 结构中添加了 `is_async` 布尔字段，以跟踪模块是否为异步。
  - 修改了处理模块的优化逻辑，跳过异步模块的处理，优化了模块图的控制流。

- **修复**
  - 确保在优化过程中异步模块不被替换，保持现有功能的完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->