### PR TITLE
feat: support externals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref 0.5.2",
+ "vsimd",
+]
+
+[[package]]
 name = "better_scoped_tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,7 +627,6 @@ dependencies = [
  "bundler-core",
  "console-subscriber",
  "dhat",
- "mdxjs",
  "napi",
  "napi-build",
  "napi-derive",
@@ -786,7 +795,7 @@ version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
- "semver 1.0.26",
+ "semver",
  "serde",
  "toml 0.5.11",
  "url",
@@ -809,7 +818,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -823,7 +832,7 @@ checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -2456,7 +2465,7 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version 0.4.1",
+ "rustc_version",
  "serde",
  "spin 0.9.8",
  "stable_deref_trait",
@@ -3337,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.65"
+version = "1.0.0-alpha.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84f971730745f4aaac013b6cf4328baf1548efc973c0d95cfd843a3c1ca07af"
+checksum = "9a73ffa17de66534e4b527232f44aa0a89fad22c4f4e0735f9be35494f058e54"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.9.0",
@@ -3538,7 +3547,6 @@ checksum = "e150eac3f8b1537b1c07216679b289ee7b5b7503e09fce87b8c1001269bf1447"
 dependencies = [
  "markdown",
  "rustc-hash 2.1.1",
- "serde",
  "swc_core",
 ]
 
@@ -3793,7 +3801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.26",
+ "semver",
  "syn 2.0.100",
 ]
 
@@ -4060,6 +4068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4099,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "parcel_selectors"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccbc6fb560df303a44e511618256029410efbc87779018f751ef12c488271fe"
+checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -4121,7 +4135,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "485b74d7218068b2b7c0e3ff12fbc61ae11d57cb5d8224f525bd304c6be05bbb"
 dependencies = [
- "base64-simd",
+ "base64-simd 0.7.0",
  "data-url",
  "rkyv 0.7.45",
  "serde",
@@ -4468,7 +4482,7 @@ dependencies = [
  "from_variant",
  "once_cell",
  "rustc-hash 2.1.1",
- "semver 1.0.26",
+ "semver",
  "serde",
  "st-map",
  "tracing",
@@ -5124,20 +5138,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.26",
+ "semver",
 ]
 
 [[package]]
@@ -5363,27 +5368,12 @@ checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -5652,7 +5642,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
- "outref",
+ "outref 0.1.0",
 ]
 
 [[package]]
