### PR TITLE
fix: less,sass,postcss loader panic

### DIFF
--- a/packages/mako/src/index.ts
+++ b/packages/mako/src/index.ts
@@ -110,6 +110,7 @@ export async function build(params: BuildParams) {
     params.config.postcss = true;
 
     params.config.plugins.push(
+      // @ts-ignore
       new PostcssPlugin({
         ...params,
         resolveAlias,
@@ -119,6 +120,7 @@ export async function build(params: BuildParams) {
 
   // built-in less-loader
   params.config.plugins.push(
+    // @ts-ignore
     new LessPlugin({
       ...params,
       resolveAlias,
@@ -132,6 +134,7 @@ export async function build(params: BuildParams) {
     };
 
     params.config.plugins.push(
+      // @ts-ignore
       new SassPlugin({
         ...params,
         resolveAlias,

--- a/packages/mako/src/plugins/less/index.ts
+++ b/packages/mako/src/plugins/less/index.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import url from 'url';
 import { BuildParams } from '../../';
 import * as binding from '../../../binding';
+import { PluginContext } from '../../binding';
 import { RunLoadersOptions, createParallelLoader } from '../../runLoaders';
 
 export interface LessLoaderOpts {
@@ -40,6 +41,7 @@ export class LessPlugin implements binding.JsHooks {
   extOpts: RunLoadersOptions;
   lessOptions: LessLoaderOpts;
   moduleGraph: Map<string, LessModule> = new Map();
+  __isPatched = true;
 
   constructor(params: BuildParams & { resolveAlias: Record<string, string> }) {
     this.name = 'less';
@@ -57,9 +59,12 @@ export class LessPlugin implements binding.JsHooks {
     };
   }
 
+  // @ts-ignore
   load: (
+    _ctx: PluginContext,
     filePath: string,
   ) => Promise<{ content: string; type: 'css' } | undefined> = async (
+    _ctx: PluginContext,
     filePath: string,
   ) => {
     if (!isTargetFile(filePath)) {
@@ -142,7 +147,8 @@ export class LessPlugin implements binding.JsHooks {
     };
   };
 
-  beforeRebuild = async (paths: string[]) => {
+  // @ts-ignore
+  beforeRebuild = async (_ctx: {}, paths: string[]) => {
     const result = new Set<string>();
 
     paths.forEach((filePath) => {

--- a/packages/mako/src/plugins/postcss/index.ts
+++ b/packages/mako/src/plugins/postcss/index.ts
@@ -9,6 +9,7 @@ export class PostcssPlugin implements binding.JsHooks {
   params: BuildParams & { resolveAlias: Record<string, string> };
   extOpts: RunLoadersOptions;
   parallelLoader: ReturnType<typeof createParallelLoader> | undefined;
+  __isPatched = true;
 
   constructor(params: BuildParams & { resolveAlias: Record<string, string> }) {
     this.name = 'postcss';
@@ -19,7 +20,9 @@ export class PostcssPlugin implements binding.JsHooks {
     };
   }
 
+  // @ts-ignore
   transform = async (
+    _ctx: binding.PluginContext,
     content: string,
     filename: string,
   ): Promise<{ content: string; type: 'css' | 'js' } | void> => {

--- a/packages/mako/src/plugins/sass/index.ts
+++ b/packages/mako/src/plugins/sass/index.ts
@@ -18,6 +18,7 @@ export class SassPlugin implements binding.JsHooks {
   sassOptions: Options<'async'>;
   extOpts: RunLoadersOptions;
   moduleGraph: Map<string, SassModule> = new Map();
+  __isPatched = true;
 
   constructor(params: BuildParams & { resolveAlias: Record<string, string> }) {
     this.name = 'sass';
@@ -29,9 +30,12 @@ export class SassPlugin implements binding.JsHooks {
     this.sassOptions = params.config?.sass || {};
   }
 
+  // @ts-ignore
   load: (
+    _ctx: binding.PluginContext,
     filePath: string,
   ) => Promise<{ content: string; type: 'css' } | undefined> = async (
+    _ctx: binding.PluginContext,
     filePath: string,
   ) => {
     if (!isTargetFile(filePath)) {
@@ -111,7 +115,8 @@ export class SassPlugin implements binding.JsHooks {
     };
   };
 
-  beforeRebuild = async (paths: string[]) => {
+  // @ts-ignore
+  beforeRebuild = async (_ctx: {}, paths: string[]) => {
     const result = new Set<string>();
 
     paths.forEach((filePath) => {


### PR DESCRIPTION
See: https://github.com/umijs/mako/blob/5f68c35a00688b7ca466948c0ad7a9a39e0acf6e/packages/mako/src/index.ts#L230,
"this" (the class instance) is lost.