### PR TITLE
fix: disable parallel sassLoader

### DIFF
--- a/packages/mako/src/plugins/sass/index.ts
+++ b/packages/mako/src/plugins/sass/index.ts
@@ -1,9 +1,9 @@
-import path from 'path';
 import url from 'url';
 import { type Options } from 'sass';
 import { BuildParams } from '../../';
 import * as binding from '../../../binding';
-import { RunLoadersOptions, createParallelLoader } from '../../runLoaders';
+import { RunLoadersOptions } from '../../runLoaders';
+import { renderSass } from './render';
 
 type SassModule = {
   id: string;
@@ -18,7 +18,6 @@ export class SassPlugin implements binding.JsHooks {
   sassOptions: Options<'async'>;
   extOpts: RunLoadersOptions;
   moduleGraph: Map<string, SassModule> = new Map();
-  parallelLoader: ReturnType<typeof createParallelLoader> | undefined;
 
   constructor(params: BuildParams & { resolveAlias: Record<string, string> }) {
     this.name = 'sass';
@@ -52,10 +51,7 @@ export class SassPlugin implements binding.JsHooks {
       this.moduleGraph.set(filename, module);
     }
 
-    this.parallelLoader ||= createParallelLoader(
-      path.resolve(__dirname, './render.js'),
-    );
-    const result = await this.parallelLoader.run({
+    const result = await renderSass({
       filename,
       opts: this.sassOptions,
       extOpts: this.extOpts,
@@ -138,13 +134,6 @@ export class SassPlugin implements binding.JsHooks {
     });
 
     return Array.from(result);
-  };
-
-  generateEnd = () => {
-    if (!this.params.watch) {
-      this.parallelLoader?.destroy();
-      this.parallelLoader = undefined;
-    }
   };
 }
 

--- a/packages/mako/src/plugins/sass/render.ts
+++ b/packages/mako/src/plugins/sass/render.ts
@@ -1,11 +1,15 @@
 import { type Options } from 'sass';
-import { RunLoadersOptions, runLoaders } from '../../runLoaders';
+import {
+  RunLoaderResult,
+  RunLoadersOptions,
+  runLoaders,
+} from '../../runLoaders';
 
-async function render(param: {
+export async function renderSass(param: {
   filename: string;
-  opts: Options<'async'> & { resources: string[] };
+  opts: Options<'async'>;
   extOpts: RunLoadersOptions;
-}) {
+}): Promise<RunLoaderResult & { missingDependencies: string[] }> {
   const options = { style: 'compressed', ...param.opts };
   const extOpts = param.extOpts;
 
@@ -27,5 +31,3 @@ async function render(param: {
       throw new Error(err.toString());
     });
 }
-
-module.exports = render;

--- a/packages/mako/src/runLoaders/index.ts
+++ b/packages/mako/src/runLoaders/index.ts
@@ -80,7 +80,7 @@ export function runLoaders(
     loaders: any[];
     processResource?: (ctx: any, resource: string, callback: any) => void;
   } & RunLoadersOptions,
-): Promise<loaderRunner.RunLoaderResult> {
+): Promise<loaderRunner.RunLoaderResult & { missingDependencies: string[] }> {
   return new Promise((resolve, reject) => {
     loaderRunner.runLoaders(
       {
@@ -99,7 +99,11 @@ export function runLoaders(
           reject(error);
           return;
         }
-        resolve(data);
+        resolve(
+          data as loaderRunner.RunLoaderResult & {
+            missingDependencies: string[];
+          },
+        );
       },
     );
   });


### PR DESCRIPTION
disable parallel sassLoader because sassOptions.function cann't be shared cross workers, see https://github.com/umijs/mako/blob/master/e2e/fixtures.umi/config.sassLoader/.umirc.ts#L7