### PR TITLE
feat: utoo bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,17 +277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auto-hash-map"
 version = "0.1.0"
 source = "git+https://github.com/vercel/next.js.git?tag=v15.2.3#535e26d3c69de49df8bd17618a424cbe65ec897b"
@@ -798,21 +787,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
@@ -829,7 +803,7 @@ checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.4",
+ "clap_lex",
  "strsim 0.11.1",
 ]
 
@@ -843,15 +817,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -1202,7 +1167,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.32",
+ "clap",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -2297,15 +2262,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -3823,12 +3779,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "outref"
@@ -8031,7 +7981,7 @@ version = "0.1.0"
 source = "git+https://github.com/vercel/next.js.git?tag=v15.2.3#535e26d3c69de49df8bd17618a424cbe65ec897b"
 dependencies = [
  "anyhow",
- "clap 4.5.32",
+ "clap",
  "crossterm 0.26.1",
  "owo-colors 3.5.0",
  "rustc-hash 2.1.1",
@@ -8643,37 +8593,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "utoo"
-version = "0.0.0-alpha.0"
-dependencies = [
- "async-compression",
- "clap 3.2.25",
- "criterion",
- "dirs 4.0.0",
- "flate2",
- "futures",
- "glob",
- "indicatif",
- "libc",
- "once_cell",
- "owo-colors 4.2.0",
- "reqwest",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "tar",
- "tempfile",
- "tokio",
- "tokio-retry",
- "tokio-tar",
-]
-
-[[package]]
 name = "utoo-bundler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.32",
+ "clap",
  "console-subscriber",
  "criterion",
  "crossterm 0.28.1",
@@ -8710,11 +8634,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "utoo-cli"
+version = "0.0.0-alpha.0"
+dependencies = [
+ "async-compression",
+ "clap",
+ "criterion",
+ "dirs 4.0.0",
+ "flate2",
+ "futures",
+ "glob",
+ "indicatif",
+ "libc",
+ "once_cell",
+ "owo-colors 4.2.0",
+ "reqwest",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "tokio",
+ "tokio-retry",
+ "tokio-tar",
+]
+
+[[package]]
 name = "utoo-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.32",
+ "clap",
  "dirs 5.0.1",
  "serde",
  "tempfile",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,9 +1,34 @@
 [package]
-name = "utoo"
+name = "utoo-cli"
 version = "0.0.0-alpha.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+name = "utoo_cli"
+path = "src/lib.rs"
+
+[[bin]]
+name = "utoo-clean"
+path = "src/bin/utoo-clean.rs"
+
+[[bin]]
+name = "utoo-install"
+path = "src/bin/utoo-install.rs"
+
+[[bin]]
+name = "utoo-rebuild"
+path = "src/bin/utoo-rebuild.rs"
+
+[[bin]]
+name = "utoo-deps"
+path = "src/bin/utoo-deps.rs"
+
+[[bin]]
+name = "utoo"
+path = "src/main.rs"
+
 
 [dependencies]
 tokio = { workspace = true }
@@ -15,7 +40,7 @@ flate2 = "1.0"
 tar = "0.4"
 dirs = "4.0"
 libc = "0.2"
-clap = "3"
+clap = { workspace = true }
 indicatif = "0.17.8"
 once_cell = "1.19.0"
 async-compression = { version = "0.3", features = ["tokio", "gzip"] }

--- a/crates/cli/src/bin/utoo-clean.rs
+++ b/crates/cli/src/bin/utoo-clean.rs
@@ -1,0 +1,29 @@
+use clap::Parser;
+use std::process;
+use utoo_cli::{cmd::clean::clean, constants::{APP_VERSION, cmd::CLEAN_ABOUT}};
+
+#[derive(Parser)]
+#[command(
+    name = "utoo-clean",
+    version = APP_VERSION,
+    about = CLEAN_ABOUT
+)]
+struct Cli {
+    /// Package pattern to clean (e.g., "react*", "@types/*", "*")
+    #[arg(default_value = "*")]
+    pattern: String,
+
+    /// Show verbose output
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+
+    if let Err(err) = clean(&cli.pattern).await {
+        eprintln!("Error: {}", err);
+        process::exit(1);
+    }
+}

