### PR TITLE
fix(pack): inlineCss config type could be optional

### DIFF
--- a/examples/with-style-loader/project_options.json
+++ b/examples/with-style-loader/project_options.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../packages/pack/config_schema.json",
   "rootPath": "../../",
   "projectPath": "./",
   "config": {
@@ -15,6 +16,9 @@
     },
     "styles": {
       "inlineCss": {}
+    },
+    "optimization": {
+      "minify": false
     }
   }
 }

--- a/packages/pack/src/types.ts
+++ b/packages/pack/src/types.ts
@@ -167,7 +167,7 @@ export interface ConfigComplete {
         };
     inlineCss?: {
       insert?: string;
-      injectType: string;
+      injectType?: string;
     };
     styledComponents?: boolean | StyledComponentsConfig;
     emotion?: boolean | EmotionConfig;


### PR DESCRIPTION
`inlineCss` 的两个参数 `insert` 以及 `insertType` 可以不传，默认情况下 insertType 会处理成 `header`.