### PR TITLE
feat: support unplugin context (again)

### DIFF
--- a/crates/binding/src/js_hook.rs
+++ b/crates/binding/src/js_hook.rs
@@ -3,6 +3,7 @@ use napi::NapiRaw;
 use napi_derive::napi;
 use serde_json::Value;
 
+use crate::js_plugin::PluginContext;
 use crate::threadsafe_function::ThreadsafeFunction;
 
 #[napi(object)]
@@ -81,19 +82,21 @@ pub struct JsHooks {
     pub transform_include: Option<JsFunction>,
 }
 
+type ResolveIdFuncParams = (PluginContext, String, String, ResolveIdParams);
+
 pub struct TsFnHooks {
-    pub build_start: Option<ThreadsafeFunction<(), ()>>,
-    pub build_end: Option<ThreadsafeFunction<(), ()>>,
-    pub write_bundle: Option<ThreadsafeFunction<(), ()>>,
-    pub generate_end: Option<ThreadsafeFunction<Value, ()>>,
-    pub load: Option<ThreadsafeFunction<String, Option<LoadResult>>>,
-    pub load_include: Option<ThreadsafeFunction<String, Option<bool>>>,
-    pub watch_changes: Option<ThreadsafeFunction<(String, WatchChangesParams), ()>>,
-    pub resolve_id:
-        Option<ThreadsafeFunction<(String, String, ResolveIdParams), Option<ResolveIdResult>>>,
-    pub _on_generate_file: Option<ThreadsafeFunction<WriteFile, ()>>,
-    pub transform: Option<ThreadsafeFunction<(String, String), Option<TransformResult>>>,
-    pub transform_include: Option<ThreadsafeFunction<String, Option<bool>>>,
+    pub build_start: Option<ThreadsafeFunction<PluginContext, ()>>,
+    pub build_end: Option<ThreadsafeFunction<PluginContext, ()>>,
+    pub write_bundle: Option<ThreadsafeFunction<PluginContext, ()>>,
+    pub generate_end: Option<ThreadsafeFunction<(PluginContext, Value), ()>>,
+    pub load: Option<ThreadsafeFunction<(PluginContext, String), Option<LoadResult>>>,
+    pub load_include: Option<ThreadsafeFunction<(PluginContext, String), Option<bool>>>,
+    pub watch_changes: Option<ThreadsafeFunction<(PluginContext, String, WatchChangesParams), ()>>,
+    pub resolve_id: Option<ThreadsafeFunction<ResolveIdFuncParams, Option<ResolveIdResult>>>,
+    pub _on_generate_file: Option<ThreadsafeFunction<(PluginContext, WriteFile), ()>>,
+    pub transform:
+        Option<ThreadsafeFunction<(PluginContext, String, String), Option<TransformResult>>>,
+    pub transform_include: Option<ThreadsafeFunction<(PluginContext, String), Option<bool>>>,
 }
 
 impl TsFnHooks {

--- a/crates/binding/src/js_plugin.rs
+++ b/crates/binding/src/js_plugin.rs
@@ -6,6 +6,7 @@ use mako::ast::file::{Content, JsContent};
 use mako::compiler::Context;
 use mako::plugin::{Plugin, PluginGenerateEndParams, PluginLoadParam, PluginResolveIdParams};
 use mako::resolve::{ExternalResource, Resolution, ResolvedResource, ResolverResource};
+use napi_derive::napi;
 
 use crate::js_hook::{
     LoadResult, ResolveIdParams, ResolveIdResult, TransformResult, TsFnHooks, WatchChangesParams,
@@ -27,6 +28,29 @@ fn content_from_result(result: TransformResult) -> Result<Content> {
     }
 }
 
+#[napi]
+pub struct PluginContext {
+    context: Arc<Context>,
+}
+
+#[napi]
+impl PluginContext {
+    #[napi]
+    pub fn warn(&self, msg: String) {
+        println!("WARN: {}", msg)
+    }
+    #[napi]
+    pub fn error(&self, msg: String) {
+        println!("ERROR: {}", msg)
+    }
+    #[napi]
+    pub fn emit_file(&self, origin_path: String, output_path: String) {
+        let mut assets_info = self.context.assets_info.lock().unwrap();
+        assets_info.insert(origin_path, output_path);
+        drop(assets_info);
+    }
+}
+
 pub struct JsPlugin {
     pub hooks: TsFnHooks,
     pub name: Option<String>,
@@ -42,27 +66,33 @@ impl Plugin for JsPlugin {
         self.enforce.as_deref()
     }
 
-    fn build_start(&self, _context: &Arc<Context>) -> Result<()> {
+    fn build_start(&self, context: &Arc<Context>) -> Result<()> {
         if let Some(hook) = &self.hooks.build_start {
-            hook.call(())?
+            hook.call(PluginContext {
+                context: context.clone(),
+            })?
         }
         Ok(())
     }
 
-    fn load(&self, param: &PluginLoadParam, _context: &Arc<Context>) -> Result<Option<Content>> {
+    fn load(&self, param: &PluginLoadParam, context: &Arc<Context>) -> Result<Option<Content>> {
         if let Some(hook) = &self.hooks.load {
             if self.hooks.load_include.is_some()
-                && self
-                    .hooks
-                    .load_include
-                    .as_ref()
-                    .unwrap()
-                    .call(param.file.path.to_string_lossy().to_string())?
-                    == Some(false)
+                && self.hooks.load_include.as_ref().unwrap().call((
+                    PluginContext {
+                        context: context.clone(),
+                    },
+                    param.file.path.to_string_lossy().to_string(),
+                ))? == Some(false)
             {
                 return Ok(None);
             }
-            let x: Option<LoadResult> = hook.call(param.file.path.to_string_lossy().to_string())?;
+            let x: Option<LoadResult> = hook.call((
+                PluginContext {
+                    context: context.clone(),
+                },
+                param.file.path.to_string_lossy().to_string(),
+            ))?;
             if let Some(x) = x {
                 return content_from_result(TransformResult {
                     content: x.content,
@@ -79,10 +109,13 @@ impl Plugin for JsPlugin {
         source: &str,
         importer: &str,
         params: &PluginResolveIdParams,
-        _context: &Arc<Context>,
+        context: &Arc<Context>,
     ) -> Result<Option<ResolverResource>> {
         if let Some(hook) = &self.hooks.resolve_id {
             let x: Option<ResolveIdResult> = hook.call((
+                PluginContext {
+                    context: context.clone(),
+                },
                 source.to_string(),
                 importer.to_string(),
                 ResolveIdParams {
@@ -110,21 +143,31 @@ impl Plugin for JsPlugin {
         Ok(None)
     }
 
-    fn generate_end(&self, param: &PluginGenerateEndParams, _context: &Arc<Context>) -> Result<()> {
+    fn generate_end(&self, param: &PluginGenerateEndParams, context: &Arc<Context>) -> Result<()> {
         // keep generate_end for compatibility
         // since build_end does not have none error params in unplugin's api spec
         if let Some(hook) = &self.hooks.generate_end {
-            hook.call(serde_json::to_value(param)?)?
+            hook.call((
+                PluginContext {
+                    context: context.clone(),
+                },
+                serde_json::to_value(param)?,
+            ))?
         }
         if let Some(hook) = &self.hooks.build_end {
-            hook.call(())?
+            hook.call(PluginContext {
+                context: context.clone(),
+            })?
         }
         Ok(())
     }
 
-    fn watch_changes(&self, id: &str, event: &str, _context: &Arc<Context>) -> Result<()> {
+    fn watch_changes(&self, id: &str, event: &str, context: &Arc<Context>) -> Result<()> {
         if let Some(hook) = &self.hooks.watch_changes {
             hook.call((
+                PluginContext {
+                    context: context.clone(),
+                },
                 id.to_string(),
                 WatchChangesParams {
                     event: event.to_string(),
@@ -134,19 +177,31 @@ impl Plugin for JsPlugin {
         Ok(())
     }
 
-    fn write_bundle(&self, _context: &Arc<Context>) -> Result<()> {
+    fn write_bundle(&self, context: &Arc<Context>) -> Result<()> {
         if let Some(hook) = &self.hooks.write_bundle {
-            hook.call(())?
+            hook.call(PluginContext {
+                context: context.clone(),
+            })?
         }
         Ok(())
     }
 
-    fn before_write_fs(&self, path: &std::path::Path, content: &[u8]) -> Result<()> {
+    fn before_write_fs(
+        &self,
+        path: &std::path::Path,
+        content: &[u8],
+        context: &Arc<Context>,
+    ) -> Result<()> {
         if let Some(hook) = &self.hooks._on_generate_file {
-            hook.call(WriteFile {
-                path: path.to_string_lossy().to_string(),
-                content: content.to_vec(),
-            })?;
+            hook.call((
+                PluginContext {
+                    context: context.clone(),
+                },
+                WriteFile {
+                    path: path.to_string_lossy().to_string(),
+                    content: content.to_vec(),
+                },
+            ))?;
         }
         Ok(())
     }
@@ -155,10 +210,16 @@ impl Plugin for JsPlugin {
         &self,
         content: &mut Content,
         path: &str,
-        _context: &Arc<Context>,
+        context: &Arc<Context>,
     ) -> Result<Option<Content>> {
         if let Some(hook) = &self.hooks.transform_include {
-            if hook.call(path.to_string())? == Some(false) {
+            if hook.call((
+                PluginContext {
+                    context: context.clone(),
+                },
+                path.to_string(),
+            ))? == Some(false)
+            {
                 return Ok(None);
             }
         }
@@ -170,7 +231,13 @@ impl Plugin for JsPlugin {
                 _ => return Ok(None),
             };
 
-            let result: Option<TransformResult> = hook.call((content_str, path.to_string()))?;
+            let result: Option<TransformResult> = hook.call((
+                PluginContext {
+                    context: context.clone(),
+                },
+                content_str,
+                path.to_string(),
+            ))?;
 
             if let Some(result) = result {
                 return content_from_result(result).map(Some);

--- a/crates/mako/src/plugin.rs
+++ b/crates/mako/src/plugin.rs
@@ -184,7 +184,12 @@ pub trait Plugin: Any + Send + Sync {
         Ok(())
     }
 
-    fn before_write_fs(&self, _path: &Path, _content: &[u8]) -> Result<()> {
+    fn before_write_fs(
+        &self,
+        _path: &Path,
+        _content: &[u8],
+        _context: &Arc<Context>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -422,9 +427,10 @@ impl PluginDriver {
         &self,
         path: P,
         content: C,
+        context: &Arc<Context>,
     ) -> Result<()> {
         for p in &self.plugins {
-            p.before_write_fs(path.as_ref(), content.as_ref())?;
+            p.before_write_fs(path.as_ref(), content.as_ref(), context)?;
         }
 
         Ok(())

--- a/crates/mako/src/plugins/bundless_compiler.rs
+++ b/crates/mako/src/plugins/bundless_compiler.rs
@@ -130,7 +130,7 @@ impl BundlessCompiler {
 
         self.context
             .plugin_driver
-            .before_write_fs(&to, content.as_ref())
+            .before_write_fs(&to, content.as_ref(), &self.context)
             .unwrap();
 
         if !self.context.config.output.skip_write {

--- a/docs/config.md
+++ b/docs/config.md
@@ -574,7 +574,6 @@ Notice: When using `"node"`, you also need to set `dynamicImportToRequire` to `t
 Specify the plugins to use.
 
 ```ts
-// JSHooks
 {
   name?: string;
   enforce?: "pre" | "post";
@@ -599,12 +598,15 @@ Specify the plugins to use.
 }
 ```
 
-JSHooks is a set of hook functions used to extend the compilation process of Mako.
+And you can also use this methods in hook functions.
 
-- `name`, plugin name
-- `buildStart`, called before Build starts
-- `load`, used to load files, return file content and type, type supports `css`, `js`, `jsx`, `ts`, `tsx`
-- `generateEnd`, called after Generate completes, `isFirstCompile` can be used to determine if it is the first compilation, `time` is the compilation time, and `stats` is the compilation statistics information
+- `this.emitFile({ type: 'asset', fileName: string, source: string | Uint8Array })`, emit a file
+- `this.warn(message: string)`, emit a warning
+- `this.error(message: string)`, emit a error
+- `this.parse(code: string)`, parse the code (CURRENTLY NOT SUPPORTED)
+- `this.addWatchFile(filePath: string)`, add a watch file (CURRENTLY NOT SUPPORTED)
+
+Plugins is compatible with [unplugin](https://unplugin.unjs.io/), so you can use plugins from unplugin like [unplugin-icons](https://github.com/unplugin/unplugin-icons), [unplugin-replace](https://github.com/unplugin/unplugin-replace) and so on.
 
 ### progress
 

--- a/docs/config.zh-CN.md
+++ b/docs/config.zh-CN.md
@@ -572,7 +572,6 @@ import(/* webpackIgnore: true */ "./foo");
 指定使用的插件。
 
 ```ts
-// JSHooks
 {
   name?: string;
   enforce?: "pre" | "post";
@@ -597,12 +596,15 @@ import(/* webpackIgnore: true */ "./foo");
 }
 ```
 
-JSHooks 是一组用来扩展 Mako 编译过程的钩子函数。
+你还可以在 hook 函数里用以下方法。
 
-- `name`，插件名称
-- `buildStart`，构建开始前调用
-- `load`，用于加载文件，返回文件内容和类型，类型支持 `css`、`js`、`jsx`、`ts`、`tsx`
-- `generateEnd`，生成完成后调用，`isFirstCompile` 可用于判断是否为首次编译，`time` 为编译时间，`stats` 是编译统计信息
+- `this.emitFile({ type: 'asset', fileName: string, source: string | Uint8Array })`, 添加文件到输出目录
+- `this.warn(message: string)`, 添加一个警告
+- `this.error(message: string)`, 添加一个错误
+- `this.parse(code: string)`, 解析代码 (CURRENTLY NOT SUPPORTED)
+- `this.addWatchFile(filePath: string)`, 添加一个监听文件 (CURRENTLY NOT SUPPORTED)
+
+Plugins 兼容 [unplugin](https://unplugin.unjs.io/)，所以你可以使用 unplugin 的插件，比如 [unplugin-icons](https://github.com/unplugin/unplugin-icons), [unplugin-replace](https://github.com/unplugin/unplugin-replace) 等。
 
 ### progress
 

--- a/e2e/fixtures/plugins.context/expect.js
+++ b/e2e/fixtures/plugins.context/expect.js
@@ -1,0 +1,7 @@
+const assert = require("assert");
+
+const { parseBuildResult, trim, moduleReg } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+const content = files["index.js"];
+assert.strictEqual(files['test.txt'], 'test');

--- a/e2e/fixtures/plugins.context/mako.config.json
+++ b/e2e/fixtures/plugins.context/mako.config.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "./plugin"
+  ],
+  "minify": false
+}

--- a/e2e/fixtures/plugins.context/plugin.js
+++ b/e2e/fixtures/plugins.context/plugin.js
@@ -1,0 +1,6 @@
+
+module.exports = {
+  async load(path) {
+    path.endsWith('.hoo');
+  }
+};

--- a/e2e/fixtures/plugins.context/plugins.config.js
+++ b/e2e/fixtures/plugins.context/plugins.config.js
@@ -1,0 +1,27 @@
+module.exports = [
+  {
+    async loadInclude(path) {
+      // this.warn('loadInclude: ' + path);
+      path.endsWith('.hoo');
+      return true;
+    },
+    async load(path) {
+      if (path.endsWith('.hoo')) {
+        this.warn('load: ' + path);
+        this.warn({
+          message: 'test warn with object',
+        });
+        this.error('error: ' + path);
+        this.emitFile({
+          type: 'asset',
+          fileName: 'test.txt',
+          source: 'test',
+        });
+        return {
+          content: `export default () => <Foooo>.hoo</Foooo>;`,
+          type: 'jsx',
+        };
+      }
+    }
+  },
+];

--- a/e2e/fixtures/plugins.context/src/foo.hoo
+++ b/e2e/fixtures/plugins.context/src/foo.hoo
@@ -1,0 +1,1 @@
+// should be handled with load hook

--- a/e2e/fixtures/plugins.context/src/index.tsx
+++ b/e2e/fixtures/plugins.context/src/index.tsx
@@ -1,0 +1,1 @@
+console.log(require('./foo.hoo'));

--- a/e2e/fixtures/plugins.unplugin/expect.js
+++ b/e2e/fixtures/plugins.unplugin/expect.js
@@ -1,0 +1,8 @@
+const assert = require("assert");
+
+const { parseBuildResult } = require('../../../scripts/test-utils');
+const { files } = parseBuildResult(__dirname);
+
+const content = files['index.js'];
+assert(content.includes('fooooooo'), `should replace FOOOO with "fooooooo" with unplugin-replace`);
+assert(content.includes('fill: "currentColor",'), `should include fill: "currentColor" with unplugin-icons`);

--- a/e2e/fixtures/plugins.unplugin/mako.config.json
+++ b/e2e/fixtures/plugins.unplugin/mako.config.json
@@ -1,0 +1,7 @@
+{
+  "externals": {
+    "react": "React",
+    "react/jsx-dev-runtime": "React.jsx"
+  },
+  "minify": false
+}

--- a/e2e/fixtures/plugins.unplugin/plugins.config.js
+++ b/e2e/fixtures/plugins.unplugin/plugins.config.js
@@ -1,0 +1,18 @@
+const replace = require('unplugin-replace');
+const icons = require('unplugin-icons');
+
+module.exports = [
+  replace.raw({
+    values: [
+      {
+        find: 'FOOOO',
+        replacement: '"fooooooo"',
+      },
+    ],
+  }),
+  icons.default.raw({
+    compiler: 'jsx',
+    jsx: 'react',
+    autoInstall: false,
+  }),
+];

--- a/e2e/fixtures/plugins.unplugin/src/index.tsx
+++ b/e2e/fixtures/plugins.unplugin/src/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import IconAccountBox from '~icons/mdi/account-box';
+
+console.log(FOOOO);
+export default () => <IconAccountBox />;

--- a/e2e/fixtures/plugins/node_modules/plugin/index.js
+++ b/e2e/fixtures/plugins/node_modules/plugin/index.js
@@ -1,8 +1,6 @@
-console.log('================ load', 1);
 
 module.exports = {
   async load(path) {
-    console.log('================ load', path);
     if (path.endsWith('.haha')) {
       return {
         content: `export default () => <Foooo>.haha</Foooo>;`,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@biomejs/biome": "^1.4.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@iconify-json/mdi": "^1.2.2",
     "@jest/expect": "^29.7.0",
     "@swc/helpers": "0.5.1",
     "@taplo/cli": "^0.7.0",
@@ -55,6 +56,8 @@
     "semver": "^7.5.4",
     "typescript": "^5.4.3",
     "umi": "^4.3.1",
+    "unplugin-icons": "^0.22.0",
+    "unplugin-replace": "^0.3.3",
     "wait-port": "^1.1.0",
     "webpack": "^5.0.0",
     "zx": "^7.2.3"

--- a/packages/mako/binding.d.ts
+++ b/packages/mako/binding.d.ts
@@ -272,3 +272,8 @@ export interface BuildParams {
   watch: boolean;
 }
 export declare function build(buildParams: BuildParams): Promise<void>;
+export class PluginContext {
+  warn(msg: string): void;
+  error(msg: string): void;
+  emitFile(originPath: string, outputPath: string): void;
+}

--- a/packages/mako/binding.js
+++ b/packages/mako/binding.js
@@ -304,6 +304,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`);
 }
 
-const { build } = nativeBinding;
+const { PluginContext, build } = nativeBinding;
 
+module.exports.PluginContext = PluginContext;
 module.exports.build = build;

--- a/packages/mako/src/index.ts
+++ b/packages/mako/src/index.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { omit } from 'lodash';
 import resolve from 'resolve';
@@ -141,6 +142,7 @@ export async function build(params: BuildParams) {
       },
     });
   }
+
   // support dump mako config
   if (process.env.DUMP_MAKO_CONFIG) {
     const configFile = path.join(params.root, 'mako.config.json');
@@ -191,6 +193,125 @@ export async function build(params: BuildParams) {
       );
     }
   });
+
+  // add context to each plugin's hook
+  plugins.forEach((plugin: any) => {
+    // plugin may be patched already
+    // ref: https://github.com/umijs/mako/pull/1737
+    if (plugin.__isPatched) {
+      return;
+    }
+    plugin.__isPatched = true;
+    Object.keys(plugin).forEach((key) => {
+      const oldValue = plugin[key];
+      if (typeof oldValue === 'function') {
+        plugin[key] = (context: any, ...args: any[]) => {
+          let result = oldValue.apply(
+            {
+              // https://rollupjs.org/plugin-development/#this-parse
+              parse(_code: string) {
+                throw new Error('parse is not supported');
+              },
+              // https://rollupjs.org/plugin-development/#this-addwatchfile
+              addWatchFile(_file: string) {
+                throw new Error('addWatchFile is not supported');
+              },
+              // https://rollupjs.org/plugin-development/#this-emitfile
+              // only support asset type
+              emitFile(file: {
+                type: 'asset' | 'chunk' | 'prebuilt-chunk';
+                name?: string;
+                fileName?: string;
+                source?: string | Uint8Array;
+              }) {
+                if (file.type !== 'asset') {
+                  throw new Error('emitFile only support asset type');
+                }
+                if (file.name && !file.fileName) {
+                  throw new Error(
+                    'name in emitFile is not supported yet, please supply fileName instead',
+                  );
+                }
+                // Since assets_info in mako is a <origin_path, output_path> map,
+                // we need to generate a tmp file to store the content, and then emit it
+                // TODO: we should use a better way to handle this
+                const tmpFile = path.join(
+                  os.tmpdir(),
+                  Math.random().toString(36).substring(2, 15),
+                );
+                fs.writeFileSync(tmpFile, file.source!);
+                context.emitFile(tmpFile, file.fileName!);
+              },
+              warn(
+                message:
+                  | string
+                  | { message: string; pluginCode?: string; meta?: string },
+              ) {
+                if (typeof message === 'object') {
+                  const msg = [
+                    message.message,
+                    message.pluginCode
+                      ? `pluginCode: ${message.pluginCode}`
+                      : '',
+                    message.meta ? `meta: ${message.meta}` : '',
+                  ]
+                    .filter(Boolean)
+                    .join('\n');
+                  context.warn(msg);
+                } else {
+                  context.warn(message);
+                }
+              },
+              error(
+                message:
+                  | string
+                  | { message: string; pluginCode?: string; meta?: string },
+              ) {
+                if (typeof message === 'object') {
+                  const msg = [
+                    message.message,
+                    message.pluginCode
+                      ? `pluginCode: ${message.pluginCode}`
+                      : '',
+                    message.meta ? `meta: ${message.meta}` : '',
+                  ]
+                    .filter(Boolean)
+                    .join('\n');
+                  context.error(msg);
+                } else {
+                  context.error(message);
+                }
+              },
+            },
+            [...args],
+          );
+          // adapter mako hooks for unplugin
+          if (key === 'load' || key === 'transform') {
+            // if result is null, return the original code
+            if (result === null) {
+              result = args[0];
+            }
+            const isPromise = typeof result === 'object' && result.then;
+            if (isPromise) {
+              result = result.then((result: any) => adapterResult(result));
+            } else {
+              result = adapterResult(result);
+            }
+          }
+          if (key === 'resolveId') {
+            if (typeof result === 'string') {
+              result = {
+                id: result,
+                external: false,
+              };
+            }
+          }
+          return result;
+        };
+      }
+    });
+  });
+
   params.config = omit(params.config, [
     'less',
     'sass',
@@ -209,4 +330,19 @@ export async function build(params: BuildParams) {
     });
     forkTypeChecker.runTypeCheckInChildProcess();
   }
+}
+
+function adapterResult(result: any) {
+  if (typeof result === 'string') {
+    return {
+      content: result,
+      type: 'tsx',
+    };
+  } else if (typeof result === 'object' && result.code) {
+    return {
+      content: result.code,
+      type: 'tsx',
+    };
+  }
+  return result;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.0
         version: 11.11.5(@emotion/react@11.11.4)(react@18.2.0)
+      '@iconify-json/mdi':
+        specifier: ^1.2.2
+        version: 1.2.2
       '@jest/expect':
         specifier: ^29.7.0
         version: 29.7.0
@@ -110,6 +113,12 @@ importers:
       umi:
         specifier: ^4.3.1
         version: 4.3.1(@babel/core@7.23.6)(@types/node@20.14.2)(eslint@8.41.0)(prettier@2.8.8)(react-dom@18.2.0)(react@18.2.0)(sass@1.77.8)(stylelint@14.16.1)(typescript@5.4.5)(webpack@5.91.0)
+      unplugin-icons:
+        specifier: ^0.22.0
+        version: 0.22.0(@svgr/core@6.5.1)
+      unplugin-replace:
+        specifier: ^0.3.3
+        version: 0.3.3
       wait-port:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1336,6 +1345,24 @@ packages:
     dependencies:
       execa: 5.1.1
       find-up: 5.0.0
+    dev: true
+
+  /@antfu/install-pkg@0.4.1:
+    resolution: {integrity: sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==}
+    dependencies:
+      package-manager-detector: 0.2.8
+      tinyexec: 0.3.1
+    dev: true
+
+  /@antfu/install-pkg@0.5.0:
+    resolution: {integrity: sha512-dKnk2xlAyC7rvTkpkHmu+Qy/2Zc3Vm/l8PtNyIOGDBtXPY3kThfU4ORNEp3V7SXw5XSOb+tOJaUYpfquPzL/Tg==}
+    dependencies:
+      package-manager-detector: 0.2.8
+      tinyexec: 0.3.1
+    dev: true
+
+  /@antfu/utils@0.7.10:
+    resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
     dev: true
 
   /@antfu/utils@0.7.3:
@@ -4546,7 +4573,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.4.0
       espree: 9.5.2
       globals: 13.20.0
       ignore: 5.2.4
@@ -4637,7 +4664,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4653,6 +4680,12 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
+  /@iconify-json/mdi@1.2.2:
+    resolution: {integrity: sha512-84aznJXzfGdbOXGe8xB7E5uNAb7Yo5IABwTgq2X3kczb819qZeS9eL31bTVn7wJdCLK5ieaoUc2GTS3QYIkJ6g==}
+    dependencies:
+      '@iconify/types': 2.0.0
+    dev: true
+
   /@iconify/types@2.0.0:
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
     dev: true
@@ -4666,6 +4699,21 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@iconify/utils@2.2.1:
+    resolution: {integrity: sha512-0/7J7hk4PqXmxo5PDBDxmnecw5PxklZJfNjIVG9FM0mEfVrvfudS22rYWsqVk6gR3UJ/mSYS90X4R3znXnqfNA==}
+    dependencies:
+      '@antfu/install-pkg': 0.4.1
+      '@antfu/utils': 0.7.10
+      '@iconify/types': 2.0.0
+      debug: 4.4.0
+      globals: 15.14.0
+      kolorist: 1.8.0
+      local-pkg: 0.5.1
+      mlly: 1.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4842,6 +4890,10 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
+  /@jridgewell/sourcemap-codec@1.5.0:
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+    dev: true
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -5292,6 +5344,20 @@ packages:
     resolution: {integrity: sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==}
     engines: {node: '>=14'}
 
+  /@rollup/pluginutils@5.1.4:
+    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    dev: true
+
   /@rushstack/node-core-library@3.63.0(@types/node@20.14.2):
     resolution: {integrity: sha512-Q7B3dVpBQF1v+mUfxNcNZh5uHVR8ntcnkN5GYjbBLrxUYHBGKbnCM+OdcN+hzCpFlLBH6Ob0dEHhZ0spQwf24A==}
     peerDependencies:
@@ -5343,7 +5409,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.6
       postcss: 8.4.39
-      postcss-syntax: 0.36.2(postcss@8.4.39)
+      postcss-syntax: 0.36.2(postcss@8.4.49)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6490,7 +6556,7 @@ packages:
       eslint-plugin-react: 7.33.2(eslint@8.41.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.41.0)
       postcss: 8.4.39
-      postcss-syntax: 0.36.2(postcss@8.4.39)
+      postcss-syntax: 0.36.2(postcss@8.4.49)
       stylelint-config-standard: 25.0.0(stylelint@14.16.1)
     transitivePeerDependencies:
       - eslint
@@ -7213,12 +7279,12 @@ packages:
       acorn: 8.8.2
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.11.2):
+  /acorn-jsx@5.3.2(acorn@8.14.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.14.0
     dev: true
 
   /acorn-walk@8.2.0:
@@ -7234,6 +7300,12 @@ packages:
 
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -8586,6 +8658,10 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  /confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    dev: true
+
   /connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
@@ -8967,6 +9043,18 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 5.5.0
+
+  /debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -9883,7 +9971,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -9927,8 +10015,8 @@ packages:
     resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.11.2
-      acorn-jsx: 5.3.2(acorn@8.11.2)
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 3.4.1
     dev: true
 
@@ -9960,6 +10048,10 @@ packages:
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+    dev: true
+
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
 
   /esutils@2.0.3:
@@ -10735,6 +10827,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: true
+
+  /globals@15.14.0:
+    resolution: {integrity: sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==}
+    engines: {node: '>=18'}
     dev: true
 
   /globalthis@1.0.3:
@@ -12216,6 +12313,14 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.7.3
+      pkg-types: 1.2.1
+    dev: true
+
   /locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -12324,6 +12429,12 @@ packages:
   /lru-cache@9.1.2:
     resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
     engines: {node: 14 || >=16.14}
+
+  /magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+    dev: true
 
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -12563,6 +12674,15 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  /mlly@1.7.3:
+    resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
+    dependencies:
+      acorn: 8.14.0
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      ufo: 1.5.4
+    dev: true
 
   /moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
@@ -13061,6 +13181,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /package-manager-detector@0.2.8:
+    resolution: {integrity: sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==}
+    dev: true
+
   /pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -13177,6 +13301,10 @@ packages:
     dev: false
     optional: true
 
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
   /pause-stream@0.0.11:
     resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
     dependencies:
@@ -13211,9 +13339,18 @@ packages:
   /picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
+  /picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    dev: true
+
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  /picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+    dev: true
 
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -13259,6 +13396,14 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
+    dev: true
+
+  /pkg-types@1.2.1:
+    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.3
+      pathe: 1.1.2
     dev: true
 
   /pkg-up@3.1.0:
@@ -14007,13 +14152,13 @@ packages:
     resolution: {integrity: sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==}
     dev: true
 
-  /postcss-safe-parser@6.0.0(postcss@8.4.39):
+  /postcss-safe-parser@6.0.0(postcss@8.4.49):
     resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
     dev: true
 
   /postcss-selector-not@5.0.0(postcss@8.4.24):
@@ -14042,7 +14187,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /postcss-syntax@0.36.2(postcss@8.4.39):
+  /postcss-syntax@0.36.2(postcss@8.4.49):
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
@@ -14063,7 +14208,7 @@ packages:
       postcss-scss:
         optional: true
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
     dev: true
 
   /postcss-value-parser@4.2.0:
@@ -14085,6 +14230,15 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
+    dev: true
+
+  /postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
     dev: true
 
   /preact@10.22.0:
@@ -16880,6 +17034,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
     dependencies:
@@ -17263,7 +17422,7 @@ packages:
       colord: 2.9.3
       cosmiconfig: 7.1.0
       css-functions-list: 3.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.4.0
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 6.0.1
@@ -17280,11 +17439,11 @@ packages:
       meow: 9.0.0
       micromatch: 4.0.5
       normalize-path: 3.0.0
-      picocolors: 1.0.1
-      postcss: 8.4.39
+      picocolors: 1.1.1
+      postcss: 8.4.49
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.1
-      postcss-safe-parser: 6.0.0(postcss@8.4.39)
+      postcss-safe-parser: 6.0.0(postcss@8.4.49)
       postcss-selector-parser: 6.0.13
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
@@ -17538,6 +17697,10 @@ packages:
   /tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
+  /tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+    dev: true
+
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -17779,6 +17942,10 @@ packages:
     hasBin: true
     dev: true
 
+  /ufo@1.5.4:
+    resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
+    dev: true
+
   /umi@4.3.1(@babel/core@7.23.6)(@types/node@20.14.2)(eslint@8.41.0)(prettier@2.8.8)(react-dom@18.2.0)(react@18.2.0)(sass@1.77.8)(stylelint@14.16.1)(typescript@5.4.5)(webpack@5.91.0):
     resolution: {integrity: sha512-eMLoRVLlWmATqdrsXjF2xS5OjeIbLsLSRYSq+NY82W39LzAcJIKQyiWT2sFxgED+4W0/XPSd8CGc5pkczlHplQ==}
     engines: {node: '>=14'}
@@ -17890,6 +18057,68 @@ packages:
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  /unplugin-icons@0.22.0(@svgr/core@6.5.1):
+    resolution: {integrity: sha512-CP+iZq5U7doOifer5bcM0jQ9t3Is7EGybIYt3myVxceI8Zuk8EZEpe1NPtJvh7iqMs1VdbK0L41t9+um9VuuLw==}
+    peerDependencies:
+      '@svgr/core': '>=7.0.0'
+      '@svgx/core': ^1.0.1
+      '@vue/compiler-sfc': ^3.0.2 || ^2.7.0
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+      vue-template-compiler: ^2.6.12
+      vue-template-es2015-compiler: ^1.9.0
+    peerDependenciesMeta:
+      '@svgr/core':
+        optional: true
+      '@svgx/core':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      svelte:
+        optional: true
+      vue-template-compiler:
+        optional: true
+      vue-template-es2015-compiler:
+        optional: true
+    dependencies:
+      '@antfu/install-pkg': 0.5.0
+      '@antfu/utils': 0.7.10
+      '@iconify/utils': 2.2.1
+      '@svgr/core': 6.5.1
+      debug: 4.4.0
+      kolorist: 1.8.0
+      local-pkg: 0.5.1
+      unplugin: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /unplugin-replace@0.3.3:
+    resolution: {integrity: sha512-EHv9QpShJSez8jinjXAlpBeQwj5gQt4ZLkEjqOlYfMladTTDAlrIgGmcOYzXMK7SGjQCaXD2srsWVkHV3DDSjw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@rollup/pluginutils': 5.1.4
+      magic-string: 0.30.17
+      unplugin: 1.16.0
+    transitivePeerDependencies:
+      - rollup
+    dev: true
+
+  /unplugin@1.16.0:
+    resolution: {integrity: sha512-5liCNPuJW8dqh3+DM6uNM2EI3MLLpCKp/KY+9pB5M2S2SR2qvvDHhKgBOaTWEbZTAws3CXfB0rKTIolWKL05VQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      acorn: 8.14.0
+      webpack-virtual-modules: 0.6.2
+    dev: true
+
+  /unplugin@2.1.0:
+    resolution: {integrity: sha512-us4j03/499KhbGP8BU7Hrzrgseo+KdfJYWcbcajCOqsAyb8Gk0Yn2kiUIcZISYCb1JFaZfIuG3b42HmguVOKCQ==}
+    engines: {node: '>=18.12.0'}
+    dependencies:
+      acorn: 8.14.0
+      webpack-virtual-modules: 0.6.2
+    dev: true
 
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
@@ -18239,6 +18468,10 @@ packages:
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+    dev: true
+
+  /webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
     dev: true
 
   /webpack@5.84.1(webpack-cli@4.7.2):

--- a/scripts/mako.js
+++ b/scripts/mako.js
@@ -7,22 +7,24 @@ const cwd = process.argv[2];
 
 console.log('> run mako build for', cwd);
 const config = getMakoConfig();
+const watch = process.argv.includes('--watch');
 build({
   root: cwd,
   config,
-  watch: process.argv.includes('--watch'),
-}).catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+  watch,
+})
+  .then(() => {
+    if (!watch) {
+      process.exit(0);
+    }
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
 
 function getPlugins() {
   let plugins = [];
-  const hooksPath = path.join(cwd, 'hooks.config.js');
-  if (fs.existsSync(hooksPath)) {
-    let hooks = require(hooksPath);
-    plugins.push(hooks);
-  }
   const pluginsPath = path.join(cwd, 'plugins.config.js');
   if (fs.existsSync(pluginsPath)) {
     plugins.push(...require(pluginsPath));


### PR DESCRIPTION
## tasks

- [x] tested `npx dumi build` in repo ant-design/ant-design

## ref
https://github.com/umijs/mako/pull/1737

## why is load args undefined?
since the plugin item is patched twice. so it's only break when ssr is on, which means we will run mako twice.

## how to reproduce origin problem?

1. generate a simple umi project

```
umi g page index
```

2. enable mako and ssr

```
export default {
    ssr: {
        builder: 'mako',
    },
    mako: {}
};
```

3. disable concatenateModules since it will panic in this situation

```
{
    "optimization": {
        "concatenateModules": false
    }
}
```

4. npm build with mako

```
umi build
```

## how to fix this problem?

avoid patch twice in `packages/mako/src/index.ts`.

```diff
+ // plugin may be patched already
+ // ref: https://github.com/umijs/mako/pull/1737
+ if (plugin.__isPatched) {
+   return;
+ }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本发布说明

- **新功能**
  - 引入 `PluginContext`，增强插件开发能力
  - 新增插件方法：`emitFile`、`warn`、`error`
  - 支持 `unplugin` 生态系统插件

- **文档更新**
  - 更新配置文档，详细说明插件使用和别名规则
  - 补充插件钩子函数的方法说明

- **依赖更新**
  - 新增开发依赖：`@iconify-json/mdi`、`unplugin-icons`、`unplugin-replace`

- **性能优化**
  - 改进插件上下文管理
  - 标准化插件结果处理机制

本次更新主要聚焦于提升插件系统的灵活性和开发体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->