### PR TITLE
fix: ensure parent directories are created when writing to disk in MemoryChunkFileCache

### DIFF
--- a/crates/mako/src/compiler.rs
+++ b/crates/mako/src/compiler.rs
@@ -84,6 +84,7 @@ impl MemoryChunkFileCache {
     fn write_to_disk<T: AsRef<str>>(&self, path: T, content: &[u8]) -> Result<()> {
         if let Some(root) = &self.root {
             let path = root.join(path.as_ref());
+            fs::create_dir_all(path.parent().unwrap())?;
             fs::write(path, content)?;
         }
         Ok(())


### PR DESCRIPTION
Close https://github.com/umijs/mako/issues/1749

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests and other checks with `just ready`

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
	- 改进文件写入过程，确保在写入文件时自动创建必要的父目录，提高文件系统操作的健壮性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->