### PR TITLE
fix: hmr with magic comment chunk name

### DIFF
--- a/e2e/fixtures/magic-comments.chunk-name/expect.js
+++ b/e2e/fixtures/magic-comments.chunk-name/expect.js
@@ -4,11 +4,13 @@ const { files } = parseBuildResult(__dirname);
 
 assert("chunk_a-async.js" in files
   && files["chunk_a-async.js"].includes('console.log("lazy_a_0")')
-  && files["chunk_a-async.js"].includes('console.log("lazy_a_1")'),
+  && files["chunk_a-async.js"].includes('console.log("lazy_a_1")')
+  && files["chunk_a-async.js"].includes('__mako_require__.ensure("src/lazy_inner.ts")'),
 "should have chunk_a-async.js");
 
 assert("chunk_b-async.js" in files
-  && files["chunk_b-async.js"].includes('console.log("lazy_b")'),
+  && files["chunk_b-async.js"].includes('console.log("lazy_b")')
+  && files["chunk_b-async.js"].includes('__mako_require__.ensure("src/lazy_inner.ts")'),
 "should have chunk_b-async.js");
 
 assert("my_worker-worker.js" in files

--- a/e2e/fixtures/magic-comments.chunk-name/public/index.html
+++ b/e2e/fixtures/magic-comments.chunk-name/public/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <div id="root"></div>
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/e2e/fixtures/magic-comments.chunk-name/src/lazy_a_0.ts
+++ b/e2e/fixtures/magic-comments.chunk-name/src/lazy_a_0.ts
@@ -1,2 +1,4 @@
 console.log("lazy_a_0");
 export {}
+
+import('./lazy_inner');

--- a/e2e/fixtures/magic-comments.chunk-name/src/lazy_b.ts
+++ b/e2e/fixtures/magic-comments.chunk-name/src/lazy_b.ts
@@ -1,2 +1,5 @@
 console.log("lazy_b");
 export {}
+
+import('./lazy_inner');
+

--- a/e2e/fixtures/magic-comments.chunk-name/src/lazy_inner.ts
+++ b/e2e/fixtures/magic-comments.chunk-name/src/lazy_inner.ts
@@ -1,0 +1,2 @@
+console.log("lazy_inner");
+export {}


### PR DESCRIPTION
If there is a dynamic import in chunk which named with a magic comment, the runtime will be broken and hmr will fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 引入了新的 HTML 文件结构，为动态内容提供基础。
	- 在多个文件中添加了动态导入 `lazy_inner` 模块的功能。
	- 更新了 JavaScript 生成逻辑，以更好地处理不同类型的块。

- **错误修复**
	- 改进了依赖处理逻辑，确保所有依赖项在块添加到图中之前都被正确更新。

- **文档**
	- 新增了 `index.html` 文件，包含基本的 HTML 结构和脚本加载。

- **样式**
	- 在多个 JavaScript 文件中添加了控制台日志输出，以增强调试信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->