### PR TITLE
fix: save prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9045,7 +9045,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoo-cli"
-version = "0.0.0-alpha.20"
+version = "0.0.0-alpha.27"
 dependencies = [
  "async-compression",
  "clap",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utoo-cli"
-version = "0.0.0-alpha.20"
+version = "0.0.0-alpha.27"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/cli/src/helper/lock.rs
+++ b/crates/cli/src/helper/lock.rs
@@ -236,10 +236,16 @@ mod tests {
 
         for (version, spec, expected) in test_cases {
             let version_to_write = match spec {
-                spec if spec.is_empty() || spec == "*" || spec == "latest" => format!("^{}", version),
+                spec if spec.is_empty() || spec == "*" || spec == "latest" => {
+                    format!("^{}", version)
+                }
                 spec => spec.to_string(),
             };
-            assert_eq!(version_to_write, expected, "Failed for version: {}, spec: {}", version, spec);
+            assert_eq!(
+                version_to_write, expected,
+                "Failed for version: {}, spec: {}",
+                version, spec
+            );
         }
     }
 }


### PR DESCRIPTION
> Implement savePrefix Logic with ^ Default

* 🔭 Automatically adds ^ prefix when saving dependencies **only if**:
    * No custom spec is provided (e.g., utoo install package@1.2.3 won't be modified)
    * The version isn't already prefixed (e.g., ~1.2.3, ^1.2.3 remain unchanged)