### PR TITLE
feat: enable magicComment features by default

### DIFF
--- a/crates/mako/src/config/mako.config.default.json
+++ b/crates/mako/src/config/mako.config.default.json
@@ -67,7 +67,7 @@
   "experimental": {
     "webpackSyntaxValidate": [],
     "requireContext": true,
-    "magicComment": false,
+    "magicComment": true,
     "detectCircularDependence": {
       "ignores": ["node_modules"],
       "graphviz": false


### PR DESCRIPTION
默认开启 magic comment 功能。
找了几个内部的大项目验证没问题，G6 官网开启这个 features 也发上线了，运行时正常。可以默认开启。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了配置文件中的 `magicComment` 属性，使其在构建过程中启用魔法注释功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->