@@ -5753,17 +5743,16 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.1.2"
+version = "9.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c4ea7042fd1a155ad95335b5d505ab00d5124ea0332a06c8390d200bb1a76a"
+checksum = "bdee719193ae5c919a3ee43f64c2c0dd87f9b9a451d67918a2a5ec2e3c70561c"
 dependencies = [
- "base64-simd",
+ "base64-simd 0.8.0",
  "bitvec",
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash 1.1.0",
- "rustc_version 0.2.3",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -6786,7 +6775,7 @@ dependencies = [
  "once_cell",
  "preset_env_base",
  "rustc-hash 2.1.1",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_json",
  "st-map",
@@ -7288,9 +7277,9 @@ dependencies = [
 
 [[package]]
 name = "swc_trace_macro"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c78717a841565df57f811376a3d19c9156091c55175e12d378f3a522de70cef"
+checksum = "559185db338f1bcb50297aafd4f79c0956c84dc71a66da4cffb57acf9d93fd88"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9245,6 +9234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "wai-bindgen-gen-core"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9541,7 +9536,7 @@ dependencies = [
  "hex",
  "indexmap 2.9.0",
  "schemars",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_json",
  "serde_yml",
@@ -9563,7 +9558,7 @@ dependencies = [
  "hex",
  "indexmap 2.9.0",
  "schemars",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_json",
  "serde_yml",
@@ -9622,7 +9617,7 @@ dependencies = [
  "ciborium",
  "flate2",
  "insta",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -9648,7 +9643,7 @@ dependencies = [
  "ciborium",
  "flate2",
  "insta",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -9744,7 +9739,7 @@ dependencies = [
  "rand 0.8.5",
  "rkyv 0.8.10",
  "rusty_pool",
- "semver 1.0.26",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9808,7 +9803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
 dependencies = [
  "indexmap 2.9.0",
- "semver 1.0.26",
+ "semver",
 ]
 
 [[package]]
@@ -9821,7 +9816,7 @@ dependencies = [
  "bitflags 2.9.0",
  "hashbrown 0.14.5",
  "indexmap 2.9.0",
- "semver 1.0.26",
+ "semver",
 ]
 
 [[package]]
@@ -9832,7 +9827,7 @@ checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.9.0",
  "indexmap 2.9.0",
- "semver 1.0.26",
+ "semver",
 ]
 
 [[package]]

--- a/crates/bundler-api/src/project.rs
+++ b/crates/bundler-api/src/project.rs
@@ -110,7 +110,7 @@ pub struct ProjectOptions {
     /// A path inside the root_path which contains the app directories.
     pub project_path: RcStr,
 
-    /// The contents of next.config.js, serialized to JSON.
+    /// The contents of bundler config, serialized to JSON.
     pub config: RcStr,
 
     /// A map of environment variables to use when compiling code.

--- a/crates/bundler-cli/src/main.rs
+++ b/crates/bundler-cli/src/main.rs
@@ -49,49 +49,49 @@ fn main() {
         .block_on(async move {
             let trace = std::env::var("TURBOPACK_TRACING").ok();
 
-            let _guard = if let Some(mut trace) = trace.filter(|v| !v.is_empty()) {
-                // Trace presets
-                match trace.as_str() {
-                    "overview" | "1" => {
-                        trace = TRACING_OVERVIEW_TARGETS.join(",");
+            let _guard =
+                if let Some(mut trace) = trace.filter(|v| !v.is_empty()) {
+                    // Trace presets
+                    match trace.as_str() {
+                        "overview" | "1" => {
+                            trace = TRACING_OVERVIEW_TARGETS.join(",");
+                        }
+                        "bundler" => {
+                            trace = TRACING_TARGETS.join(",");
+                        }
+                        "turbopack" => {
+                            trace = TRACING_TURBOPACK_TARGETS.join(",");
+                        }
+                        "turbo-tasks" => {
+                            trace = TRACING_TURBO_TASKS_TARGETS.join(",");
+                        }
+                        _ => {}
                     }
-                    "bundler" => {
-                        trace = TRACING_TARGETS.join(",");
-                    }
-                    "turbopack" => {
-                        trace = TRACING_TURBOPACK_TARGETS.join(",");
-                    }
-                    "turbo-tasks" => {
-                        trace = TRACING_TURBO_TASKS_TARGETS.join(",");
-                    }
-                    _ => {}
-                }
 
-                let subscriber = Registry::default();
+                    let subscriber = Registry::default();
 
-                let subscriber = subscriber.with(FilterLayer::try_new(&trace).unwrap());
-                let trace_file = PathBuf::from(&project_path).join("trace.log");
-                let trace_writer = File::create(trace_file).unwrap();
-                let (trace_writer, guard) = TraceWriter::new(trace_writer);
-                let subscriber = subscriber.with(RawTraceLayer::new(trace_writer));
+                    let subscriber = subscriber.with(FilterLayer::try_new(&trace).unwrap());
+                    let trace_file = PathBuf::from(&project_path).join("trace.log");
+                    let trace_writer = File::create(trace_file).unwrap();
+                    let (trace_writer, guard) = TraceWriter::new(trace_writer);
+                    let subscriber = subscriber.with(RawTraceLayer::new(trace_writer));
 
-                let guard = ExitGuard::new(guard).unwrap();
+                    let guard = ExitGuard::new(guard).unwrap();
 
-                subscriber.init();
+                    subscriber.init();
 
-                Some(guard)
-            } else {
-                tracing_subscriber::fmt()
-                    .with_env_filter(
-                        EnvFilter::try_from_default_env()
-                            .unwrap_or_else(|_| EnvFilter::new("bundler_cli=info")),
-                    )
-                    .with_timer(tracing_subscriber::fmt::time::SystemTime)
-                    .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NEW)
-                    .init();
+                    Some(guard)
+                } else {
+                    tracing_subscriber::fmt()
+                        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                            EnvFilter::new("bundler_cli=info,bundler_api=info")
+                        }))
+                        .with_timer(tracing_subscriber::fmt::time::SystemTime)
+                        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NEW)
+                        .init();
 
-                None
-            };
+                    None
+                };
 
             let turbo_tasks = TurboTasks::new(TurboTasksBackend::new(
                 BackendOptions {

--- a/crates/bundler-core/src/config.rs
+++ b/crates/bundler-core/src/config.rs
@@ -111,7 +111,6 @@ pub struct Config {
     persistent_caching: Option<bool>,
     cache_handler: Option<RcStr>,
     externals: Option<FxIndexMap<RcStr, ExternalConfig>>,
-    clean_dist_dir: Option<bool>,
 }
 
 #[derive(
@@ -593,8 +592,8 @@ impl Config {
         let externals = self
             .externals
             .as_ref()
-            .unwrap_or(&FxIndexMap::default())
-            .clone();
+            .map(|ext| ext.clone())
+            .unwrap_or_default();
 
         ExternalsConfig(externals).cell()
     }

--- a/crates/bundler-core/src/config.rs
+++ b/crates/bundler-core/src/config.rs
@@ -110,6 +110,41 @@ pub struct Config {
     experimental: ExperimentalConfig,
     persistent_caching: Option<bool>,
     cache_handler: Option<RcStr>,
+    externals: Option<FxIndexMap<RcStr, ExternalConfig>>,
+    clean_dist_dir: Option<bool>,
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+)]
+#[serde(untagged)]
+pub enum ExternalConfig {
+    Basic(RcStr),
+    Advanced(ExternalAdvanced),
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+)]
+pub enum ExternalType {
+    #[serde(rename = "script")]
+    Script,
+    #[serde(rename = "commonjs")]
+    CommonJs,
+    #[serde(rename = "esm")]
+    ESM,
+    #[serde(rename = "global")]
+    Global,
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalAdvanced {
+    pub root: RcStr,
+    #[serde(rename = "type")]
+    pub r#type: Option<ExternalType>,
 }
 
 #[turbo_tasks::value(eq = "manual")]
@@ -526,6 +561,9 @@ pub struct OptionalMdxTransformOptions(Option<ResolvedVc<MdxTransformOptions>>);
 #[turbo_tasks::value(transparent)]
 pub struct OptionServerActions(Option<ServerActions>);
 
+#[turbo_tasks::value(transparent)]
+pub struct ExternalsConfig(FxIndexMap<RcStr, ExternalConfig>);
+
 #[turbo_tasks::value_impl]
 impl Config {
     #[turbo_tasks::function]
@@ -548,6 +586,19 @@ impl Config {
     #[turbo_tasks::function]
     pub fn cache_handler(&self) -> Vc<Option<RcStr>> {
         Vc::cell(self.cache_handler.clone())
+    }
+
+    #[turbo_tasks::function]
+    pub fn externals_config(&self) -> Vc<ExternalsConfig> {
+        let externals: FxIndexMap<RcStr, ExternalConfig> = self
+            .externals
+            .as_ref()
+            .unwrap_or(&FxIndexMap::default())
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        ExternalsConfig(externals).cell()
     }
 
     #[turbo_tasks::function]
@@ -1016,5 +1067,54 @@ impl Issue for OutdatedConfigIssue {
         Vc::cell(Some(
             StyledString::Text(self.description.clone()).resolved_cell(),
         ))
+    }
+}
+
+#[test]
+fn test_externals_deserialization() {
+    let json = serde_json::json!({
+        "entry": [{"import": "./index.js"}],
+        "externals": {
+            "foo": "foo",
+            "foo_require": "commonjs foo",
+            "foo_require2": {
+                "root": "foo",
+                "type": "commonjs"
+            },
+            "foo_import": "esm foo",
+            "foo_import2": {
+                "root": "foo",
+                "type": "esm"
+            }
+        }
+    });
+
+    let config: Config = serde_json::from_value(json).unwrap();
+    let externals = config.externals.unwrap();
+
+    // test basic external config
+    assert!(
+        matches!(externals.get("foo"), Some(ExternalConfig::Basic(name)) if name.as_str() == "foo")
+    );
+    assert!(
+        matches!(externals.get("foo_require"), Some(ExternalConfig::Basic(name)) if name.as_str() == "commonjs foo")
+    );
+    assert!(
+        matches!(externals.get("foo_import"), Some(ExternalConfig::Basic(name)) if name.as_str() == "esm foo")
+    );
+
+    // test advanced external config
+    if let Some(ExternalConfig::Advanced(advanced)) = externals.get("foo_require2") {
+        assert_eq!(advanced.root.as_str(), "foo");
+        assert_eq!(advanced.r#type, Some(ExternalType::CommonJs));
+    } else {
+        panic!("Expected ExternalConfig::Advanced for foo_require2");
+    }
+
+    if let Some(ExternalConfig::Advanced(advanced)) = externals.get("foo_import2") {
+        assert_eq!(advanced.root.as_str(), "foo");
+        assert_eq!(advanced.r#type, Some(ExternalType::ESM));
+    } else {
+        panic!("Expected ExternalConfig::Advanced for foo_import2");
     }
 }

--- a/crates/bundler-core/src/config.rs
+++ b/crates/bundler-core/src/config.rs
@@ -590,13 +590,11 @@ impl Config {
 
     #[turbo_tasks::function]
     pub fn externals_config(&self) -> Vc<ExternalsConfig> {
-        let externals: FxIndexMap<RcStr, ExternalConfig> = self
+        let externals = self
             .externals
             .as_ref()
             .unwrap_or(&FxIndexMap::default())
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+            .clone();
 
         ExternalsConfig(externals).cell()
     }

--- a/crates/bundler-core/src/shared/mod.rs
+++ b/crates/bundler-core/src/shared/mod.rs
@@ -1,2 +1,3 @@
+pub mod resolve;
 pub mod transforms;
 pub mod webpack_rules;

--- a/crates/bundler-core/src/shared/resolve/after_resolve_external_plugin.rs
+++ b/crates/bundler-core/src/shared/resolve/after_resolve_external_plugin.rs
@@ -1,0 +1,451 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use turbo_rcstr::RcStr;
+use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, Value, Vc};
+use turbo_tasks_fs::{self, glob::Glob, FileJsonContent, FileSystemPath};
+use turbopack_core::{
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
+    resolve::{
+        find_context_file,
+        node::{node_cjs_resolve_options, node_esm_resolve_options},
+        package_json,
+        parse::Request,
+        pattern::Pattern,
+        plugin::{AfterResolvePlugin, AfterResolvePluginCondition},
+        resolve, ExternalTraced, ExternalType, FindContextFileResult, ResolveResult,
+        ResolveResultItem, ResolveResultOption,
+    },
+    source::Source,
+};
+
+#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, Debug, NonLocalValue)]
+pub struct PackagesGlobs {
+    path_glob: ResolvedVc<Glob>,
+    request_glob: ResolvedVc<Glob>,
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionPackagesGlobs(Option<PackagesGlobs>);
+
+#[turbo_tasks::function]
+async fn packages_glob(packages: Vc<Vec<RcStr>>) -> Result<Vc<OptionPackagesGlobs>> {
+    let packages = packages.await?;
+    if packages.is_empty() {
+        return Ok(Vc::cell(None));
+    }
+    let path_glob = Glob::new(format!("**/node_modules/{{{}}}/**", packages.join(",")).into());
+    let request_glob =
+        Glob::new(format!("{{{},{}/**}}", packages.join(","), packages.join("/**,")).into());
+    Ok(Vc::cell(Some(PackagesGlobs {
+        path_glob: path_glob.to_resolved().await?,
+        request_glob: request_glob.to_resolved().await?,
+    })))
+}
+
+/// Mark modules as external follow the config `externals_rules`,
+/// the module which is marked will be resolved at runtime instead of bundled.
+#[turbo_tasks::value]
+pub struct AfterResolveExternalPlugin {
+    project_path: ResolvedVc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
+    externals_rules: ResolvedVc<Vec<RcStr>>,
+    import_externals: bool,
+}
+
+#[turbo_tasks::value_impl]
+impl AfterResolveExternalPlugin {
+    #[turbo_tasks::function]
+    pub fn new(
+        project_path: ResolvedVc<FileSystemPath>,
+        root: ResolvedVc<FileSystemPath>,
+        externals_rules: ResolvedVc<Vec<RcStr>>,
+        import_externals: bool,
+    ) -> Vc<Self> {
+        AfterResolveExternalPlugin {
+            project_path,
+            root,
+            externals_rules,
+            import_externals,
+        }
+        .cell()
+    }
+}
+
+#[turbo_tasks::function]
+fn condition(root: Vc<FileSystemPath>) -> Vc<AfterResolvePluginCondition> {
+    AfterResolvePluginCondition::new(root, Glob::new("**/node_modules/**".into()))
+}
+
+#[turbo_tasks::value_impl]
+impl AfterResolvePlugin for AfterResolveExternalPlugin {
+    #[turbo_tasks::function]
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
+        condition(*self.root)
+    }
+
+    #[turbo_tasks::function]
+    async fn after_resolve(
+        &self,
+        fs_path: ResolvedVc<FileSystemPath>,
+        lookup_path: ResolvedVc<FileSystemPath>,
+        reference_type: Value<ReferenceType>,
+        request: ResolvedVc<Request>,
+    ) -> Result<Vc<ResolveResultOption>> {
+        let request_value = &*request.await?;
+        let Request::Module {
+            module: package,
+            path: package_subpath,
+            ..
+        } = request_value
+        else {
+            return Ok(ResolveResultOption::none());
+        };
+
+        let Pattern::Constant(package_subpath) = package_subpath else {
+            return Ok(ResolveResultOption::none());
+        };
+
+        let request_str: RcStr = format!("{package}{package_subpath}").into();
+
+        let raw_fs_path = &*fs_path.await?;
+
+        let external_glob = packages_glob(*self.externals_rules).await?;
+
+        if let Some(PackagesGlobs {
+            path_glob,
+            request_glob,
+        }) = *external_glob
+        {
+            let path_match = path_glob.await?.execute(&raw_fs_path.path);
+            let request_match = request_glob.await?.execute(&request_str);
+
+            if !path_match && !request_match {
+                return Ok(ResolveResultOption::none());
+            }
+        } else {
+            return Ok(ResolveResultOption::none());
+        }
+
+        let is_esm = self.import_externals
+            && ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined)
+                .includes(&reference_type);
+
+        #[derive(Debug, Copy, Clone)]
+        enum FileType {
+            CommonJs,
+            EcmaScriptModule,
+            UnsupportedExtension,
+            InvalidPackageJson,
+        }
+
+        async fn get_file_type(
+            fs_path: Vc<FileSystemPath>,
+            raw_fs_path: &FileSystemPath,
+        ) -> Result<FileType> {
+            // node.js only supports these file extensions
+            // mjs is an esm module and we can't bundle that yet
+            let ext = raw_fs_path.extension_ref();
+            if matches!(ext, Some("cjs" | "node" | "json")) {
+                return Ok(FileType::CommonJs);
+            }
+            if matches!(ext, Some("mjs")) {
+                return Ok(FileType::EcmaScriptModule);
+            }
+            if matches!(ext, Some("js")) {
+                // for .js extension in cjs context, we need to check the actual module type via
+                // package.json
+                let FindContextFileResult::Found(package_json, _) =
+                    *find_context_file(fs_path.parent(), package_json()).await?
+                else {
+                    // can't find package.json
+                    return Ok(FileType::CommonJs);
+                };
+                let FileJsonContent::Content(package) = &*package_json.read_json().await? else {
+                    // can't parse package.json
+                    return Ok(FileType::InvalidPackageJson);
+                };
+
+                if let Some("module") = package["type"].as_str() {
+                    return Ok(FileType::EcmaScriptModule);
+                }
+
+                return Ok(FileType::CommonJs);
+            }
+
+            Ok(FileType::UnsupportedExtension)
+        }
+
+        let unable_to_externalize = |reason: Vec<StyledString>| {
+            ExternalizeIssue {
+                file_path: lookup_path,
+                package: package.clone(),
+                request_str: request_str.clone(),
+                reason,
+            }
+            .resolved_cell()
+            .emit();
+            Ok(ResolveResultOption::none())
+        };
+
+        let mut request = *request;
+        let mut request_str = request_str.to_string();
+
+        let node_resolve_options = if is_esm {
+            node_esm_resolve_options(lookup_path.root())
+        } else {
+            node_cjs_resolve_options(lookup_path.root())
+        };
+
+        let result_from_original_location = loop {
+            let node_resolved_from_original_location = resolve(
+                *lookup_path,
+                reference_type.clone(),
+                request,
+                node_resolve_options,
+            );
+
+            let Some(result_from_original_location) =
+                *node_resolved_from_original_location.first_source().await?
+            else {
+                if is_esm
+                    && !package_subpath.is_empty()
+                    && package_subpath != "/"
+                    && !request_str.ends_with(".js")
+                {
+                    // fallback solution: If user doesn't have an extension in the request we try to append ".js"
+                    // automatically
+                    request_str.push_str(".js");
+                    request = request.append_path(".js".into()).resolve().await?;
+                    continue;
+                }
+                // this can't resolve with node.js from the original location, we will bundle it
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The request could not be resolved by Node.js from the importing module."
+                        .into(),
+                )]);
+            };
+            break result_from_original_location;
+        };
+        let node_resolved = resolve(
+            *self.project_path,
+            reference_type.clone(),
+            request,
+            node_resolve_options,
+        );
+
+        let Some(result) = *node_resolved.first_source().await? else {
+            // this can't resolve with node.js from the project directory, so bundle it
+            return unable_to_externalize(vec![
+                StyledString::Text(
+                    "The request could not be resolved by Node.js from the project \
+                     directory.\nPackages that should be external need to be installed in the \
+                     project directory, so they can be resolved from the output files.\nTry to \
+                     install it into the project directory by running "
+                        .into(),
+                ),
+                StyledString::Code(format!("npm install {package}").into()),
+                StyledString::Text(" from the project directory.".into()),
+            ]);
+        };
+        if result_from_original_location != result {
+            let package_json_file = find_context_file(
+                result.ident().path().parent().resolve().await?,
+                package_json(),
+            );
+            let package_json_from_original_location = find_context_file(
+                result_from_original_location
+                    .ident()
+                    .path()
+                    .parent()
+                    .resolve()
+                    .await?,
+                package_json(),
+            );
+            let FindContextFileResult::Found(package_json_file, _) = *package_json_file.await?
+            else {
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The package.json of the package resolved from the project directory can't be \
+                     found."
+                        .into(),
+                )]);
+            };
+            let FindContextFileResult::Found(package_json_from_original_location, _) =
+                *package_json_from_original_location.await?
+            else {
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The package.json of the package can't be found.".into(),
+                )]);
+            };
+            let FileJsonContent::Content(package_json_file) =
+                &*package_json_file.read_json().await?
+            else {
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The package.json of the package resolved from project directory can't be \
+                     parsed."
+                        .into(),
+                )]);
+            };
+            let FileJsonContent::Content(package_json_from_original_location) =
+                &*package_json_from_original_location.read_json().await?
+            else {
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The package.json of the package can't be parsed.".into(),
+                )]);
+            };
+            let (Some(name), Some(version)) = (
+                package_json_file.get("name").and_then(|v| v.as_str()),
+                package_json_file.get("version").and_then(|v| v.as_str()),
+            ) else {
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The package.json of the package has no name or version.".into(),
+                )]);
+            };
+            let (Some(name2), Some(version2)) = (
+                package_json_from_original_location
+                    .get("name")
+                    .and_then(|v| v.as_str()),
+                package_json_from_original_location
+                    .get("version")
+                    .and_then(|v| v.as_str()),
+            ) else {
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The package.json of the package resolved from project directory has no name \
+                     or version."
+                        .into(),
+                )]);
+            };
+            if (name, version) != (name2, version2) {
+                // this can't resolve with node.js from the original location, so bundle it
+                return unable_to_externalize(vec![StyledString::Text(
+                    format!(
+                        "The package resolves to a different version when requested from the \
+                         project directory ({version}) compared to the package requested from the \
+                         importing module ({version2}).\nMake sure to install the same version of \
+                         the package in both locations."
+                    )
+                    .into(),
+                )]);
+            }
+        }
+        let path = result.ident().path().resolve().await?;
+        let file_type = get_file_type(path, &*path.await?).await?;
+
+        let _external_type = match (file_type, is_esm) {
+            (FileType::UnsupportedExtension, _) => {
+                // unsupported file type, bundle it
+                return unable_to_externalize(vec![StyledString::Text(
+                    "Only .mjs, .cjs, .js, .json, or .node can be handled by Node.js.".into(),
+                )]);
+            }
+            (FileType::InvalidPackageJson, _) => {
+                // invalid package.json, bundle it
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The package.json can't be found or parsed.".into(),
+                )]);
+            }
+            // commonjs without esm is always external
+            (FileType::CommonJs, false) => ExternalType::CommonJs,
+            (FileType::CommonJs, true) => {
+                // It would be more efficient to use an CJS external instead of an ESM external,
+                // but we need to verify if that would be correct (as in resolves to the same file).
+                let node_resolve_options = node_cjs_resolve_options(lookup_path.root());
+                let node_resolved = resolve(
+                    *self.project_path,
+                    reference_type.clone(),
+                    request,
+                    node_resolve_options,
+                );
+                let resolves_equal = if let Some(result) = *node_resolved.first_source().await? {
+                    let cjs_path = result.ident().path();
+                    cjs_path.resolve().await? == path
+                } else {
+                    false
+                };
+
+                // When resolves_equal is set this is weird edge case. There are different
+                // results for CJS and ESM resolving, but ESM resolving points to a CJS file.
+                // While this might be valid, there is a good chance that this is a invalid
+                // packages, where `type: module` or `.mjs` is missing and would fail in
+                // Node.js. So when this wasn't an explicit opt-in we avoid making it external
+                // to be safe.
+                if resolves_equal {
+                    ExternalType::CommonJs
+                } else {
+                    ExternalType::EcmaScriptModule
+                }
+            }
+            // ecmascript with esm is always external
+            (FileType::EcmaScriptModule, true) => ExternalType::EcmaScriptModule,
+            (FileType::EcmaScriptModule, false) => {
+                // even with require() this resolves to a ESM, which would break node.js, bundle it
+                return unable_to_externalize(vec![StyledString::Text(
+                    "The package seems invalid. require() resolves to a EcmaScript module, which \
+                     would result in an error in Node.js."
+                        .into(),
+                )]);
+            }
+        };
+
+        Ok(ResolveResultOption::some(*ResolveResult::primary(
+            ResolveResultItem::External {
+                name: request_str.into(),
+                ty: ExternalType::Global,
+                traced: ExternalTraced::Traced,
+            },
+        )))
+    }
+}
+
+#[turbo_tasks::value]
+struct ExternalizeIssue {
+    file_path: ResolvedVc<FileSystemPath>,
+    package: RcStr,
+    request_str: RcStr,
+    reason: Vec<StyledString>,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for ExternalizeIssue {
+    #[turbo_tasks::function]
+    fn severity(&self) -> Vc<IssueSeverity> {
+        IssueSeverity::Warning.cell()
+    }
+
+    #[turbo_tasks::function]
+    async fn title(&self) -> Vc<StyledString> {
+        StyledString::Line(vec![
+            StyledString::Text("Package ".into()),
+            StyledString::Code(self.package.clone()),
+            StyledString::Text(" can't be external".into()),
+        ])
+        .cell()
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Config.into()
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        *self.file_path
+    }
+
+    #[turbo_tasks::function]
+    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+        Ok(Vc::cell(Some(
+            StyledString::Stack(vec![
+                StyledString::Line(vec![
+                    StyledString::Text("The request ".into()),
+                    StyledString::Code(self.request_str.clone()),
+                    StyledString::Text(" matches ".into()),
+                    StyledString::Code("serverExternalPackages".into()),
+                    StyledString::Text(" (or the default list).".into()),
+                ]),
+                StyledString::Line(self.reason.clone()),
+            ])
+            .resolved_cell(),
+        )))
+    }
+}

