### PR TITLE
fix: normalize Windows paths in Compiler output path handling

### DIFF
--- a/crates/mako/src/stats.rs
+++ b/crates/mako/src/stats.rs
@@ -11,6 +11,7 @@ use pathdiff::diff_paths;
 use serde::Serialize;
 use swc_core::common::source_map::SmallPos;
 
+use crate::ast::file::win_path;
 use crate::compiler::{Compiler, Context};
 use crate::features::rsc::{RscClientInfo, RscCssModules};
 use crate::generate::chunk::ChunkType;
@@ -216,7 +217,7 @@ impl Compiler {
         let abs_path = &self.context.root;
         let output_path = &self.context.config.output.path;
         let dist_path = diff_paths(output_path, abs_path).unwrap_or_else(|| output_path.clone());
-        let mut path_str = dist_path.to_str().unwrap().to_string();
+        let mut path_str = win_path(dist_path.to_str().unwrap());
         if !path_str.ends_with('/') {
             path_str.push('/');
         }


### PR DESCRIPTION
as pictures below.

<img width="777" alt="image" src="https://github.com/user-attachments/assets/e0031d16-ca02-491c-9402-01d57878ca38" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了路径处理功能，增强了对Windows路径的支持。

- **Bug 修复**
	- 优化了路径字符串的生成方法，提高了跨平台兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->