### PR TITLE
fix: library project output assets should generate corret extension

### DIFF
--- a/crates/bundler-core/src/library/chunking_context.rs
+++ b/crates/bundler-core/src/library/chunking_context.rs
@@ -349,9 +349,15 @@ impl ChunkingContext for LibraryChunkingContext {
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
         let root_path = self.output_root;
-        let name = ident_to_output_filename(ident, *self.root_path, extension.clone())
+        let mut name = ident_to_output_filename(ident, *self.root_path, extension.clone())
             .owned()
             .await?;
+
+        // Check if the name already ends with the extension
+        if !name.ends_with(&*extension) {
+            // If doesn't end with extension, add the provided extension
+            name = format!("{}{}", name, extension).into();
+        }
 
         Ok(root_path.join(name))
     }

--- a/crates/bundler-core/src/library/contexts.rs
+++ b/crates/bundler-core/src/library/contexts.rs
@@ -14,6 +14,8 @@ use crate::mode::Mode;
 
 use super::LibraryChunkingContext;
 /// TODO: avoid so many arguments
+/// TODO: seems like turbo_tasks:function onlt accept 12 arguments, so chunk_filename is not supported here temporarily.
+/// maybe need to store filename and chunk_filename in the context struct.
 #[turbo_tasks::function]
 pub async fn get_library_chunking_context(
     root_path: ResolvedVc<FileSystemPath>,

--- a/examples/with-less/project_options.json
+++ b/examples/with-less/project_options.json
@@ -10,8 +10,13 @@
         }
       }
     ],
+    "styles": {
+      "inlineCss": {}
+    },
     "output": {
-      "path": "./dist"
+      "path": "./dist",
+      "filename": "[name].[contenthash:8].js",
+      "chunkFilename": "[name].[contenthash:8].js"
     }
   }
 }


### PR DESCRIPTION
A follow up pr for https://github.com/umijs/mako/issues/1902

In the last pr, just fix the app project output asset filename extension, this pr will solve the library project build.