### PR TITLE
feat(copy): support advanced copy configuration with custom target paths

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -74,7 +74,7 @@ pub struct BuildParams {
             };
         }
     >;
-    copy?: string[];
+    copy?: (string | { from: string; to: string })[];
     codeSplitting?:
       | false
       | {

--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -124,6 +124,13 @@ pub enum Platform {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(untagged)]
+pub enum CopyConfig {
+    Basic(String),
+    Advanced { from: String, to: String },
+}
+
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     pub entry: HashMap<String, PathBuf>,
@@ -137,7 +144,7 @@ pub struct Config {
     pub devtool: Option<DevtoolConfig>,
     pub externals: HashMap<String, ExternalConfig>,
     pub providers: Providers,
-    pub copy: Vec<String>,
+    pub copy: Vec<CopyConfig>,
     pub public_path: String,
     pub inline_limit: usize,
     pub inline_excludes_extensions: Vec<String>,

--- a/crates/mako/src/plugins/copy.rs
+++ b/crates/mako/src/plugins/copy.rs
@@ -80,9 +80,8 @@ impl CopyPlugin {
                     let src = context.root.join(from);
                     let target = dest.join(to.trim_start_matches("/"));
 
-                    let target = target.canonicalize()?;
-                    let dest_canonical = dest.canonicalize()?;
-                    if !target.starts_with(&dest_canonical) {
+                    let dest_path = dest.to_path_buf();
+                    if !target.starts_with(&dest_path) {
                         return Err(anyhow!("Invalid target path: {:?}", target));
                     }
 

--- a/crates/mako/src/plugins/copy.rs
+++ b/crates/mako/src/plugins/copy.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -11,6 +12,7 @@ use tracing::debug;
 
 use crate::ast::file::win_path;
 use crate::compiler::Context;
+use crate::config::CopyConfig;
 use crate::plugin::Plugin;
 use crate::stats::StatsJsonMap;
 use crate::utils::tokio_runtime;
@@ -29,8 +31,12 @@ impl CopyPlugin {
                 notify::Config::default(),
             )
             .unwrap();
-            for src in context.config.copy.iter() {
-                let src = context.root.join(src);
+            for config in context.config.copy.iter() {
+                let src = match config {
+                    CopyConfig::Basic(src) => context.root.join(src),
+                    CopyConfig::Advanced { from, .. } => context.root.join(from),
+                };
+
                 if src.exists() {
                     debug!("watch {:?}", src);
                     let mode = if src.is_dir() {
@@ -62,10 +68,26 @@ impl CopyPlugin {
     fn copy(context: &Arc<Context>) -> Result<()> {
         debug!("copy");
         let dest = context.config.output.path.as_path();
-        for src in context.config.copy.iter() {
-            let src = context.root.join(src);
-            debug!("copy {:?} to {:?}", src, dest);
-            copy(src.as_path(), dest)?;
+        for config in context.config.copy.iter() {
+            match config {
+                CopyConfig::Basic(src) => {
+                    let src = context.root.join(src);
+                    debug!("copy {:?} to {:?}", src, dest);
+                    copy(&src, dest)?;
+                }
+
+                CopyConfig::Advanced { from, to } => {
+                    let src = context.root.join(from);
+                    let target = dest.join(to.trim_start_matches("/"));
+
+                    if !target.exists() {
+                        fs::create_dir_all(&target)?;
+                    }
+
+                    debug!("copy {:?} to {:?}", src, target);
+                    copy(&src, &target)?;
+                }
+            }
         }
         Ok(())
     }

--- a/crates/mako/src/plugins/copy.rs
+++ b/crates/mako/src/plugins/copy.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use fs_extra;
 use glob::glob;
 use notify::event::{CreateKind, DataChange, ModifyKind, RenameMode};
@@ -79,6 +79,12 @@ impl CopyPlugin {
                 CopyConfig::Advanced { from, to } => {
                     let src = context.root.join(from);
                     let target = dest.join(to.trim_start_matches("/"));
+
+                    let target = target.canonicalize()?;
+                    let dest_canonical = dest.canonicalize()?;
+                    if !target.starts_with(&dest_canonical) {
+                        return Err(anyhow!("Invalid target path: {:?}", target));
+                    }
 
                     if !target.exists() {
                         fs::create_dir_all(&target)?;

--- a/docs/config.md
+++ b/docs/config.md
@@ -116,7 +116,7 @@ Specify the code splitting strategy. Use `auto` or `granular` strategy for SPA, 
 
 ### copy
 
-- Type: `string[]`
+- Type: `(string | { from: string; to: string })[]`
 - Default: `["public"]`
 
 Specify the files or directories to be copied. By default, the files under the `public` directory will be copied to the output directory.

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -116,7 +116,7 @@
 
 ### copy
 
-- 类型：`string[]`
+- 类型：`(string | { from: string; to: string })[]`
 - 默认值：`["public"]`
 
 指定需要复制的文件或目录。默认情况下，会将 `public` 目录下的文件复制到输出目录。

--- a/e2e/fixtures/config.copy/expect.js
+++ b/e2e/fixtures/config.copy/expect.js
@@ -2,4 +2,8 @@ const assert = require("assert");
 const { parseBuildResult } = require("../../../scripts/test-utils");
 const { files } = parseBuildResult(__dirname);
 
-assert("foo.js" in files, "assets files not copy");
+// Test original string pattern (copies to root)
+assert("foo.js" in files, "assets files not copied (string pattern)");
+
+// Test new from/to pattern (copies to assets-from-to directory)
+assert("assets-from-to/foo.js" in files, "assets files not copied to correct location (from/to pattern)");

--- a/e2e/fixtures/config.copy/mako.config.json
+++ b/e2e/fixtures/config.copy/mako.config.json
@@ -1,3 +1,9 @@
 {
-  "copy": ["src/assets"]
+  "copy": [
+    "src/assets",
+    {
+      "from": "src/assets",
+      "to": "assets-from-to"
+    }
+  ]
 }

--- a/packages/bundler-mako/index.js
+++ b/packages/bundler-mako/index.js
@@ -249,13 +249,13 @@ function checkConfig(opts) {
       `umi config mako.${key} is not supported`,
     );
   });
-  // 暂不支持 { from, to } 格式
   const { copy } = opts.config;
   if (copy) {
     for (const item of copy) {
       assert(
-        typeof item === 'string',
-        `copy config item must be string in Mako bundler, but got ${item}`,
+        typeof item === 'string' ||
+          (typeof item === 'object' && item.from && item.to),
+        `copy config item must be string or { from: string, to: string } in Mako bundler, but got ${JSON.stringify(item)}`,
       );
     }
   }

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -134,7 +134,7 @@ export interface BuildParams {
           };
         }
     >;
-    copy?: string[];
+    copy?: (string | { from: string; to: string })[];
     codeSplitting?:
       | false
       | {

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -232,6 +232,7 @@ export interface BuildParams {
       | false
       | {
           skipModules?: boolean;
+          concatenateModules?: boolean;
         };
     react?: {
       runtime?: 'automatic' | 'classic';


### PR DESCRIPTION
🎯 Features:
- Added CopyConfig enum supporting both basic and advanced modes
- Maintained backward compatibility with string[] format
- Introduced {from, to} format for custom target paths
- Enhanced copy plugin for both configuration types
- Added automatic target directory creation

📝 Example Configuration:
```
{
  'copy': [
    'public',                       
    {                              
      'from': 'assets',
      'to': 'static'
    }
  ]
}
```

🔍 Details:
- Basic mode preserves existing string[] functionality
- Advanced mode enables precise path control
- Directories are created automatically as needed
- Both modes can be mixed in the same config"
- fix: https://github.com/umijs/mako/issues/1416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 引入了 `CopyConfig` 枚举，支持基本和高级的文件复制配置。
	- 更新了 `CopyPlugin`，支持更灵活的源-目标路径关系，确保高级配置下的路径有效性。
	- 更新了构建参数，允许更复杂的文件复制配置。

- **文档**
	- 更新了配置文档，提供了更清晰的示例和说明，增强了可用性。
	- 增加了中文文档，确保用户更好地理解配置选项。

- **测试**
	- 增加了测试用例，验证文件复制行为的正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->