### PR TITLE
feat(pack): entry.import support absolute path

### DIFF
--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -1,3 +1,5 @@
+use std::path::MAIN_SEPARATOR;
+
 use anyhow::{bail, Result};
 use futures::stream::{self, StreamExt};
 use pack_core::client::context::{
@@ -113,7 +115,7 @@ impl AppEntrypoint {
 
         // Handle import path: convert absolute path to relative, keep relative path as-is
         let project_path = self.project().project_path().await?;
-        let project_dir_name = project_path.path.split('/').last().unwrap_or("");
+        let project_dir_name = project_path.path.split(MAIN_SEPARATOR).last().unwrap_or("");
         let relative_import = self
             .convert_to_relative_import(this.import.clone(), project_dir_name.into())
             .await?;
@@ -226,14 +228,14 @@ impl AppEntrypoint {
         import_path: RcStr,
         project_dir_name: RcStr,
     ) -> Vc<RcStr> {
-        if import_path.starts_with('/') {
-            let pattern = format!("/{}/", project_dir_name);
+        if import_path.starts_with(MAIN_SEPARATOR) {
+            let pattern = format!("{}{}{}", MAIN_SEPARATOR, project_dir_name, MAIN_SEPARATOR);
             import_path
                 .find(&pattern)
                 .and_then(|pos| {
                     let relative_part = &import_path[pos + pattern.len()..];
                     if !relative_part.is_empty() {
-                        let relative_import = format!("./{}", relative_part);
+                        let relative_import = format!(".{}{}", MAIN_SEPARATOR, relative_part);
                         Some(Vc::cell(relative_import.into()))
                     } else {
                         None

--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -227,23 +227,22 @@ impl AppEntrypoint {
         self: Vc<Self>,
         import_path: RcStr,
         project_dir_name: RcStr,
-    ) -> Vc<RcStr> {
+    ) -> Result<Vc<RcStr>> {
         if import_path.starts_with(MAIN_SEPARATOR) {
             let pattern = format!("{}{}{}", MAIN_SEPARATOR, project_dir_name, MAIN_SEPARATOR);
-            import_path
-                .find(&pattern)
-                .and_then(|pos| {
-                    let relative_part = &import_path[pos + pattern.len()..];
-                    if !relative_part.is_empty() {
-                        let relative_import = format!(".{}{}", MAIN_SEPARATOR, relative_part);
-                        Some(Vc::cell(relative_import.into()))
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| Vc::cell(import_path))
+            if let Some(pos) = import_path.find(&pattern) {
+                let relative_part = &import_path[pos + pattern.len()..];
+                if !relative_part.is_empty() {
+                    let relative_import = format!(".{}{}", MAIN_SEPARATOR, relative_part);
+                    Ok(Vc::cell(relative_import.into()))
+                } else {
+                    bail!("Invalid import path: {}", import_path)
+                }
+            } else {
+                bail!("Invalid import path: {}", import_path)
+            }
         } else {
-            Vc::cell(import_path)
+            Ok(Vc::cell(import_path))
         }
     }
 }

--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -110,8 +110,16 @@ impl AppEntrypoint {
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<Modules>> {
         let this = self.await?;
+
+        // Handle import path: convert absolute path to relative, keep relative path as-is
+        let project_path = self.project().project_path().await?;
+        let project_dir_name = project_path.path.split('/').last().unwrap_or("");
+        let relative_import = self
+            .convert_to_relative_import(this.import.clone(), project_dir_name.into())
+            .await?;
+
         let entry_request = Request::relative(
-            Value::new(this.import.clone().into()),
+            Value::new((*relative_import).clone().into()),
             Default::default(),
             Default::default(),
             false,
@@ -210,6 +218,31 @@ impl AppEntrypoint {
             .await?
             .assets;
         Ok(chunk_group_assets)
+    }
+
+    #[turbo_tasks::function]
+    pub fn convert_to_relative_import(
+        self: Vc<Self>,
+        import_path: RcStr,
+        project_dir_name: RcStr,
+    ) -> Vc<RcStr> {
+        if import_path.starts_with('/') {
+            let pattern = format!("/{}/", project_dir_name);
+            import_path
+                .find(&pattern)
+                .and_then(|pos| {
+                    let relative_part = &import_path[pos + pattern.len()..];
+                    if !relative_part.is_empty() {
+                        let relative_import = format!("./{}", relative_part);
+                        Some(Vc::cell(relative_import.into()))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| Vc::cell(import_path))
+        } else {
+            Vc::cell(import_path)
+        }
     }
 }
 

--- a/crates/pack-api/src/entrypoint.rs
+++ b/crates/pack-api/src/entrypoint.rs
@@ -65,10 +65,10 @@ pub async fn all_output_assets_operation(
         .try_join()
         .await?;
 
-    let mut output_assets: FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>> = FxIndexSet::default();
-    for assets in endpoint_assets {
-        output_assets.extend(assets.iter());
-    }
+    let output_assets: FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>> = endpoint_assets
+        .into_iter()
+        .flat_map(|assets| assets.into_iter().copied())
+        .collect();
 
     Ok(Vc::cell(output_assets.into_iter().collect()))
 }

--- a/crates/pack-api/src/entrypoint.rs
+++ b/crates/pack-api/src/entrypoint.rs
@@ -66,8 +66,8 @@ pub async fn all_output_assets_operation(
         .await?;
 
     let output_assets: FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>> = endpoint_assets
-        .into_iter()
-        .flat_map(|assets| assets.into_iter().copied())
+        .iter()
+        .flat_map(|assets| assets.iter().copied())
         .collect();
 
     Ok(Vc::cell(output_assets.into_iter().collect()))

--- a/crates/pack-api/src/library.rs
+++ b/crates/pack-api/src/library.rs
@@ -292,23 +292,22 @@ impl LibraryEndpoint {
         self: Vc<Self>,
         import_path: RcStr,
         project_dir_name: RcStr,
-    ) -> Vc<RcStr> {
+    ) -> Result<Vc<RcStr>> {
         if import_path.starts_with(MAIN_SEPARATOR) {
             let pattern = format!("{}{}{}", MAIN_SEPARATOR, project_dir_name, MAIN_SEPARATOR);
-            import_path
-                .find(&pattern)
-                .and_then(|pos| {
-                    let relative_part = &import_path[pos + pattern.len()..];
-                    if !relative_part.is_empty() {
-                        let relative_import = format!(".{}{}", MAIN_SEPARATOR, relative_part);
-                        Some(Vc::cell(relative_import.into()))
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| Vc::cell(import_path))
+            if let Some(pos) = import_path.find(&pattern) {
+                let relative_part = &import_path[pos + pattern.len()..];
+                if !relative_part.is_empty() {
+                    let relative_import = format!(".{}{}", MAIN_SEPARATOR, relative_part);
+                    Ok(Vc::cell(relative_import.into()))
+                } else {
+                    bail!("Invalid import path: {}", import_path)
+                }
+            } else {
+                bail!("Invalid import path: {}", import_path)
+            }
         } else {
-            Vc::cell(import_path)
+            Ok(Vc::cell(import_path))
         }
     }
 }

--- a/crates/pack-api/src/library.rs
+++ b/crates/pack-api/src/library.rs
@@ -1,3 +1,5 @@
+use std::path::MAIN_SEPARATOR;
+
 use anyhow::{bail, Result};
 use pack_core::{
     client::context::{
@@ -174,7 +176,7 @@ impl LibraryEndpoint {
 
         // Handle import path: convert absolute path to relative, keep relative path as-is
         let project_path = self.project().project_path().await?;
-        let project_dir_name = project_path.path.split('/').last().unwrap_or("");
+        let project_dir_name = project_path.path.split(MAIN_SEPARATOR).last().unwrap_or("");
         let relative_import = self
             .convert_to_relative_import(this.import.clone(), project_dir_name.into())
             .await?;
@@ -291,14 +293,14 @@ impl LibraryEndpoint {
         import_path: RcStr,
         project_dir_name: RcStr,
     ) -> Vc<RcStr> {
-        if import_path.starts_with('/') {
-            let pattern = format!("/{}/", project_dir_name);
+        if import_path.starts_with(MAIN_SEPARATOR) {
+            let pattern = format!("{}{}{}", MAIN_SEPARATOR, project_dir_name, MAIN_SEPARATOR);
             import_path
                 .find(&pattern)
                 .and_then(|pos| {
                     let relative_part = &import_path[pos + pattern.len()..];
                     if !relative_part.is_empty() {
-                        let relative_import = format!("./{}", relative_part);
+                        let relative_import = format!(".{}{}", MAIN_SEPARATOR, relative_part);
                         Some(Vc::cell(relative_import.into()))
                     } else {
                         None

--- a/examples/with-library/project_options.json
+++ b/examples/with-library/project_options.json
@@ -6,7 +6,7 @@
     "entry": [
       {
         "name": "library",
-        "import": "./src/index.ts",
+        "import": "/Users/zoomdong/mako/examples/with-library/src/index.ts",
         "library": {
           "name": "MyLibrary",
           "export": ["default", "value"]

--- a/examples/with-library/project_options.json
+++ b/examples/with-library/project_options.json
@@ -6,7 +6,7 @@
     "entry": [
       {
         "name": "library",
-        "import": "/Users/zoomdong/mako/examples/with-library/src/index.ts",
+        "import": "./src/index.ts",
         "library": {
           "name": "MyLibrary",
           "export": ["default", "value"]


### PR DESCRIPTION
- 支持 `entry.import` 传入绝对路径:

![image](https://github.com/user-attachments/assets/bba17eea-5bb7-4014-9968-97e5a31ce51a)

修复思路: 把 `import` 在内部都统一处理成相对路径，绝对路径也转换成相对路径

后续还需要添加一个报错机制，用于 entry 的 resolve error。

ref issue: https://github.com/umijs/mako/issues/1972