--- a/crates/cli/src/bin/utoo-deps.rs
+++ b/crates/cli/src/bin/utoo-deps.rs
@@ -1,0 +1,52 @@
+use clap::Parser;
+use std::process;
+use utoo_cli::{
+    cmd::deps::{build_deps, build_workspace},
+    constants::{cmd::DEPS_ABOUT, APP_VERSION},
+    util::logger::{log_error, write_verbose_logs_to_file},
+};
+
+#[derive(Parser)]
+#[command(
+    name = "utoo-deps",
+    version = APP_VERSION,
+    about = DEPS_ABOUT
+)]
+struct Cli {
+    /// Only build workspace dependencies
+    #[arg(long = "workspace-only")]
+    workspace_only: bool,
+
+    /// Show detailed dependency information
+    #[arg(short, long)]
+    detail: bool,
+
+    /// Show only production dependencies
+    #[arg(long)]
+    prod: bool,
+
+    /// Show only development dependencies
+    #[arg(long)]
+    dev: bool,
+
+    /// Show verbose output
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+
+    let result = if cli.workspace_only {
+        build_workspace().await
+    } else {
+        build_deps().await
+    };
+
+    if let Err(e) = result {
+        log_error(&e.to_string());
+        let _ = write_verbose_logs_to_file();
+        process::exit(1);
+    }
+}

--- a/crates/cli/src/bin/utoo-install.rs
+++ b/crates/cli/src/bin/utoo-install.rs
@@ -1,0 +1,34 @@
+use clap::Parser;
+use std::process;
+use utoo_cli::{
+    cmd::install::install,
+    constants::{cmd::INSTALL_ABOUT, APP_VERSION},
+    util::logger::{log_error, write_verbose_logs_to_file},
+};
+
+#[derive(Parser)]
+#[command(
+    name = "utoo-install",
+    version = APP_VERSION,
+    about = INSTALL_ABOUT
+)]
+struct Cli {
+    /// Skip running scripts during installation
+    #[arg(long = "ignore-scripts")]
+    ignore_scripts: bool,
+
+    /// Show verbose output
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+
+    if let Err(e) = install(cli.ignore_scripts).await {
+        log_error(&e.to_string());
+        let _ = write_verbose_logs_to_file();
+        process::exit(1);
+    }
+}

