### PR TITLE
fix: chunk groups' order when building mpa

### DIFF
--- a/crates/mako/src/config.rs
+++ b/crates/mako/src/config.rs
@@ -28,7 +28,7 @@ mod tree_shaking;
 mod umd;
 mod watch;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -128,7 +128,7 @@ pub enum Platform {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
-    pub entry: HashMap<String, PathBuf>,
+    pub entry: BTreeMap<String, PathBuf>,
     pub output: OutputConfig,
     pub resolve: ResolveConfig,
     #[serde(deserialize_with = "deserialize_manifest", default)]

--- a/crates/mako/src/module_graph.rs
+++ b/crates/mako/src/module_graph.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
@@ -15,7 +15,7 @@ use crate::module::{Dependencies, Dependency, Module, ModuleId};
 pub struct ModuleGraph {
     pub id_index_map: HashMap<ModuleId, NodeIndex<DefaultIx>>,
     pub graph: StableDiGraph<Module, Dependencies>,
-    entries: HashSet<ModuleId>,
+    entries: BTreeSet<ModuleId>,
 }
 
 impl ModuleGraph {
@@ -23,7 +23,7 @@ impl ModuleGraph {
         Self {
             id_index_map: HashMap::new(),
             graph: StableDiGraph::new(),
-            entries: HashSet::new(),
+            entries: BTreeSet::new(),
         }
     }
 

--- a/e2e/fixtures/css.css-merge-multi-entries/expect.js
+++ b/e2e/fixtures/css.css-merge-multi-entries/expect.js
@@ -1,0 +1,18 @@
+const assert = require("assert");
+const { parseBuildResult } = require("../../../scripts/test-utils");
+const { files } = parseBuildResult(__dirname);
+
+assert(
+  files['common.css'].includes(`
+body::after {
+  content: "common_1";
+}
+body::after {
+  content: "common_2";
+}
+body::after {
+  content: "common_3";
+}
+`.trim()),
+  "css merge in mpa should works"
+);

--- a/e2e/fixtures/css.css-merge-multi-entries/mako.config.json
+++ b/e2e/fixtures/css.css-merge-multi-entries/mako.config.json
@@ -1,0 +1,21 @@
+{
+  "entry": {
+    "a": "./src/a.ts",
+    "b": "./src/b.ts",
+    "c": "./src/c.ts"
+  },
+  "codeSplitting": {
+    "strategy": "advanced",
+    "options": {
+      "minSize": 1,
+      "groups": [
+        {
+          "name": "common",
+          "allowChunks": "entry",
+          "minChunks": 2,
+          "minSize": 1
+        }
+      ]
+    }
+  }
+}

--- a/e2e/fixtures/css.css-merge-multi-entries/src/a.css
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/a.css
@@ -1,0 +1,3 @@
+body {
+  color: azure;
+}

--- a/e2e/fixtures/css.css-merge-multi-entries/src/a.ts
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/a.ts
@@ -1,0 +1,6 @@
+import "./common_1.css";
+import "./common_2.css";
+import "./common_3.css";
+import "./a.css";
+console.log('a');
+

--- a/e2e/fixtures/css.css-merge-multi-entries/src/b.css
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/b.css
@@ -1,0 +1,3 @@
+body {
+  color: blue;
+}

--- a/e2e/fixtures/css.css-merge-multi-entries/src/b.ts
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/b.ts
@@ -1,0 +1,5 @@
+import "./common_2.css";
+import "./common_1.css";
+import "./common_3.css";
+import "./b.css";
+console.log('b');

--- a/e2e/fixtures/css.css-merge-multi-entries/src/c.css
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/c.css
@@ -1,0 +1,3 @@
+body {
+  color: cyan;
+}

--- a/e2e/fixtures/css.css-merge-multi-entries/src/c.ts
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/c.ts
@@ -1,0 +1,4 @@
+import "./common_2.css";
+import "./common_3.css";
+import "./common_1.css";
+console.log("c");

--- a/e2e/fixtures/css.css-merge-multi-entries/src/common_1.css
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/common_1.css
@@ -1,0 +1,3 @@
+body::after {
+  content: "common_1";
+}

--- a/e2e/fixtures/css.css-merge-multi-entries/src/common_2.css
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/common_2.css
@@ -1,0 +1,3 @@
+body::after {
+  content: "common_2";
+}

--- a/e2e/fixtures/css.css-merge-multi-entries/src/common_3.css
+++ b/e2e/fixtures/css.css-merge-multi-entries/src/common_3.css
@@ -1,0 +1,3 @@
+body::after {
+  content: "common_3";
+}


### PR DESCRIPTION
The entry modules' order should be stable, or else, the css order in common chunks will be unstable.
