### PR TITLE
feat: binary mirror config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7738,6 +7738,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9059,6 +9072,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-tar",
+ "tokio-test",
  "utoo-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7738,19 +7738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-test"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
-dependencies = [
- "async-stream",
- "bytes",
- "futures-core",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9064,7 +9051,6 @@ dependencies = [
  "owo-colors 4.2.0",
  "regex",
  "reqwest",
- "semver 1.0.26",
  "serde",
  "serde_json",
  "tar",
@@ -9072,7 +9058,6 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-tar",
- "tokio-test",
  "utoo-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9035,7 +9035,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoo-cli"
-version = "0.0.0-alpha.18"
+version = "0.0.0-alpha.19"
 dependencies = [
  "async-compression",
  "clap",
@@ -9049,7 +9049,9 @@ dependencies = [
  "libc",
  "once_cell",
  "owo-colors 4.2.0",
+ "regex",
  "reqwest",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "tar",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -63,3 +63,7 @@ semver = "1.0"
 name = "install_benchmark"
 harness = false
 path = "benches/deps_benchmark.rs"
+
+[dev-dependencies]
+tempfile = "3.8"
+tokio-test = "0.4"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -57,13 +57,8 @@ glob = "0.3.1"
 criterion = { workspace = true }
 utoo-core = { path = "../core/" }
 regex = "1.10"
-semver = "1.0"
 
 [[bench]]
 name = "install_benchmark"
 harness = false
 path = "benches/deps_benchmark.rs"
-
-[dev-dependencies]
-tempfile = "3.8"
-tokio-test = "0.4"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utoo-cli"
-version = "0.0.0-alpha.18"
+version = "0.0.0-alpha.19"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -46,7 +46,7 @@ dirs = "4.0"
 libc = "0.2"
 clap = { workspace = true }
 indicatif = "0.17.8"
-once_cell = "1.19.0"
+once_cell = "1.19"
 async-compression = { version = "0.3", features = ["tokio", "gzip"] }
 tokio-tar = "0.3.1"
 tokio-retry = "0.3"
@@ -56,6 +56,8 @@ futures = { workspace = true }
 glob = "0.3.1"
 criterion = { workspace = true }
 utoo-core = { path = "../core/" }
+regex = "1.10"
+semver = "1.0"
 
 [[bench]]
 name = "install_benchmark"

--- a/crates/cli/src/constants.rs
+++ b/crates/cli/src/constants.rs
@@ -1,6 +1,6 @@
-pub const APP_NAME: &str = "🌖 utoo";
+pub const APP_NAME: &str = "utoo";
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const APP_ABOUT: &str = "/juːtuː/ Unified Toolchain: Open & Optimized";
+pub const APP_ABOUT: &str = "🌖 /juːtuː/ Unified Toolchain: Open & Optimized";
 
 pub mod cmd {
     pub const CLEAN_NAME: &str = "clean";

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,15 +28,16 @@ use crate::constants::{APP_ABOUT, APP_NAME, APP_VERSION};
 #[command(name = APP_NAME)]
 #[command(version = APP_VERSION)]
 #[command(about = APP_ABOUT)]
+#[command(version = None)]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
     #[arg(long)]
     ignore_scripts: bool,
 
     #[arg(long, global = true)]
     verbose: bool,
-
-    #[arg(short, long)]
-    version: bool,
 
     #[arg(long, global = true)]
     registry: Option<String>,
@@ -44,8 +45,8 @@ struct Cli {
     #[arg(long, global = true, action = clap::ArgAction::SetTrue)]
     legacy_peer_deps: Option<bool>,
 
-    #[command(subcommand)]
-    command: Option<Commands>,
+    #[arg(short = 'v', long)]
+    version: bool,
 }
 
 #[derive(Subcommand)]
@@ -136,18 +137,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         set_legacy_peer_deps(cli.legacy_peer_deps);
     }
 
+    // Handle --version flag
+    if cli.version {
+        println!("{}", APP_VERSION);
+        return Ok(());
+    }
+
     // Ensure the version is up to date, weak dependency
     if let Err(_e) = init_auto_update().await {
         log_warning(&format!("Auto update cancelled"));
     }
-
-    // load package.json
-    // if let Some(result) = cmd::pkg::handle_command_v4(&cli) {
-    //     if let Err(e) = result {
-    //         log_error(&e);
-    //     }
-    //     return;
-    // }
 
     match cli.command {
         Some(Commands::Clean { pattern }) => {

--- a/crates/cli/src/service/binary.rs
+++ b/crates/cli/src/service/binary.rs
@@ -1,7 +1,7 @@
 use crate::util::config::get_registry;
 use crate::util::logger::log_info;
+use crate::util::semver::matches;
 use regex::Regex;
-use semver::Version;
 use serde_json::{Map, Value};
 use std::path::Path;
 use tokio::fs;
@@ -215,10 +215,7 @@ async fn handle_cypress(
     });
 
     let platforms = if let Some(new_platforms) = binary_mirror.get("newPlatforms") {
-        if Version::parse(pkg["version"].as_str().unwrap())
-            .map(|v| v >= Version::parse("3.3.0").unwrap())
-            .unwrap_or(false)
-        {
+        if matches(">=3.3.0", pkg["version"].as_str().unwrap()) {
             new_platforms
         } else {
             &default_platforms

--- a/crates/cli/src/service/binary.rs
+++ b/crates/cli/src/service/binary.rs
@@ -1,0 +1,291 @@
+use std::path::Path;
+use serde_json::{Value, Map};
+use tokio::fs;
+use regex::Regex;
+use semver::Version;
+use tokio::sync::OnceCell;
+use crate::util::config::get_registry;
+use crate::util::logger::log_info;
+
+#[derive(Debug)]
+pub enum BinaryError {
+    InvalidConfig(String),
+    FileOperation(String),
+    NetworkError(String),
+    ParseError(String),
+}
+
+impl std::fmt::Display for BinaryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BinaryError::InvalidConfig(msg) => write!(f, "Invalid config: {}", msg),
+            BinaryError::FileOperation(msg) => write!(f, "File operation failed: {}", msg),
+            BinaryError::NetworkError(msg) => write!(f, "Network error: {}", msg),
+            BinaryError::ParseError(msg) => write!(f, "Parse error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for BinaryError {}
+
+static CONFIG: OnceCell<Value> = OnceCell::const_new();
+
+async fn load_config() -> Result<&'static Value, BinaryError> {
+    CONFIG.get_or_try_init(|| async {
+        let registry = get_registry();
+        let url = format!("{}/binary-mirror-config/latest", registry);
+        let response = reqwest::get(&url)
+            .await
+            .map_err(|e| BinaryError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(BinaryError::NetworkError(format!("HTTP status: {}", response.status())));
+        }
+
+        response.json()
+            .await
+            .map_err(|e| BinaryError::ParseError(e.to_string()))
+    }).await
+}
+
+fn update_binary_config(pkg: &mut Value, binary_mirror: &Map<String, Value>) {
+    // Get existing binary configuration
+    let mut new_binary = if let Some(binary) = pkg.get("binary") {
+        if let Some(obj) = binary.as_object() {
+            obj.clone()
+        } else {
+            Map::new()
+        }
+    } else {
+        Map::new()
+    };
+
+    // Merge new configuration
+    for (key, value) in binary_mirror {
+        if key != "replaceHostFiles" {
+            new_binary.insert(key.clone(), value.clone());
+        }
+    }
+
+    // Update binary configuration
+    pkg["binary"] = Value::Object(new_binary.clone());
+
+    // Safely get package name and version
+    let name = pkg.get("name").and_then(|n| n.as_str()).unwrap_or("unknown");
+    let version = pkg.get("version").and_then(|v| v.as_str()).unwrap_or("unknown");
+
+    log_info(&format!("{}@{} download from binary mirror: {:?}",
+        name,
+        version,
+        new_binary
+    ));
+}
+
+async fn handle_node_pre_gyp_versioning(dir: &Path) -> Result<(), BinaryError> {
+    let versioning_file = dir.join("node_modules/node-pre-gyp/lib/util/versioning.js");
+    if versioning_file.exists() {
+        let content = fs::read_to_string(&versioning_file)
+            .await
+            .map_err(|e| BinaryError::FileOperation(e.to_string()))?;
+
+        let new_content = content.replace(
+            "if (protocol === 'http:') {",
+            "if (false && protocol === 'http:') { // hack by npminstall"
+        );
+
+        fs::write(&versioning_file, new_content)
+            .await
+            .map_err(|e| BinaryError::FileOperation(e.to_string()))?;
+    }
+    Ok(())
+}
+
+fn should_handle_replace_host(binary_mirror: &Map<String, Value>) -> bool {
+    (binary_mirror.contains_key("replaceHost") && binary_mirror.contains_key("host")) ||
+    binary_mirror.contains_key("replaceHostMap") ||
+    binary_mirror.contains_key("replaceHostRegExpMap")
+}
+
+fn get_replace_host_files(binary_mirror: &Map<String, Value>) -> Vec<&str> {
+    binary_mirror.get("replaceHostFiles")
+        .and_then(|f| f.as_array())
+        .map(|f| f.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+        .unwrap_or_else(|| vec!["lib/index.js", "lib/install.js"])
+}
+
+fn replace_with_regex(content: &str, replace_map: &Value) -> Result<String, BinaryError> {
+    let mut result = content.to_string();
+    for (pattern, replacement) in replace_map.as_object().unwrap() {
+        let re = Regex::new(pattern)
+            .map_err(|e| BinaryError::ParseError(format!("Invalid regex pattern {}: {}", pattern, e)))?;
+        result = re.replace_all(&result, replacement.as_str().unwrap()).to_string();
+    }
+    Ok(result)
+}
+
+fn replace_with_map(content: &str, binary_mirror: &Map<String, Value>) -> Result<String, BinaryError> {
+    let replace_map = if let Some(map) = binary_mirror.get("replaceHostMap") {
+        map.as_object().unwrap().clone()
+    } else {
+        let mut map = Map::new();
+        let hosts = binary_mirror.get("replaceHost")
+            .and_then(|h| h.as_array())
+            .map(|h| h.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+            .unwrap_or_else(|| vec![binary_mirror["host"].as_str().unwrap()]);
+
+        for host in hosts {
+            map.insert(host.to_string(), Value::String(binary_mirror["host"].as_str().unwrap().to_string()));
+        }
+        map
+    };
+
+    let mut result = content.to_string();
+    for (from, to) in replace_map {
+        result = result.replace(&from, to.as_str().unwrap());
+    }
+    Ok(result)
+}
+
+async fn handle_replace_host(dir: &Path, binary_mirror: &Map<String, Value>) -> Result<(), BinaryError> {
+    if !should_handle_replace_host(binary_mirror) {
+        return Ok(());
+    }
+
+    let replace_host_files = get_replace_host_files(binary_mirror);
+    for file in replace_host_files {
+        let file_path = dir.join(file);
+        if file_path.exists() {
+            let content = fs::read_to_string(&file_path)
+                .await
+                .map_err(|e| BinaryError::FileOperation(e.to_string()))?;
+
+            let new_content = if let Some(replace_map) = binary_mirror.get("replaceHostRegExpMap") {
+                replace_with_regex(&content, replace_map)?
+            } else {
+                replace_with_map(&content, binary_mirror)?
+            };
+
+            fs::write(&file_path, new_content)
+                .await
+                .map_err(|e| BinaryError::FileOperation(e.to_string()))?;
+        }
+    }
+    Ok(())
+}
+
+async fn handle_cypress(dir: &Path, pkg: &Value, binary_mirror: &Map<String, Value>) -> Result<(), BinaryError> {
+    if pkg["name"].as_str().unwrap() != "cypress" {
+        return Ok(());
+    }
+
+    let default_platforms = serde_json::json!({
+        "darwin": "osx64",
+        "linux": "linux64",
+        "win32": "win64"
+    });
+
+    let platforms = if let Some(new_platforms) = binary_mirror.get("newPlatforms") {
+        if Version::parse(pkg["version"].as_str().unwrap())
+            .map(|v| v >= Version::parse("3.3.0").unwrap())
+            .unwrap_or(false)
+        {
+            new_platforms
+        } else {
+            &default_platforms
+        }
+    } else {
+        &default_platforms
+    };
+
+    if let Some(target_platform) = platforms[std::env::consts::OS].as_str() {
+        let download_file = dir.join("lib/tasks/download.js");
+        if download_file.exists() {
+            let content = fs::read_to_string(&download_file)
+                .await
+                .map_err(|e| BinaryError::FileOperation(e.to_string()))?;
+
+            let new_content = content
+                .replace(
+                    "return version ? prepend(`desktop/${version}`) : prepend('desktop')",
+                    &format!("return \"{}\" + version + \"/{}/cypress.zip\"; // hack by npminstall",
+                        binary_mirror["host"].as_str().unwrap(), target_platform)
+                )
+                .replace(
+                    "return version ? prepend('desktop/' + version) : prepend('desktop');",
+                    &format!("return \"{}\" + version + \"/{}/cypress.zip\"; // hack by npminstall",
+                        binary_mirror["host"].as_str().unwrap(), target_platform)
+                );
+
+            fs::write(&download_file, new_content)
+                .await
+                .map_err(|e| BinaryError::FileOperation(e.to_string()))?;
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn update_package_binary(dir: &Path, name: &str) -> Result<(), BinaryError> {
+    let config = load_config().await?;
+
+    let mirrors = config["mirrors"]["china"].as_object()
+        .ok_or_else(|| BinaryError::InvalidConfig("Invalid binary mirror config format".to_string()))?;
+
+    if let Some(binary_mirror) = mirrors.get(name) {
+        let binary_mirror = binary_mirror.as_object()
+            .ok_or_else(|| BinaryError::InvalidConfig("Invalid binary mirror format".to_string()))?;
+
+        // Read package.json
+        let pkg_path = dir.join("package.json");
+        let content = fs::read_to_string(&pkg_path)
+            .await
+            .map_err(|e| BinaryError::FileOperation(e.to_string()))?;
+
+        let mut pkg: Value = serde_json::from_str(&content)
+            .map_err(|e| BinaryError::ParseError(e.to_string()))?;
+
+        // has install script and not replaceHostFiles
+        let should_update_binary = if let Some(scripts) = pkg["scripts"].as_object() {
+            scripts.contains_key("install") && !binary_mirror.contains_key("replaceHostFiles")
+        } else {
+            false
+        };
+
+        // detect node-pre-gyp
+        let should_handle_node_pre_gyp = if let Some(scripts) = pkg["scripts"].as_object() {
+            scripts.get("install")
+                .and_then(|s| s.as_str())
+                .map(|s| s.contains("node-pre-gyp install"))
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
+        // update binary config
+        if should_update_binary {
+            update_binary_config(&mut pkg, binary_mirror);
+        }
+
+        // process node-pre-gyp
+        if should_handle_node_pre_gyp {
+            handle_node_pre_gyp_versioning(dir).await?;
+        }
+
+        handle_replace_host(dir, binary_mirror).await?;
+        handle_cypress(dir, &pkg, binary_mirror).await?;
+
+        // Write updated package.json
+        fs::write(pkg_path, serde_json::to_string_pretty(&pkg).unwrap())
+            .await
+            .map_err(|e| BinaryError::FileOperation(e.to_string()))?;
+    }
+
+    Ok(())
+}
+pub async fn get_envs() -> Option<&'static Map<String, Value>> {
+    match load_config().await {
+        Ok(_) => CONFIG.get()
+            .and_then(|config| config["mirrors"]["china"]["ENVS"].as_object()),
+        Err(_) => None,
+    }
+}

--- a/crates/cli/src/service/install.rs
+++ b/crates/cli/src/service/install.rs
@@ -12,6 +12,8 @@ use crate::util::downloader::download;
 use crate::util::linker::link;
 use crate::util::logger::{log_progress, log_verbose, PROGRESS_BAR};
 
+use super::binary::update_package_binary;
+
 async fn clean_deps(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
@@ -177,6 +179,7 @@ pub async fn install_packages(
                                 log_verbose(&format!("{} resolved", name));
                                 PROGRESS_BAR.inc(1);
                                 log_progress(&format!("{} resolved", name));
+                                update_package_binary(&cwd_clone.join(&path), &name).await?;
                                 Ok(())
                             }
                             Err(e) => Err(format!(

--- a/crates/cli/src/service/mod.rs
+++ b/crates/cli/src/service/mod.rs
@@ -2,3 +2,4 @@ pub mod install;
 pub mod package;
 pub mod script;
 pub mod update;
+pub mod binary;

--- a/crates/cli/src/service/mod.rs
+++ b/crates/cli/src/service/mod.rs
@@ -1,5 +1,5 @@
+pub mod binary;
 pub mod install;
 pub mod package;
 pub mod script;
 pub mod update;
-pub mod binary;

--- a/crates/cli/src/service/script.rs
+++ b/crates/cli/src/service/script.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tokio::fs;
 
+use super::binary::get_envs;
+
 pub struct ScriptService;
 
 impl ScriptService {
@@ -47,6 +49,13 @@ impl ScriptService {
                 .env("npm_config_prefix", "")
                 .env("npm_config_global", "false");
 
+            if let Some(envs) = get_envs().await {
+                for (key, value) in envs {
+                    if let Some(value_str) = value.as_str() {
+                        cmd.env(key, value_str);
+                    }
+                }
+            }
             log_verbose(&format!("Executing command: {:?}", cmd));
 
             let output = tokio::process::Command::from(cmd)
@@ -255,6 +264,14 @@ impl ScriptService {
             )
             .env("npm_config_prefix", "")
             .env("npm_config_global", "false");
+
+        if let Some(envs) = get_envs().await {
+            for (key, value) in envs {
+                if let Some(value_str) = value.as_str() {
+                    cmd.env(key, value_str);
+                }
+            }
+        }
 
         log_verbose(&format!("Executing command: {:?}", cmd));
 

--- a/crates/cli/src/service/script.rs
+++ b/crates/cli/src/service/script.rs
@@ -250,7 +250,6 @@ impl ScriptService {
             .arg(script_content)
             .current_dir(&package.path)
             .env("PATH", env_path)
-            .env("npm_lifecycle_event", script_name)
             .env(
                 "INIT_CWD",
                 env::current_dir()


### PR DESCRIPTION
1. 🌏 load `binary-mirror-config` to modify the binary configuration in npm pkg.
2. 🔧 add `service/binary.rs`, inject the mirror env variables.
3. 🐞 fix $cwd/node_modules/.bin not found

![image](https://github.com/user-attachments/assets/3cb81b59-4bb1-4262-8db4-f60db8aa6d41)
