### PR TITLE
fix(pack): ignore config concatenate_modules in dev mode

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -432,7 +432,7 @@ pub async fn get_client_chunking_context(
     config: ResolvedVc<Config>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let minify = config.minify(mode);
-    let concatenate_modules = config.concatenate_modules();
+    let concatenate_modules = config.concatenate_modules(mode);
     let mode = mode.await?;
 
     let runtime_type = {

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -1142,13 +1142,16 @@ impl Config {
     }
 
     #[turbo_tasks::function]
-    pub fn concatenate_modules(&self) -> Vc<bool> {
-        Vc::cell(
-            self.optimization
+    pub async fn concatenate_modules(&self, mode: Vc<Mode>) -> Result<Vc<bool>> {
+        Ok(Vc::cell(match *mode.await? {
+            // Ignore configuration in development mode to not break HMR
+            Mode::Development => false,
+            Mode::Production => self
+                .optimization
                 .as_ref()
                 .map(|op| op.concatenate_modules.unwrap_or(false))
                 .unwrap_or(false),
-        )
+        }))
     }
 
     #[turbo_tasks::function]

--- a/crates/pack-core/src/library/contexts.rs
+++ b/crates/pack-core/src/library/contexts.rs
@@ -28,7 +28,7 @@ pub async fn get_library_chunking_context(
     config: ResolvedVc<Config>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let minify = config.minify(mode);
-    let concatenate_modules = config.concatenate_modules();
+    let concatenate_modules = config.concatenate_modules(mode);
     let mode = mode.await?;
 
     let runtime_type = {


### PR DESCRIPTION
## Summary

Ignore configuration in development mode to not break HMR

## Test Plan

Snapshot need to support dev mode in future.
