### PR TITLE
fix: node ignore should support node: prefixed only built-in modules

### DIFF
--- a/crates/mako/src/features/node.rs
+++ b/crates/mako/src/features/node.rs
@@ -21,11 +21,13 @@ impl Node {
             config.targets = HashMap::from([("node".into(), *target)]);
             // ignore all built-in node modules
             config.ignores.push(format!(
-                "^(node:)?({})(/.+|$)",
-                Self::get_all_node_modules().join("|")
+                "^({})(/.+|$)",
+                Self::get_all_builtin_modules_besides_node_prefixed_only().join("|")
             ));
-            // If it starts with "node:", they are all built-in node modules.
-            config.ignores.push("^(node:)(.+)".to_string());
+            config.ignores.push(format!(
+                "^node:({})(/.+|$)",
+                Self::get_all_builtin_modules().join("|")
+            ));
             // polifyll __dirname & __filename is supported with MockFilenameAndDirname Visitor
         } else {
             // polyfill __dirname & __filename for browser
@@ -125,7 +127,17 @@ impl Node {
         .collect()
     }
 
-    fn get_all_node_modules() -> Vec<String> {
+    fn get_node_prefixed_only_builtin_modules() -> Vec<String> {
+        ["sqlite", "test"].iter().map(|s| s.to_string()).collect()
+    }
+
+    fn get_all_builtin_modules() -> Vec<String> {
+        let mut modules = Self::get_all_builtin_modules_besides_node_prefixed_only();
+        modules.extend(Self::get_node_prefixed_only_builtin_modules());
+        modules
+    }
+
+    fn get_all_builtin_modules_besides_node_prefixed_only() -> Vec<String> {
         let mut modules = Self::get_polyfill_modules();
         modules.extend(Self::get_empty_modules());
         modules

--- a/e2e/fixtures/config.platform.node/expect.js
+++ b/e2e/fixtures/config.platform.node/expect.js
@@ -35,3 +35,4 @@ assert.match(
   "should transform __dirname"
 );
 assert(content.includes(`require('crypto');`), `should keep require for crypto`);
+assert(content.includes(`require('node:sqlite');`), `should keep require for node:sqlite`);

--- a/e2e/fixtures/config.platform.node/src/index.ts
+++ b/e2e/fixtures/config.platform.node/src/index.ts
@@ -17,3 +17,5 @@ try {
 } catch {
   hasCrypto = false
 }
+
+require('node:sqlite');


### PR DESCRIPTION
Re-implementation #1716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入对 `node:sqlite` 模块的支持，确保在转换输出中保留相关的 `require` 语句。
- **测试**
	- 添加了新的断言以验证 `require('node:sqlite');` 的存在。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->