### PR TITLE
feat: externals support umd format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,15 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,11 +185,10 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast_node"
-version = "3.0.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ea666cbca3830383d6ce836593e88ade6f61b12c6066c09dc1257c3079a5b6"
+checksum = "a1e2cddd48eafd883890770673b1971faceaf80a185445671abc3ea0c00593ee"
 dependencies = [
- "proc-macro2",
  "quote",
  "swc_macros_common",
  "syn 2.0.100",
@@ -268,7 +258,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "hashbrown 0.14.5",
  "rustc-hash 2.1.1",
@@ -1986,11 +1976,10 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accfe8b52dc15c1bace718020831f72ce91a4c096709a4d733868f4f4034e22a"
+checksum = "308530a56b099da144ebc5d8e179f343ad928fa2b3558d1eb3db9af18d6eff43"
 dependencies = [
- "proc-macro2",
  "swc_macros_common",
  "syn 2.0.100",
 ]
@@ -2377,14 +2366,13 @@ dependencies = [
 
 [[package]]
 name = "hstr"
-version = "1.1.1"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1638d2018a21b9ff65d7fc28c2271c76a5af6ff4f621b204d032bc649763a4"
+checksum = "a78e25778a8c9e6ed47b02e668a8bd949f7017b5141edcf80221eb3a4ca11b4b"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
  "once_cell",
- "phf",
  "rustc-hash 2.1.1",
  "triomphe 0.1.14",
 ]
@@ -3587,10 +3575,10 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "swc_atoms 6.0.0",
+ "swc_atoms 6.0.1",
  "swc_cached",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_visit 13.0.0",
 ]
 
@@ -4063,7 +4051,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_core 30.0.1",
+ "swc_core 30.1.2",
  "tracing",
  "turbo-esregex",
  "turbo-rcstr",
@@ -4105,7 +4093,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_core 30.0.1",
+ "swc_core 30.1.2",
  "tokio",
  "tracing",
  "tracing-chrome",
