### PR TITLE
fix(pack): umd external function not load

### DIFF
--- a/crates/pack-core/js/src/umd/base-externals-utils.ts
+++ b/crates/pack-core/js/src/umd/base-externals-utils.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="./runtime-utils.ts" />
+
+/// A 'base' utilities to support runtime can have externals.
+/// Currently this is for node.js / edge runtime both.
+/// If a fn requires node.js specific behavior, it should be placed in `node-external-utils` instead.
+
+async function externalImport(id: DependencySpecifier) {
+    let raw
+    try {
+        raw = await import(id)
+    } catch (err) {
+        // TODO(alexkirsz) This can happen when a client-side module tries to load
+        // an external module we don't provide a shim for (e.g. querystring, url).
+        // For now, we fail semi-silently, but in the future this should be a
+        // compilation error.
+        throw new Error(`Failed to load external module ${id}: ${err}`)
+    }
+
+    if (raw && raw.__esModule && raw.default && 'default' in raw.default) {
+        return interopEsm(raw.default, createNS(raw), true)
+    }
+
+    return raw
+}
+
+function externalRequire(
+    id: ModuleId,
+    thunk: () => any,
+    esm: boolean = false
+): Exports | EsmNamespaceObject {
+    let raw
+    try {
+        raw = thunk()
+    } catch (err) {
+        // TODO(alexkirsz) This can happen when a client-side module tries to load
+        // an external module we don't provide a shim for (e.g. querystring, url).
+        // For now, we fail semi-silently, but in the future this should be a
+        // compilation error.
+        throw new Error(`Failed to load external module ${id}: ${err}`)
+    }
+
+    if (!esm || raw.__esModule) {
+        return raw
+    }
+
+    return interopEsm(raw, createNS(raw), true)
+}
+
+externalRequire.resolve = (
+    id: string,
+    options?: {
+        paths?: string[]
+    }
+) => {
+    return require.resolve(id, options)
+}
+

--- a/crates/pack-core/js/src/umd/runtime-backend-dom.ts
+++ b/crates/pack-core/js/src/umd/runtime-backend-dom.ts
@@ -9,10 +9,10 @@
 
 /// <reference path="./runtime-base.ts" />
 /// <reference path="./runtime-types.d.ts" />
+/// <reference path="./base-externals-utils.ts" />
   
-function augmentContext(context: unknown): unknown {
+function augmentContext(context: TurbopackBaseContext<Module>): TurbopackBaseContext<Module> {
+  context.x = externalRequire;
+  context.y = externalImport;
   return context;
 }
-
-  
-  

--- a/crates/pack-core/js/src/umd/runtime-types.d.ts
+++ b/crates/pack-core/js/src/umd/runtime-types.d.ts
@@ -14,6 +14,8 @@ type ChunkPath = string & { readonly brand: unique symbol };
 type ChunkScript = CurrentScript & { readonly brand: unique symbol };
 type ChunkUrl = string & { readonly brand: unique symbol };
 type ModuleId = string;
+// The dependency specifier when importing externals
+type DependencySpecifier = string
 
 interface Exports {
   __esModule?: boolean;
@@ -24,11 +26,11 @@ interface Exports {
 type ChunkData =
   | ChunkPath
   | {
-      path: ChunkPath;
-      included: ModuleId[];
-      excluded: ModuleId[];
-      moduleChunks: ChunkPath[];
-    };
+    path: ChunkPath;
+    included: ModuleId[];
+    excluded: ModuleId[];
+    moduleChunks: ChunkPath[];
+  };
 
 type CommonJsRequire = (moduleId: ModuleId) => Exports;
 type ModuleContextFactory = (map: ModuleContextMap) => ModuleContext;
@@ -66,9 +68,9 @@ interface Module {
   loaded: boolean;
   id: ModuleId;
   namespaceObject?:
-    | EsmNamespaceObject
-    | Promise<EsmNamespaceObject>
-    | AsyncModulePromise<EsmNamespaceObject>;
+  | EsmNamespaceObject
+  | Promise<EsmNamespaceObject>
+  | AsyncModulePromise<EsmNamespaceObject>;
   [REEXPORTED_OBJECTS]?: any[];
 }
 
@@ -77,7 +79,14 @@ interface ModuleWithDirection extends Module {
   parents: ModuleId[];
 }
 
-
+type ExternalRequire = (
+  id: DependencySpecifier,
+  thunk: () => any,
+  esm?: boolean
+) => Exports | EsmNamespaceObject
+type ExternalImport = (
+  id: DependencySpecifier
+) => Promise<Exports | EsmNamespaceObject>
 interface TurbopackBaseContext<M> {
   a: AsyncModule;
   e: Module["exports"];
@@ -95,6 +104,8 @@ interface TurbopackBaseContext<M> {
   g: typeof globalThis;
   P: ResolveAbsolutePath;
   U: RelativeURL;
+  x: ExternalRequire
+  y: ExternalImport
   z: CommonJsRequire
   d: string;
 }

--- a/crates/pack-core/src/library/runtime/runtime_code.rs
+++ b/crates/pack-core/src/library/runtime/runtime_code.rs
@@ -73,6 +73,15 @@ pub async fn get_library_runtime_code(
     code.push_code(
         &*embed_static_code(
             asset_context,
+            "umd/base-externals-utils.ts".into(),
+            generate_source_map,
+        )
+        .await?,
+    );
+
+    code.push_code(
+        &*embed_static_code(
+            asset_context,
             "umd/runtime-backend-dom.ts".into(),
             generate_source_map,
         )

--- a/packages/pack/src/types.ts
+++ b/packages/pack/src/types.ts
@@ -84,7 +84,7 @@ export type TurbopackLoaderItem =
     };
 
 export type TurbopackRuleConfigItemOptions = {
-  loaders: TurbopackRuleConfigItem[];
+  loaders: TurbopackLoaderItem[];
   as?: string;
 };
 


### PR DESCRIPTION
## Summary

Part of: https://github.com/umijs/mako/pull/2091

先把 external 在 umd 场景下 `cjs require` 以及 `esm require` 运行时函数没导入的问题修复掉，运行时函数优化需要花一些时间去验证。

## Test Plan

真实项目测试(umd under cjs):

<img width="1340" height="1218" alt="image" src="https://github.com/user-attachments/assets/6ce5227f-93b0-4a49-bc9b-3c05678551c2" />


umd under browser 也正常
