### PR TITLE
fix: umd config deserialization

### DIFF
--- a/crates/mako/src/config/umd.rs
+++ b/crates/mako/src/config/umd.rs
@@ -21,6 +21,7 @@ where
             name,
             ..Default::default()
         })),
+        serde_json::Value::Bool(false) => Ok(None),
         _ => Err(serde::de::Error::custom(format!(
             "invalid `{}` value: {}",
             stringify!(deserialize_umd).replace("deserialize_", ""),


### PR DESCRIPTION
Forget to convert `false` config to `None`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 修改了反序列化功能，以处理布尔值 `false` 的情况，返回 `Ok(None)`，指示不创建 `Umd` 实例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->