### PR TITLE
fix: normalize Windows paths in ModuleId constructors

### DIFF
--- a/crates/mako/src/module.rs
+++ b/crates/mako/src/module.rs
@@ -282,7 +282,9 @@ impl PartialOrd for ModuleId {
 impl ModuleId {
     // we use absolute path as module id now
     pub fn new(id: String) -> Self {
-        Self { id }
+        Self {
+            id: win_path(id.as_str()),
+        }
     }
 
     pub fn generate(&self, context: &Arc<Context>) -> String {
@@ -304,20 +306,22 @@ impl ModuleId {
 
 impl From<String> for ModuleId {
     fn from(id: String) -> Self {
-        Self { id }
+        Self {
+            id: win_path(id.as_str()),
+        }
     }
 }
 
 impl From<&str> for ModuleId {
     fn from(id: &str) -> Self {
-        Self { id: id.to_string() }
+        Self { id: win_path(id) }
     }
 }
 
 impl From<PathBuf> for ModuleId {
     fn from(path: PathBuf) -> Self {
         Self {
-            id: path.to_string_lossy().to_string(),
+            id: win_path(path.to_string_lossy().to_string().as_str()),
         }
     }
 }


### PR DESCRIPTION
Close https://github.com/umijs/mako/issues/1668


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
	- 更新了 `ModuleId` 结构体的 ID 处理方式，现在使用 `win_path` 函数对 ID 进行标准化处理。
	- 修改了从不同类型（`String`、`&str`、`PathBuf`）创建 `ModuleId` 实例的方法，确保 ID 格式一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->