### PR TITLE
fix: pnpm workspace watch too many files

### DIFF
--- a/crates/mako/src/dev/watch.rs
+++ b/crates/mako/src/dev/watch.rs
@@ -150,10 +150,11 @@ impl<'a> Watcher<'a> {
     }
 
     fn watch_file_or_dir(&mut self, path: PathBuf, ignore_list: &[PathBuf]) -> anyhow::Result<()> {
-        if Self::should_ignore_watch(&path, ignore_list) {
+        if Self::should_ignore_watch(&path, ignore_list)
+            || path.to_string_lossy().contains("node_modules")
+        {
             return Ok(());
         }
-
         if path.is_file() && !self.watched_files.contains(&path) {
             self.watcher
                 .watch(path.as_path(), notify::RecursiveMode::NonRecursive)?;


### PR DESCRIPTION
monorepo 仅忽略了 `root` -> all `parents root` 下的 `node_modules` 文件监听, 对于`monorepo` 兄弟子包的依赖, 会把 `node_modules`囊括进去.

eg.
```
-root
  -node_modules
  -repo1
      -repo2
      -node_modules
  -repo2
      -node_modules
```
以上会忽略`root/node_modules`,  `repo1/node_modules` 监听`repo2/node_modules`
显然`repo2/node_modules`是不需要被监听的

整个`watch` 模块之后需要一次大的重构, 目前的判断模式过于繁琐低效.
目前没有时间o(╥﹏╥)o, 先简单对大型`monorepo`项目做个修复.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强文件监视功能，自动忽略“node_modules”目录，减少不必要的事件处理。

- **变更**
  - 更新了`Watcher`结构体中的方法签名，以改进监视逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->