### PR TITLE
fix(pack): config.alias not work for absolute path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "next.js"]
 	path = next.js
-	url = git@github.com:umijs/next.js.git
+	url = https://github.com/umijs/next.js.git
 	shallow = true

--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -6,6 +6,7 @@ use pack_core::client::context::{
     get_client_module_options_context, get_client_resolve_options_context,
     get_client_runtime_entries,
 };
+use pack_core::util::convert_to_relative_import;
 use qstring::QString;
 use tracing::{Instrument, info_span};
 use turbo_rcstr::{RcStr, rcstr};
@@ -124,11 +125,9 @@ impl AppEntrypoint {
             .split(MAIN_SEPARATOR)
             .next_back()
             .unwrap_or("");
-        let relative_import = self
-            .project()
-            .convert_to_relative_import(this.import.clone(), project_dir_name.into())
-            .await?
-            .clone_value();
+
+        let relative_import =
+            convert_to_relative_import(this.import.clone(), project_dir_name.into())?;
 
         let entry_request = Request::relative(
             relative_import.into(),

--- a/crates/pack-api/src/library.rs
+++ b/crates/pack-api/src/library.rs
@@ -7,6 +7,7 @@ use pack_core::{
         get_client_runtime_entries,
     },
     library::contexts::get_library_chunking_context,
+    util::convert_to_relative_import,
 };
 use qstring::QString;
 use tracing::{Instrument, info_span};
@@ -181,11 +182,8 @@ impl LibraryEndpoint {
             .split(MAIN_SEPARATOR)
             .next_back()
             .unwrap_or("");
-        let relative_import = self
-            .project()
-            .convert_to_relative_import(this.import.clone(), project_dir_name.into())
-            .await?
-            .clone_value();
+        let relative_import =
+            convert_to_relative_import(this.import.clone(), project_dir_name.into())?;
 
         let entry_request = Request::relative(
             relative_import.into(),

--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -1081,41 +1081,6 @@ impl Project {
             }
         }
     }
-
-    #[turbo_tasks::function]
-    pub fn convert_to_relative_import(
-        self: Vc<Self>,
-        import_path: RcStr,
-        project_dir_name: RcStr,
-    ) -> Result<Vc<RcStr>> {
-        // When project is root, the project_dir_name is empty
-        // In this case, the import path is already relative
-        let project_dir_name = if project_dir_name.is_empty() {
-            std::env::current_dir()
-                .ok()
-                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
-                .unwrap_or_default()
-                .into()
-        } else {
-            project_dir_name
-        };
-        if import_path.starts_with(MAIN_SEPARATOR) {
-            let pattern = format!("{MAIN_SEPARATOR}{project_dir_name}{MAIN_SEPARATOR}");
-            if let Some(pos) = import_path.find(&pattern) {
-                let relative_part = &import_path[pos + pattern.len()..];
-                if !relative_part.is_empty() {
-                    let relative_import = format!(".{MAIN_SEPARATOR}{relative_part}");
-                    Ok(Vc::cell(relative_import.into()))
-                } else {
-                    bail!("Invalid import path: {}", import_path)
-                }
-            } else {
-                bail!("Invalid import path: {}", import_path)
-            }
-        } else {
-            Ok(Vc::cell(import_path))
-        }
-    }
 }
 
 // This is a performance optimization. This function is a root aggregation function that

--- a/crates/pack-core/src/import_map.rs
+++ b/crates/pack-core/src/import_map.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};
@@ -19,7 +19,7 @@ use turbopack_core::{
 };
 use turbopack_node::execution_context::ExecutionContext;
 
-use crate::{config::Config, mode::Mode};
+use crate::{config::Config, mode::Mode, util::convert_to_relative_import};
 
 pub fn mdx_import_source_file() -> RcStr {
     unreachable!()
@@ -136,15 +136,25 @@ fn export_value_to_import_mapping(
         None
     } else {
         Some(if result.len() == 1 {
-            ImportMapping::PrimaryAlternative(result[0].0.into(), Some(project_path.clone()))
+            let relative_import =
+                convert_to_relative_import(result[0].0.into(), project_path.clone().path).ok()?;
+            ImportMapping::PrimaryAlternative(relative_import, Some(project_path.clone()))
                 .resolved_cell()
         } else {
             ImportMapping::Alternatives(
                 result
                     .iter()
-                    .map(|(m, _)| {
-                        ImportMapping::PrimaryAlternative((*m).into(), Some(project_path.clone()))
-                            .resolved_cell()
+                    .filter_map(|(m, _)| {
+                        let relative_import =
+                            convert_to_relative_import((*m).into(), project_path.clone().path)
+                                .ok()?;
+                        Some(
+                            ImportMapping::PrimaryAlternative(
+                                relative_import,
+                                Some(project_path.clone()),
+                            )
+                            .resolved_cell(),
+                        )
                     })
                     .collect(),
             )

--- a/crates/pack-core/src/import_map.rs
+++ b/crates/pack-core/src/import_map.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};

--- a/crates/pack-core/src/util.rs
+++ b/crates/pack-core/src/util.rs
@@ -1,4 +1,6 @@
-use anyhow::Result;
+use std::path::MAIN_SEPARATOR;
+
+use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, TaskInput, Vc, trace::TraceRawVcs};
@@ -88,4 +90,34 @@ pub async fn internal_assets_conditions() -> Result<ContextCondition> {
                 .clone_value(),
         ),
     ]))
+}
+
+pub fn convert_to_relative_import(import_path: RcStr, project_path: RcStr) -> Result<RcStr> {
+    // When project is root, the project_path is empty
+    // In this case, the import path is already relative
+    let project_path = if project_path.is_empty() {
+        std::env::current_dir()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+            .unwrap_or_default()
+            .into()
+    } else {
+        project_path
+    };
+    if import_path.starts_with(MAIN_SEPARATOR) {
+        let pattern = format!("{MAIN_SEPARATOR}{project_path}{MAIN_SEPARATOR}");
+        if let Some(pos) = import_path.find(&pattern) {
+            let relative_part = &import_path[pos + pattern.len()..];
+            if !relative_part.is_empty() {
+                let relative_import = format!(".{MAIN_SEPARATOR}{relative_part}");
+                Ok(relative_import.into())
+            } else {
+                bail!("Invalid import path: {}", import_path)
+            }
+        } else {
+            bail!("Invalid import path: {}", import_path)
+        }
+    } else {
+        Ok(import_path)
+    }
 }


### PR DESCRIPTION
closes: #2020 

把之前处理 `entry.import` 在非 monorepo 项目下的绝对路径处理逻辑抽了个 `pack_core` 里面的util 方法，后续还有类似 issue 直接参考使用这个方法处理就好