### PR TITLE
fix(pack): resolve config align with napi config

### DIFF
--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -242,9 +242,10 @@ pub struct StyleConfig {
     NonLocalValue,
     OperationValue,
 )]
-#[serde(rename_all = "camelCase")]
 pub struct ResolveConfig {
+    #[serde(rename = "alias")]
     resolve_alias: Option<FxIndexMap<RcStr, JsonValue>>,
+    #[serde(rename = "extensions")]
     resolve_extensions: Option<Vec<RcStr>>,
 }
 

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -393,11 +393,13 @@ pub struct SchemaResolveConfig {
     /// Resolve alias mapping
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Resolve alias mapping")]
+    #[serde(rename = "alias")]
     pub resolve_alias: Option<HashMap<String, serde_json::Value>>,
 
     /// Resolve extensions
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Resolve extensions")]
+    #[serde(rename = "extensions")]
     pub resolve_extensions: Option<Vec<String>>,
 }
 

--- a/examples/define/package.json
+++ b/examples/define/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "@utoo/pack-cli": "*"
-  },
-  "repository": "git@github.com:umijs/mako.git"
+  }
 }
 

--- a/examples/resolve/.gitignore
+++ b/examples/resolve/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/examples/resolve/package.json
+++ b/examples/resolve/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "with-resolve",
+    "version": "1.0.0",
+    "description": "Resolver example",
+    "author": "zoomdong",
+    "license": "MIT",
+    "scripts": {
+        "build": "utoo-pack build -p . -r ../..",
+        "dev": "utoo-pack dev -p . -r ../.."
+    },
+    "devDependencies": {
+        "@utoo/pack-cli": "*"
+    }
+}

--- a/examples/resolve/project_options.json
+++ b/examples/resolve/project_options.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "../../packages/pack/config_schema.json",
+    "rootPath": "../../",
+    "projectPath": "./",
+    "config": {
+        "output": {
+            "clean": true
+        },
+        "entry": [
+            {
+                "import": "./src/index.ts",
+                "name": "alias-demo"
+            }
+        ],
+        "resolve": {
+            "alias": {
+                "hello-a": "./src/a.ts"
+            }
+        },
+        "optimization": {
+            "minify": false
+        }
+    }
+}

--- a/examples/resolve/src/a.ts
+++ b/examples/resolve/src/a.ts
@@ -1,0 +1,1 @@
+export const a = "aaa";

--- a/examples/resolve/src/index.ts
+++ b/examples/resolve/src/index.ts
@@ -1,0 +1,3 @@
+import { a } from "hello-a";
+
+console.log(a);

--- a/justfile
+++ b/justfile
@@ -36,3 +36,6 @@ fmt-check:
 # Clean build artifacts
 clean:
     cargo clean
+
+update-submodule:
+    git submodule update --init

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "examples/with-less",
         "examples/with-library",
         "examples/with-sass",
-        "examples/with-style-loader"
+        "examples/with-style-loader",
+        "examples/resolve"
       ],
       "devDependencies": {
         "@biomejs/biome": "2.0.5"
@@ -97,6 +98,14 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "examples/resolve": {
+      "name": "with-resolve",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@utoo/pack-cli": "*"
       }
     },
     "examples/webpack-compat": {
@@ -9400,6 +9409,10 @@
     },
     "node_modules/with-library": {
       "resolved": "examples/with-library",
+      "link": true
+    },
+    "node_modules/with-resolve": {
+      "resolved": "examples/resolve",
       "link": true
     },
     "node_modules/with-sass": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "examples/with-less",
     "examples/with-library",
     "examples/with-sass",
-    "examples/with-style-loader"
+    "examples/with-style-loader",
+    "examples/resolve"
   ],
   "repository": "https://github.com/umijs/mako"
 }

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -666,7 +666,7 @@
       "description": "Resolve configuration",
       "type": "object",
       "properties": {
-        "resolveAlias": {
+        "alias": {
           "description": "Resolve alias mapping",
           "type": [
             "object",
@@ -674,7 +674,7 @@
           ],
           "additionalProperties": true
         },
-        "resolveExtensions": {
+        "extensions": {
           "description": "Resolve extensions",
           "type": [
             "array",


### PR DESCRIPTION
closes: #2018

Support `config.resolve.alias` and `config.resolve.extensions` instead of `config.resolve.resolveAlias` and `config.resolve.resolveExtensions` in napi side.