### PR TITLE
fix(pack): umd support bundle async chunk

### DIFF
--- a/crates/pack-core/src/library/chunking_context.rs
+++ b/crates/pack-core/src/library/chunking_context.rs
@@ -33,7 +33,10 @@ use turbopack_core::{
     },
     output::{OutputAsset, OutputAssets},
 };
-use turbopack_ecmascript::chunk::{EcmascriptChunk, EcmascriptChunkType};
+use turbopack_ecmascript::{
+    chunk::{EcmascriptChunk, EcmascriptChunkType},
+    manifest::{chunk_asset::ManifestAsyncModule, loader_item::ManifestLoaderChunkItem},
+};
 use turbopack_ecmascript_runtime::RuntimeType;
 
 use crate::library::ecmascript::chunk::EcmascriptLibraryEvaluateChunk;
@@ -85,6 +88,11 @@ impl LibraryChunkingContextBuilder {
 
     pub fn runtime_type(mut self, runtime_type: RuntimeType) -> Self {
         self.chunking_context.runtime_type = runtime_type;
+        self
+    }
+
+    pub fn manifest_chunks(mut self) -> Self {
+        self.chunking_context.manifest_chunks = true;
         self
     }
 
@@ -163,6 +171,8 @@ pub struct LibraryChunkingContext {
     minify_type: MinifyType,
     /// Whether to generate source maps
     source_maps_type: SourceMapsType,
+    /// Whether to use manifest chunks for lazy compilation
+    manifest_chunks: bool,
     /// The module id strategy to use
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     /// The module export usage info, if available.
@@ -198,6 +208,7 @@ impl LibraryChunkingContext {
                 runtime_root,
                 runtime_export,
                 enable_module_merging: false,
+                manifest_chunks: true,
             },
         }
     }
