### PR TITLE
refactor: 🎨 no need to resolve empty url in css

### DIFF
--- a/crates/mako/src/resolve.rs
+++ b/crates/mako/src/resolve.rs
@@ -280,7 +280,7 @@ fn do_resolve(
                 }
                 _ => {
                     eprintln!(
-                        "failed to resolve {} from {} with resolver err: {:?}",
+                        "failed to resolve `{}` from `{}` with resolver err: {:?}",
                         source,
                         path.to_string_lossy(),
                         oxc_resolve_err

--- a/crates/mako/src/visitors/css_assets.rs
+++ b/crates/mako/src/visitors/css_assets.rs
@@ -28,14 +28,12 @@ impl VisitMut for CSSAssets {
             box UrlValue::Raw(s) => s.value.to_string(),
         };
 
-        if is_remote_or_data_or_hash(&url) {
+        if is_remote_or_data_or_hash(&url) || url.is_empty() {
             return;
         }
+
         let url = remove_first_tilde(url);
 
-        if url.is_empty() {
-            return;
-        }
         let dep = Dependency {
             source: url,
             resolve_as: None,
@@ -111,6 +109,14 @@ mod tests {
         assert_eq!(
             run(r#".foo { background: url(should-not-exists.png) }"#),
             ".foo{background:url(should-not-exists.png)}"
+        );
+    }
+
+    #[test]
+    fn test_empty_url() {
+        assert_eq!(
+            run(r#".foo { background: url("") }"#),
+            r#".foo{background:url("")}"#
         );
     }
 

--- a/crates/mako/src/visitors/css_assets.rs
+++ b/crates/mako/src/visitors/css_assets.rs
@@ -32,6 +32,10 @@ impl VisitMut for CSSAssets {
             return;
         }
         let url = remove_first_tilde(url);
+
+        if url.is_empty() {
+            return;
+        }
         let dep = Dependency {
             source: url,
             resolve_as: None,


### PR DESCRIPTION
## problem

```css
background: url('')
```

## solution 
don't resolve the empty url, just ignore it 

### extra 
better warning log



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 改进了错误消息的格式，使其在解析错误时更清晰。
	- 增强了对空 URL 的处理，确保在 URL 为空时提前返回，避免进一步处理。

- **修复**
	- 改善了错误处理逻辑，确保在解析过程中更好地识别问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->