### PR TITLE
fix(bundler): fix sourcemap

### DIFF
--- a/crates/bundler-core/src/library/chunking_context.rs
+++ b/crates/bundler-core/src/library/chunking_context.rs
@@ -80,6 +80,11 @@ impl LibraryChunkingContextBuilder {
         self
     }
 
+    pub fn use_file_source_map_uris(mut self) -> Self {
+        self.chunking_context.should_use_file_source_map_uris = true;
+        self
+    }
+
     pub fn module_id_strategy(
         mut self,
         module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,

--- a/crates/bundler-core/src/library/contexts.rs
+++ b/crates/bundler-core/src/library/contexts.rs
@@ -27,7 +27,7 @@ pub async fn get_library_chunking_context(
     no_mangling: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let mode = mode.await?;
-    let builder = LibraryChunkingContext::builder(
+    let mut builder = LibraryChunkingContext::builder(
         root_path,
         output_root,
         output_root_to_root_path,
@@ -47,6 +47,10 @@ pub async fn get_library_chunking_context(
         SourceMapsType::None
     })
     .module_id_strategy(module_id_strategy);
+
+    if mode.is_development() {
+        builder = builder.use_file_source_map_uris();
+    }
 
     Ok(Vc::upcast(builder.build()))
 }

--- a/crates/bundler-core/src/library/ecmascript/chunk.rs
+++ b/crates/bundler-core/src/library/ecmascript/chunk.rs
@@ -83,6 +83,7 @@ impl EcmascriptLibraryChunk {
             *this.chunking_context,
             self,
             this.chunk.chunk_content(),
+            self.source_map(),
         ))
     }
 


### PR DESCRIPTION
After update next.js to 15.3.0, sourcemaps is broken. We need to follow changes of: https://github.com/vercel/next.js/pull/77735
Close: https://github.com/umijs/mako/issues/1851