### PR TITLE
feat: init utoo-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,7 +1653,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1665,6 +1674,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3796,6 +3817,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"
@@ -8622,7 +8649,7 @@ dependencies = [
  "async-compression",
  "clap 3.2.25",
  "criterion",
- "dirs",
+ "dirs 4.0.0",
  "flate2",
  "futures",
  "glob",
@@ -8680,6 +8707,19 @@ dependencies = [
  "turbopack-static",
  "turbopack-trace-utils",
  "webbrowser",
+]
+
+[[package]]
+name = "utoo-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.5.32",
+ "dirs 5.0.1",
+ "serde",
+ "tempfile",
+ "thiserror 1.0.69",
+ "toml 0.8.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/bundler",
   "crates/cli",
+  "crates/core",
   # Waiting https://github.com/denoland/deno_ast/pull/297 to be resolved
   # "crates/runtime",
 ]
@@ -26,6 +27,8 @@ dunce = "1.0.5"
 webbrowser = "1.0.4"
 regex = "1.11.1"
 criterion = "0.5.1"
+dirs = "5.0"
+toml = "0.8"
 
 # Dependencies from nextjs, should keep the same rev!
 ## Dependencies for common cache and task. See https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbopack/architecture.md

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "utoo-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+serde = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+dirs = { workspace = true }
+toml = { workspace = true }
+thiserror = "1.0"
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,0 +1,73 @@
+use std::path::{Path, PathBuf};
+use std::fs;
+use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use crate::error::Result;
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Config {
+    values: HashMap<String, String>,
+}
+
+// global config path is ~/.utoo/config.toml
+// local config path is .utoo/config.toml
+impl Config {
+    pub fn load(global: bool) -> Result<Self> {
+        if global {
+            return Self::load_from_path(&Self::global_config_path()?);
+        }
+
+        let mut config = Self::load_from_path(&Self::global_config_path()?)?;
+        if let Ok(local_config) = Self::load_from_path(&Self::local_config_path()?) {
+            // merge config values
+            config.values.extend(local_config.values);
+        }
+        Ok(config)
+    }
+
+    pub fn set(&mut self, key: &str, value: String, global: bool) -> Result<()> {
+        self.values.insert(key.to_string(), value);
+        self.save(global)
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<String>> {
+        Ok(self.values.get(key).cloned())
+    }
+
+    fn load_from_path(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Config::default());
+        }
+
+        let content = fs::read_to_string(path)?;
+        let config = toml::from_str(&content)?;
+        Ok(config)
+    }
+
+    pub fn save(&self, global: bool) -> Result<()> {
+        let path = if global {
+            Self::global_config_path()?
+        } else {
+            Self::local_config_path()?
+        };
+
+        // ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let content = toml::to_string_pretty(self)?;
+        fs::write(&path, content)?;
+        Ok(())
+    }
+
+    fn global_config_path() -> Result<PathBuf> {
+        Ok(dirs::home_dir()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Home directory not found"))?
+            .join(".utoo/config.toml"))
+    }
+
+    fn local_config_path() -> Result<PathBuf> {
+        Ok(std::env::current_dir()?.join(".utoo.toml"))
+    }
+}

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -18,8 +18,9 @@ impl Config {
         }
 
         let mut config = Self::load_from_path(&Self::global_config_path()?)?;
