### PR TITLE
fix: 🐛 typing of stats

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -119,7 +119,9 @@ pub struct BuildParams {
         selectorDoubleList?: string[];
         mediaQuery?: boolean;
     };
-    stats?: boolean;
+    stats?: false | {
+        modules?: boolean;
+    };
     hash?: boolean;
     autoCSSModules?: boolean;
     ignoreCSSParserErrors?: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `BuildParams` 结构体中的 `stats` 字段，允许更复杂的配置选项，用户现在可以选择包含模块统计信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->