### PR TITLE
feat(pack): support config.copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4082,6 +4082,7 @@ dependencies = [
  "turbopack-core",
  "turbopack-node",
  "turbopack-nodejs",
+ "turbopack-static",
  "turbopack-trace-utils",
  "url",
  "urlencoding",

--- a/crates/pack-api/Cargo.toml
+++ b/crates/pack-api/Cargo.toml
@@ -27,6 +27,7 @@ turbopack-browser = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-node = { workspace = true }
 turbopack-nodejs = { workspace = true }
+turbopack-static = { workspace = true }
 turbopack-trace-utils = { workspace = true }
 
 [build-dependencies]

--- a/crates/pack-api/src/entrypoint.rs
+++ b/crates/pack-api/src/entrypoint.rs
@@ -57,7 +57,7 @@ pub async fn all_output_assets_operation(
     container: ResolvedVc<ProjectContainer>,
 ) -> Result<Vc<OutputAssets>> {
     let project = container.project();
-    
+
     // Get assets from all endpoints
     let endpoint_assets = project
         .get_all_endpoints()

--- a/crates/pack-api/src/entrypoint.rs
+++ b/crates/pack-api/src/entrypoint.rs
@@ -56,8 +56,10 @@ pub async fn all_entrypoints_write_to_disk_operation(
 pub async fn all_output_assets_operation(
     container: ResolvedVc<ProjectContainer>,
 ) -> Result<Vc<OutputAssets>> {
-    let endpoint_assets = container
-        .project()
+    let project = container.project();
+    
+    // Get assets from all endpoints
+    let endpoint_assets = project
         .get_all_endpoints()
         .await?
         .iter()
@@ -65,10 +67,14 @@ pub async fn all_output_assets_operation(
         .try_join()
         .await?;
 
-    let output_assets: FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>> = endpoint_assets
+    let mut output_assets: FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>> = endpoint_assets
         .iter()
         .flat_map(|assets| assets.iter().copied())
         .collect();
+
+    // Also include copy assets
+    let copy_assets = project.copy_output_assets().await?;
+    output_assets.extend(copy_assets.iter().copied());
 
     Ok(Vc::cell(output_assets.into_iter().collect()))
 }

--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -47,6 +47,7 @@ use turbopack_core::{
     version::{
         NotFoundVersion, OptionVersionedContent, Update, Version, VersionState, VersionedContent,
     },
+    raw_output::RawOutput
 };
 use turbopack_node::execution_context::ExecutionContext;
 use turbopack_nodejs::NodeJsChunkingContext;
@@ -926,16 +927,28 @@ impl Project {
                     tracing::warn!("Failed to clean dist directory: {}", e);
                 }
             }
-
-            let all_output_assets = all_assets_from_entries_operation(output_assets);
-
             let client_root = self.client_root().owned().await?;
             let dist_root = self.dist_root().owned().await?;
 
+            let all_output_assets_op = all_assets_from_entries_operation(output_assets);
+            
             if let Some(map) = self.await?.versioned_content_map {
+                // Insert the main output assets
                 let _ = map
                     .insert_output_assets(
-                        all_output_assets,
+                        all_output_assets_op,
+                        dist_root.clone(),
+                        client_root.clone(),
+                        dist_root.clone(),
+                    )
+                    .resolve()
+                    .await?;
+                
+                // Also insert copy assets into the versioned content map
+                let copy_assets_op = copy_output_assets_operation(self.to_resolved().await?);
+                let _ = map
+                    .insert_output_assets(
+                        copy_assets_op,
                         dist_root.clone(),
                         client_root.clone(),
                         dist_root.clone(),
@@ -945,8 +958,12 @@ impl Project {
 
                 Ok(())
             } else {
+                let all_output_assets = all_output_assets_op.connect();
+                let copy_assets = self.copy_output_assets();
+                let all_assets_combined = all_output_assets.concatenate(copy_assets);
+                
                 let _ = emit_assets(
-                    all_output_assets.connect(),
+                    all_assets_combined,
                     dist_root.clone(),
                     client_root,
                     dist_root,
@@ -1084,6 +1101,29 @@ impl Project {
             }
         }
     }
+
+    #[turbo_tasks::function]
+    pub async fn copy_output_assets(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
+        let project_path = self.project_path().owned().await?;
+        let dist_root = self.dist_root().owned().await?;
+        
+        let output_config = self.config().output().await?;
+        let copy_config = output_config.copy.as_ref();
+
+        let mut assets = vec![];
+        if let Some(patterns) = copy_config {
+            for pattern in patterns {
+                // Resolve from_path relative to project_path, not project_root
+                let from_path = project_path.join(&pattern.from)?;
+                let to_path = dist_root.join(&pattern.to)?;
+                
+                let source = turbopack_core::file_source::FileSource::new(from_path);
+                let asset = RawOutput::new(to_path, Vc::upcast(source));
+                assets.push(Vc::upcast(asset));
+            }
+        }
+        Ok(OutputAssets::new(assets))
+    }
 }
 
 // This is a performance optimization. This function is a root aggregation function that
@@ -1171,6 +1211,29 @@ async fn all_assets_from_entries_operation(
 ) -> Result<Vc<OutputAssets>> {
     let assets = operation.connect();
     Ok(all_assets_from_entries(assets))
+}
+
+#[turbo_tasks::function(operation)]
+async fn copy_output_assets_operation(
+    project: ResolvedVc<Project>,
+) -> Result<Vc<OutputAssets>> {
+    let project_path = project.project_path().owned().await?;
+    let dist_root = project.dist_root().owned().await?;
+    let output_config = project.config().output().await?;
+    let copy_config = output_config.copy.as_ref();
+
+    let mut assets = vec![];
+    if let Some(patterns) = copy_config {
+        for pattern in patterns {
+            // Resolve from_path relative to project_path, not project_root
+            let from_path = project_path.join(&pattern.from)?;
+            let to_path = dist_root.join(&pattern.to)?;
+            let source = turbopack_core::file_source::FileSource::new(from_path);
+            let asset = RawOutput::new(to_path, Vc::upcast(source));
+            assets.push(Vc::upcast(asset));
+        }
+    }
+    Ok(OutputAssets::new(assets))
 }
 
 pub struct ProjectInstance {

--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -43,11 +43,11 @@ use turbopack_core::{
         chunk_group_info::ChunkGroupEntry,
     },
     output::{OutputAsset, OutputAssets},
+    raw_output::RawOutput,
     source_map::OptionStringifiedSourceMap,
     version::{
         NotFoundVersion, OptionVersionedContent, Update, Version, VersionState, VersionedContent,
     },
-    raw_output::RawOutput
 };
 use turbopack_node::execution_context::ExecutionContext;
 use turbopack_nodejs::NodeJsChunkingContext;
@@ -931,7 +931,7 @@ impl Project {
             let dist_root = self.dist_root().owned().await?;
 
             let all_output_assets_op = all_assets_from_entries_operation(output_assets);
-            
+
             if let Some(map) = self.await?.versioned_content_map {
                 // Insert the main output assets
                 let _ = map
@@ -943,7 +943,7 @@ impl Project {
                     )
                     .resolve()
                     .await?;
-                
+
                 // Also insert copy assets into the versioned content map
                 let copy_assets_op = copy_output_assets_operation(self.to_resolved().await?);
                 let _ = map
@@ -961,7 +961,7 @@ impl Project {
                 let all_output_assets = all_output_assets_op.connect();
                 let copy_assets = self.copy_output_assets();
                 let all_assets_combined = all_output_assets.concatenate(copy_assets);
-                
+
                 let _ = emit_assets(
                     all_assets_combined,
                     dist_root.clone(),
@@ -1106,7 +1106,7 @@ impl Project {
     pub async fn copy_output_assets(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
         let project_path = self.project_path().owned().await?;
         let dist_root = self.dist_root().owned().await?;
-        
+
         let output_config = self.config().output().await?;
         let copy_config = output_config.copy.as_ref();
 
@@ -1116,7 +1116,7 @@ impl Project {
                 // Resolve from_path relative to project_path, not project_root
                 let from_path = project_path.join(&pattern.from)?;
                 let to_path = dist_root.join(&pattern.to)?;
-                
+
                 let source = turbopack_core::file_source::FileSource::new(from_path);
                 let asset = RawOutput::new(to_path, Vc::upcast(source));
                 assets.push(Vc::upcast(asset));
@@ -1214,9 +1214,7 @@ async fn all_assets_from_entries_operation(
 }
 
 #[turbo_tasks::function(operation)]
-async fn copy_output_assets_operation(
-    project: ResolvedVc<Project>,
-) -> Result<Vc<OutputAssets>> {
+async fn copy_output_assets_operation(project: ResolvedVc<Project>) -> Result<Vc<OutputAssets>> {
     let project_path = project.project_path().owned().await?;
     let dist_root = project.dist_root().owned().await?;
     let output_config = project.config().output().await?;

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -289,6 +289,15 @@ pub struct OptimizationConfig {
     pub split_chunks: FxIndexMap<RcStr, SplitChunkConfig>,
 }
 
+#[derive(
+    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct CopyItem {
+    pub from: RcStr,
+    pub to: RcStr,
+}
+
 #[turbo_tasks::value(eq = "manual")]
 #[derive(Clone, Debug, PartialEq, Default, OperationValue)]
 #[serde(rename_all = "camelCase")]
@@ -299,6 +308,7 @@ pub struct OutputConfig {
     // TODO: make sure this is needed
     pub r#type: Option<OutputType>,
     pub clean: Option<bool>,
+    pub copy: Option<Vec<CopyItem>>,
 }
 
 #[derive(

--- a/crates/pack-core/src/emit.rs
+++ b/crates/pack-core/src/emit.rs
@@ -5,7 +5,7 @@ use turbo_tasks::{
     ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal},
 };
-use turbo_tasks_fs::{FileSystemPath, rebase};
+use turbo_tasks_fs::{FileSystem, FileSystemPath, rebase};
 use turbopack_core::{
     asset::Asset,
     output::{OutputAsset, OutputAssets},

--- a/crates/pack-core/src/emit.rs
+++ b/crates/pack-core/src/emit.rs
@@ -5,7 +5,7 @@ use turbo_tasks::{
     ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal},
 };
-use turbo_tasks_fs::{FileSystem, FileSystemPath, rebase};
+use turbo_tasks_fs::{FileSystemPath, rebase};
 use turbopack_core::{
     asset::Asset,
     output::{OutputAsset, OutputAssets},

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -137,6 +137,19 @@ pub struct SchemaLibraryOptions {
     pub export: Option<Vec<String>>,
 }
 
+/// Copy item configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaCopyItem {
+    /// Source path to copy from
+    #[schemars(description = "Source path to copy from")]
+    pub from: String,
+
+    /// Destination path to copy to
+    #[schemars(description = "Destination path to copy to")]
+    pub to: String,
+}
+
 /// Output configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -165,6 +178,11 @@ pub struct SchemaOutputConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Whether to clean output directory before build")]
     pub clean: Option<bool>,
+
+    /// Copy files configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Copy files configuration")]
+    pub copy: Option<Vec<SchemaCopyItem>>,
 }
 
 /// Output type

--- a/crates/pack-tests/tests/snapshot/basic/copy/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/copy/config.json
@@ -9,7 +9,7 @@
         "path": "./output",
         "copy": [
             {
-                "from": "input/reset.css",
+                "from": "./input/reset.css",
                 "to": "./reset.css"
             }
         ]

--- a/crates/pack-tests/tests/snapshot/basic/copy/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/copy/config.json
@@ -1,0 +1,17 @@
+{
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "output": {
+        "path": "./output",
+        "copy": [
+            {
+                "from": "input/reset.css",
+                "to": "./reset.css"
+            }
+        ]
+    }
+  }

--- a/crates/pack-tests/tests/snapshot/basic/copy/input/index.js
+++ b/crates/pack-tests/tests/snapshot/basic/copy/input/index.js
@@ -1,0 +1,1 @@
+console.log('copy example');

--- a/crates/pack-tests/tests/snapshot/basic/copy/input/reset.css
+++ b/crates/pack-tests/tests/snapshot/basic/copy/input/reset.css
@@ -1,0 +1,3 @@
+body {
+    background-color: white;
+}

--- a/crates/pack-tests/tests/snapshot/basic/copy/output/crates_pack-tests_tests_snapshot_basic_copy_input_index_3611f3a0.js
+++ b/crates/pack-tests/tests/snapshot/basic/copy/output/crates_pack-tests_tests_snapshot_basic_copy_input_index_3611f3a0.js
@@ -1,0 +1,11 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([typeof document === "object" ? document.currentScript : undefined, {
+
+73: ((__turbopack_context__) => {
+
+var { m: module, e: exports } = __turbopack_context__;
+{
+console.log('copy example');
+}}),
+}]);
+
+//# sourceMappingURL=crates_pack-tests_tests_snapshot_basic_copy_input_index_3611f3a0.js.map

--- a/crates/pack-tests/tests/snapshot/basic/copy/output/crates_pack-tests_tests_snapshot_basic_copy_input_index_3611f3a0.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/copy/output/crates_pack-tests_tests_snapshot_basic_copy_input_index_3611f3a0.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 6, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/basic/copy/input/index.js"],"sourcesContent":["console.log('copy example');"],"names":[],"mappings":"AAAA,QAAQ,GAAG,CAAC"}}]
+}

--- a/crates/pack-tests/tests/snapshot/basic/copy/output/main.js
+++ b/crates/pack-tests/tests/snapshot/basic/copy/output/main.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {},
+    {"otherChunks":["crates_pack-tests_tests_snapshot_basic_copy_input_index_3611f3a0.js"],"runtimeModuleIds":[73]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/basic/copy/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/copy/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/basic/copy/output/reset.css
+++ b/crates/pack-tests/tests/snapshot/basic/copy/output/reset.css
@@ -1,0 +1,3 @@
+body {
+    background-color: white;
+}

--- a/examples/define/.gitignore
+++ b/examples/define/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.turbopack/

--- a/examples/react/.gitignore
+++ b/examples/react/.gitignore
@@ -1,0 +1,2 @@
+dist
+.turbopack

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -1,0 +1,17 @@
+## react-exmaple
+
+A simple demo for utoopack bundle react app.
+
+### dev
+
+Use the following command under `root directory`:
+
+```bash
+cargo run --bin pack-cli -- --mode dev --watch true --project-dir examples/react --root-dir .
+```
+
+### build
+
+```bash
+npm run build
+```

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "react-example",
+    "version": "0.0.1",
+    "scripts": {
+        "build": "utoo-pack build -p . -r ../../",
+        "dev": "utoo-pack dev -p . -r ../../"
+    },
+    "dependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    },
+    "devDependencies": {
+        "@utoo/pack-cli": "*"
+    }
+}

--- a/examples/react/project_options.json
+++ b/examples/react/project_options.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "../../packages/pack/config_schema.json",
+    "rootPath": "../../",
+    "projectPath": "./",
+    "config": {
+        "entry": [
+            {
+                "import": "./src/index.tsx",
+                "name": "index"
+            }
+        ],
+        "output": {
+            "path": "./dist",
+            "clean": true,
+            "copy": [
+                {
+                    "from": "./static/index.css",
+                    "to": "./index.css"
+                }
+            ]
+        }
+    }
+}

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { foo } from './foo.ts';
+export function App() {
+  return <h1>App {foo} - HMR test5</h1>;
+}

--- a/examples/react/src/foo.ts
+++ b/examples/react/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 1212;

--- a/examples/react/src/index.tsx
+++ b/examples/react/src/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/examples/react/static/index.css
+++ b/examples/react/static/index.css
@@ -1,0 +1,3 @@
+body {
+    background-color: white;
+}

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -177,6 +177,24 @@
         }
       }
     },
+    "SchemaCopyItem": {
+      "description": "Copy item configuration",
+      "type": "object",
+      "required": [
+        "from",
+        "to"
+      ],
+      "properties": {
+        "from": {
+          "description": "Source path to copy from",
+          "type": "string"
+        },
+        "to": {
+          "description": "Destination path to copy to",
+          "type": "string"
+        }
+      }
+    },
     "SchemaEntryOptions": {
       "description": "Entry point configuration",
       "type": "object",
@@ -601,6 +619,16 @@
             "boolean",
             "null"
           ]
+        },
+        "copy": {
+          "description": "Copy files configuration",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemaCopyItem"
+          }
         },
         "filename": {
           "description": "Filename pattern for main files",

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -9,6 +9,12 @@ export declare class ExternalObject<T> {
     [K: symbol]: T
   }
 }
+export interface TransformOutput {
+  code: string
+  map?: string
+  output?: string
+  diagnostics: Array<string>
+}
 export interface NapiEndpointConfig {
   
 }

--- a/packages/pack/src/types.ts
+++ b/packages/pack/src/types.ts
@@ -119,6 +119,10 @@ export interface ConfigComplete {
     filename?: string;
     chunkFilename?: string;
     clean?: boolean;
+    copy?: Array<{
+      from: string;
+      to: string;
+    }>;
   };
   target?: string;
   sourceMaps?: boolean;


### PR DESCRIPTION
## Summary

closes: #2006 

支持 `output.copy` 配置用于承接 https://webpack.js.org/plugins/copy-webpack-plugin/ 的能力，配置设计如下:

```json
"output": {
  "copy": [
      {
           "from": "input/reset.css",
           "to": "./reset.css"
       }
    ]
}
```

目前还没支持 glob 匹配，后续需要完善一下。

## Test Plan

参考 `pack-tests` 中的测试 case。
