### PR TITLE
fix: docker nodejs-rust:lts-alpine contains llvm-dev

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -34,6 +34,9 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
               set -e &&
+              rm /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
               apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup target add aarch64-unknown-linux-musl &&
@@ -48,6 +51,9 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
               set -ex &&
+              rm /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
               apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup target add x86_64-unknown-linux-musl &&


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9ac4fd45-0705-4883-983e-5a797a39f133)

镜像 `nodejs-rust:lts-alpine` 里面应该已经有 llvm-dev 这个依赖了，~~可以不用安装，会出现依赖覆盖导致抛错的问题~~

用最新的 `llvm-dev` 依赖，参考 swc 的处理: https://github.com/swc-project/swc/blob/main/.github/workflows/publish-npm-package.yml#L122