--- a/crates/bundler-core/src/shared/resolve/externals_plugin.rs
+++ b/crates/bundler-core/src/shared/resolve/externals_plugin.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks_fs::{self, glob::Glob, FileSystemPath};
+use turbopack_core::{
+    reference_type::ReferenceType,
+    resolve::{
+        parse::Request,
+        pattern::Pattern,
+        plugin::{BeforeResolvePlugin, BeforeResolvePluginCondition},
+        ExternalTraced, ExternalType, ResolveResult, ResolveResultItem, ResolveResultOption,
+    },
+};
+
+use crate::config::{ExternalConfig, ExternalsConfig};
+
+#[turbo_tasks::value]
+pub struct ExternalsPlugin {
+    project_path: ResolvedVc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
+    externals_config: ResolvedVc<ExternalsConfig>,
+}
+
+#[turbo_tasks::value_impl]
+impl ExternalsPlugin {
+    #[turbo_tasks::function]
+    pub fn new(
+        project_path: ResolvedVc<FileSystemPath>,
+        root: ResolvedVc<FileSystemPath>,
+        externals_config: ResolvedVc<ExternalsConfig>,
+    ) -> Vc<Self> {
+        ExternalsPlugin {
+            project_path,
+            root,
+            externals_config,
+        }
+        .cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl BeforeResolvePlugin for ExternalsPlugin {
+    #[turbo_tasks::function]
+    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
+        BeforeResolvePluginCondition::from_request_glob(Glob::new("*".into()))
+    }
+
+    #[turbo_tasks::function]
+    async fn before_resolve(
+        &self,
+        _lookup_path: ResolvedVc<FileSystemPath>,
+        _reference_type: Value<ReferenceType>,
+        request: Vc<Request>,
+    ) -> Result<Vc<ResolveResultOption>> {
+        let externals_config = self.externals_config.await?;
+        let request_value = request.await?;
+
+        // get request module name
+        let module_name = match &*request_value {
+            Request::Module { module, .. } => module,
+            Request::Raw {
+                path: Pattern::Constant(name),
+                ..
+            } => name,
+            _ => return Ok(ResolveResultOption::none()),
+        };
+
+        // check if the module exists in externals config.
+        if let Some(external_config) = externals_config.get(module_name) {
+            let (external_name, external_type) = match external_config {
+                ExternalConfig::Basic(name) => {
+                    // resolve basic config like "foo" or "commonjs foo" or "esm foo"
+                    let name_str = name.as_str();
+                    if name_str.starts_with("commonjs ") {
+                        let actual_name = name_str.strip_prefix("commonjs ").unwrap_or(name_str);
+                        (actual_name.into(), ExternalType::CommonJs)
+                    } else if name_str.starts_with("esm ") {
+                        let actual_name = name_str.strip_prefix("esm ").unwrap_or(name_str);
+                        (actual_name.into(), ExternalType::EcmaScriptModule)
+                    } else {
+                        // Default to Global
+                        (name.clone(), ExternalType::Global)
+                    }
+                }
+                ExternalConfig::Advanced(advanced) => {
+                    // advanced config.
+                    let external_type = match &advanced.r#type {
+                        Some(crate::config::ExternalType::CommonJs) => ExternalType::CommonJs,
+                        Some(crate::config::ExternalType::ESM) => ExternalType::EcmaScriptModule,
+                        Some(crate::config::ExternalType::Script) => ExternalType::Global,
+                        Some(crate::config::ExternalType::Global) => ExternalType::Global,
+                        None => ExternalType::Global,
+                    };
+                    (advanced.root.clone(), external_type)
+                }
+            };
+
+            return Ok(ResolveResultOption::some(*ResolveResult::primary(
+                ResolveResultItem::External {
+                    name: external_name,
+                    ty: external_type,
+                    traced: ExternalTraced::Traced,
+                },
+            )));
+        }
+
+        Ok(ResolveResultOption::none())
+    }
+}

