### PR TITLE
fix: optional deps

### DIFF
--- a/crates/cli/src/service/package.rs
+++ b/crates/cli/src/service/package.rs
@@ -282,6 +282,8 @@ impl PackageService {
     }
 
     fn has_cached(package: &PackageInfo) -> bool {
+        // FIXME disable cache for now
+        return false;
         if !package.has_script() {
             return false;
         }
@@ -290,6 +292,8 @@ impl PackageService {
     }
 
     async fn store_build_result(package: &PackageInfo) {
+        // FIXME disable cache for now
+        return;
         if Self::has_cached(package) {
             return;
         }

--- a/crates/cli/src/util/node.rs
+++ b/crates/cli/src/util/node.rs
@@ -383,7 +383,7 @@ impl Node {
         }
 
         log_verbose(&format!(
-            "{}@{} type changed [all_optional{}]",
+            "{}@{} type changed [all_optional {}]",
             &self.name, &self.version, all_optional
         ));
 

--- a/crates/cli/src/util/registry.rs
+++ b/crates/cli/src/util/registry.rs
@@ -183,14 +183,18 @@ impl Registry {
         log_verbose(&format!("Resolved {}@{} => {}", name, spec, version));
         if let Some(obj) = manifest.as_object_mut() {
             // merge dependencies and devDependencies
-            if let Some(optional_deps) = obj.get("optionalDependencies").and_then(|v| v.as_object()) {
+            if let Some(optional_deps) = obj.get("optionalDependencies").and_then(|v| v.as_object())
+            {
                 let optional_keys: Vec<String> = optional_deps.keys().cloned().collect();
                 if let Some(deps) = obj.get_mut("dependencies").and_then(|v| v.as_object_mut()) {
                     for key in &optional_keys {
                         deps.remove(key);
                     }
                 }
-                if let Some(dev_deps) = obj.get_mut("devDependencies").and_then(|v| v.as_object_mut()) {
+                if let Some(dev_deps) = obj
+                    .get_mut("devDependencies")
+                    .and_then(|v| v.as_object_mut())
+                {
                     for key in &optional_keys {
                         dev_deps.remove(key);
                     }

--- a/crates/cli/src/util/registry.rs
+++ b/crates/cli/src/util/registry.rs
@@ -179,8 +179,24 @@ impl Registry {
     }
 
     async fn resolve_package(&self, name: &str, spec: &str) -> io::Result<ResolvedPackage> {
-        let (version, manifest) = self.get_package_manifest(name, spec).await?;
+        let (version, mut manifest) = self.get_package_manifest(name, spec).await?;
         log_verbose(&format!("Resolved {}@{} => {}", name, spec, version));
+        if let Some(obj) = manifest.as_object_mut() {
+            // merge dependencies and devDependencies
+            if let Some(optional_deps) = obj.get("optionalDependencies").and_then(|v| v.as_object()) {
+                let optional_keys: Vec<String> = optional_deps.keys().cloned().collect();
+                if let Some(deps) = obj.get_mut("dependencies").and_then(|v| v.as_object_mut()) {
+                    for key in &optional_keys {
+                        deps.remove(key);
+                    }
+                }
+                if let Some(dev_deps) = obj.get_mut("devDependencies").and_then(|v| v.as_object_mut()) {
+                    for key in &optional_keys {
+                        dev_deps.remove(key);
+                    }
+                }
+            }
+        }
 
         Ok(ResolvedPackage {
             name: name.to_string(),


### PR DESCRIPTION
1. Follow `npm`. If a dependency declares both deps and optionalDeps, only keep optionalDeps.
2. Temporarily disable the scripts cache.