### PR TITLE
fix(ci): napi-rs override cargo config rustflags under musl

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -57,6 +57,7 @@ rustflags = [
 ]
 
 [target.aarch64-unknown-linux-musl]
+# Config need to be mirrowed to .github/workflows/pack-release.yml
 linker = "aarch64-linux-musl-gcc"
 rustflags = [
   "--cfg",
@@ -68,6 +69,7 @@ rustflags = [
 ]
 
 [target.x86_64-unknown-linux-musl]
+# Config need to be mirrowed to .github/workflows/pack-release.yml
 rustflags = [
   "--cfg",
   "tokio_unstable",

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -37,6 +37,7 @@ jobs:
               apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup target add aarch64-unknown-linux-musl &&
+              export RUSTFLAGS='--cfg tokio_unstable -Zshare-generics=y -Zthreads=8 -Zunstable-options -Csymbol-mangling-version=v0 -Clinker-flavor=gnu-lld-cc -Clink-self-contained=+linker' &&
               cd packages/pack && npm run build:binding -- --target aarch64-unknown-linux-musl
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -50,6 +51,7 @@ jobs:
               apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup target add x86_64-unknown-linux-musl &&
+              export RUSTFLAGS='--cfg tokio_unstable -Zshare-generics=y -Zthreads=8 -Csymbol-mangling-version=v0 -Ctarget-feature=-crt-static' &&
               cd packages/pack && npm run build:binding -- --target x86_64-unknown-linux-musl
           # swc_plugin_runner not supported on aarch64 windows now
           # - host: windows-latest


### PR DESCRIPTION
napi-rs 给 musl targets 设置了 RUSTFLAGS: https://github.com/napi-rs/napi-rs/issues/2151

`.cargo/config.toml` 里面配置的 rustflags 会不生效，这里通过传 env 的方式去修复一下。

CI 地址: https://github.com/umijs/mako/actions/runs/15772673907/job/44460348038，目前 musl 会挂。