--- a/crates/bundler-core/src/shared/resolve/mod.rs
+++ b/crates/bundler-core/src/shared/resolve/mod.rs
@@ -1,0 +1,3 @@
+// TODO: remove after_resolve_externals_plugin when i support subpath and regexp externals.
+pub mod after_resolve_external_plugin;
+pub mod externals_plugin;

--- a/crates/bundler-napi/Cargo.toml
+++ b/crates/bundler-napi/Cargo.toml
@@ -86,7 +86,6 @@ turbo-tasks-backend = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 bundler-api = { workspace = true }
 bundler-core = { workspace = true }
-mdxjs = { version = "0.3", features = ["serializable"] }
 turbo-tasks-malloc = { workspace = true, default-features = false, features = [
   "custom_allocator",
 ] }

--- a/examples/externals/.gitignore
+++ b/examples/externals/.gitignore
@@ -1,0 +1,2 @@
+!node_modules
+dist

--- a/examples/externals/genHtml.js
+++ b/examples/externals/genHtml.js
@@ -1,0 +1,30 @@
+const fs = require("fs");
+const path = require("path");
+
+const distPath = path.join(__dirname, "dist");
+
+const assets = fs
+  .readdirSync(distPath)
+  .filter(
+    (p) =>
+      fs.statSync(path.join(distPath, p)).isFile() &&
+      (p.endsWith(".js") || p.endsWith(".css")),
+  );
+
+const html = `<!doctype html>
+<html lang="en">
+  <body>
+    <div id="root"></div>
+    ${assets
+      .filter((a) => a.endsWith(".js"))
+      .map((a) => `<script src="${a}"></script>`)
+      .join("\n    ")}
+    ${assets
+      .filter((a) => a.endsWith(".css"))
+      .map((a) => `<link rel="stylesheet" href="${a}">`)
+      .join("\n    ")}
+  </body>
+</html>
+`;
+
+fs.writeFileSync(path.join(distPath, "index.html"), html);