-        if let Ok(local_config) = Self::load_from_path(&Self::local_config_path()?) {
-            // merge config values
+        let local_path = Self::local_config_path()?;
+        if local_path.exists() {
+            let local_config = Self::load_from_path(&local_path)?;
             config.values.extend(local_config.values);
         }
         Ok(config)

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,8 +1,8 @@
-use std::path::{Path, PathBuf};
-use std::fs;
-use std::collections::HashMap;
-use serde::{Deserialize, Serialize};
 use crate::error::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Config {
@@ -63,7 +63,9 @@ impl Config {
 
     fn global_config_path() -> Result<PathBuf> {
         Ok(dirs::home_dir()
-            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Home directory not found"))?
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::NotFound, "Home directory not found")
+            })?
             .join(".utoo/config.toml"))
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("TOML serialization error: {0}")]
+    Toml(#[from] toml::ser::Error),
+
+    #[error("TOML deserialization error: {0}")]
+    TomlDe(#[from] toml::de::Error),
+}
+
+pub type Result<T> = std::result::Result<T, ConfigError>;

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -6,7 +6,7 @@ pub enum ConfigError {
     Io(#[from] std::io::Error),
 
     #[error("TOML serialization error: {0}")]
-    Toml(#[from] toml::ser::Error),
+    TomlSe(#[from] toml::ser::Error),
 
     #[error("TOML deserialization error: {0}")]
     TomlDe(#[from] toml::de::Error),

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,5 +1,5 @@
-use clap::{Parser, Subcommand};
 use anyhow::Result;
+use clap::{Parser, Subcommand};
 use std::collections::HashMap;
 
 mod config;
@@ -43,7 +43,9 @@ enum ConfigCommands {
 
 // parse key val manullay
 fn parse_key_val(s: &str) -> Result<(String, String)> {
-    let pos = s.find('=').ok_or_else(|| anyhow::anyhow!("invalid KEY=value: no `=` found in `{}`", s))?;
+    let pos = s
+        .find('=')
+        .ok_or_else(|| anyhow::anyhow!("invalid KEY=value: no `=` found in `{}`", s))?;
     Ok((s[..pos].to_string(), s[pos + 1..].to_string()))
 }
 
@@ -51,38 +53,40 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Config { command } => {
-            match command {
-                ConfigCommands::Set { key, value, global } => {
-                    let mut config = Config::load(global)?;
-                    config.set(&key, value, global)?;
-                    println!("Successfully set {} (global: {})", key, global);
-                }
-                ConfigCommands::Get { key, global, override_values } => {
-                    let overrides: HashMap<String, String> = override_values
-                        .iter()
-                        .filter_map(|arg| {
-                            if arg.starts_with("--") {
-                                if let Ok((k, v)) = parse_key_val(&arg[2..]) {
-                                    return Some((k, v));
-                                }
+        Commands::Config { command } => match command {
+            ConfigCommands::Set { key, value, global } => {
+                let mut config = Config::load(global)?;
+                config.set(&key, value, global)?;
+                println!("Successfully set {} (global: {})", key, global);
+            }
+            ConfigCommands::Get {
+                key,
+                global,
+                override_values,
+            } => {
+                let overrides: HashMap<String, String> = override_values
+                    .iter()
+                    .filter_map(|arg| {
+                        if arg.starts_with("--") {
+                            if let Ok((k, v)) = parse_key_val(&arg[2..]) {
+                                return Some((k, v));
                             }
-                            None
-                        })
-                        .collect();
-
-                    if let Some(value) = overrides.get(&key) {
-                        println!("{}", value);
-                    } else {
-                        let config = Config::load(global)?;
-                        match config.get(&key)? {
-                            Some(value) => println!("{}", value),
-                            None => println!("No value set for {}", key),
                         }
+                        None
+                    })
+                    .collect();
+
+                if let Some(value) = overrides.get(&key) {
+                    println!("{}", value);
+                } else {
+                    let config = Config::load(global)?;
+                    match config.get(&key)? {
+                        Some(value) => println!("{}", value),
+                        None => println!("No value set for {}", key),
                     }
                 }
             }
-        }
+        },
     }
 
     Ok(())
@@ -91,9 +95,9 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
     use std::fs;
     use tempfile::TempDir;
-    use std::env;
 
     #[test]
     fn test_invalid_config() {
@@ -112,14 +116,21 @@ mod tests {
         let global_config_path = home_dir.path().join(".utoo/config.toml");
         fs::create_dir_all(global_config_path.parent().unwrap()).unwrap();
 
-        fs::write(&global_config_path, r#"
+        fs::write(
+            &global_config_path,
+            r#"
             values = { "test.key" = "global_value" }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
 
         std::env::set_var("HOME", home_dir.path());
 
         let config = Config::load(true).unwrap();
-        assert_eq!(config.get("test.key").unwrap(), Some("global_value".to_string()));
+        assert_eq!(
+            config.get("test.key").unwrap(),
+            Some("global_value".to_string())
+        );
     }
 
     #[test]
@@ -129,26 +140,38 @@ mod tests {
 
         let global_config_path = home_dir.path().join(".utoo/config.toml");
         fs::create_dir_all(global_config_path.parent().unwrap()).unwrap();
-        fs::write(&global_config_path, r#"
+        fs::write(
+            &global_config_path,
+            r#"
             values = { "test.key" = "global_value" }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
 
         let local_config_path = work_dir.path().join(".utoo.toml");
-        fs::write(&local_config_path, r#"
+        fs::write(
+            &local_config_path,
+            r#"
             values = { "test.key" = "local_value" }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
 
         std::env::set_var("HOME", home_dir.path());
         std::env::set_current_dir(work_dir.path()).unwrap();
 
         let config = Config::load(false).unwrap();
-        assert_eq!(config.get("test.key").unwrap(), Some("local_value".to_string()));
+        assert_eq!(
+            config.get("test.key").unwrap(),
+            Some("local_value".to_string())
+        );
     }
 
     #[test]
     fn test_cli_override() {
         let args = vec!["--test.key=cli_value"];
-        let overrides: HashMap<String, String> = args.iter()
+        let overrides: HashMap<String, String> = args
+            .iter()
             .filter_map(|arg| {
                 if arg.starts_with("--") {
                     if let Ok((k, v)) = parse_key_val(&arg[2..]) {

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -95,21 +95,8 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
     use std::fs;
     use tempfile::TempDir;
-
-    #[test]
-    fn test_invalid_config() {
-        let temp_dir = TempDir::new().unwrap();
-        let config_path = temp_dir.path().join(".utoo.toml");
-        fs::write(&config_path, "invalid toml ][").unwrap();
-
-        env::set_current_dir(temp_dir.path()).unwrap();
-        let result = Config::load(false);
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), error::ConfigError::TomlDe(_)));
-    }
 
     #[test]
     fn test_global_config() {

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,0 +1,164 @@
+use clap::{Parser, Subcommand};
+use anyhow::Result;
+use std::collections::HashMap;
+
+mod config;
+mod error;
+
+use config::Config;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigCommands {
+    Set {
+        key: String,
+        value: String,
+        #[arg(long)]
+        global: bool,
+    },
+    Get {
+        key: String,
+        #[arg(long)]
+        global: bool,
+        /// Allow any --key=value override
+        #[arg(allow_hyphen_values = true)]
+        #[arg(trailing_var_arg = true)]
+        override_values: Vec<String>,
+    },
+}
+
+// parse key val manullay
+fn parse_key_val(s: &str) -> Result<(String, String)> {
+    let pos = s.find('=').ok_or_else(|| anyhow::anyhow!("invalid KEY=value: no `=` found in `{}`", s))?;
+    Ok((s[..pos].to_string(), s[pos + 1..].to_string()))
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Config { command } => {
+            match command {
+                ConfigCommands::Set { key, value, global } => {
+                    let mut config = Config::load(global)?;
+                    config.set(&key, value, global)?;
+                    println!("Successfully set {} (global: {})", key, global);
+                }
+                ConfigCommands::Get { key, global, override_values } => {
+                    let overrides: HashMap<String, String> = override_values
+                        .iter()
+                        .filter_map(|arg| {
+                            if arg.starts_with("--") {
+                                if let Ok((k, v)) = parse_key_val(&arg[2..]) {
+                                    return Some((k, v));
+                                }
+                            }
+                            None
+                        })
+                        .collect();
+
+                    if let Some(value) = overrides.get(&key) {
+                        println!("{}", value);
+                    } else {
+                        let config = Config::load(global)?;
+                        match config.get(&key)? {
+                            Some(value) => println!("{}", value),
+                            None => println!("No value set for {}", key),
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+    use std::env;
+
+    #[test]
+    fn test_invalid_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(".utoo.toml");
+        fs::write(&config_path, "invalid toml ][").unwrap();
+
+        env::set_current_dir(temp_dir.path()).unwrap();
+        let result = Config::load(false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_global_config() {
+        let home_dir = TempDir::new().unwrap();
+        let global_config_path = home_dir.path().join(".utoo/config.toml");
+        fs::create_dir_all(global_config_path.parent().unwrap()).unwrap();
+
+        fs::write(&global_config_path, r#"
+            values = { "test.key" = "global_value" }
+        "#).unwrap();
+
+        std::env::set_var("HOME", home_dir.path());
+
+        let config = Config::load(true).unwrap();
+        assert_eq!(config.get("test.key").unwrap(), Some("global_value".to_string()));
+    }
+
+    #[test]
+    fn test_local_override() {
+        let home_dir = TempDir::new().unwrap();
+        let work_dir = TempDir::new().unwrap();
+
+        let global_config_path = home_dir.path().join(".utoo/config.toml");
+        fs::create_dir_all(global_config_path.parent().unwrap()).unwrap();
+        fs::write(&global_config_path, r#"
+            values = { "test.key" = "global_value" }
+        "#).unwrap();
+
+        let local_config_path = work_dir.path().join(".utoo.toml");
+        fs::write(&local_config_path, r#"
+            values = { "test.key" = "local_value" }
+        "#).unwrap();
+
+        std::env::set_var("HOME", home_dir.path());
+        std::env::set_current_dir(work_dir.path()).unwrap();
+
+        let config = Config::load(false).unwrap();
+        assert_eq!(config.get("test.key").unwrap(), Some("local_value".to_string()));
+    }
+
+    #[test]
+    fn test_cli_override() {
+        let args = vec!["--test.key=cli_value"];
+        let overrides: HashMap<String, String> = args.iter()
+            .filter_map(|arg| {
+                if arg.starts_with("--") {
+                    if let Ok((k, v)) = parse_key_val(&arg[2..]) {
+                        return Some((k, v));
+                    }
+                }
+                None
+            })
+            .collect();
+
+        assert_eq!(overrides.get("test.key").unwrap(), "cli_value");
+    }
+}

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -108,6 +108,7 @@ mod tests {
         env::set_current_dir(temp_dir.path()).unwrap();
         let result = Config::load(false);
         assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), error::ConfigError::TomlDe(_)));
     }
 
     #[test]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/51f965f6-1907-426d-9431-3f2f3f66d93f)

**Changes:**  
1. Refactor `utoo` to focus solely on **configuration management**, with a default command flow.  
2. New `config` capabilities:  
   - `utoo config set install.cmd utoo-install`  
   - `utoo config set common.registry --global https://registry.npmmirror.com`  
3. `Next PR` Split subcommands (install/deps/clean/rebuild) into **standalone packages** (`utoo-*`), allowing:  
   - Independent installation/usage  
   - Custom implementations via replacement  
4. Enforce naming convention: future subcommands must follow `utoo-xxx` format and be independently distributable.  

**Impact:**  
- Cleaner core (`utoo`), extensible architecture  
- Users can opt-in to specific functionalities  
- Simplified maintenance and custom workflows