### PR TITLE
chore: remove useless rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,17 +521,11 @@ name = "bundler-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "auto-hash-map",
  "bundler-core",
- "either",
- "futures",
- "indexmap 2.9.0",
  "qstring",
- "regex",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_core",
  "tokio",
  "tracing",
  "turbo-rcstr",
@@ -540,12 +534,9 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-env",
  "turbo-tasks-fs",
- "turbo-tasks-hash",
- "turbo-tasks-memory",
  "turbopack",
  "turbopack-browser",
  "turbopack-core",
- "turbopack-ecmascript",
  "turbopack-node",
  "turbopack-nodejs",
  "turbopack-trace-utils",
@@ -562,10 +553,8 @@ dependencies = [
  "bundler-api",
  "bundler-core",
  "clap",
- "console-subscriber",
  "dunce",
  "futures-util",
- "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "tokio",
@@ -576,13 +565,7 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-backend",
  "turbo-tasks-build",
- "turbo-tasks-env",
- "turbo-tasks-fs",
  "turbo-tasks-malloc",
- "turbo-tasks-memory",
- "turbopack",
- "turbopack-browser",
- "turbopack-core",
  "turbopack-trace-utils",
 ]
 
@@ -592,13 +575,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "auto-hash-map",
  "base64 0.22.1",
- "either",
- "futures",
- "indexmap 2.9.0",
  "indoc",
- "lazy-regex",
  "mime_guess",
  "modularize_imports 0.79.0",
  "qstring",
@@ -607,9 +585,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "serde_qs",
  "swc_core",
- "thiserror 1.0.69",
  "tracing",
  "turbo-rcstr",
  "turbo-tasks",
@@ -627,7 +603,6 @@ dependencies = [
  "turbopack-ecmascript-runtime",
  "turbopack-image",
  "turbopack-node",
- "turbopack-nodejs",
  "turbopack-resolve",
  "turbopack-static",
  "turbopack-trace-utils",
@@ -643,7 +618,6 @@ dependencies = [
  "bundler-core",
  "console-subscriber",
  "dhat",
- "futures",
  "mdxjs",
  "napi",
  "napi-build",
@@ -3213,29 +3187,6 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
-]
-
-[[package]]
-name = "lazy-regex"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.100",
 ]
 
 [[package]]

--- a/crates/bundler-api/Cargo.toml
+++ b/crates/bundler-api/Cargo.toml
@@ -6,17 +6,11 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
-auto-hash-map = { workspace = true }
-either = { workspace = true }
-futures = { workspace = true }
-indexmap = { workspace = true }
 bundler-core = { workspace = true }
 qstring = { workspace = true }
-regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-swc_core = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
@@ -25,13 +19,10 @@ turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
-turbo-tasks-hash = { workspace = true }
-turbo-tasks-memory = { workspace = true }
 turbo-tasks-backend = { workspace = true }
 turbopack = { workspace = true }
 turbopack-browser = { workspace = true }
 turbopack-core = { workspace = true }
-turbopack-ecmascript = { workspace = true }
 turbopack-node = { workspace = true }
 turbopack-nodejs = { workspace = true }
 turbopack-trace-utils = { workspace = true }

--- a/crates/bundler-cli/Cargo.toml
+++ b/crates/bundler-cli/Cargo.toml
@@ -15,9 +15,7 @@ bundler-core = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-console-subscriber = { workspace = true, optional = true }
 tokio = { workspace = true }
-rustc-hash = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true }
 dunce = { workspace = true }
@@ -27,13 +25,7 @@ futures-util = "0.3.30"
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-backend = { workspace = true }
-turbo-tasks-fs = { workspace = true }
-turbo-tasks-env = { workspace = true }
-turbo-tasks-memory = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
-turbopack = { workspace = true }
-turbopack-browser = { workspace = true }
-turbopack-core = { workspace = true }
 turbopack-trace-utils = { workspace = true }
 
 

--- a/crates/bundler-core/Cargo.toml
+++ b/crates/bundler-core/Cargo.toml
@@ -14,22 +14,15 @@ plugin = [
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.22.1"
-either = { workspace = true }
-lazy-regex = "3.0.1"
 qstring = "0.7.2"
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_qs = { workspace = true }
-indexmap = { workspace = true, features = ["serde"] }
 mime_guess = "2.0.4"
 indoc = "2.0.6"
-futures = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
 remove_console = "0.34.0"
-auto-hash-map = { workspace = true }
 urlencoding = { workspace = true }
 modularize_imports = { version = "0.79.0" }
 swc_core = { workspace = true, features = [
@@ -68,7 +61,6 @@ turbopack-ecmascript-plugins = { workspace = true, features = [
 ] }
 turbopack-ecmascript-runtime = { workspace = true }
 turbopack-node = { workspace = true }
-turbopack-nodejs = { workspace = true }
 turbopack-static = { workspace = true }
 turbopack-image = { workspace = true }
 turbopack-resolve = { workspace = true }

--- a/crates/bundler-napi/Cargo.toml
+++ b/crates/bundler-napi/Cargo.toml
@@ -69,7 +69,6 @@ console-subscriber = { workspace = true, optional = true }
 rand = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
I use [`cargo-shear`](https://github.com/Boshen/cargo-shear) to detect and remove some useless rust dependencies, and `cargo build` execute is successfully at my local.

