### PR TITLE
feat: registry args

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,4 +1,4 @@
-name: Cli-Benchmark
+name: utoo-cli-benchmark
 
 on: [pull_request]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: utoo-ci
 
 on: [pull_request]
 

--- a/crates/cli/src/helper/auto_update.rs
+++ b/crates/cli/src/helper/auto_update.rs
@@ -1,3 +1,4 @@
+use crate::util::config::get_registry;
 use crate::util::logger::{log_error, log_info, log_warning};
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -74,7 +75,7 @@ fn execute_update() -> Result<(), String> {
 }
 
 async fn check_remote_version() -> Result<(), String> {
-    let registry_url = "https://registry.npmmirror.com/utoo/latest";
+    let registry_url = format!("{}/utoo/latest", get_registry());
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_millis(2000))
         .build()

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,6 +6,7 @@ use cmd::install::install;
 use cmd::rebuild::rebuild;
 use cmd::{clean::clean, deps::build_workspace};
 use helper::auto_update::init_auto_update;
+use util::config::set_registry;
 use util::logger::{log_error, log_info, log_warning, set_verbose, write_verbose_logs_to_file};
 
 mod cmd;
@@ -40,6 +41,12 @@ async fn main() {
             .short('v')
             .long("version")
             .help("Print version info and exit"))
+        .arg(clap::Arg::with_name("registry")
+            .long("registry")
+            .global(true)
+            .takes_value(true)
+            .default_value("https://registry.npmmirror.com")
+            .help("Specify npm registry URL for dependency resolution and installation"))
         .subcommand(
             SubCommand::with_name("install")
                 .alias("i")
@@ -87,6 +94,9 @@ async fn main() {
 
     // global verbose
     set_verbose(matches.is_present("verbose"));
+
+    // global registry
+    set_registry(matches.value_of("registry").unwrap());
 
     // load package.json
     if let Some(result) = cmd::pkg::handle_command(&matches) {

--- a/crates/cli/src/util/config.rs
+++ b/crates/cli/src/util/config.rs
@@ -1,0 +1,14 @@
+use std::sync::OnceLock;
+
+static REGISTRY: OnceLock<String> = OnceLock::new();
+
+pub fn set_registry(registry: &str) {
+    let _ = REGISTRY.set(registry.to_string());
+}
+
+pub fn get_registry() -> &'static str {
+    REGISTRY
+        .get()
+        .map(|s| s.as_str())
+        .unwrap_or("https://registry.npmmirror.com")
+}

--- a/crates/cli/src/util/mod.rs
+++ b/crates/cli/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod cloner;
+pub mod config;
 pub mod downloader;
 pub mod linker;
 pub mod logger;

--- a/crates/cli/src/util/registry.rs
+++ b/crates/cli/src/util/registry.rs
@@ -7,6 +7,7 @@ use std::io;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use super::config::get_registry;
 use super::logger::log_verbose;
 
 pub static PACKAGE_CACHE: Lazy<PackageCache> = Lazy::new(|| PackageCache::new());
@@ -101,7 +102,7 @@ impl Registry {
     pub fn new() -> Self {
         Self {
             client: reqwest::Client::new(),
-            base_url: "https://registry.npmmirror.com".to_string(),
+            base_url: get_registry().to_string(),
         }
     }
 


### PR DESCRIPTION
* Added `--registry` global args to support custom registry configuration for dependency resolution and installation services.
* Due to reliance on `semver` version resolution, currently only support cnpmcore registry.
* Use `https://registry.npmmirror.com`  by default.