### PR TITLE
[WIP] test: add e2e css.css-order-after-optimization

### DIFF
--- a/e2e/fixtures/css.css-order-after-optimization/expect.js
+++ b/e2e/fixtures/css.css-order-after-optimization/expect.js
@@ -1,0 +1,17 @@
+const assert = require("assert");
+const { parseBuildResult  } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const content = files["index.css"];
+
+assert(
+  content.includes(`
+body {
+  color: red;
+}
+body {
+  color: blue;
+}
+  `.trim()),
+  "css should be right after optimization"
+);

--- a/e2e/fixtures/css.css-order-after-optimization/mako.config.json
+++ b/e2e/fixtures/css.css-order-after-optimization/mako.config.json
@@ -1,0 +1,6 @@
+{
+  "minify": false,
+  "optimization": {
+    "concatenateModules": true
+  }
+}

--- a/e2e/fixtures/css.css-order-after-optimization/src/blue.css
+++ b/e2e/fixtures/css.css-order-after-optimization/src/blue.css
@@ -1,0 +1,3 @@
+body {
+  color: blue;
+}

--- a/e2e/fixtures/css.css-order-after-optimization/src/blue.js
+++ b/e2e/fixtures/css.css-order-after-optimization/src/blue.js
@@ -1,0 +1,5 @@
+import './blue.css';
+
+const blue = "blue";
+
+export { blue  }

--- a/e2e/fixtures/css.css-order-after-optimization/src/index.ts
+++ b/e2e/fixtures/css.css-order-after-optimization/src/index.ts
@@ -1,0 +1,2 @@
+import "./red";
+import "./blue";

--- a/e2e/fixtures/css.css-order-after-optimization/src/red.css
+++ b/e2e/fixtures/css.css-order-after-optimization/src/red.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/fixtures/css.css-order-after-optimization/src/red.js
+++ b/e2e/fixtures/css.css-order-after-optimization/src/red.js
@@ -1,0 +1,6 @@
+import "./red.css";
+import { blue } from "./blue";
+
+const red = "red";
+console.log(blue + red);
+


### PR DESCRIPTION
As title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了一个新的 CSS 优化测试场景
	- 引入了红色和蓝色文本颜色的 CSS 规则

- **测试**
	- 新增测试脚本验证 CSS 文件优化后的顺序和内容

- **配置**
	- 添加了构建配置文件，禁用压缩并启用模块合并

这些更改主要关注于 CSS 样式和构建过程的优化测试，确保模块和样式能够正确加载和应用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->