### PR TITLE
fix: legacy octal escape is not permitted in strict mode

### DIFF
--- a/crates/mako/src/ast/js_ast.rs
+++ b/crates/mako/src/ast/js_ast.rs
@@ -76,7 +76,12 @@ impl JsAst {
         // handle ast errors
         let mut ast_errors = parser.take_errors();
         // ignore with syntax error in strict mode
-        ast_errors.retain_mut(|error| !matches!(error.kind(), SyntaxError::WithInStrict));
+        ast_errors.retain(|error| {
+            !matches!(
+                error.kind(),
+                SyntaxError::WithInStrict | SyntaxError::LegacyOctal
+            )
+        });
         if ast.is_err() {
             ast_errors.push(ast.clone().unwrap_err());
         }
@@ -268,6 +273,14 @@ mod tests {
         run(r#"
 @foo()
 class Bar {}
+        "#);
+    }
+
+    #[test]
+    fn test_legacy_octal() {
+        // no panic
+        run(r#"
+console.log("\002F");
         "#);
     }
 

--- a/crates/mako/src/build/parse.rs
+++ b/crates/mako/src/build/parse.rs
@@ -123,11 +123,10 @@ impl Parse {
                             r#"
 import {{ moduleToDom }} from 'virtual:inline_css:runtime';
 {}
-moduleToDom(`
-{}
-`);
+moduleToDom({});
                         "#,
-                            deps, code
+                            deps,
+                            serde_json::to_string(&code)?
                         ),
                         ..Default::default()
                     }));

--- a/e2e/fixtures/config.inline_css/expect.js
+++ b/e2e/fixtures/config.inline_css/expect.js
@@ -18,5 +18,5 @@ assert(
   content.includes(`__mako_require__("src/b.css")`, `should support deps in css`),
 );
 assert(
-  content.includes(`@import "//c";`, `should keep remote imports`),
+  content.includes(`@import \\"\/\/c\\";`, `should keep remote imports`),
 );

--- a/e2e/fixtures/config.inline_css/src/a.css
+++ b/e2e/fixtures/config.inline_css/src/a.css
@@ -4,3 +4,7 @@
 .a {
   color: red;
 }
+
+.a:before {
+  content: "\002F";
+}


### PR DESCRIPTION
Close https://github.com/umijs/mako/issues/1735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增强了错误处理逻辑，改进了AST解析过程中的错误过滤。
  - 新增测试用例以验证对旧八进制转义序列的处理。
  - 改进了内联CSS处理逻辑，确保CSS内容以JSON字符串格式嵌入JavaScript输出。
  - 新增CSS规则`.a:before`，为元素添加伪元素内容。

- **Bug修复**
  - 确保在缺少依赖的情况下，返回适当的解析错误。
  - 更新了测试中的字符串检查方式，以确保正确匹配导入语句。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->