### PR TITLE
perf(pack): remove useless runtime code for umd library output

### DIFF
--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -228,6 +228,12 @@ impl AppEntrypoint {
         import_path: RcStr,
         project_dir_name: RcStr,
     ) -> Result<Vc<RcStr>> {
+        // When project is root, the project_dir_name is empty
+        // In this case, the import path is already relative
+        // TODO: test use polyrepo project.
+        if project_dir_name.is_empty() {
+            return Ok(Vc::cell(import_path));
+        }
         if import_path.starts_with(MAIN_SEPARATOR) {
             let pattern = format!("{}{}{}", MAIN_SEPARATOR, project_dir_name, MAIN_SEPARATOR);
             if let Some(pos) = import_path.find(&pattern) {

--- a/crates/pack-api/src/library.rs
+++ b/crates/pack-api/src/library.rs
@@ -293,6 +293,12 @@ impl LibraryEndpoint {
         import_path: RcStr,
         project_dir_name: RcStr,
     ) -> Result<Vc<RcStr>> {
+        // When project is root, the project_dir_name is empty
+        // In this case, the import path is already relative
+        // TODO: test use polyrepo project.
+        if project_dir_name.is_empty() {
+            return Ok(Vc::cell(import_path));
+        }
         if import_path.starts_with(MAIN_SEPARATOR) {
             let pattern = format!("{}{}{}", MAIN_SEPARATOR, project_dir_name, MAIN_SEPARATOR);
             if let Some(pos) = import_path.find(&pattern) {

--- a/crates/pack-core/src/library/runtime/runtime_code.rs
+++ b/crates/pack-core/src/library/runtime/runtime_code.rs
@@ -34,13 +34,15 @@ pub async fn get_library_runtime_code(
         generate_source_map,
     );
 
-    let mut runtime_base_code = vec!["browser/runtime/base/runtime-base.ts"];
-    match *runtime_type {
-        RuntimeType::Production => runtime_base_code.push("browser/runtime/base/build-base.ts"),
-        RuntimeType::Development => {
-            runtime_base_code.push("browser/runtime/base/dev-base.ts");
-        }
-    }
+    let runtime_base_code = vec!["browser/runtime/base/runtime-base.ts"];
+
+    // Follwing runtime code is useless for umd output:
+    // match *runtime_type {
+    //     RuntimeType::Production => runtime_base_code.push("browser/runtime/base/build-base.ts"),
+    //     RuntimeType::Development => {
+    //         runtime_base_code.push("browser/runtime/base/dev-base.ts");
+    //     }
+    // }
 
     let chunk_loading = &*asset_context
         .compile_time_info()
@@ -55,7 +57,7 @@ pub async fn get_library_runtime_code(
             runtime_backend_code.push("browser/runtime/edge/dev-backend-edge.ts");
         }
         (ChunkLoading::Edge, RuntimeType::Production) => {
-            runtime_backend_code.push("browser/runtime/edge/runtime-backend-edge.ts");
+            // runtime_backend_code.push("browser/runtime/edge/runtime-backend-edge.ts");
         }
         // This case should never be hit.
         (ChunkLoading::NodeJs, _) => {


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/dc672154-07b2-42e9-a5fa-f5c8278695f4)

## After

![image](https://github.com/user-attachments/assets/3f4047e7-0462-4c3c-ab4e-90987e4771ca)

closes: #1974 