@@ -546,19 +557,25 @@ impl ChunkingContext for LibraryChunkingContext {
     #[turbo_tasks::function]
     async fn async_loader_chunk_item(
         self: Vc<Self>,
-        _module: Vc<Box<dyn ChunkableModule>>,
-        _module_graph: Vc<ModuleGraph>,
-        _availability_info: AvailabilityInfo,
+        module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
+        availability_info: AvailabilityInfo,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
-        bail!("Library chunking context does not support async loader chunk item")
+        let manifest_asset =
+            ManifestAsyncModule::new(module, module_graph, Vc::upcast(self), availability_info);
+        Ok(Vc::upcast(ManifestLoaderChunkItem::new(
+            manifest_asset,
+            module_graph,
+            Vc::upcast(self),
+        )))
     }
 
     #[turbo_tasks::function]
     async fn async_loader_chunk_item_id(
         self: Vc<Self>,
-        _module: Vc<Box<dyn ChunkableModule>>,
+        module: Vc<Box<dyn ChunkableModule>>,
     ) -> Result<Vc<ModuleId>> {
-        bail!("Library chunking context does not support async loader chunk item id")
+        Ok(self.chunk_item_id_from_ident(ManifestLoaderChunkItem::asset_ident_for(module)))
     }
 
     #[turbo_tasks::function]

--- a/crates/pack-tests/tests/snapshot/umd/async-module/config.json
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/config.json
@@ -1,0 +1,16 @@
+{
+    "config": {
+        "entry": [
+            {
+                "import": "input/index.js",
+                "name": "main",
+                "library": {
+                    "name": "asyncModule"
+                }
+            }
+        ],
+        "optimization": {
+            "minify": false
+        }
+    }
+}

--- a/crates/pack-tests/tests/snapshot/umd/async-module/input/a.js
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/input/a.js
@@ -1,0 +1,3 @@
+import x from "./shared";
+
+export default x + " world";

--- a/crates/pack-tests/tests/snapshot/umd/async-module/input/b.js
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/input/b.js
@@ -1,0 +1,3 @@
+import x from "./shared";
+
+export default x + " world";

--- a/crates/pack-tests/tests/snapshot/umd/async-module/input/index.js
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/input/index.js
@@ -1,0 +1,3 @@
+const result = await require("./main");
+
+result.default;

--- a/crates/pack-tests/tests/snapshot/umd/async-module/input/main.js
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/input/main.js
@@ -1,0 +1,4 @@
+import a from "./a";
+import b from "./b";
+
+export default a + ", " + b;

--- a/crates/pack-tests/tests/snapshot/umd/async-module/input/shared.js
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/input/shared.js
@@ -1,0 +1,3 @@
+await 1;
+await 1;
+export default "hello";

--- a/crates/pack-tests/tests/snapshot/umd/async-module/output/main.js
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/output/main.js
@@ -1,0 +1,86 @@
+((__TURBOPACK__) => {
+// Dummy runtime
+})([["main.js", {
+
+75: ((__turbopack_context__) => {
+"use strict";
+
+return __turbopack_context__.a(async (__turbopack_handle_async_dependencies__, __turbopack_async_result__) => { try {
+
+__turbopack_context__.s({
+    "default": ()=>__TURBOPACK__default__export__
+});
+await 1;
+await 1;
+const __TURBOPACK__default__export__ = "hello";
+__turbopack_async_result__();
+} catch(e) { __turbopack_async_result__(e); } }, true);}),
+58: ((__turbopack_context__) => {
+"use strict";
+
+return __turbopack_context__.a(async (__turbopack_handle_async_dependencies__, __turbopack_async_result__) => { try {
+
+__turbopack_context__.s({
+    "default": ()=>__TURBOPACK__default__export__
+});
+var __TURBOPACK__imported__module__75__ = __turbopack_context__.i(75);
+var __turbopack_async_dependencies__ = __turbopack_handle_async_dependencies__([
+    __TURBOPACK__imported__module__75__
+]);
+[__TURBOPACK__imported__module__75__] = __turbopack_async_dependencies__.then ? (await __turbopack_async_dependencies__)() : __turbopack_async_dependencies__;
+;
+const __TURBOPACK__default__export__ = __TURBOPACK__imported__module__75__["default"] + " world";
+__turbopack_async_result__();
+} catch(e) { __turbopack_async_result__(e); } }, false);}),
+36: ((__turbopack_context__) => {
+"use strict";
+
+return __turbopack_context__.a(async (__turbopack_handle_async_dependencies__, __turbopack_async_result__) => { try {
+
+__turbopack_context__.s({
+    "default": ()=>__TURBOPACK__default__export__
+});
+var __TURBOPACK__imported__module__75__ = __turbopack_context__.i(75);
+var __turbopack_async_dependencies__ = __turbopack_handle_async_dependencies__([
+    __TURBOPACK__imported__module__75__
+]);
+[__TURBOPACK__imported__module__75__] = __turbopack_async_dependencies__.then ? (await __turbopack_async_dependencies__)() : __turbopack_async_dependencies__;
+;
+const __TURBOPACK__default__export__ = __TURBOPACK__imported__module__75__["default"] + " world";
+__turbopack_async_result__();
+} catch(e) { __turbopack_async_result__(e); } }, false);}),
+66: ((__turbopack_context__) => {
+"use strict";
+
+return __turbopack_context__.a(async (__turbopack_handle_async_dependencies__, __turbopack_async_result__) => { try {
+
+__turbopack_context__.s({
+    "default": ()=>__TURBOPACK__default__export__
+});
+var __TURBOPACK__imported__module__58__ = __turbopack_context__.i(58);
+var __TURBOPACK__imported__module__36__ = __turbopack_context__.i(36);
+var __turbopack_async_dependencies__ = __turbopack_handle_async_dependencies__([
+    __TURBOPACK__imported__module__58__,
+    __TURBOPACK__imported__module__36__
+]);
+[__TURBOPACK__imported__module__58__, __TURBOPACK__imported__module__36__] = __turbopack_async_dependencies__.then ? (await __turbopack_async_dependencies__)() : __turbopack_async_dependencies__;
+;
+;
+const __TURBOPACK__default__export__ = __TURBOPACK__imported__module__58__["default"] + ", " + __TURBOPACK__imported__module__36__["default"];
+__turbopack_async_result__();
+} catch(e) { __turbopack_async_result__(e); } }, false);}),
+35: ((__turbopack_context__) => {
+"use strict";
+
+return __turbopack_context__.a(async (__turbopack_handle_async_dependencies__, __turbopack_async_result__) => { try {
+
+const result = await __turbopack_context__.r(66);
+result.default;
+__turbopack_async_result__();
+} catch(e) { __turbopack_async_result__(e); } }, true);}),
+},
+{"otherChunks":[],"runtimeModuleIds":[35]},
+]]);
+
+
+//# sourceMappingURL=main.js.map

--- a/crates/pack-tests/tests/snapshot/umd/async-module/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/output/main.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 9, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/umd/async-module/input/shared.js"],"sourcesContent":["await 1;\nawait 1;\nexport default \"hello\";\n"],"names":[],"mappings":";;;AAAA,MAAM;AACN,MAAM;uCACS"}},
+    {"offset": {"line": 22, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/umd/async-module/input/a.js"],"sourcesContent":["import x from \"./shared\";\n\nexport default x + \" world\";\n"],"names":[],"mappings":";;;AAAA;;;;;;uCAEe,8CAAC,GAAG"}},
+    {"offset": {"line": 39, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/umd/async-module/input/b.js"],"sourcesContent":["import x from \"./shared\";\n\nexport default x + \" world\";\n"],"names":[],"mappings":";;;AAAA;;;;;;uCAEe,8CAAC,GAAG"}},
+    {"offset": {"line": 56, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/umd/async-module/input/main.js"],"sourcesContent":["import a from \"./a\";\nimport b from \"./b\";\n\nexport default a + \", \" + b;\n"],"names":[],"mappings":";;;AAAA;AACA;;;;;;;;uCAEe,8CAAC,GAAG,OAAO,8CAAC"}},
+    {"offset": {"line": 76, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/umd/async-module/input/index.js"],"sourcesContent":["const result = await require(\"./main\");\n\nresult.default;"],"names":[],"mappings":"AAAA,MAAM,SAAS;AAEf,OAAO,OAAO"}}]
+}

--- a/examples/react/.gitignore
+++ b/examples/react/.gitignore
@@ -1,2 +1,3 @@
 dist
 .turbopack
+node_modules


### PR DESCRIPTION
## Summary

closes: #2132 

使用 ManifestLoaderChunkItem 去处理 umd bundle 里面的 async chunk，类似于 webpack 的 output.asyncChunks 设置为 false，在 umd 的时候默认用 ManifestLoaderChunkItem.

## Test Plan

更新了快照测试
