### PR TITLE
fix: plugin context gc

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![feature(ptr_as_ref_unchecked)]
 
 extern crate swc_malloc;
 


### PR DESCRIPTION
The js land should not hold a strong reference of PluginContext, or else, it will prevent Drop::drop of PluginHook, and the main thread will hang forever.