### PR TITLE
fix: update createEnv & add externals for library examples

### DIFF
--- a/examples/with-library/project_options.json
+++ b/examples/with-library/project_options.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../packages/pack/config_schema.json",
   "rootPath": "../../",
   "projectPath": "./",
   "config": {
@@ -14,11 +15,15 @@
     ],
     "output": {
       "path": "./dist",
-      "filename": "[name].[contenthash:8].js"
+      "filename": "[name].[contenthash:8].js",
+      "clean": true
     },
     "optimization": {
       "moduleIds": "named",
       "minify": false
+    },
+    "externals": {
+      "lodash": "$"
     }
   }
 }

--- a/examples/with-library/src/index.ts
+++ b/examples/with-library/src/index.ts
@@ -1,3 +1,7 @@
+import _ from "lodash";
+
+console.log(_);
+
 const library = "library";
 
 export { library };

--- a/packages/pack/src/index.ts
+++ b/packages/pack/src/index.ts
@@ -45,9 +45,10 @@ export async function buildWithOptions(options: ProjectOptions, cwd?: string) {
   const project = await createProject(
     {
       processEnv: options.processEnv ?? ({} as Record<string, string>),
-      processDefineEnv: options.processDefineEnv ?? createDefineEnv({
+      processDefineEnv: createDefineEnv({
         config: options.config,
         dev: options.dev ?? false,
+        optionDefineEnv: options.processDefineEnv,
       }),
       watch: options.watch ?? {
         enable: false,

--- a/packages/pack/src/util.ts
+++ b/packages/pack/src/util.ts
@@ -186,6 +186,7 @@ export function rustifyEnv(env: Record<string, string>): RustifiedEnv {
 interface DefineEnvOptions {
   config: ConfigComplete,
   dev: boolean,
+  optionDefineEnv?: DefineEnv,
   // isClient: boolean,
   // isNodeServer: boolean
 }
@@ -199,7 +200,7 @@ interface SerializedDefineEnv {
 }
 
 export function createDefineEnv(options: DefineEnvOptions): DefineEnv {
-  let defineEnv: DefineEnv = {
+  let defineEnv: DefineEnv = options.optionDefineEnv ?? {
     client: [],
     edge: [],
     nodejs: [],


### PR DESCRIPTION
A simple update:
- Adjust `createEnv` function to accept `options.defineEnv` by default
- Add externals config for umd  library bundler.