### PR TITLE
fix(pack): hmr work fine by rust execute

### DIFF
--- a/crates/pack-core/js/src/hmr/websocket.ts
+++ b/crates/pack-core/js/src/hmr/websocket.ts
@@ -9,26 +9,31 @@ type WebSocketMessage =
       data: Record<string, any>;
     };
 
-let source: WebSocket;
-const eventCallbacks: ((msg: WebSocketMessage) => void)[] = [];
+let source: WebSocket | null = null;
+let eventCallbacks: Array<(event: WebSocketMessage) => void> = [];
 
-function getSocketProtocol(): string {
-  let protocol = location.protocol;
-  return protocol === "http:" ? "ws" : "wss";
-}
-
-export function addMessageListener(cb: (msg: WebSocketMessage) => void) {
-  eventCallbacks.push(cb);
+export function addMessageListener(
+  callback: (event: WebSocketMessage) => void,
+) {
+  eventCallbacks.push(callback);
 }
 
 export function sendMessage(data: any) {
-  if (!source || source.readyState !== source.OPEN) return;
-  return source.send(data);
+  if (source && source.readyState === source.OPEN) {
+    const message = typeof data === 'string' ? data : JSON.stringify(data);
+    source.send(message);
+  }
 }
 
-export type HMROptions = {
+function getSocketProtocol() {
+  return typeof location !== "undefined" && location.protocol === "https:"
+    ? "wss"
+    : "ws";
+}
+
+export interface HMROptions {
   path: string;
-};
+}
 
 let reconnections = 0;
 let reloading = false;
@@ -44,6 +49,12 @@ export function connectHMR(options: HMROptions) {
     function handleOnline() {
       reconnections = 0;
       window.console.log("[HMR] connected");
+      
+      // Send the turbopack-connected message to trigger handleSocketConnected
+      const connected: WebSocketMessage = { type: 'turbopack-connected' };
+      for (const eventCallback of eventCallbacks) {
+        eventCallback(connected);
+      }
     }
 
     function handleMessage(event: MessageEvent<string>) {
@@ -51,34 +62,63 @@ export function connectHMR(options: HMROptions) {
         return;
       }
 
-      const msg = JSON.parse(event.data);
+      try {
+        const msg = JSON.parse(event.data);
 
-      if (msg.action === "turbopack-connected") {
-        if (
-          serverSessionId !== null &&
-          serverSessionId !== msg.data.sessionId
-        ) {
+        // Handle the different message formats from different servers
+        if (msg.action === "turbopack-connected") {
+          if (
+            serverSessionId !== null &&
+            serverSessionId !== msg.data.sessionId
+          ) {
+            window.location.reload();
+            reloading = true;
+            return;
+          }
+
+          serverSessionId = msg.data.sessionId;
+          
+          // Convert to turbopack format and trigger handleSocketConnected
+          const connected: WebSocketMessage = { type: 'turbopack-connected' };
+          for (const eventCallback of eventCallbacks) {
+            eventCallback(connected);
+          }
+          return;
+        }
+
+        if (msg.action === "reload") {
           window.location.reload();
           reloading = true;
           return;
         }
 
-        serverSessionId = msg.data.sessionId;
-      }
-
-      if (msg.action === "reload") {
-        window.location.reload();
-        reloading = true;
-        return;
-      }
-
-      if (["turbopack-connected", "turbopack-message"].includes(msg.action)) {
-        for (const eventCallback of eventCallbacks) {
-          eventCallback({ type: msg.action, data: msg.data });
+        if (msg.action === "turbopack-message") {
+          const turbopackMessage: WebSocketMessage = { 
+            type: 'turbopack-message', 
+            data: msg.data 
+          };
+          for (const eventCallback of eventCallbacks) {
+            eventCallback(turbopackMessage);
+          }
+          return;
         }
-      }
 
-      // TODO: handle rest msg.actions
+        // Handle direct turbopack-dev-server messages
+        if (msg.type && ["partial", "restart", "notFound", "issues"].includes(msg.type)) {
+          const turbopackMessage: WebSocketMessage = { 
+            type: 'turbopack-message', 
+            data: msg 
+          };
+          for (const eventCallback of eventCallbacks) {
+            eventCallback(turbopackMessage);
+          }
+          return;
+        }
+
+        // TODO: handle rest msg.actions
+      } catch (e) {
+        console.error("[HMR] Failed to parse message:", e);
+      }
     }
 
     let timer: ReturnType<typeof setTimeout>;

--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -178,16 +178,14 @@ pub async fn get_client_runtime_entries(
             )
         };
 
-        if watch {
-            runtime_entries.push(
-                RuntimeEntry::Source(ResolvedVc::upcast(
-                    FileSource::new(embed_file_path(rcstr!("hmr/bootstrap.ts")).owned().await?)
-                        .to_resolved()
-                        .await?,
-                ))
-                .resolved_cell(),
-            );
-        }
+        runtime_entries.push(
+            RuntimeEntry::Source(ResolvedVc::upcast(
+                FileSource::new(embed_file_path(rcstr!("hmr/bootstrap.ts")).owned().await?)
+                    .to_resolved()
+                    .await?,
+            ))
+            .resolved_cell(),
+        );
     }
 
     Ok(Vc::cell(runtime_entries))

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 import { foo } from './foo.ts';
 export function App() {
-  return <h1>App {foo} - HMR test5</h1>;
+  return <h1>App {foo} - HMR Test</h1>;
 }

--- a/examples/react/src/foo.ts
+++ b/examples/react/src/foo.ts
@@ -1,1 +1,1 @@
-export const foo = 1212;
+export const foo = 12121;


### PR DESCRIPTION
## Summary

修复使用 `cargo` 运行 pack-cli 的时候 hmr 失效的问题，例如:

```bash
cargo run --bin pack-cli -- --mode dev --watch true --project-dir examples/react --root-dir .
```

排查发现是 turbopack-dev-server 跟浏览器没有建立 socket 通信，实际上要客户端这边主动发送一条 `{type: "turbopack-connected"}` 信息来建立连接，我在 hmr 运行时函数中添加了一段初始化的代码(turbopack-cli 的 hmr 也是同样实现):

<img width="1684" height="534" alt="image" src="https://github.com/user-attachments/assets/501cd14f-5185-4171-8c46-f1cc7541866c" />

具体效果如下:

https://github.com/user-attachments/assets/dfec5cdc-a50e-4767-9182-d8d48fe459f5

## Test Plan

暂时没添加 hmr 相关的测试，后续有空再研究 devServer 怎么测试。