--- a/crates/cli/src/bin/utoo-rebuild.rs
+++ b/crates/cli/src/bin/utoo-rebuild.rs
@@ -1,0 +1,37 @@
+use clap::Parser;
+use std::process;
+use utoo_cli::{
+    cmd::rebuild::rebuild,
+    constants::{cmd::REBUILD_ABOUT, APP_VERSION},
+    util::logger::{log_error, log_info, write_verbose_logs_to_file},
+};
+
+#[derive(Parser)]
+#[command(
+    name = "utoo-rebuild",
+    version = APP_VERSION,
+    about = REBUILD_ABOUT
+)]
+struct Cli {
+    /// Skip running scripts during rebuild
+    #[arg(long = "ignore-scripts")]
+    ignore_scripts: bool,
+
+    /// Show verbose output
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+#[tokio::main]
+async fn main() {
+
+    log_info("Executing dependency hook scripts and creating node_modules/.bin links");
+
+    if let Err(e) = rebuild().await {
+        log_error(&e.to_string());
+        let _ = write_verbose_logs_to_file();
+        process::exit(1);
+    }
+
+    log_info("💫 All dependencies rebuild completed");
+}

--- a/crates/cli/src/cmd/pkg.rs
+++ b/crates/cli/src/cmd/pkg.rs
@@ -1,146 +1,146 @@
-use crate::util::logger::log_info;
-use clap::{App, ArgMatches, SubCommand};
-use serde_json::Value;
-use std::fs;
-use std::process::{Command, Stdio};
+// use crate::util::logger::log_info;
+// use clap::{App, ArgMatches, SubCommand};
+// use serde_json::Value;
+// use std::fs;
+// use std::process::{Command, Stdio};
 
-pub struct PackageJson {
-    scripts: Option<Value>,
-}
+// pub struct PackageJson {
+//     scripts: Option<Value>,
+// }
 
-impl PackageJson {
-    fn load() -> Option<Self> {
-        if let Ok(content) = fs::read_to_string("package.json") {
-            if let Ok(json) = serde_json::from_str::<Value>(&content) {
-                return Some(PackageJson {
-                    scripts: json.get("scripts").cloned(),
-                });
-            }
-        }
-        None
-    }
+// impl PackageJson {
+//     fn load() -> Option<Self> {
+//         if let Ok(content) = fs::read_to_string("package.json") {
+//             if let Ok(json) = serde_json::from_str::<Value>(&content) {
+//                 return Some(PackageJson {
+//                     scripts: json.get("scripts").cloned(),
+//                 });
+//             }
+//         }
+//         None
+//     }
 
-    fn run_script(&self, script_name: &str) -> Result<(), String> {
-        if let Some(Value::Object(scripts)) = &self.scripts {
-            if scripts.contains_key(script_name) {
-                log_info(&format!("Executing npm run {}", script_name));
-                let status = Command::new("npm")
-                    .args(&["run", script_name])
-                    .stdout(Stdio::inherit())
-                    .stderr(Stdio::inherit())
-                    .status()
-                    .map_err(|e| e.to_string())?;
+//     fn run_script(&self, script_name: &str) -> Result<(), String> {
+//         if let Some(Value::Object(scripts)) = &self.scripts {
+//             if scripts.contains_key(script_name) {
+//                 log_info(&format!("Executing npm run {}", script_name));
+//                 let status = Command::new("npm")
+//                     .args(&["run", script_name])
+//                     .stdout(Stdio::inherit())
+//                     .stderr(Stdio::inherit())
+//                     .status()
+//                     .map_err(|e| e.to_string())?;
 
-                if !status.success() {
-                    return Err(format!("npm run {} execution failed", script_name));
-                }
-                return Ok(());
-            }
-        }
-        Err(format!("Script not found: {}", script_name))
-    }
-}
+//                 if !status.success() {
+//                     return Err(format!("npm run {} execution failed", script_name));
+//                 }
+//                 return Ok(());
+//             }
+//         }
+//         Err(format!("Script not found: {}", script_name))
+//     }
+// }
 
-pub fn extend_app(mut app: App) -> (App, String) {
-    let pkg = PackageJson::load();
-    let mut scripts_help = String::new();
+// pub fn extend_app(mut app: App) -> (App, String) {
+//     let pkg = PackageJson::load();
+//     let mut scripts_help = String::new();
 
-    app = app.subcommand(
-        SubCommand::with_name("run")
-            .about(
-                "Run scripts defined in package.json (e.g. utoo build, utoo run build) (alias: r)",
-            )
-            .alias("r")
-            .arg(
-                clap::Arg::with_name("script")
-                    .help("Script name to run")
-                    .required(true),
-            ),
-    );
+//     app = app.subcommand(
+//         SubCommand::with_name("run")
+//             .about(
+//                 "Run scripts defined in package.json (e.g. utoo build, utoo run build) (alias: r)",
+//             )
+//             .alias("r")
+//             .arg(
+//                 clap::Arg::with_name("script")
+//                     .help("Script name to run")
+//                     .required(true),
+//             ),
+//     );
 
-    if let Some(pkg_ref) = &pkg {
-        if let Some(Value::Object(scripts)) = &pkg_ref.scripts {
-            let reserved_commands = ["install", "rebuild", "clean", "run", "deps"];
+//     if let Some(pkg_ref) = &pkg {
+//         if let Some(Value::Object(scripts)) = &pkg_ref.scripts {
+//             let reserved_commands = ["install", "rebuild", "clean", "run", "deps"];
 
-            // Build script help information
-            scripts_help = {
-                const GREEN: &str = "\x1b[32m";
-                const YELLOW: &str = "\x1b[33m";
-                const RESET: &str = "\x1b[0m";
+//             // Build script help information
+//             scripts_help = {
+//                 const GREEN: &str = "\x1b[32m";
+//                 const YELLOW: &str = "\x1b[33m";
+//                 const RESET: &str = "\x1b[0m";
 
-                let mut help = format!("\n{}SCRIPTS (IN PACKAGE.JSON){}:\n", YELLOW, RESET);
+//                 let mut help = format!("\n{}SCRIPTS (IN PACKAGE.JSON){}:\n", YELLOW, RESET);
 
-                // Find the longest command name length
-                let max_name_len = scripts
-                    .keys()
-                    .filter(|name| !reserved_commands.contains(&name.as_str()))
-                    .map(|name| name.len())
-                    .max()
-                    .unwrap_or(0);
+//                 // Find the longest command name length
+//                 let max_name_len = scripts
+//                     .keys()
+//                     .filter(|name| !reserved_commands.contains(&name.as_str()))
+//                     .map(|name| name.len())
+//                     .max()
+//                     .unwrap_or(0);
 
-                const MAX_DESC_LEN: usize = 50;
+//                 const MAX_DESC_LEN: usize = 50;
 
-                for (name, cmd) in scripts {
-                    if !reserved_commands.contains(&name.as_str()) {
-                        if let Value::String(cmd_str) = cmd {
-                            let desc = if cmd_str.len() > MAX_DESC_LEN {
-                                format!("{}...", &cmd_str[..MAX_DESC_LEN - 3])
-                            } else {
-                                cmd_str.to_string()
-                            };
+//                 for (name, cmd) in scripts {
+//                     if !reserved_commands.contains(&name.as_str()) {
+//                         if let Value::String(cmd_str) = cmd {
+//                             let desc = if cmd_str.len() > MAX_DESC_LEN {
+//                                 format!("{}...", &cmd_str[..MAX_DESC_LEN - 3])
+//                             } else {
+//                                 cmd_str.to_string()
+//                             };
 
-                            // Separate name handling and padding
-                            let colored_name = format!("{}{}", GREEN, name);
-                            let padding = " ".repeat(max_name_len - name.len());
+//                             // Separate name handling and padding
+//                             let colored_name = format!("{}{}", GREEN, name);
+//                             let padding = " ".repeat(max_name_len - name.len());
 
-                            help.push_str(&format!(
-                                "    {}{}{}{}\n",
-                                colored_name,
-                                padding,
-                                RESET,
-                                format!("    {}", desc)
-                            ));
-                        }
-                        let sub = SubCommand::with_name(name)
-                            .about("Run npm script")
-                            .hide(true);
-                        app = app.subcommand(sub);
-                    }
-                }
-                help
-            };
-        }
-    }
+//                             help.push_str(&format!(
+//                                 "    {}{}{}{}\n",
+//                                 colored_name,
+//                                 padding,
+//                                 RESET,
+//                                 format!("    {}", desc)
+//                             ));
+//                         }
+//                         let sub = SubCommand::with_name(name)
+//                             .about("Run npm script")
+//                             .hide(true);
+//                         app = app.subcommand(sub);
+//                     }
+//                 }
+//                 help
+//             };
+//         }
+//     }
 
-    (app, scripts_help)
-}
+//     (app, scripts_help)
+// }
 
-pub fn handle_command(matches: &ArgMatches) -> Option<Result<(), String>> {
-    let pkg = PackageJson::load()?;
+// pub fn handle_command(matches: &ArgMatches) -> Option<Result<(), String>> {
+//     let pkg = PackageJson::load()?;
 
-    let cmd_name = matches.subcommand_name()?;
+//     let cmd_name = matches.subcommand_name()?;
 
-    // Skip built-in commands
-    if ["install", "rebuild", "clean", "deps"].contains(&cmd_name) {
-        return None;
-    }
+//     // Skip built-in commands
+//     if ["install", "rebuild", "clean", "deps"].contains(&cmd_name) {
+//         return None;
+//     }
 
-    match cmd_name {
-        "run" => {
-            let run_matches = matches.subcommand_matches("run")?;
-            let script = run_matches.value_of("script").unwrap();
-            Some(pkg.run_script(script))
-        }
-        script_name => {
-            if let Some(Value::Object(scripts)) = &pkg.scripts {
-                if scripts.contains_key(script_name) {
-                    Some(pkg.run_script(script_name))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        }
-    }
-}
+//     match cmd_name {
+//         "run" => {
+//             let run_matches = matches.subcommand_matches("run")?;
+//             let script = run_matches.value_of("script").unwrap();
+//             Some(pkg.run_script(script))
+//         }
+//         script_name => {
+//             if let Some(Value::Object(scripts)) = &pkg.scripts {
+//                 if scripts.contains_key(script_name) {
+//                     Some(pkg.run_script(script_name))
+//                 } else {
+//                     None
+//                 }
+//             } else {
+//                 None
+//             }
+//         }
+//     }
+// }

--- a/crates/cli/src/constants.rs
+++ b/crates/cli/src/constants.rs
@@ -1,0 +1,14 @@
+pub const APP_NAME: &str = "🌖 utoo";
+pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const APP_ABOUT: &str = "/juːtuː/ Unified Toolchain: Open & Optimized";
+
+pub mod cmd {
+    pub const CLEAN_NAME: &str = "clean";
+    pub const CLEAN_ABOUT: &str = "Clean package cache in global storage";
+    pub const DEPS_NAME: &str = "deps";
+    pub const DEPS_ABOUT: &str = "List and analyze project dependencies";
+    pub const INSTALL_NAME: &str = "install";
+    pub const INSTALL_ABOUT: &str = "Install project dependencies";
+    pub const REBUILD_NAME: &str = "rebuild";
+    pub const REBUILD_ABOUT: &str = "Rebuild native modules";
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod cmd;
+pub mod util;
+pub mod helper;
+pub mod model;
+pub mod service;
+pub mod constants;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::process;
 
-use clap::{App, SubCommand};
+use clap::{Parser, Subcommand};
 use cmd::deps::build_deps;
 use cmd::install::install;
 use cmd::rebuild::rebuild;
@@ -14,6 +14,60 @@ mod helper;
 mod model;
 mod service;
 mod util;
+mod constants;
+
+use crate::constants::{APP_NAME, APP_VERSION, APP_ABOUT};
+use crate::constants::cmd::{
+    CLEAN_NAME, CLEAN_ABOUT,
+    DEPS_NAME, DEPS_ABOUT,
+    INSTALL_NAME, INSTALL_ABOUT,
+    REBUILD_NAME, REBUILD_ABOUT,
+};
+
+#[derive(Parser)]
+#[command(name = APP_NAME)]
+#[command(version = APP_VERSION)]
+#[command(about = APP_ABOUT)]
+struct Cli {
+    #[arg(long)]
+    ignore_scripts: bool,
+
+    #[arg(short = 'V', long, global = true)]
+    verbose: bool,
+
+    #[arg(short, long)]
+    version: bool,
+
+    #[arg(long, global = true, default_value = "https://registry.npmmirror.com")]
+    registry: String,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    #[command(name = INSTALL_NAME, alias = "i", about = INSTALL_ABOUT)]
+    Install {
+        #[arg(long)]
+        ignore_scripts: bool,
+    },
+
+    #[command(name = REBUILD_NAME, alias = "rb", about = REBUILD_ABOUT)]
+    Rebuild,
+
+    #[command(name = CLEAN_NAME, alias = "c", about = CLEAN_ABOUT)]
+    Clean {
+        #[arg(default_value = "*")]
+        pattern: String,
+    },
+
+    #[command(name = DEPS_NAME, alias = "d", about = DEPS_ABOUT)]
+    Deps {
+        #[arg(long)]
+        workspace_only: bool,
+    },
+}
 
 #[tokio::main]
 async fn main() {
@@ -26,120 +80,38 @@ async fn main() {
         log_warning(&format!("Auto update cancelled"));
     }
 
-    let app = App::new("🌖 utoo")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about("/juːtuː/ Unified Toolchain: Open & Optimized")
-        .arg(clap::Arg::with_name("ignore-scripts")
-            .long("ignore-scripts")
-            .help("Install, skip running npm scripts during installation"))
-        .arg(clap::Arg::with_name("verbose")
-            .long("verbose")
-            .short('V')
-            .global(true)
-            .help("Verbose, show verbose log"))
-        .arg(clap::Arg::with_name("version")
-            .short('v')
-            .long("version")
-            .help("Print version info and exit"))
-        .arg(clap::Arg::with_name("registry")
-            .long("registry")
-            .global(true)
-            .takes_value(true)
-            .default_value("https://registry.npmmirror.com")
-            .help("Specify npm registry URL for dependency resolution and installation"))
-        .subcommand(
-            SubCommand::with_name("install")
-                .alias("i")
-                .about("Go to install deps (alias: i)")
-                .arg(clap::Arg::with_name("ignore-scripts")
-                    .long("ignore-scripts")
-                    .help("Skip running npm scripts during installation"))
-        )
-        .subcommand(
-            SubCommand::with_name("rebuild")
-                .alias("rb")
-                .about("Do rebuild deps hook scripts (alias: r)")
-        )
-        // .subcommand(
-        //     SubCommand::with_name("update")
-        //         .alias("up")
-        //         .about("Update node_modules in current project (alias: up)")
-        //         .arg(clap::Arg::with_name("ignore-scripts")
-        //             .long("ignore-scripts")
-        //             .help("Skip running npm scripts during installation"))
-        // )
-
-        .subcommand(
-            SubCommand::with_name("clean")
-                .alias("c")
-                .about("Clean store in ~/.cache/nm (alias: c)")
-                .arg(clap::Arg::with_name("pattern")
-                    .help("Package name and version (e.g. markdown-it@2.0.0, markdown-*@*, *@2.0.0)")
-                    .default_value("*")
-                    .required(false))
-        )
-        .subcommand(
-            SubCommand::with_name("deps")
-                .alias("d")
-                .about("Generate package-lock.json file (alias: d), expiremental feature")
-                .arg(clap::Arg::with_name("workspace-only")
-                    .long("workspace-only")
-                    .help("Only build workspace packages"))
-        );
-
-    // extend app
-    let (extended_app, scripts_help) = cmd::pkg::extend_app(app);
-    let app_with_help = extended_app.after_help(&*scripts_help);
-    let matches = app_with_help.get_matches();
+    let cli = Cli::parse();
 
     // global verbose
-    set_verbose(matches.is_present("verbose"));
+    set_verbose(cli.verbose);
 
     // global registry
-    set_registry(matches.value_of("registry").unwrap());
+    set_registry(&cli.registry);
 
     // load package.json
-    if let Some(result) = cmd::pkg::handle_command(&matches) {
-        if let Err(e) = result {
-            log_error(&e);
-        }
-        return;
-    }
+    // if let Some(result) = cmd::pkg::handle_command_v4(&cli) {
+    //     if let Err(e) = result {
+    //         log_error(&e);
+    //     }
+    //     return;
+    // }
 
-    // inner command
-    match matches.subcommand_name() {
-        // Some("update") => {
-        //     if let Some(update_matches) = matches.subcommand_matches("update") {
-        //         if let Err(e) = update().await {
-        //             log_error(&e.to_string());
-        //             process::exit(1);
-        //         }
-        //         if let Err(e) = install(update_matches.is_present("ignore-scripts")).await {
-        //             log_error(&e.to_string());
-        //             let _ = write_verbose_logs_to_file();
-        //             process::exit(1);
-        //         }
-        //     }
-        // }
-        Some("clean") => {
-            if let Some(clean_matches) = matches.subcommand_matches("clean") {
-                if let Err(e) = clean(clean_matches.value_of("pattern").unwrap()).await {
-                    log_error(&e.to_string());
-                    let _ = write_verbose_logs_to_file();
-                    process::exit(1);
-                }
+    match cli.command {
+        Some(Commands::Clean { pattern }) => {
+            if let Err(e) = clean(&pattern).await {
+                log_error(&e.to_string());
+                let _ = write_verbose_logs_to_file();
+                process::exit(1);
             }
         }
-        Some("install") => {
-            if let Some(install_matches) = matches.subcommand_matches("install") {
-                if let Err(e) = install(install_matches.is_present("ignore-scripts")).await {
-                    log_error(&e.to_string());
-                    let _ = write_verbose_logs_to_file();
-                    process::exit(1);
-                }
+        Some(Commands::Install { ignore_scripts }) => {
+            if let Err(e) = install(ignore_scripts).await {
+                log_error(&e.to_string());
+                let _ = write_verbose_logs_to_file();
+                process::exit(1);
             }
         }
-        Some("rebuild") => {
+        Some(Commands::Rebuild) => {
             log_info("Executing dependency hook scripts and creating node_modules/.bin links");
             if let Err(e) = rebuild().await {
                 log_error(&e);
@@ -147,24 +119,22 @@ async fn main() {
             }
             log_info("💫 All dependencies rebuild completed");
         }
-        Some("deps") => {
-            if let Some(deps_matches) = matches.subcommand_matches("deps") {
-                let result = if deps_matches.is_present("workspace-only") {
-                    build_workspace().await
-                } else {
-                    build_deps().await
-                };
+        Some(Commands::Deps { workspace_only }) => {
+            let result = if workspace_only {
+                build_workspace().await
+            } else {
+                build_deps().await
+            };
 
-                if let Err(e) = result {
-                    log_error(&e.to_string());
-                    let _ = write_verbose_logs_to_file();
-                    process::exit(1);
-                }
+            if let Err(e) = result {
+                log_error(&e.to_string());
+                let _ = write_verbose_logs_to_file();
+                process::exit(1);
             }
         }
-        _ => {
+        None => {
             // install by default
-            if let Err(e) = install(matches.is_present("ignore-scripts")).await {
+            if let Err(e) = install(cli.ignore_scripts).await {
                 log_error(&e.to_string());
                 let _ = write_verbose_logs_to_file();
                 process::exit(1);


### PR DESCRIPTION
> follow https://github.com/umijs/mako/pull/1782
1. Split `utoo` into standalone binaries: `utoo-clean`, `utoo-deps`, `utoo-install`, `utoo-rebuild`.
2. Migrate `clap` from `clap@3` to `clap@4` in workspace.
3.`next pr`: Custom dependency mounting in `pkgs` needs to be migrated to `utoo-core`.
4. `next pr`: `utoo-update` depends on `deps` to parse workspace results.