### PR TITLE
chore: upgrade next.js to utoo-wasm branch

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -94,12 +94,14 @@ rustflags = [
   "--cfg",
   'getrandom_backend="wasm_js"',
   "-Zshare-generics=y",
+  "-Ctarget-feature=+atomics,+bulk-memory,+mutable-globals",
   "-Aunused",
 ]
 
 [unstable.git]
 shallow_index = true
 shallow_deps = true
+
 [unstable.gitoxide]
 fetch = true
 checkout = true

--- a/crates/utoo-wasm/.cargo/config.toml
+++ b/crates/utoo-wasm/.cargo/config.toml
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["std", "panic_abort"]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/umijs/mako/blob/next/README.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
We need the [tokio::sync::oneshot](https://docs.rs/tokio/1.47.1/tokio/sync/oneshot/index.html), so need to enable `std::sync::atomic` on wasm.
After that, we can also using multi thread by `WebWorker`
Ref:
- https://docs.rs/wasm-bindgen-spawn/0.0.2/wasm_bindgen_spawn/

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
