### PR TITLE
fix(SSU): 🐛 in case external not avaible to all  entries

### DIFF
--- a/crates/mako/src/plugins/central_ensure.rs
+++ b/crates/mako/src/plugins/central_ensure.rs
@@ -61,7 +61,7 @@ impl Plugin for CentralChunkEnsure {
   let map = {ensure_map};
   requireModule.updateEnsure2Map = function(newMapping) {{
     map = newMapping;
-  }}
+  }};
   requireModule.ensure2 = function(chunkId){{
     let toEnsure = map[chunkId];
     if (toEnsure) {{

--- a/crates/mako/src/plugins/ssu.rs
+++ b/crates/mako/src/plugins/ssu.rs
@@ -258,7 +258,9 @@ let patch = require._su_patch();
 console.log(patch);
 try{{
 {}
-}}catch(e){{}}
+}}catch(e){{ 
+//ignore the error 
+}}
 module.export = Promise.all(
     patch.map((d)=>__mako_require__.ensure(d))
 ).then(()=>{{

--- a/crates/mako/src/plugins/ssu.rs
+++ b/crates/mako/src/plugins/ssu.rs
@@ -256,7 +256,9 @@ require("{SSU_MOCK_JS_FILE}");
 }}catch(e){{}};
 let patch = require._su_patch();
 console.log(patch);
+try{{
 {}
+}}catch(e){{}}
 module.export = Promise.all(
     patch.map((d)=>__mako_require__.ensure(d))
 ).then(()=>{{
@@ -566,7 +568,7 @@ requireModule._su_patch = function(){{
         cssChunksIdToUrlMap[key] = css_patch[key];
     }}
     return Object.keys(js_patch).sort();
-}}
+}};
 "#,
                 serde_json::to_string(&cache.js_patch_map).unwrap(),
                 serde_json::to_string(&cache.css_patch_map).unwrap(),
@@ -598,7 +600,7 @@ requireModule._su_patch = function(){
         cssChunksIdToUrlMap[key] = css_patch[key];
     }
   return ["node_modules"];
-}"#
+};"#
             .to_string()])
         }
     }


### PR DESCRIPTION
## problem 

found in internal h5 project which has multi entries, different entry has different html  script tag
so the external maybe not available every page

## solution 
wrap those require in  `try catch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
  - 增强了缓存状态加载的错误处理，返回更安全的选项。
  - 改进了构建过程中的日志记录，特别是在缓存验证和状态管理方面。
  - 更新了写入当前缓存状态的方法，确保仅在必要时写入。
  - 修复了模块块管理中的 JavaScript 运行时代码生成问题。

- **性能优化**
  - 在生成块文件的过程中引入并行处理，提升性能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->