### PR TITLE
feat(wasm): enable postcss & webpack-loader cfg

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -33,6 +33,7 @@ use turbopack_node::{
     transforms::postcss::{PostCssConfigLocation, PostCssTransformOptions},
 };
 
+use crate::shared::webpack_rules::webpack_loader_options;
 use crate::{
     client::runtime_entry::RuntimeEntries,
     config::{
@@ -61,10 +62,6 @@ use crate::{
     },
     util::{foreign_code_context_condition, internal_assets_conditions},
 };
-
-// TODO: support this in wasm
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-use crate::shared::webpack_rules::webpack_loader_options;
 
 use super::{
     react_refresh::assert_can_resolve_react_refresh, runtime_entry::RuntimeEntry,
@@ -230,39 +227,22 @@ pub async fn get_client_module_options_context(
     // foreign_code_context_condition. This allows to import codes from
     // node_modules that requires webpack loaders, which next-dev implicitly
     // does by default.
-    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     let conditions = vec!["browser".into(), mode.await?.condition().into()];
-    let foreign_enable_webpack_loaders = {
-        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-        {
-            webpack_loader_options(
-                project_path.clone(),
-                config,
-                conditions
-                    .iter()
-                    .cloned()
-                    .chain(once("foreign".into()))
-                    .collect(),
-            )
-            .await?
-        }
-        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-        {
-            None
-        }
-    };
+
+    let foreign_enable_webpack_loaders = webpack_loader_options(
+        project_path.clone(),
+        config,
+        conditions
+            .iter()
+            .cloned()
+            .chain(once("foreign".into()))
+            .collect(),
+    )
+    .await?;
 
     // Now creates a webpack rules that applies to all codes.
-    let enable_webpack_loaders = {
-        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-        {
-            webpack_loader_options(project_path.clone(), config, conditions).await?
-        }
-        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-        {
-            None
-        }
-    };
+    let enable_webpack_loaders =
+        webpack_loader_options(project_path.clone(), config, conditions).await?;
 
     let tree_shaking_mode_for_user_code = *config
         .tree_shaking_mode_for_user_code(mode_ref.is_development())

--- a/crates/pack-core/src/shared/mod.rs
+++ b/crates/pack-core/src/shared/mod.rs
@@ -1,4 +1,3 @@
 pub mod resolve;
 pub mod transforms;
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 pub mod webpack_rules;

--- a/crates/pack-core/src/shared/webpack_rules/less.rs
+++ b/crates/pack-core/src/shared/webpack_rules/less.rs
@@ -35,9 +35,12 @@ pub async fn maybe_add_less_loader(
             .or(Some(&empty_additional_data)));
         let rule = rules.get_mut(pattern);
         let less_loader = WebpackLoaderItem {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             loader: get_utoopack_dependency_package(project_path.clone(), rcstr!("less-loader"))
                 .owned()
                 .await?,
+            #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+            loader: rcstr!("less-loader"),
             options: take(
                 serde_json::json!({
                     "implementation": less_options.get("implementation"),

--- a/crates/pack-core/src/shared/webpack_rules/mod.rs
+++ b/crates/pack-core/src/shared/webpack_rules/mod.rs
@@ -47,11 +47,14 @@ pub async fn webpack_loader_options(
             WebpackLoadersOptions {
                 rules,
                 conditions,
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
                 loader_runner_package: Some(
                     loader_runner_package_mapping(project_path)
                         .to_resolved()
                         .await?,
                 ),
+                #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+                loader_runner_package: None,
             }
             .resolved_cell(),
         )

--- a/crates/pack-core/src/shared/webpack_rules/sass.rs
+++ b/crates/pack-core/src/shared/webpack_rules/sass.rs
@@ -47,9 +47,12 @@ pub async fn maybe_add_sass_loader(
             .or(Some(&empty_additional_data)));
         let rule = rules.get_mut(pattern);
         let sass_loader = WebpackLoaderItem {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             loader: get_utoopack_dependency_package(project_path.clone(), rcstr!("sass-loader"))
                 .owned()
                 .await?,
+            #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+            loader: rcstr!("sass-loader"),
             options: take(
                 serde_json::json!({
                     "implementation": sass_options.get("implementation"),
@@ -62,12 +65,15 @@ pub async fn maybe_add_sass_loader(
             ),
         };
         let resolve_url_loader = WebpackLoaderItem {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             loader: get_utoopack_dependency_package(
                 project_path.clone(),
                 rcstr!("resolve-url-loader"),
             )
             .owned()
             .await?,
+            #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+            loader: rcstr!("resolve-url-loader"),
             options: take(
                 serde_json::json!({
                     //https://github.com/vercel/turbo/blob/d527eb54be384a4658243304cecd547d09c05c6b/crates/turbopack-node/src/transforms/webpack.rs#L191

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -41,6 +41,7 @@ rustc-hash = { workspace = true }
 tokio-fs-ext = { version = "0.5.6", features = ["wasm_offload"] }
 console_error_panic_hook = { version = "0.1.7" }
 opfs-project = "0.1.4"
+lazy_static = "1.4"
 
 ## turbpack specific - conditional on utoo-pack feature
 turbo-rcstr = { workspace = true, optional = true }

--- a/examples/utooweb-demo/src/demoFiles.ts
+++ b/examples/utooweb-demo/src/demoFiles.ts
@@ -3,7 +3,9 @@ export const demoFiles = {
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import Demo from './demo';
-import SassDemo from './sass-demo.tsx';
+// import SassDemo from './sass-demo';
+
+// console.log(SassDemo);
 
 createRoot(document.getElementById('root')).render(<Demo />);
 `,
@@ -97,24 +99,28 @@ const App: React.FC = () => (
 export default App;
 `,
   "src/sass-demo.tsx": `
-     import React from 'react';
-     import styles from './index.module.scss';
+// import React from 'react';
+import styles from './index.module.scss';
 
-     export default function SassDemo() {
-        return (
-          <div>
-            <h1 className={styles.title}>Utoopack web with Sass</h1>
-          </div>
-        )
-     }
+console.log(styles);
+console.log('hello world');
+
+// const SassDemo: React.FC = () => {
+//   return (
+//     <div>
+//       <h1 className={styles.title}>Utoopack web with Sass</h1>
+//     </div>
+//   )
+// }
+// export default SassDemo;
   `,
   "src/index.module.scss": `
-    $primary-color: rgb(121, 202, 242);
+$primary-color: rgb(121, 202, 242);
 
-    .title {
-      background: $primary-color;
-      display: inline-block;
-    }
+.title {
+  background: $primary-color;
+  display: inline-block;
+}
   `,
   "utoopack.json": JSON.stringify(
     {

--- a/examples/utooweb-demo/src/hooks/useBuild.ts
+++ b/examples/utooweb-demo/src/hooks/useBuild.ts
@@ -46,7 +46,7 @@ export const useBuild = (project: UtooProject | null, fileTree: FileTreeNode[], 
             }
         } catch (e: any) {
             console.error("Build failed: ", e);
-            setError(`Build failed: ${e.message}`);
+            setError(`Build failed: ${JSON.stringify(e)}`);
         } finally {
             setIsBuilding(false);
         }


### PR DESCRIPTION
## Summary

把 postcss / webpack-loader 在 wasm 场景下的 cfg 先打开了，在非 wasm 场景下会取真实的 package 路径，在 wasm 场景下会取包的名称。

## Test Plan


