### PR TITLE
feat: compatible codeSplitting config with umi

### DIFF
--- a/crates/mako/src/config/code_splitting.rs
+++ b/crates/mako/src/config/code_splitting.rs
@@ -85,7 +85,7 @@ pub struct ChunkGroup {
     #[serde(default = "GenericUsizeDefault::<5000000>::value")]
     pub max_size: usize,
     #[serde(default)]
-    pub min_module_size: Option<usize>,
+    pub min_package_size: Option<usize>,
     #[serde(default)]
     pub priority: i8,
     #[serde(default)]
@@ -102,7 +102,7 @@ impl Default for ChunkGroup {
             max_size: GenericUsizeDefault::<5000000>::value(),
             name: String::default(),
             name_suffix: None,
-            min_module_size: None,
+            min_package_size: None,
             test: None,
             priority: i8::default(),
         }

--- a/crates/mako/src/generate/optimize_chunk.rs
+++ b/crates/mako/src/generate/optimize_chunk.rs
@@ -43,11 +43,11 @@ impl Compiler {
             // stage: modules
             self.module_to_optimize_infos(&mut optimize_chunks_infos, None);
 
-            // stage: size
-            self.optimize_chunk_size(&mut optimize_chunks_infos);
-
             // stage: name_suffix
             self.optimize_name_suffix(&mut optimize_chunks_infos);
+
+            // stage: size
+            self.optimize_chunk_size(&mut optimize_chunks_infos);
 
             // stage: apply
             self.apply_optimize_infos(&optimize_chunks_infos);

--- a/crates/mako/src/plugins/ssu.rs
+++ b/crates/mako/src/plugins/ssu.rs
@@ -171,7 +171,7 @@ impl Plugin for SUPlus {
                             min_chunks: 0,
                             min_size: 0,
                             max_size: usize::MAX,
-                            min_module_size: None,
+                            min_package_size: None,
                             priority: 10,
                             test: Some(r"[/\\]node_modules[/\\]".to_string()),
                         },
@@ -182,7 +182,7 @@ impl Plugin for SUPlus {
                             min_size: 1,
                             max_size: usize::MAX,
                             name_suffix: None,
-                            min_module_size: None,
+                            min_package_size: None,
                             priority: 0,
                             ..Default::default()
                         },

--- a/e2e/fixtures/code-splitting.granular/expect.js
+++ b/e2e/fixtures/code-splitting.granular/expect.js
@@ -14,10 +14,10 @@ assert(
   && !files["lib_lib1-async.js"].includes("normal")
   && files["lib_lib2-async.js"].includes('console.log("lib2")')
   && !files["lib_lib2-async.js"].includes("normal")
-  && files["lib_shared1-async.js"].includes('console.log("shared1")')
-  && !files["lib_shared1-async.js"].includes("normal")
-  && files["lib_shared2-async.js"].includes('console.log("shared2")')
-  && !files["lib_shared2-async.js"].includes("normal"),
+  && files["lib-async.js"].includes('console.log("shared1")')
+  && files["lib-async.js"].includes("normal")
+  && files["lib-async.js"].includes('console.log("shared2")')
+  && files["lib-async.js"].includes("normal"),
   "should split lib chunks"
 );
 

--- a/e2e/fixtures/code-splitting.granular/expect.js
+++ b/e2e/fixtures/code-splitting.granular/expect.js
@@ -10,14 +10,14 @@ assert(
 );
 
 assert(
-  files["lib_0_lib1-async.js"].includes('console.log("lib1")')
-  && !files["lib_0_lib1-async.js"].includes("normal")
-  && files["lib_1_lib2-async.js"].includes('console.log("lib2")')
-  && !files["lib_1_lib2-async.js"].includes("normal")
-  && files["lib_0_shared1-async.js"].includes('console.log("shared1")')
-  && !files["lib_0_shared1-async.js"].includes("normal")
-  && files["lib_0_shared2-async.js"].includes('console.log("shared2")')
-  && !files["lib_0_shared2-async.js"].includes("normal"),
+  files["lib_lib1-async.js"].includes('console.log("lib1")')
+  && !files["lib_lib1-async.js"].includes("normal")
+  && files["lib_lib2-async.js"].includes('console.log("lib2")')
+  && !files["lib_lib2-async.js"].includes("normal")
+  && files["lib_shared1-async.js"].includes('console.log("shared1")')
+  && !files["lib_shared1-async.js"].includes("normal")
+  && files["lib_shared2-async.js"].includes('console.log("shared2")')
+  && !files["lib_shared2-async.js"].includes("normal"),
   "should split lib chunks"
 );
 

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -594,11 +594,13 @@ async function getMakoConfig(opts) {
               options: {
                 groups: [
                   {
-                    name: 'vendors',
+                    name: 'npm',
                     allowChunks: 'async',
                     test: '[\\\\/]node_modules[\\\\/]',
-                    priority: -10,
                     nameSuffix: 'packageName',
+                    priority: -10,
+                    minSize: 1,
+                    minPackageSize: 1,
                   },
                   {
                     name: 'common',

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -566,26 +566,50 @@ async function getMakoConfig(opts) {
 
   const normalizedDevtool = devtool === false ? false : 'source-map';
 
-  if (process.env.GRANULAR_CHUNKS) {
-    codeSplitting = {
-      strategy: 'granular',
-      options: {
-        // copy from https://github.com/umijs/umi/blob/d8f3f1fa9586a8c7cab4d3b6a9e1637a6f47e1dc/packages/preset-umi/src/features/codeSplitting/codeSplitting.ts#L60
-        frameworkPackages: [
-          'react-dom',
-          'react',
-          // 'core-js',
-          // 'regenerator-runtime',
-          'history',
-          'react-router',
-          'react-router-dom',
-          'scheduler',
-          // TODO
-          // add renderer-react
-        ],
-      },
-    };
-  }
+  let makoCodeSplittingConfig =
+    codeSplitting === false
+      ? false
+      : codeSplitting?.jsStrategy === 'granularChunks'
+        ? {
+            strategy: 'granular',
+            options: {
+              // copy from https://github.com/umijs/umi/blob/d8f3f1fa9586a8c7cab4d3b6a9e1637a6f47e1dc/packages/preset-umi/src/features/codeSplitting/codeSplitting.ts#L60
+              frameworkPackages: [
+                'react-dom',
+                'react',
+                // 'core-js',
+                // 'regenerator-runtime',
+                'history',
+                'react-router',
+                'react-router-dom',
+                'scheduler',
+                // TODO
+                // add renderer-react
+              ],
+            },
+          }
+        : codeSplitting?.jsStrategy === 'depPerChunk'
+          ? {
+              strategy: 'advanced',
+              options: {
+                groups: [
+                  {
+                    name: 'vendors',
+                    allowChunks: 'async',
+                    test: '[\\\\/]node_modules[\\\\/]',
+                    priority: -10,
+                    nameSuffix: 'packageName',
+                  },
+                  {
+                    name: 'common',
+                    allowChunks: 'async',
+                    minChunks: 2,
+                    priority: -20,
+                  },
+                ],
+              },
+            }
+          : { strategy: 'auto' };
 
   const makoConfig = {
     entry: opts.entry,
@@ -600,13 +624,7 @@ async function getMakoConfig(opts) {
     },
     manifest,
     mdx: !!mdx,
-    codeSplitting:
-      codeSplitting === false
-        ? false
-        : typeof codeSplitting === 'object' &&
-            codeSplitting.strategy === 'granular'
-          ? codeSplitting
-          : { strategy: 'auto' },
+    codeSplitting: makoCodeSplittingConfig,
     devtool: normalizedDevtool,
     cjs,
     dynamicImportToRequire,


### PR DESCRIPTION
Compatible mako codeSplitting config for [umi/codeSplitting](https://umijs.org/docs/api/config#codesplitting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 引入了更灵活的代码拆分配置，支持不同的策略（细粒度、先进和自动）。
- **Bug 修复**
  - 更新了构建后 JavaScript 文件内容验证的断言，反映了文件命名约定的重组。
- **文档**
  - 更新了 Mako 打包器的配置以增强代码拆分功能的可配置性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->