### PR TITLE
feat: log clean

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8999,7 +8999,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoo-cli"
-version = "0.0.0-alpha.29"
+version = "0.0.0-alpha.30"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.2+3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4032,6 +4041,7 @@ checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -9013,6 +9023,7 @@ dependencies = [
  "indicatif",
  "libc",
  "once_cell",
+ "openssl",
  "owo-colors 4.2.0",
  "regex",
  "reqwest",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utoo-cli"
-version = "0.0.0-alpha.29"
+version = "0.0.0-alpha.30"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -58,6 +58,7 @@ criterion = { workspace = true }
 utoo-core = { path = "../core/" }
 regex = "1.10"
 anyhow = { workspace = true }
+openssl = { version = "0.10", features = ["vendored"] }
 
 [[bench]]
 name = "install_benchmark"

--- a/crates/cli/src/service/install.rs
+++ b/crates/cli/src/service/install.rs
@@ -1,7 +1,10 @@
+use anyhow::Context;
 use anyhow::Result;
 use glob::glob;
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
@@ -112,27 +115,55 @@ async fn clean_unused_packages(
     node_modules: &Path,
     cwd: &Path,
     valid_packages: &std::collections::HashSet<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let pattern = node_modules
-        .join("**/*/package.json")
-        .to_string_lossy()
-        .to_string();
-    for entry in glob(&pattern)? {
-        if let Ok(path) = entry {
-            let pkg_dir = path.parent().unwrap();
-            // /Users/xxx/utoo/node_modules/utoo-cli/node_modules/ora/package.json
-            // => ora
-            if let Some(pkg_name) = path_to_pkg_name(&pkg_dir.to_string_lossy()) {
-                let pkg_path = pkg_dir.strip_prefix(cwd).unwrap();
-                if !valid_packages.contains(pkg_path.to_string_lossy().as_ref()) {
-                    log_verbose(&format!("Cleaning unused package: {}", pkg_name));
-                    if let Err(e) = tokio::fs::remove_dir_all(pkg_dir).await {
-                        log_verbose(&format!("Failed to remove {}: {}", pkg_name, e));
+) -> Result<()> {
+    // Helper function for recursive search
+    fn find_and_clean<'a>(
+        node_modules: &'a Path,
+        cwd: &'a Path,
+        valid_packages: &'a std::collections::HashSet<String>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            let patterns = [
+                node_modules.join("*/package.json"),
+                node_modules.join("@*/*/package.json"),
+            ];
+            for pattern in patterns.iter() {
+                let pattern_str = pattern.to_string_lossy().to_string();
+                for entry in glob(&pattern_str)
+                    .with_context(|| format!("Glob failed for pattern: {}", pattern_str))?
+                {
+                    let pkg_json_path = entry.with_context(|| {
+                        format!("Glob entry error for pattern: {}", pattern_str)
+                    })?;
+                    let pkg_dir = pkg_json_path
+                        .parent()
+                        .context("Failed to get parent directory of package.json")?;
+                    if let Some(pkg_name) = path_to_pkg_name(&pkg_dir.to_string_lossy()) {
+                        let pkg_path = pkg_dir.strip_prefix(cwd).with_context(|| {
+                            format!(
+                                "Failed to strip prefix {} from {}",
+                                cwd.display(),
+                                pkg_dir.display()
+                            )
+                        })?;
+                        if !valid_packages.contains(pkg_path.to_string_lossy().as_ref()) {
+                            log_verbose(&format!("Cleaning unused package: {}", pkg_name));
+                            if let Err(e) = tokio::fs::remove_dir_all(pkg_dir).await {
+                                log_verbose(&format!("Failed to remove {}: {}", pkg_name, e));
+                            }
+                        }
+                    }
+                    // Recursively check nested node_modules
+                    let nested_node_modules = pkg_dir.join("node_modules");
+                    if nested_node_modules.exists() {
+                        find_and_clean(&nested_node_modules, cwd, valid_packages).await?;
                     }
                 }
             }
-        }
+            Ok(())
+        })
     }
+    find_and_clean(node_modules, cwd, valid_packages).await?;
     Ok(())
 }
 

--- a/crates/cli/src/util/cloner.rs
+++ b/crates/cli/src/util/cloner.rs
@@ -178,7 +178,7 @@ pub async fn clone(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
             ));
             return Ok(());
         } else {
-            log_warning(&format!("{:?} --> {:?} overrides", real_src, dst));
+            log_verbose(&format!("{:?} --> {:?} overrides", real_src, dst));
             if let Err(e) = fs::remove_dir_all(dst).await {
                 log_warning(&format!(
                     "Failed to clean target directory {}: {}",

--- a/crates/cli/src/util/logger.rs
+++ b/crates/cli/src/util/logger.rs
@@ -27,6 +27,8 @@ pub fn finish_progress_bar(msg: &str) {
     );
     PROGRESS_BAR.finish_with_message(msg.to_string());
     PROGRESS_BAR.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+    // reset color
+    println!("\x1b[0m");
 }
 
 pub fn abort_progress_bar() {
@@ -61,7 +63,7 @@ use crate::util::timer::Timer;
 
 pub fn log_verbose(msg: &str) {
     if VERBOSE.load(Ordering::Relaxed) {
-        println!("🔍 {}\x1b[0m", msg);
+        println!("🔍 {}", msg);
     }
     if let Ok(mut logs) = VERBOSE_LOGS.lock() {
         logs.push(format!("[{}][VERBOSE] {}", Timer::format_datetime(), msg));
@@ -77,12 +79,12 @@ pub fn get_verbose_logs() -> Vec<String> {
 
 pub fn log_warning(text: &str) {
     if VERBOSE.load(Ordering::Relaxed) {
-        PROGRESS_BAR.suspend(|| println!("[WARNING] {}", text));
+        PROGRESS_BAR.suspend(|| println!("[WARN] {}", text));
     } else {
-        PROGRESS_BAR.suspend(|| println!("{} {}\x1b[0m", " WARNING ".on_yellow(), text));
+        PROGRESS_BAR.suspend(|| println!("{} {}", " WARN ".on_yellow(), text));
     }
     if let Ok(mut logs) = VERBOSE_LOGS.lock() {
-        logs.push(format!("[{}][WARNING] {}", Timer::format_datetime(), text));
+        logs.push(format!("[{}][WARN] {}", Timer::format_datetime(), text));
     }
 }
 
@@ -90,7 +92,7 @@ pub fn log_error(text: &str) {
     if VERBOSE.load(Ordering::Relaxed) {
         PROGRESS_BAR.suspend(|| println!("[ERROR] {}", text));
     } else {
-        PROGRESS_BAR.suspend(|| println!("{} {}\x1b[0m", " ERROR ".on_red(), text));
+        PROGRESS_BAR.suspend(|| println!("{} {}", " ERROR ".on_red(), text));
     }
     if let Ok(mut logs) = VERBOSE_LOGS.lock() {
         logs.push(format!("[{}][ERROR] {}", Timer::format_datetime(), text));
@@ -101,7 +103,7 @@ pub fn log_info(text: &str) {
     if VERBOSE.load(Ordering::Relaxed) {
         PROGRESS_BAR.suspend(|| println!("[INFO] {}", text));
     } else {
-        PROGRESS_BAR.suspend(|| println!("{} {}\x1b[0m", " INFO ".on_cyan(), text));
+        PROGRESS_BAR.suspend(|| println!("{} {}", " INFO ".on_cyan(), text));
     }
     if let Ok(mut logs) = VERBOSE_LOGS.lock() {
         logs.push(format!("[{}][INFO] {}", Timer::format_datetime(), text));

--- a/crates/cli/src/util/node.rs
+++ b/crates/cli/src/util/node.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
-use super::logger::{log_info, log_verbose};
+use super::logger::log_verbose;
 use super::registry::resolve;
 use super::semver::is_valid_version;
 use crate::util::semver::matches;
@@ -201,7 +201,7 @@ impl Node {
                         .await
                     {
                         if let Some(edge_mut) = Arc::get_mut(&mut edge) {
-                            log_info(&format!(
+                            log_verbose(&format!(
                                 "Override rule applied {}@{} => {}",
                                 rule.name, rule.spec, rule.target_spec
                             ));


### PR DESCRIPTION
* 🪄 log improvements: `WARNING` => `WARN`.
* 🗜️ manual color output reset.
* 🐞 fixed nested node_modules path resolution during directory cleanup.
* 🔗 statically link openssl dependencies
