### PR TITLE
feat: run in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9045,7 +9045,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoo-cli"
-version = "0.0.0-alpha.20"
+version = "0.0.0-alpha.27"
 dependencies = [
  "async-compression",
  "clap",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utoo-cli"
-version = "0.0.0-alpha.20"
+version = "0.0.0-alpha.27"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/cli/src/cmd/run.rs
+++ b/crates/cli/src/cmd/run.rs
@@ -9,10 +9,17 @@ use std::path::PathBuf;
 
 pub async fn run_script(script_name: &str, workspace: Option<String>) -> Result<(), String> {
     let pkg = if let Some(workspace_name) = &workspace {
-        let workspace_dir = find_workspace_path(&std::env::current_dir().map_err(|e| e.to_string())?, workspace_name)
-            .await
-            .map_err(|e| e.to_string())?;
-        log_info(&format!("Using workspace: {} at path: {}", workspace_name, workspace_dir.display()));
+        let workspace_dir = find_workspace_path(
+            &std::env::current_dir().map_err(|e| e.to_string())?,
+            workspace_name,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+        log_info(&format!(
+            "Using workspace: {} at path: {}",
+            workspace_name,
+            workspace_dir.display()
+        ));
         load_package_json_from_path(&workspace_dir)?
     } else {
         load_package_json()?
@@ -23,9 +30,12 @@ pub async fn run_script(script_name: &str, workspace: Option<String>) -> Result<
 
     let package = PackageInfo {
         path: if let Some(workspace_name) = workspace {
-            find_workspace_path(&std::env::current_dir().map_err(|e| e.to_string())?, &workspace_name)
-                .await
-                .map_err(|e| e.to_string())?
+            find_workspace_path(
+                &std::env::current_dir().map_err(|e| e.to_string())?,
+                &workspace_name,
+            )
+            .await
+            .map_err(|e| e.to_string())?
         } else {
             std::env::current_dir().map_err(|e| e.to_string())?
         },

--- a/crates/cli/src/cmd/run.rs
+++ b/crates/cli/src/cmd/run.rs
@@ -1,18 +1,34 @@
 use crate::helper::package::parse_package_name;
+use crate::helper::workspace::find_workspace_path;
 use crate::model::package::{PackageInfo, Scripts};
 use crate::service::script::ScriptService;
 use crate::util::logger::log_info;
 use serde_json::Value;
 use std::fs;
+use std::path::PathBuf;
 
-pub async fn run_script(script_name: &str) -> Result<(), String> {
-    let pkg = load_package_json()?;
+pub async fn run_script(script_name: &str, workspace: Option<String>) -> Result<(), String> {
+    let pkg = if let Some(workspace_name) = &workspace {
+        let workspace_dir = find_workspace_path(&std::env::current_dir().map_err(|e| e.to_string())?, workspace_name)
+            .await
+            .map_err(|e| e.to_string())?;
+        log_info(&format!("Using workspace: {} at path: {}", workspace_name, workspace_dir.display()));
+        load_package_json_from_path(&workspace_dir)?
+    } else {
+        load_package_json()?
+    };
 
     let (scope, name, fullname) =
         parse_package_name(pkg.get("name").and_then(|v| v.as_str()).unwrap_or_default());
 
     let package = PackageInfo {
-        path: std::env::current_dir().map_err(|e| e.to_string())?,
+        path: if let Some(workspace_name) = workspace {
+            find_workspace_path(&std::env::current_dir().map_err(|e| e.to_string())?, &workspace_name)
+                .await
+                .map_err(|e| e.to_string())?
+        } else {
+            std::env::current_dir().map_err(|e| e.to_string())?
+        },
         bin_files: Default::default(),
         scripts: Scripts::default(),
         scope,
@@ -49,6 +65,14 @@ fn load_package_json() -> Result<Value, String> {
     serde_json::from_str(&content).map_err(|e| format!("Failed to parse package.json: {}", e))
 }
 
+fn load_package_json_from_path(path: &PathBuf) -> Result<Value, String> {
+    let package_json_path = path.join("package.json");
+    let content = fs::read_to_string(package_json_path)
+        .map_err(|e| format!("Failed to read package.json: {}", e))?;
+
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse package.json: {}", e))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,7 +95,7 @@ mod tests {
         let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(_dir.path()).unwrap();
 
-        let result = run_script("nonexistent").await;
+        let result = run_script("nonexistent", None).await;
 
         std::env::set_current_dir(original_dir).unwrap();
         assert!(result.is_err());
@@ -89,7 +113,7 @@ mod tests {
         let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(_dir.path()).unwrap();
 
-        let result = run_script("test").await;
+        let result = run_script("test", None).await;
 
         std::env::set_current_dir(original_dir).unwrap();
         assert!(result.is_err());

--- a/crates/cli/src/helper/lock.rs
+++ b/crates/cli/src/helper/lock.rs
@@ -9,7 +9,7 @@ use crate::util::save_type::{PackageAction, SaveType};
 use crate::util::{cache::parse_pattern, cloner::clone, downloader::download};
 use crate::{cmd::deps::build_deps, util::logger::log_info};
 
-use super::workspace::find_workspaces;
+use super::workspace::find_workspace_path;
 
 #[derive(Deserialize)]
 pub struct PackageLock {
@@ -127,19 +127,6 @@ pub async fn parse_package_spec(
     let (name, version_spec) = parse_pattern(spec);
     let resolved = resolve(&name, &version_spec).await?;
     Ok((name, resolved.version))
-}
-
-async fn find_workspace_path(
-    cwd: &PathBuf,
-    workspace: &str,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let workspaces = find_workspaces(cwd).await?;
-    for (name, path, _) in workspaces {
-        if name == workspace || path.to_string_lossy() == workspace {
-            return Ok(path);
-        }
-    }
-    Err(format!("Workspace '{}' not found", workspace).into())
 }
 
 pub async fn prepare_global_package_json(

--- a/crates/cli/src/helper/workspace.rs
+++ b/crates/cli/src/helper/workspace.rs
@@ -72,7 +72,10 @@ pub async fn find_workspaces(root_path: &PathBuf) -> io::Result<Vec<(String, Pat
     Ok(workspaces)
 }
 
-pub async fn find_workspace_path(cwd: &PathBuf, workspace: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+pub async fn find_workspace_path(
+    cwd: &PathBuf,
+    workspace: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let workspaces = find_workspaces(cwd).await?;
     for (name, path, _) in workspaces {
         // Try exact name match


### PR DESCRIPTION

🔹 **Basic `--workspace` Parameter**  
Supports targeting **a single workspace** by name or path:  
```bash
utoo run build --workspace=core       # by name
utoo run test --workspace=packages/ui # by exact path
```

🚧 **Single-workspace only**  
- Does _not_ yet support:  
  - Glob patterns (`packages/*`)  
  - Multiple workspaces (comma-separated)  