### PR TITLE
fix(pack): deal relative path under polyrepo project

### DIFF
--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -125,6 +125,7 @@ impl AppEntrypoint {
             .next_back()
             .unwrap_or("");
         let relative_import = self
+            .project()
             .convert_to_relative_import(this.import.clone(), project_dir_name.into())
             .await?;
 
@@ -236,36 +237,6 @@ impl AppEntrypoint {
             .await?
             .assets;
         Ok(chunk_group_assets)
-    }
-
-    #[turbo_tasks::function]
-    pub fn convert_to_relative_import(
-        self: Vc<Self>,
-        import_path: RcStr,
-        project_dir_name: RcStr,
-    ) -> Result<Vc<RcStr>> {
-        // When project is root, the project_dir_name is empty
-        // In this case, the import path is already relative
-        // TODO: test use polyrepo project.
-        if project_dir_name.is_empty() {
-            return Ok(Vc::cell(import_path));
-        }
-        if import_path.starts_with(MAIN_SEPARATOR) {
-            let pattern = format!("{}{}{}", MAIN_SEPARATOR, project_dir_name, MAIN_SEPARATOR);
-            if let Some(pos) = import_path.find(&pattern) {
-                let relative_part = &import_path[pos + pattern.len()..];
-                if !relative_part.is_empty() {
-                    let relative_import = format!(".{}{}", MAIN_SEPARATOR, relative_part);
-                    Ok(Vc::cell(relative_import.into()))
-                } else {
-                    bail!("Invalid import path: {}", import_path)
-                }
-            } else {
-                bail!("Invalid import path: {}", import_path)
-            }
-        } else {
-            Ok(Vc::cell(import_path))
-        }
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4693,6 +4693,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
@@ -10496,6 +10503,7 @@
         "@napi-rs/cli": "^2.18.0",
         "@swc/helpers": "^0.5.15",
         "@types/babel__code-frame": "7.0.2",
+        "@types/mime-types": "3.0.1",
         "@types/node": "^20.3.0",
         "@types/send": "0.14.4",
         "@types/webpack": "^5.28.5",

--- a/packages/pack/package.json
+++ b/packages/pack/package.json
@@ -61,7 +61,8 @@
     "typescript": "^5.8.3",
     "@types/ws": "^8.18.1",
     "@types/webpack": "^5.28.5",
-    "@types/send": "0.14.4"
+    "@types/send": "0.14.4",
+    "@types/mime-types": "3.0.1"
   },
   "engines": {
     "node": ">= 10"


### PR DESCRIPTION
MR 修复两个问题:
- utoo-pack 在非 monorepo 项目下的 entry resolver 问题

https://github.com/umijs/mako/blob/next/crates/pack-api/src/library.rs#L192

入口解析会用相对路径，当 `project_dir` 和  `root_dir` 在一个层级的时候(非 monorepo 单项目场景)，内部计算 `project_path` 和 `root_path` 会处理成 `""`，这种情况下，`relative_import` 实际上会处理成绝对路径，turbopack 会解析不到绝对路径，这里添加上一个分支处理，当存在 project_path 为 `""` 的情况下，用 `cwd` 计算相对路径。

 - utoo-pack build cjs 依赖缺失的问题