### PR TITLE
refactor(dev): 🔥  reduce ensure2 chunk map size

### DIFF
--- a/crates/mako/src/plugins/central_ensure.rs
+++ b/crates/mako/src/plugins/central_ensure.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::iter::once;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -32,8 +33,9 @@ pub fn module_ensure_map(context: &Arc<Context>) -> anyhow::Result<BTreeMap<Stri
                 .iter()
                 .for_each(|chunk| {
                     let deps_chunks = cg
-                        .installable_descendants_chunk(&chunk.id)
+                        .sync_dependencies_chunk(&chunk.id)
                         .iter()
+                        .chain(once(&chunk.id))
                         .map(|chunk_id| chunk_id.generate(context))
                         .collect::<Vec<_>>();
 


### PR DESCRIPTION
the former `installable_descendants_chunk` returns almost all the chunk in this build.
`sync_dependencies_chunk` is  the best choice  and aligning with production behaviors 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了模块依赖项的获取方式，增强了动态导入模块的依赖管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->