### PR TITLE
fix(pack): runtimeModules adjust under umd runtime

### DIFF
--- a/crates/pack-core/src/library/runtime/runtime_code.rs
+++ b/crates/pack-core/src/library/runtime/runtime_code.rs
@@ -19,7 +19,7 @@ pub async fn get_library_runtime_code(
     environment: Vc<Environment>,
     chunk_base_path: Vc<Option<RcStr>>,
     chunk_suffix_path: Vc<Option<RcStr>>,
-    runtime_type: RuntimeType,
+    _runtime_type: RuntimeType,
     output_root_to_root_path: Vc<RcStr>,
     generate_source_map: bool,
     runtime_root: Vc<Option<RcStr>>,
@@ -98,16 +98,6 @@ pub async fn get_library_runtime_code(
             chunksToRegister.forEach(registerChunk);
         "#
     )?;
-    if matches!(runtime_type, RuntimeType::Development) {
-        writedoc!(
-            code,
-            r#"
-            const chunkListsToRegister = globalThis.TURBOPACK_CHUNK_LISTS || [];
-            chunkListsToRegister.forEach(registerChunkList);
-            globalThis.TURBOPACK_CHUNK_LISTS = {{ push: registerChunkList }};
-        "#
-        )?;
-    }
 
     let runtime_root = &*runtime_root.await?;
     let runtime_export = &*runtime_export.await?;
@@ -125,9 +115,18 @@ pub async fn get_library_runtime_code(
         code,
         r#"
             function factory () {{
-                let moduleIds = Object.keys(moduleCache);
-                return esmImport(moduleIds[moduleIds.length - 1]);
-            }};
+                for (const [,, runtimeParams] of chunksToRegister) {{
+                    if (runtimeParams?.runtimeModuleIds?.length > 0) {{
+                        const module = moduleCache[runtimeParams.runtimeModuleIds[0]];
+                        if (module.error) throw module.error;
+                        // any ES module has to have `module.namespaceObject` defined.
+                        if (module.namespaceObject) return module.namespaceObject;
+                        // only ESM can be an async module, so we don't need to worry about exports being a promise here.
+                        const raw = module.exports;
+                        return module.namespaceObject = interopEsm(raw, createNS(raw), raw && raw.__esModule);
+                    }}
+                }}
+            }}
 
             if (typeof exports === 'object' && typeof module === 'object') {{
                 module.exports = factory();
@@ -168,6 +167,7 @@ pub async fn get_library_runtime_code(
         code,
         r#"
             }}
+            globalThis.TURBOPACK = [];
             }})();
         "#
     )?;

--- a/crates/pack-tests/tests/snapshot/runtime/library_build_runtime/output/main.js
+++ b/crates/pack-tests/tests/snapshot/runtime/library_build_runtime/output/main.js
@@ -799,9 +799,18 @@ const chunksToRegister = globalThis.TURBOPACK;
 globalThis.TURBOPACK = { push: registerChunk };
 chunksToRegister.forEach(registerChunk);
 function factory () {
-    let moduleIds = Object.keys(moduleCache);
-    return esmImport(moduleIds[moduleIds.length - 1]);
-};
+    for (const [,, runtimeParams] of chunksToRegister) {
+        if (runtimeParams?.runtimeModuleIds?.length > 0) {
+            const module = moduleCache[runtimeParams.runtimeModuleIds[0]];
+            if (module.error) throw module.error;
+            // any ES module has to have `module.namespaceObject` defined.
+            if (module.namespaceObject) return module.namespaceObject;
+            // only ESM can be an async module, so we don't need to worry about exports being a promise here.
+            const raw = module.exports;
+            return module.namespaceObject = interopEsm(raw, createNS(raw), raw && raw.__esModule);
+        }
+    }
+}
 
 if (typeof exports === 'object' && typeof module === 'object') {
     module.exports = factory();
@@ -810,6 +819,7 @@ if (typeof exports === 'object' && typeof module === 'object') {
 } else {
     globalThis["MyLibrary"] = factory();
 }
+globalThis.TURBOPACK = [];
 })();
 
 


### PR DESCRIPTION
## Summary

解决两个问题:
- 调整一下 runtimeModules 的引入逻辑(之前 turbopack 会在运行时放个全局变量记录，后来删除了，这里 utoopack umd runtime 自己去取一下)
- 对 issue: https://github.com/umijs/mako/issues/2107 做个 workaround，即每次 umd 模块执行完之后把 `globalThis.TURBOPACK` 置空

验证方式:

<img width="2748" height="2072" alt="image" src="https://github.com/user-attachments/assets/2771183a-08f3-4d5a-a445-772b3b694d22" />

本地通过 utoopack 去构建 ant-design 仓库 umd，在开启 scopeHoisting 的场景下，ant-design 的所有测试都通过。

## Test Plan

观察快照测试的更新