--- a/examples/externals/index.js
+++ b/examples/externals/index.js
@@ -1,0 +1,7 @@
+import foo from "foo";
+import foo_require from "foo_require";
+import foo_require2 from "foo_require2";
+import foo_import from "foo_import";
+import foo_import2 from "foo_import2";
+
+console.log(foo, foo_require, foo_require2, foo_import, foo_import2);

--- a/examples/externals/package.json
+++ b/examples/externals/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "externals-example",
+    "version": "1.0.0",
+    "description": "",
+    "keywords": [],
+    "license": "MIT",
+    "scripts": {
+        "build": "utoo-bundler .",
+        "build:tracing": "TURBOPACK_TRACE_SERVER=1 TURBOPACK_TRACING=overview utoo-bundler .",
+        "dev": "utoo-bundler . dev",
+        "serve": "npm run build && node ./genHtml.js && serve ./dist"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "@utoo/bundler": "*",
+        "serve": "^14.2.4"
+    }
+}

--- a/examples/externals/project_options.json
+++ b/examples/externals/project_options.json
@@ -1,0 +1,34 @@
+{
+  "rootPath": "../../",
+  "projectPath": "./",
+  "config": {
+    "entry": [
+      {
+        "import": "./index.js"       
+      }
+    ],
+    "output": {
+      "path": "./dist",
+      "filename": "[name].[contenthash:6].js",
+      "chunkFilename": "[name].[contenthash:8].js",
+      "clean": true
+    },
+    "optimization": {
+      "moduleIds": "named",
+      "minify": false
+    },
+    "externals": {
+      "foo": "foo",
+      "foo_require": "commonjs foo",
+      "foo_require2": {
+        "root": "foo",
+        "type": "commonjs"
+      },
+      "foo_import": "esm foo",
+      "foo_import2": {
+        "root": "foo",
+        "type": "esm"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Pre: https://github.com/umijs/next.js/pull/3

Support externals config for utoo bundler.

User config as follows:

```json
{
  "rootPath": "../../",
  "projectPath": "./",
  "config": {
    "cleanDistDir": true,
    "entry": [
      {
        "import": "./index.js"       
      }
    ],
    "output": {
      "path": "./dist",
      "filename": "[name].[contenthash:6].js",
      "chunkFilename": "[name].[contenthash:8].js"
    },
    "optimization": {
      "moduleIds": "named",
      "minify": false
    },
    "externals": {
      "foo": "foo",
      "foo_require": "commonjs foo",
      "foo_require2": {
        "root": "foo",
        "type": "commonjs"
      },
      "foo_import": "esm foo",
      "foo_import2": {
        "root": "foo",
        "type": "esm"
      }
    }
  }
}
```

The packge `external-package` will not be bundled here.