### PR TITLE
perf(ci): parallel cargo build & rename pack-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ env:
   CARGO_INCREMENTAL: 1
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
+  CARGO_BUILD_JOBS: 0
 
 jobs:
   detect-changes:
@@ -65,7 +66,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        submoduls: false
+        submodules: false
     
     - name: Add SSH private keys for submodule repositories
       uses: webfactory/ssh-agent@v0.7.0
@@ -83,9 +84,12 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          ~/.cargo/.crates.toml
+          ~/.cargo/.crates2.json
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          ${{ runner.os }}-cargo-
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -105,26 +109,71 @@ jobs:
         toolchain: nightly-2025-06-04
         args: --all -- --check
 
-    - name: Check and lint changed crates
+    - name: Lint changed crates
       run: |
-        for crate in ${{ needs.detect-changes.outputs.changed-crates }}; do
-          echo "Checking and linting crate: $crate"
+        CHANGED_CRATES="${{ needs.detect-changes.outputs.changed-crates }}"
+        echo "Running clippy for changed crates: $CHANGED_CRATES"
+        
+        SPECIAL_CRATES=""
+        REGULAR_CRATES=""
+        
+        for crate in $CHANGED_CRATES; do
           if [ "$crate" == "utoo_runtime" ]; then
-            cd crates/runtime && cargo check && cargo clippy
+            SPECIAL_CRATES="$SPECIAL_CRATES $crate"
           else
-            cargo check -p $crate && cargo clippy -p $crate
+            REGULAR_CRATES="$REGULAR_CRATES $crate"
           fi
         done
+        
+        if [[ $SPECIAL_CRATES == *"utoo_runtime"* ]]; then
+          echo "Running clippy for utoo_runtime..."
+          cd crates/runtime && cargo clippy
+          cd ../..
+        fi
+        
+        if [ -n "$(echo $REGULAR_CRATES | xargs)" ]; then
+          echo "Running clippy for regular crates: $REGULAR_CRATES"
+          PACKAGE_ARGS=""
+          for crate in $REGULAR_CRATES; do
+            PACKAGE_ARGS="$PACKAGE_ARGS -p $crate"
+          done
+          cargo clippy $PACKAGE_ARGS
+        fi
 
     - name: Test changed crates
       run: |
-        for crate in ${{ needs.detect-changes.outputs.changed-crates }}; do
-          echo "Testing crate: $crate"
-          if [ "$crate" == "utoo_runtime" ]; then
-            cd crates/runtime && cargo test
-          elif [ "$crate" == "utoopack-tests" ]; then
-            cd crates/pack-tests && cargo nextest run --no-capture
+        CHANGED_CRATES="${{ needs.detect-changes.outputs.changed-crates }}"
+        echo "Running tests for changed crates: $CHANGED_CRATES"
+        
+        SPECIAL_CRATES=""
+        REGULAR_CRATES=""
+        
+        for crate in $CHANGED_CRATES; do
+          if [ "$crate" == "utoo_runtime" ] || [ "$crate" == "pack-tests" ]; then
+            SPECIAL_CRATES="$SPECIAL_CRATES $crate"
           else
-            cargo test -p $crate
+            REGULAR_CRATES="$REGULAR_CRATES $crate"
           fi
         done
+        
+        for crate in $SPECIAL_CRATES; do
+          if [ "$crate" == "utoo_runtime" ]; then
+            echo "Testing utoo_runtime..."
+            cd crates/runtime && cargo test
+            cd ../..
+          elif [ "$crate" == "pack-tests" ]; then
+            echo "Testing pack-tests..."
+            cd crates/pack-tests && cargo nextest run --no-capture
+            cd ../..
+          fi
+        done
+        
+        if [ -n "$(echo $REGULAR_CRATES | xargs)" ]; then
+          echo "Testing regular crates: $REGULAR_CRATES"
+          PACKAGE_ARGS=""
+          for crate in $REGULAR_CRATES; do
+            PACKAGE_ARGS="$PACKAGE_ARGS -p $crate"
+          done
+          cargo test $PACKAGE_ARGS
+        fi
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,6 +4122,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pack-tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "once_cell",
+ "pack-api",
+ "pack-core",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "testing",
+ "tokio",
+ "tracing-subscriber",
+ "turbo-rcstr",
+ "turbo-tasks",
+ "turbo-tasks-backend",
+ "turbo-tasks-build",
+ "turbo-tasks-bytes",
+ "turbo-tasks-env",
+ "turbo-tasks-fs",
+ "turbopack",
+ "turbopack-browser",
+ "turbopack-core",
+ "turbopack-ecmascript-plugins",
+ "turbopack-ecmascript-runtime",
+ "turbopack-node",
+ "turbopack-nodejs",
+ "turbopack-resolve",
+ "turbopack-test-utils",
+]
+
+[[package]]
 name = "par-core"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9253,39 +9286,6 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "toml 0.8.20",
-]
-
-[[package]]
-name = "utoopack-tests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "dunce",
- "once_cell",
- "pack-api",
- "pack-core",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "testing",
- "tokio",
- "tracing-subscriber",
- "turbo-rcstr",
- "turbo-tasks",
- "turbo-tasks-backend",
- "turbo-tasks-build",
- "turbo-tasks-bytes",
- "turbo-tasks-env",
- "turbo-tasks-fs",
- "turbopack",
- "turbopack-browser",
- "turbopack-core",
- "turbopack-ecmascript-plugins",
- "turbopack-ecmascript-runtime",
- "turbopack-node",
- "turbopack-nodejs",
- "turbopack-resolve",
- "turbopack-test-utils",
 ]
 
 [[package]]

--- a/crates/pack-tests/Cargo.toml
+++ b/crates/pack-tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "utoopack-tests"
+name = "pack-tests"
 version = "0.1.0"
 description = "TBD"
 license = "MIT"

--- a/crates/pack-tests/README.md
+++ b/crates/pack-tests/README.md
@@ -1,4 +1,4 @@
-# utoopack-tests
+# pack-tests
 
 An extracted create to perform snapshot tests on utoopack.
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/umijs/mako/blob/next/README.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

调整一下 ci 的运行方式，以前是会对变更过的 crate 去单独的运行: `cd crates/chaged-crate && cargo clippy` 这样实际上是在串行执行，现在调整一下在 workspace 直接运行 `cargo check -p xxx1 -p xxx2` 这样可以并行编译依赖。


## Test Plan

No need.

<!-- What demonstrates that your implementation is correct? -->