@@ -4536,9 +4524,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7592384c098e7cdb7e31d0ce7294d922f5cd381f170f0eb9e545e50fb87d613"
+checksum = "8d71cb9fb3dd3ade85cc2afc2f8f607a870d33f6f91fa676420fb4b8590e8a9a"
 dependencies = [
  "anyhow",
  "browserslist-rs 0.19.0",
@@ -5073,10 +5061,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e6982af908d352dc6f1e5dfe8bd2432268d4d1065926615be64b02e04426a4"
 dependencies = [
  "serde",
- "swc_atoms 6.0.0",
+ "swc_atoms 6.0.1",
  "swc_cached",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_visit 13.0.0",
 ]
 
@@ -5981,11 +5969,10 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_enum"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b0e5369ebc6ec5fadbc400599467eb6ba5a614c03de094fcb233dddac2f5f4"
+checksum = "ae36a4951ca7bd1cfd991c241584a9824a70f6aff1e7d4f693fb3f2465e4030e"
 dependencies = [
- "proc-macro2",
  "quote",
  "swc_macros_common",
  "syn 2.0.100",
@@ -6014,10 +6001,10 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "tracing",
 ]
@@ -6035,8 +6022,8 @@ dependencies = [
  "preset_env_base",
  "rustc-hash 2.1.1",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_compat",
@@ -6044,11 +6031,11 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast 13.0.0",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_minifier",
- "swc_ecma_parser 18.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_parser 18.0.2",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_plugin_macro",
  "tracing",
@@ -6062,9 +6049,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swc"
-version = "29.0.0"
+version = "29.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ddfe0560df8c0097d6183e7cc4e80c40b6464bd6d5e275c5bcfcfc7d9e4be"
+checksum = "824b10a6f6fec763153f463bc51ba54cdfbaa5024e03489b49452d5f216c22ed"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6073,35 +6060,33 @@ dependencies = [
  "either",
  "indexmap 2.9.0",
  "jsonc-parser 0.26.2",
- "lru",
  "napi",
  "napi-derive",
  "once_cell",
  "par-core 2.0.0",
  "par-iter 2.0.0",
  "parking_lot",
- "pathdiff",
  "regex",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_codegen 15.0.1",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_codegen 15.0.2",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser 18.0.0",
+ "swc_ecma_parser 18.0.2",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_optimization",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_error_reporters",
  "swc_node_comments",
@@ -6119,16 +6104,14 @@ dependencies = [
 
 [[package]]
 name = "swc_allocator"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b926f0d94bbb34031fe5449428cfa1268cdc0b31158d6ad9c97e0fc1e79dd"
+checksum = "9d7eefd2c8b228a8c73056482b2ae4b3a1071fbe07638e3b55ceca8570cc48bb"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.14.5",
- "ptr_meta 0.3.0",
  "rustc-hash 2.1.1",
- "triomphe 0.1.14",
 ]
 
 [[package]]
@@ -6145,25 +6128,24 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf4c40238f7224596754940676547dab6bbf8f33d9f4560b966fc66f2fe00db"
+checksum = "6fda66fe4175cddc27a79643ded7ce297b6b2bf133f038ec5907fb4673e4b2ba"
 dependencies = [
  "bytecheck 0.8.1",
  "hstr",
  "once_cell",
  "rancor",
  "rkyv 0.8.10",
- "rustc-hash 2.1.1",
  "serde",
  "shrink-to-fit",
 ]
 
 [[package]]
 name = "swc_bundler"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b3b74e9ae0f72eed6c9fc83eac566eb3a3226a4d07383a10f92cb204fcc7cc"
+checksum = "f4dd6e9eaa17c94e0770300eefb260d1fc2c913fe9c948d5e0835f5c41cc1e33"
 dependencies = [
  "anyhow",
  "crc",
@@ -6171,21 +6153,20 @@ dependencies = [
  "indexmap 2.9.0",
  "is-macro",
  "once_cell",
- "parking_lot",
  "petgraph 0.7.1",
  "radix_fmt",
  "rayon",
  "relative-path",
  "rustc-hash 2.1.1",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_codegen 15.0.1",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_codegen 15.0.2",
  "swc_ecma_loader",
- "swc_ecma_parser 18.0.0",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_ecma_parser 18.0.2",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_optimization",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_graph_analyzer",
  "tracing",
@@ -6235,16 +6216,15 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "13.0.2"
+version = "13.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc28daa84b57762ecf28d8fdf6a3204ff04c8b8d98d35b9e8b9f56d4a7fafffa"
+checksum = "e103c3a47a343a175e9f65603122c5d3c8ec007776b00a4a4bc368a1347c4770"
 dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
  "bytecheck 0.8.1",
  "bytes-str",
- "cfg-if",
  "either",
  "from_variant",
  "new_debug_unreachable",
@@ -6257,8 +6237,7 @@ dependencies = [
  "serde",
  "shrink-to-fit",
  "siphasher 0.3.11",
- "swc_allocator",
- "swc_atoms 6.0.0",
+ "swc_atoms 6.0.1",
  "swc_eq_ignore_macros",
  "swc_sourcemap",
  "swc_visit",
@@ -6270,9 +6249,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "26.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83bc1443865d7cf6e567497a8af84f7d788c66d699281e06be851e7c5cb5232"
+checksum = "dac948172a3690b6a97f185ad284ef75363e6bb347270b175f274ee7570ec694"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6284,14 +6263,13 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_allocator",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_config",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_codegen 15.0.1",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_codegen 15.0.2",
  "swc_ecma_minifier",
- "swc_ecma_parser 18.0.0",
+ "swc_ecma_parser 18.0.2",
  "swc_ecma_visit 13.0.0",
  "swc_sourcemap",
  "swc_timer",
@@ -6349,31 +6327,31 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "30.0.1"
+version = "30.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec387d0be9f3a82c051ddcfc8a5075fec67023a38f7b5fb4d8cfc82d843e7710"
+checksum = "b7e50f97b3254a6290428b22f490952670537540cc3b33f69821d0411097bcb4"
 dependencies = [
  "par-core 2.0.0",
  "swc",
  "swc_allocator",
- "swc_atoms 6.0.0",
+ "swc_atoms 6.0.1",
  "swc_bundler",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_codegen 15.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_codegen 15.0.2",
  "swc_ecma_lints",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser 18.0.0",
+ "swc_ecma_parser 18.0.2",
  "swc_ecma_preset_env",
  "swc_ecma_quote_macros",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_nodejs_common",
  "swc_plugin_proxy",
@@ -6390,8 +6368,8 @@ checksum = "ccf4593805ec1ea036deec19c79396cf0b40220209588ac7650f95e44206d919"
 dependencies = [
  "is-macro",
  "string_enum",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
 ]
 
 [[package]]
@@ -6404,8 +6382,8 @@ dependencies = [
  "bitflags 2.9.0",
  "rustc-hash 2.1.1",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_css_ast",
  "swc_css_codegen_macros",
  "swc_css_utils",
@@ -6433,8 +6411,8 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -6448,8 +6426,8 @@ checksum = "3bfb906a537a51da83be9fb5f71bbad4f9fcbdc3995fb065097c480b3de966b7"
 dependencies = [
  "rustc-hash 2.1.1",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -6463,8 +6441,8 @@ checksum = "fd735dbda9ced56a1fd244763a204e4d9c3bac188b7a97674d606fac220dd2e6"
 dependencies = [
  "lexical",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_css_ast",
 ]
 
@@ -6479,8 +6457,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -6496,8 +6474,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_css_ast",
  "swc_css_visit",
 ]
@@ -6509,8 +6487,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722aea467676951de05afbe2df94082bb0abb73cf814bd50e20318f1ae09dcf3"
 dependencies = [
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_css_ast",
  "swc_visit",
 ]
@@ -6537,9 +6515,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "13.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ddc264ed13ae03aa30e1c89798502f9ddbe765a4ad695054add1074ffbc5cb"
+checksum = "3de29559723afd8436efd427648b22346fd408f741f93c0464aa0815857e69a4"
 dependencies = [
  "bitflags 2.9.0",
  "bytecheck 0.8.1",
@@ -6550,12 +6528,11 @@ dependencies = [
  "rancor",
  "rkyv 0.8.10",
  "rustc-hash 2.1.1",
- "scoped-tls",
  "serde",
  "shrink-to-fit",
  "string_enum",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_visit",
  "unicode-id-start",
 ]
@@ -6586,9 +6563,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "15.0.1"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1719b3bb5bff1c99cfb6fbd2129e7a7a363d3ddf50e22b95143c1877559d872a"
+checksum = "a639a205901c8cc0af6f2d7ff4548eb86f0935b1e70662423a9298a304ead6c2"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6600,9 +6577,9 @@ dependencies = [
  "ryu-js",
  "serde",
  "swc_allocator",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_codegen_macros",
  "swc_sourcemap",
  "tracing",
@@ -6610,12 +6587,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845c8312c82545780f837992bb15fff1dc3464f644465d5ed0abd1196cd090d3"
+checksum = "e276dc62c0a2625a560397827989c82a93fd545fcf6f7faec0935a82cc4ddbb8"
 dependencies = [
  "proc-macro2",
- "quote",
  "swc_macros_common",
  "syn 2.0.100",
 ]
@@ -6627,12 +6603,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9169f129a481546e4eb620dba0c26109862cf5bce96e3680d4db01abbb2b665e"
 dependencies = [
  "rustc-hash 2.1.1",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_compat_es2015",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6640,15 +6616,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2df0e12f54d47cca0255d99ae03766e314579ee10804f83699d0a8d7af17fa"
+checksum = "0e032ed44a63ac1d3ad86aebcb8b37d9dd8a196981ea2e653655b7ffe46d03a2"
 dependencies = [
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
- "swc_trace_macro",
 ]
 
 [[package]]
@@ -6664,15 +6639,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_config",
- "swc_ecma_ast 13.0.0",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6680,16 +6655,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da37c77b89c051adae231f418b4bc692c64d317f000b84dc6237d1684dcf6a17"
+checksum = "f2b4067e4b2b454bd8690ee8b05d579cb1fdc0f81fe3d8dbc07670b80e4458e1"
 dependencies = [
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6697,17 +6671,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda5d7eebf7bb5ebb9423e3edfeb7b821e2aada1a30e1bfe0e95960c978f6635"
+checksum = "e4a1ae3879005de7b6633f4d07973a2b40f89b39d10b20b41f4b1bc022aa3319"
 dependencies = [
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6715,18 +6687,17 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb135269fbba79ae05a36975409c41da275d317297555a954a3d113ac67d5838"
+checksum = "b4c346e5abee1657bab1116d04211a67e3614c5914ff005839653d81e1523322"
 dependencies = [
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6734,15 +6705,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e291f270b5a6837be3e8b9234d97e375ff55cb1f5abc71ea3356a6707be2dfcb"
+checksum = "60701a7fd40879b46fb16c5352e06920d3ea736fc4527a1aeb77072e247a5ead"
 dependencies = [
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6750,17 +6720,16 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135d8617f15be0d4bca63bff159354fd06aee5fa0ecb451123fb3bde19b2f946"
+checksum = "b8c307aafe115cc3c7edd1051eb02b7672d1d140697e618590c6eaea8e51eb67"
 dependencies = [
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_compat_es2022",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6768,15 +6737,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0a3142bf6430d05f19bace9efd64665a0511e02debfa76b07ee342dc213504"
+checksum = "42065e66df82927719b1c243f20229171c9c0af71d5b97696d0ab58bf7e4faae"
 dependencies = [
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6789,14 +6757,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551718d7d0304f308e28aa8418c47a0a96e3876ea0801055490e828d5ca7c658"
 dependencies = [
  "rustc-hash 2.1.1",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6804,14 +6772,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a2d522e48762ecfd40851f568eb504a22eb9fcaed03a47faf86de159c85a01"
+checksum = "c4dae760f336dd4a2ae01a846e9a48b87905ff7a1a4e23d752a34a7156fde034"
 dependencies = [
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_trace_macro",
  "tracing",
@@ -6819,15 +6786,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0583067e30e1eac8bd6adba3654d34739dd7d67175f3424b9fb00084cc9b0e8b"
+checksum = "0ad1e6607d18954bda15461e6ee06141c0755411f90f4dfc47e967018fbc9016"
 dependencies = [
  "phf",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
 ]
 
@@ -6858,9 +6824,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "18.0.0"
+version = "18.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b009fbd9113e82513e8f85f8405a3eaf4836b0e2b1bf35e1d492dba48108441"
+checksum = "8997e529b0a6923a6a680e652c6152ad1f5fef04bbd8efd938b84a2cc27a3ea4"
 dependencies = [
  "arrayvec",
  "ascii",
@@ -6869,7 +6835,6 @@ dependencies = [
  "either",
  "new_debug_unreachable",
  "num-bigint",
- "num-traits",
  "phf",
  "rustc-hash 2.1.1",
  "seq-macro",
@@ -6877,18 +6842,17 @@ dependencies = [
  "smallvec",
  "smartstring",
  "stacker",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "tracing",
- "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_lints"
-version = "19.0.0"
+version = "19.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e0d4862d46c0b6b92828b266bd663580d684f5206d1c4932739fa7be136a23"
+checksum = "8195694d584a01d92269f457f5c124d657061963858cc434340801488d2171ab"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -6897,11 +6861,11 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_config",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
 ]
 
@@ -6922,16 +6886,16 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "24.0.1"
+version = "24.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efba6301e1675e1ab9e03d0dcd691695b62a0e6eb5841d88c770524e491a793a"
+checksum = "844635d61e7ec483280f9820d13fb91cc5c91bec41c1f489a6aa8eaed585c508"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.0",
@@ -6944,22 +6908,20 @@ dependencies = [
  "parking_lot",
  "phf",
  "radix_fmt",
- "regex",
  "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "serde_json",
- "swc_allocator",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_config",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_codegen 15.0.1",
- "swc_ecma_parser 18.0.0",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_codegen 15.0.2",
+ "swc_ecma_parser 18.0.2",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_optimization",
  "swc_ecma_usage_analyzer",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_timer",
  "tracing",
@@ -6993,52 +6955,38 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "18.0.0"
+version = "18.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ebb9d932251ca0a4db5cd952a5134bef6e1f9853a914cf3bd1fbc4118f107a"
+checksum = "3ebb3a99692b8fb2152e337c0c80eb20f72313f570e92e001af19205dc58eb94"
 dependencies = [
- "arrayvec",
- "bitflags 2.9.0",
  "either",
- "new_debug_unreachable",
  "num-bigint",
- "num-traits",
- "phf",
- "rustc-hash 2.1.1",
  "serde",
- "smallvec",
- "smartstring",
- "stacker",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_lexer 18.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_lexer 18.0.2",
  "tracing",
- "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "24.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e77aa57a357c19e85b03f80780b6529f2e9f51134a94f45f252e0d4550caa1"
+checksum = "9c8843907f94ac339e2eaad5cad43e8442fddc11bff796452833e8347bf4d5ea"
 dependencies = [
- "anyhow",
- "dashmap 5.5.3",
  "indexmap 2.9.0",
  "once_cell",
  "preset_env_base",
  "rustc-hash 2.1.1",
- "semver",
  "serde",
  "serde_json",
- "st-map",
  "string_enum",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_transforms",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
 ]
 
@@ -7052,33 +7000,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc-hash 2.1.1",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_parser 18.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_parser 18.0.2",
  "swc_macros_common",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802136884637d4f9fdde93c3a34f829e4c7e1831eae2a6e6d06ebb49d54ed442"
+checksum = "7d7a229be9aa9d5f376461e12a60ac45bc140266be05d9b5d380ced33038b861"
 dependencies = [
  "par-core 2.0.0",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 18.0.2",
- "swc_ecma_visit 13.0.0",
+ "swc_ecma_utils 18.0.3",
 ]
 
 [[package]]
@@ -7107,61 +7053,53 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "19.0.0"
+version = "19.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abface3af9575e3849dce475189384d4b549335cb127fd5691d1c8f304f694c0"
+checksum = "9af528fa64c80fc633365530cc816e228cd7a3d256846c8fb85a6ac9d899719a"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.9.0",
  "indexmap 2.9.0",
  "once_cell",
  "par-core 2.0.0",
+ "par-iter 2.0.0",
  "phf",
- "rayon",
  "rustc-hash 2.1.1",
  "serde",
- "smallvec",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_parser 18.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_parser 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53837c7f0545bc03f9fe1158bf2a6aae3cf05018ab66252dc7cfdcffe4c80e04"
+checksum = "d7f65b26e8d2cdca0e0a8057a61e27650e8bddb7f8f0e479b7f699050545a866"
 dependencies = [
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "21.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e734c4cd3ffe18a38b072fd31758397014254e2b0b7fdea80f0b8d50ec723d89"
+checksum = "0a81ba47038e878285cbc989dd0df7cd55447c90dc0a8deb2b6a2c4add7e7a72"
 dependencies = [
- "arrayvec",
  "indexmap 2.9.0",
- "is-macro",
- "num-bigint",
  "par-core 2.0.0",
- "rayon",
  "serde",
- "smallvec",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_config",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -7173,12 +7111,9 @@ dependencies = [
  "swc_ecma_compat_es2021",
  "swc_ecma_compat_es2022",
  "swc_ecma_compat_es3",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_transforms_classes",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
- "swc_trace_macro",
  "tracing",
 ]
 
@@ -7196,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "21.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600c8dc240cf762e6121aef2a1076a5c2774cd438a639beb145e8afa66778f11"
+checksum = "d8a03cb7cb59dfaecfc6db0e3f84e3af45bff71c80a1f91b88abcc6065e6d240"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -7210,23 +7145,23 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_config",
- "swc_ecma_ast 13.0.0",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_loader",
- "swc_ecma_parser 18.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_parser 18.0.2",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67322d743c07fc94e3eac22f6cbbfd7e518d5022839aaaee6fb1c39432bb1bb2"
+checksum = "15dd685afdd33b77c17893b758c44a9c4a41adc53906e2202705946cfe10b1ce"
 dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
@@ -7234,85 +7169,75 @@ dependencies = [
  "once_cell",
  "par-core 2.0.0",
  "petgraph 0.7.1",
- "rayon",
  "rustc-hash 2.1.1",
  "serde_json",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_parser 18.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_parser 18.0.2",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd53518b08dcfdc21fcc2342cbb6d9bd3b7169002c0b245273d2537f9650c873"
+checksum = "5fd92a42081ed4c04aae8aa75eb3835b3c340a780e575a1b9ff74653023d6f92"
 dependencies = [
  "either",
  "rustc-hash 2.1.1",
  "serde",
- "smallvec",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_classes",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "21.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64abb192166cbd9b211642eeb93567762819980636d467f56498d349f1180f5"
+checksum = "1263d882972f7e7b075f140841a43cec4750871c71bcaf8aaa80c540140257ec"
 dependencies = [
  "base64 0.22.1",
  "bytes-str",
- "dashmap 5.5.3",
  "indexmap 2.9.0",
  "once_cell",
- "rayon",
  "rustc-hash 2.1.1",
  "serde",
  "sha1",
  "string_enum",
- "swc_allocator",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
  "swc_config",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_parser 18.0.0",
- "swc_ecma_transforms_base 19.0.0",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_parser 18.0.2",
+ "swc_ecma_transforms_base 19.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "21.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7729efdae45a96ff2ab56ae47e2c5f3d66d438c964601170aa3368673841c816"
+checksum = "3cc0341d890b0e13b5da7420728579322cdccf2393039b7e4ad5d13b5c333522"
 dependencies = [
  "bytes-str",
- "once_cell",
  "rustc-hash 2.1.1",
- "ryu-js",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_transforms_base 19.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_transforms_base 19.0.2",
  "swc_ecma_transforms_react",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
 ]
 
@@ -7325,10 +7250,10 @@ dependencies = [
  "bitflags 2.9.0",
  "indexmap 2.9.0",
  "rustc-hash 2.1.1",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_timer",
  "tracing",
@@ -7357,24 +7282,21 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "18.0.2"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d4bc1a89ef29769cf3e16c79a79836f21a7a3975fa34a9b748d0a9d3771daf"
+checksum = "1d2a10317f9c04f6345d22fc86f94f8a38a7d5b4ce0fc77b3846658a2c887776"
 dependencies = [
  "indexmap 2.9.0",
  "num_cpus",
  "once_cell",
  "par-core 2.0.0",
- "par-iter 2.0.0",
- "rayon",
  "rustc-hash 2.1.1",
  "ryu-js",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_ecma_visit 13.0.0",
  "tracing",
- "unicode-id",
 ]
 
 [[package]]
@@ -7401,9 +7323,9 @@ dependencies = [
  "new_debug_unreachable",
  "num-bigint",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_visit",
  "tracing",
 ]
@@ -7422,12 +7344,12 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "serde",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_codegen 15.0.1",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_codegen 15.0.2",
  "swc_ecma_transforms",
- "swc_ecma_utils 18.0.2",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "swc_sourcemap",
  "swc_trace_macro",
@@ -7447,30 +7369,26 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "15.0.0"
+version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f667f51b431565cf70ae62cee971eca8d9472e8b5ff17e37116842014dfacc8"
+checksum = "09b8bad18498e57f0f904e846b270af576bbfb7b583f1ee00bdeebe46748eb01"
 dependencies = [
  "anyhow",
  "miette",
  "once_cell",
- "parking_lot",
  "serde",
- "serde_derive",
- "serde_json",
- "swc_common 13.0.2",
+ "swc_common 13.0.4",
 ]
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "14.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4b7c00f9a8b2038ae9b68b9762f8d3e7b8b48323d3985a55bae9e478531b87"
+checksum = "a42314199595da31f253f6ea4dd3d67e9ed0a5745d0b07dad11de200b4ae9336"
 dependencies = [
  "auto_impl",
  "petgraph 0.7.1",
  "rustc-hash 2.1.1",
- "swc_common 13.0.2",
  "tracing",
 ]
 
@@ -7493,22 +7411,21 @@ checksum = "76aeca25bbc7c9bc4a73ea9d1ea407f2392f7b4829e03b10f59b04af49bd4e96"
 dependencies = [
  "dashmap 5.5.3",
  "rustc-hash 2.1.1",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
 ]
 
 [[package]]
 name = "swc_nodejs_common"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ccd9a395f5c7d485221b23206f0ce36d00d8e08cf9fa5d398ba56a8302b554"
+checksum = "30df4c0c5fbc9b7934c90bf270b21688b1137257b263e976412f650f52487d51"
 dependencies = [
  "anyhow",
  "napi",
  "serde",
  "serde_json",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -7533,35 +7450,33 @@ dependencies = [
  "rancor",
  "rkyv 0.8.10",
  "rustc-hash 2.1.1",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_plugin_runner"
-version = "15.0.0"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d893bf51dce4d733d45789bedffc8b312e33bec187ae1f2022408fc61b859d28"
+checksum = "7506220f0316ac29e7fd8c89de4d0c25667a6f252600675b3019ebedc143b6f5"
 dependencies = [
  "anyhow",
  "enumset",
  "futures",
- "once_cell",
  "parking_lot",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
  "swc_plugin_proxy",
  "swc_transform_common",
  "tokio",
  "tracing",
  "vergen",
- "virtual-fs",
  "wasmer",
  "wasmer-cache",
  "wasmer-compiler-cranelift",
@@ -7578,10 +7493,10 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
  "tracing",
 ]
@@ -7616,44 +7531,40 @@ dependencies = [
 
 [[package]]
 name = "swc_trace_macro"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559185db338f1bcb50297aafd4f79c0956c84dc71a66da4cffb57acf9d93fd88"
+checksum = "dfd2b4b0adb82e36f2ac688d00a6a67132c7f4170c772617516793a701be89e8"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "swc_transform_common"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958ab7a99fad6a7c68bbf7a10e857255bbc4e9a23d79dec7ad2912cbb9292c1"
+checksum = "364479c8afe381e0f0ae0c438f92f3018111004e6ec77960b4e58b2dc8038263"
 dependencies = [
  "better_scoped_tls",
- "once_cell",
  "rustc-hash 2.1.1",
  "serde",
- "serde_json",
- "swc_common 13.0.2",
+ "swc_common 13.0.4",
 ]
 
 [[package]]
 name = "swc_typescript"
-version = "17.0.1"
+version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965205aa6b60a2edc9d59369bb5f984221fd7a0c612443f1a0892d56bcfe8889"
+checksum = "51d1029243507b63e3de8d1a50ef014273ae73ef424e358b4a0b514238ed8993"
 dependencies = [
  "bitflags 2.9.0",
  "petgraph 0.7.1",
  "rustc-hash 2.1.1",
- "swc_atoms 6.0.0",
- "swc_common 13.0.2",
- "swc_ecma_ast 13.0.0",
- "swc_ecma_utils 18.0.2",
+ "swc_atoms 6.0.1",
+ "swc_common 13.0.4",
+ "swc_ecma_ast 13.0.1",
+ "swc_ecma_utils 18.0.3",
  "swc_ecma_visit 13.0.0",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7774,11 +7685,10 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "14.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ab605afeade5ad021de4acc02431c38a3beabca406d3a651a2feb445f60994"
+checksum = "ec446acef3673f1e8cc5674e70b5ed30f248495fe2cdb4aa556e4d3ab64da3e2"
 dependencies = [
- "ansi_term",
  "cargo_metadata 0.18.1",
  "difference",
  "once_cell",
@@ -7787,7 +7697,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_common 13.0.2",
+ "swc_common 13.0.4",
  "swc_error_reporters",
  "testing_macros",
  "tracing",
@@ -8349,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "turbo-esregex"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "regex",
@@ -8363,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "turbo-persistence"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -8387,12 +8297,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 
 [[package]]
 name = "turbo-rcstr"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "bytes-str",
  "napi",
@@ -8407,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8447,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-backend"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8482,7 +8392,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -8496,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8510,7 +8420,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -8523,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "reqwest 0.12.21",
@@ -8538,7 +8448,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -8548,7 +8458,6 @@ dependencies = [
  "dashmap 6.1.0",
  "dunce",
  "futures",
- "futures-retry",
  "include_dir",
  "indexmap 2.9.0",
  "jsonc-parser 0.21.1",
@@ -8575,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "turbo-tasks-macros",
  "twox-hash 1.6.3",
@@ -8584,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "either",
  "proc-macro-error",
@@ -8599,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8609,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "mimalloc",
 ]
@@ -8617,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-testing"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "futures",
@@ -8629,7 +8538,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "regex",
@@ -8661,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "either",
@@ -8687,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "clap",
@@ -8706,7 +8615,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8716,7 +8625,6 @@ dependencies = [
  "const_format",
  "data-encoding",
  "either",
- "futures",
  "indexmap 2.9.0",
  "once_cell",
  "patricia_tree",
@@ -8729,7 +8637,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "smallvec",
- "swc_core 30.0.1",
+ "swc_core 30.1.2",
  "swc_sourcemap",
  "tracing",
  "turbo-prehash",
@@ -8745,7 +8653,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8755,7 +8663,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
- "swc_core 30.0.1",
+ "swc_core 30.1.2",
  "tokio",
  "tracing",
  "turbo-rcstr",
@@ -8770,7 +8678,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8807,12 +8715,11 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "async-trait",
  "auto-hash-map",
- "bitvec",
  "bytes-str",
  "dashmap 6.1.0",
  "data-encoding",
@@ -8831,7 +8738,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "strsim 0.11.1",
- "swc_core 30.0.1",
+ "swc_core 30.1.2",
  "swc_sourcemap",
  "tokio",
  "tracing",
@@ -8850,7 +8757,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "serde",
  "serde_json",
@@ -8862,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8873,7 +8780,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 30.0.1",
+ "swc_core 30.1.2",
  "swc_emotion",
  "swc_relay",
  "tracing",
@@ -8888,7 +8795,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "indoc",
@@ -8905,7 +8812,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "turbo-rcstr",
@@ -8920,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8941,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -8956,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "markdown",
@@ -8972,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9009,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "indoc",
@@ -9028,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "regex",
@@ -9045,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "turbo-rcstr",
@@ -9061,11 +8968,11 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "parking_lot",
- "swc_core 30.0.1",
+ "swc_core 30.1.2",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -9075,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "either",
@@ -9097,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -9117,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/umijs/next.js.git#fdc7debbfd4eff4fa9aef0f24454ed61f6a84adb"
+source = "git+https://github.com/umijs/next.js.git#dee0bc75c27adf58297191e9d2f8957a39feff24"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ criterion = "0.6.0"
 dirs = "5.0"
 toml = "0.8"
 async-trait = "0.1.64"
-swc_core = { version = "30.0.1", features = [
+swc_core = { version = "30.1.1", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",

--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -206,6 +206,12 @@ impl AppEntrypoint {
             let module_graph = self.module_graph_for_entry(asset_context, runtime_entries);
 
             let query = QString::new(vec![("name", this.name.as_str())]).to_string();
+            let query = if query.is_empty() {
+                // If name is empty, provide a default fallback
+                QString::new(vec![("name", "index")]).to_string()
+            } else {
+                format!("?{query}")
+            };
 
             let app_chunk_group = app_chunking_context.evaluated_chunk_group(
                 AssetIdent::from_path(project.project_root().await?.join(this.import.as_str())?)

--- a/crates/pack-api/src/library.rs
+++ b/crates/pack-api/src/library.rs
@@ -272,6 +272,12 @@ impl LibraryEndpoint {
             let module_graph = self.library_module_graph();
 
             let query = QString::new(vec![("name", this.name.as_str())]).to_string();
+            let query = if query.is_empty() {
+                // If name is empty, provide a default fallback
+                QString::new(vec![("name", "index")]).to_string()
+            } else {
+                format!("?{query}")
+            };
 
             let library_chunk_group = library_chunking_context.evaluated_chunk_group(
                 AssetIdent::from_path(project.project_root().await?.join(this.import.as_str())?)

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -116,6 +116,7 @@ pub struct Config {
 #[serde(untagged)]
 pub enum ExternalConfig {
     Basic(RcStr),
+    Umd(ExternalUmd),
     Advanced(ExternalAdvanced),
 }
 
@@ -192,6 +193,17 @@ pub struct ExternalSubPathRule {
 pub struct ExternalSubPath {
     pub exclude: Option<Vec<RcStr>>,
     pub rules: Vec<ExternalSubPathRule>,
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalUmd {
+    /// Root global variable name
+    pub root: RcStr,
+    /// CommonJS module reference
+    pub commonjs: RcStr,
 }
 
 #[derive(
@@ -478,25 +490,6 @@ pub enum EsmExternalsValue {
 pub enum EsmExternals {
     Loose(EsmExternalsValue),
     Bool(bool),
-}
-
-// Test for esm externals deserialization.
-#[test]
-fn test_esm_externals_deserialization() {
-    let json = serde_json::json!({
-        "esmExternals": true
-    });
-    let config: ExperimentalConfig = serde_json::from_value(json).unwrap();
-    assert_eq!(config.esm_externals, Some(EsmExternals::Bool(true)));
-
-    let json = serde_json::json!({
-        "esmExternals": "loose"
-    });
-    let config: ExperimentalConfig = serde_json::from_value(json).unwrap();
-    assert_eq!(
-        config.esm_externals,
-        Some(EsmExternals::Loose(EsmExternalsValue::Loose))
-    );
 }
 
 #[derive(
@@ -1143,95 +1136,129 @@ impl Config {
     }
 }
 
-#[test]
-fn test_externals_deserialization() {
-    let json = serde_json::json!({
-        "entry": [{"import": "./index.js"}],
-        "externals": {
-            "foo": "foo",
-            "foo_require": "commonjs foo",
-            "foo_require2": {
-                "root": "foo",
-                "type": "commonjs"
-            },
-            "foo_import": "esm foo",
-            "foo_import2": {
-                "root": "foo",
-                "type": "esm"
-            },
-            "antd": {
-                "root": "antd",
-                "subPath": {
-                    "exclude": ["style"],
-                    "rules": [
-                        {
-                          "regex": "/(version|message|notification)$",
-                          "target": "$1"
-                        },
-                        {
-                          "regex": "/locale/.+$",
-                          "target": "$empty"
-                        },
-                        {
-                          "regex": "/es\\/([^\\/]+)(?:\\/.*)?$/",
-                          "target": "$1",
-                          "targetConverter": "PascalCase"
-                        }
-                    ]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_esm_externals_deserialization() {
+        let json = serde_json::json!({
+            "esmExternals": true
+        });
+        let config: ExperimentalConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.esm_externals, Some(EsmExternals::Bool(true)));
+
+        let json = serde_json::json!({
+            "esmExternals": "loose"
+        });
+        let config: ExperimentalConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            config.esm_externals,
+            Some(EsmExternals::Loose(EsmExternalsValue::Loose))
+        );
+    }
+
+    #[test]
+    fn test_externals_deserialization() {
+        let json = serde_json::json!({
+            "entry": [{"import": "./index.js"}],
+            "externals": {
+                "foo": "foo",
+                "foo_require": "commonjs foo",
+                "foo_require2": {
+                    "root": "foo",
+                    "type": "commonjs"
+                },
+                "foo_import": "esm foo",
+                "foo_import2": {
+                    "root": "foo",
+                    "type": "esm"
+                },
+                "react": {
+                    "root": "React",
+                    "commonjs": "react"
+                },
+                "antd": {
+                    "root": "antd",
+                    "subPath": {
+                        "exclude": ["style"],
+                        "rules": [
+                            {
+                              "regex": "/(version|message|notification)$",
+                              "target": "$1"
+                            },
+                            {
+                              "regex": "/locale/.+$",
+                              "target": "$empty"
+                            },
+                            {
+                              "regex": "/es\\/([^\\/]+)(?:\\/.*)?$/",
+                              "target": "$1",
+                              "targetConverter": "PascalCase"
+                            }
+                        ]
+                    }
                 }
             }
-        }
-    });
+        });
 
-    let config: Config = serde_json::from_value(json).unwrap();
-    let externals = config.externals.unwrap();
+        let config: Config = serde_json::from_value(json).unwrap();
+        let externals = config.externals.unwrap();
 
-    // test basic external config
-    assert!(
-        matches!(externals.get("foo"), Some(ExternalConfig::Basic(name)) if name.as_str() == "foo")
-    );
-    assert!(
-        matches!(externals.get("foo_require"), Some(ExternalConfig::Basic(name)) if name.as_str() == "commonjs foo")
-    );
-    assert!(
-        matches!(externals.get("foo_import"), Some(ExternalConfig::Basic(name)) if name.as_str() == "esm foo")
-    );
-
-    // test advanced external config
-    if let Some(ExternalConfig::Advanced(advanced)) = externals.get("foo_require2") {
-        assert_eq!(advanced.root.as_str(), "foo");
-        assert_eq!(advanced.r#type, Some(ExternalType::CommonJs));
-    } else {
-        panic!("Expected ExternalConfig::Advanced for foo_require2");
-    }
-
-    if let Some(ExternalConfig::Advanced(advanced)) = externals.get("foo_import2") {
-        assert_eq!(advanced.root.as_str(), "foo");
-        assert_eq!(advanced.r#type, Some(ExternalType::ESM));
-    } else {
-        panic!("Expected ExternalConfig::Advanced for foo_import2");
-    }
-
-    if let Some(ExternalConfig::Advanced(advanced)) = externals.get("antd") {
-        assert_eq!(advanced.root.as_str(), "antd");
-        assert_eq!(advanced.sub_path.as_ref().unwrap().rules.len(), 3);
-
-        let rule1 = &advanced.sub_path.as_ref().unwrap().rules[0];
-        assert_eq!(rule1.regex.as_str(), "/(version|message|notification)$");
-        assert_eq!(rule1.target, ExternalSubPathTarget::Tpl("$1".into()));
-
-        let rule2 = &advanced.sub_path.as_ref().unwrap().rules[1];
-        assert_eq!(rule2.regex.as_str(), "/locale/.+$");
-        assert_eq!(rule2.target, ExternalSubPathTarget::Empty);
-
-        let rule3 = &advanced.sub_path.as_ref().unwrap().rules[2];
-        assert_eq!(rule3.regex.as_str(), "/es\\/([^\\/]+)(?:\\/.*)?$/");
-        assert_eq!(rule3.target, ExternalSubPathTarget::Tpl("$1".into()));
-        assert_eq!(
-            rule3.target_converter,
-            Some(ExternalTargetConverter::PascalCase)
+        // test basic external config
+        assert!(
+            matches!(externals.get("foo"), Some(ExternalConfig::Basic(name)) if name.as_str() == "foo")
         );
-    } else {
-        panic!("Expected ExternalConfig::Advanced for antd");
+        assert!(
+            matches!(externals.get("foo_require"), Some(ExternalConfig::Basic(name)) if name.as_str() == "commonjs foo")
+        );
+        assert!(
+            matches!(externals.get("foo_import"), Some(ExternalConfig::Basic(name)) if name.as_str() == "esm foo")
+        );
+
+        // test advanced external config
+        if let Some(ExternalConfig::Advanced(advanced)) = externals.get("foo_require2") {
+            assert_eq!(advanced.root.as_str(), "foo");
+            assert_eq!(advanced.r#type, Some(ExternalType::CommonJs));
+        } else {
+            panic!("Expected ExternalConfig::Advanced for foo_require2");
+        }
+
+        if let Some(ExternalConfig::Advanced(advanced)) = externals.get("foo_import2") {
+            assert_eq!(advanced.root.as_str(), "foo");
+            assert_eq!(advanced.r#type, Some(ExternalType::ESM));
+        } else {
+            panic!("Expected ExternalConfig::Advanced for foo_import2");
+        }
+
+        if let Some(ExternalConfig::Umd(umd_config)) = externals.get("react") {
+            assert_eq!(umd_config.root.as_str(), "React");
+            assert_eq!(umd_config.commonjs.as_str(), "react");
+        } else {
+            panic!("Expected ExternalConfig::Umd for react");
+        }
+
+        if let Some(ExternalConfig::Advanced(advanced)) = externals.get("antd") {
+            assert_eq!(advanced.root.as_str(), "antd");
+            assert_eq!(advanced.sub_path.as_ref().unwrap().rules.len(), 3);
+
+            let rule1 = &advanced.sub_path.as_ref().unwrap().rules[0];
+            assert_eq!(rule1.regex.as_str(), "/(version|message|notification)$");
+            assert_eq!(rule1.target, ExternalSubPathTarget::Tpl("$1".into()));
+
+            let rule2 = &advanced.sub_path.as_ref().unwrap().rules[1];
+            assert_eq!(rule2.regex.as_str(), "/locale/.+$");
+            assert_eq!(rule2.target, ExternalSubPathTarget::Empty);
+
+            let rule3 = &advanced.sub_path.as_ref().unwrap().rules[2];
+            assert_eq!(rule3.regex.as_str(), "/es\\/([^\\/]+)(?:\\/.*)?$/");
+            assert_eq!(rule3.target, ExternalSubPathTarget::Tpl("$1".into()));
+            assert_eq!(
+                rule3.target_converter,
+                Some(ExternalTargetConverter::PascalCase)
+            );
+        } else {
+            panic!("Expected ExternalConfig::Advanced for antd");
+        }
     }
 }

--- a/crates/pack-core/src/library/chunking_context.rs
+++ b/crates/pack-core/src/library/chunking_context.rs
@@ -26,7 +26,11 @@ use turbopack_core::{
     environment::Environment,
     ident::AssetIdent,
     module::Module,
-    module_graph::{ModuleGraph, chunk_group_info::ChunkGroup},
+    module_graph::{
+        ModuleGraph,
+        chunk_group_info::ChunkGroup,
+        export_usage::{ExportUsageInfo, ModuleExportUsageInfo},
+    },
     output::{OutputAsset, OutputAssets},
 };
 use turbopack_ecmascript::chunk::{EcmascriptChunk, EcmascriptChunkType};
@@ -115,6 +119,11 @@ impl LibraryChunkingContextBuilder {
     pub fn build(self) -> Vc<LibraryChunkingContext> {
         LibraryChunkingContext::cell(self.chunking_context)
     }
+
+    pub fn export_usage(mut self, export_usage: Option<ResolvedVc<ExportUsageInfo>>) -> Self {
+        self.chunking_context.export_usage = export_usage;
+        self
+    }
 }
 
 /// A chunking context for development mode.
@@ -151,6 +160,8 @@ pub struct LibraryChunkingContext {
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     /// Evaluate chunk filename template
     filename: Option<RcStr>,
+    /// The module export usage info, if available.
+    export_usage: Option<ResolvedVc<ExportUsageInfo>>,
 }
 
 impl LibraryChunkingContext {
@@ -176,6 +187,7 @@ impl LibraryChunkingContext {
                 source_maps_type: SourceMapsType::Full,
                 module_id_strategy: ResolvedVc::upcast(DevModuleIdStrategy::new_resolved()),
                 filename: Default::default(),
+                export_usage: None,
                 runtime_root,
                 runtime_export,
             },
@@ -538,6 +550,18 @@ impl ChunkingContext for LibraryChunkingContext {
         _module: Vc<Box<dyn ChunkableModule>>,
     ) -> Result<Vc<ModuleId>> {
         bail!("Library chunking context does not support async loader chunk item id")
+    }
+
+    #[turbo_tasks::function]
+    async fn module_export_usage(
+        self: Vc<Self>,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> Result<Vc<ModuleExportUsageInfo>> {
+        if let Some(export_usage) = self.await?.export_usage {
+            Ok(export_usage.await?.used_exports(module))
+        } else {
+            Ok(ModuleExportUsageInfo::all())
+        }
     }
 }
 

--- a/crates/pack-core/src/library/runtime/runtime_code.rs
+++ b/crates/pack-core/src/library/runtime/runtime_code.rs
@@ -121,8 +121,6 @@ pub async fn get_library_runtime_code(
 
             if (typeof exports === 'object' && typeof module === 'object') {{
                 module.exports = factory();
-            }} else if(typeof define === 'function' && define.amd) {{
-                define([], factory);
             }} else if (typeof exports === 'object') {{
         "#,
     )?;
@@ -160,12 +158,6 @@ pub async fn get_library_runtime_code(
         code,
         r#"
             }}
-        "#,
-    )?;
-
-    writedoc!(
-        code,
-        r#"
             }})();
         "#
     )?;

--- a/crates/pack-core/src/shared/resolve/externals_plugin.rs
+++ b/crates/pack-core/src/shared/resolve/externals_plugin.rs
@@ -212,6 +212,16 @@ impl BeforeResolvePlugin for ExternalsPlugin {
                     };
                     (advanced.root.clone(), external_type)
                 }
+                ExternalConfig::Umd(umd_config) => {
+                    // Handle UMD config
+                    let external_name = format!(
+                        "root {} commonjs {}",
+                        umd_config.root.as_str(),
+                        umd_config.commonjs.as_str()
+                    );
+
+                    (external_name.into(), ExternalType::Umd)
+                }
             };
 
             return Ok(ResolveResultOption::some(*ResolveResult::primary(
@@ -341,7 +351,7 @@ impl AfterResolvePlugin for ExternalsPlugin {
                                 if external_name.is_empty() {
                                     advanced.root.to_string()
                                 } else {
-                                    format!("{}/{}", advanced.root, external_name)
+                                    format!("{} {}", advanced.root, external_name)
                                 }
                             }
                         };

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -279,11 +279,13 @@ pub use pack_core::config::{
 pub enum SchemaExternalConfig {
     /// Simple string external (e.g., \"react\" -> \"React\")
     Basic(String),
-    /// Complex external configuration
+    /// UMD external configuration
+    Umd(SchemaExternalUmd),
+    /// Subpath external configuration (for complex path handling)
     Advanced(SchemaExternalAdvanced),
 }
 
-/// Advanced external configuration
+/// Subpath external configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaExternalAdvanced {
@@ -359,6 +361,20 @@ pub enum SchemaExternalTargetConverter {
     CamelCase,
     KebabCase,
     SnakeCase,
+}
+
+/// UMD external configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaExternalUmd {
+    /// Root global variable name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Root global variable name")]
+    pub root: Option<String>,
+    /// CommonJS module reference
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "CommonJS module reference")]
+    pub commonjs: Option<String>,
 }
 
 /// Module configuration

--- a/examples/externals/index.js
+++ b/examples/externals/index.js
@@ -10,8 +10,8 @@ import Button from "antd/es/button";
 import DatePicker from "antd/es/date-picker";
 import InputGroup from "antd/es/input/Group";
 import version from "antd/es/version";
-import zh_CN from "antd/es/locale/zh_CN";
-import zh_TW from "antd/es/locale/zh_TW";
+// import zh_CN from "antd/es/locale/zh_CN";
+// import zh_TW from "antd/es/locale/zh_TW";
 // import Style from 'antd/es/button/style';
 
 console.log(foo, foo_require, foo_require2, foo_import, foo_import2);

--- a/examples/externals/project_options.json
+++ b/examples/externals/project_options.json
@@ -5,7 +5,7 @@
   "config": {
     "entry": [
       {
-        "import": "./index.js"       
+        "import": "./index.js"    
       }
     ],
     "output": {
@@ -44,14 +44,6 @@
             {
               "regex": "/(version|message|notification)$/",
               "target": "$1"
-            },
-            {
-              "regex": "/zh_CN$/",
-              "target": "$empty"
-            },
-            {
-              "regex": "/zh_TW$/",
-              "target": "$empty"
             },
             {
               "regex": "/^\/(?:es|lib)\/([a-z\\-]+)$/",

--- a/examples/with-library/project_options.json
+++ b/examples/with-library/project_options.json
@@ -23,7 +23,14 @@
       "minify": false
     },
     "externals": {
-      "lodash": "$"
+      "react": {
+        "root": "React",
+        "commonjs": "react"
+      },
+      "react-dom": {
+        "root": "ReactDOM",
+        "commonjs": "react-dom"
+      }
     }
   }
 }

--- a/examples/with-library/src/index.ts
+++ b/examples/with-library/src/index.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import "./comp2";
 
 console.log(_);
 

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -276,7 +276,7 @@
       }
     },
     "SchemaExternalAdvanced": {
-      "description": "Advanced external configuration",
+      "description": "Subpath external configuration",
       "type": "object",
       "required": [
         "root"
@@ -325,7 +325,15 @@
           "type": "string"
         },
         {
-          "description": "Complex external configuration",
+          "description": "UMD external configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaExternalUmd"
+            }
+          ]
+        },
+        {
+          "description": "Subpath external configuration (for complex path handling)",
           "allOf": [
             {
               "$ref": "#/definitions/SchemaExternalAdvanced"
@@ -408,6 +416,26 @@
         "esm",
         "global"
       ]
+    },
+    "SchemaExternalUmd": {
+      "description": "UMD external configuration",
+      "type": "object",
+      "properties": {
+        "commonjs": {
+          "description": "CommonJS module reference",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "root": {
+          "description": "Root global variable name",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     },
     "SchemaImageConfig": {
       "description": "Image configuration",


### PR DESCRIPTION
closes: #2010 

Before this pr megred, https://github.com/umijs/next.js/pull/30 should be merged.

support externals config like for the umd output format:

```json
{
  "externals": {
      "react": {
          "root": "React",
          "commonjs": "react"
      }
  }
}
```