### PR TITLE
feat: supports publicPath: auto

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -306,7 +306,9 @@ impl Config {
                 .define
                 .insert("NODE_ENV".to_string(), serde_json::Value::String(mode));
 
-            if config.public_path != "runtime" && !config.public_path.ends_with('/') {
+            if ["runtime", "auto"].iter().all(|p| *p != config.public_path)
+                && !config.public_path.ends_with('/')
+            {
                 return Err(anyhow!("public_path must end with '/' or be 'runtime'"));
             }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -629,7 +629,11 @@ Buffer;
 - Type: `string`
 - Default: `"/"`
 
-publicPath configuration. Note: There is a special value `"runtime"`, which means that it will switch to runtime mode and use the runtime `window.publicPath` as publicPath.
+publicPath configuration. Note: There is two special values
+
+- `"runtime"`, which means that it will switch to runtime mode and use the runtime `window.publicPath` as publicPath.
+
+- `"auto"`, which is just like `publicPath: "auto"` in webpack
 
 If you want to set the `publicPath` in the runtime, use `__mako_public_path__`. (Notice: `__webpack_public_path__` is also supported)
 

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -627,7 +627,9 @@ Buffer;
 - 类型：`string`
 - 默认值：`"/"`
 
-publicPath 配置。注意：有一个特殊值 `"runtime"`，这意味着它将切换到运行时模式并使用运行时的 `window.publicPath` 作为 publicPath。
+publicPath 配置。注意：有两个特殊值
+* `"runtime"`，这意味着它将切换到运行时模式并使用运行时的 `window.publicPath` 作为 publicPath;
+* `"auto"`，类似 webpack 的 `publicPath: "auto"`。
 
 如果你想在运行时设置 `publicPath`，请使用 `__mako_public_path__`。（注：`__webpack_public_path__` 也是支持的）
 

--- a/e2e/fixtures/config.public_path.auto/expect.js
+++ b/e2e/fixtures/config.public_path.auto/expect.js
@@ -1,0 +1,11 @@
+const assert = require("assert");
+const { parseBuildResult } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const content = files["index.js"];
+
+assert.match(
+  content,
+  /scriptUrl = document.currentScript.src.*requireModule.publicPath = scriptUrl/s,
+  "requireModule.publicPath not correct"
+);

--- a/e2e/fixtures/config.public_path.auto/mako.config.json
+++ b/e2e/fixtures/config.public_path.auto/mako.config.json
@@ -1,0 +1,3 @@
+{
+  "publicPath": "auto"
+}

--- a/e2e/fixtures/config.public_path.auto/src/index.tsx
+++ b/e2e/fixtures/config.public_path.auto/src/index.tsx
@@ -1,0 +1,1 @@
+console.log(1);


### PR DESCRIPTION
See: https://webpack.docschina.org/guides/public-path/#Automatic-publicPath-automaticpublicPath

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了`publicPath`配置，新增了特殊值`"runtime"`和`"auto"`。
	- 引入新的配置文件`mako.config.json`，设置`publicPath`为`"auto"`。
- **文档**
	- 更新了Mako配置文档，增强了对`publicPath`、`resolve`和`px2rem`配置的说明。
- **测试**
	- 新增测试脚本`expect.js`，用于验证`requireModule.publicPath`的正确性。
- **样式**
	- 在`src/index.tsx`中添加了控制台日志输出。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->