### PR TITLE
fix(pack): webpackCompat support deal alias key after $

### DIFF
--- a/packages/pack/src/webpackCompat.ts
+++ b/packages/pack/src/webpackCompat.ts
@@ -364,7 +364,9 @@ function compatResolve(
           )
         : Object.entries(alias).reduce((acc, [k, v]) => {
             if (typeof v === "string") {
-              Object.assign(acc, { [k]: v });
+              // Handle alias keys ending with $ by removing the $
+              const aliasKey = k.endsWith("$") ? k.slice(0, -1) : k;
+              Object.assign(acc, { [aliasKey]: v });
             } else {
               throw "non string alias value not supported yet";
             }


### PR DESCRIPTION
## Summary

Bigfish 里面有个 alias 类型在 turbopack 里面不支持，需要在 webpack compat 模式下把这种 alias 处理掉:

<img width="2282" height="948" alt="image" src="https://github.com/user-attachments/assets/c4379b25-f03c-45c5-b0b5-e908e99b853c" />

这种 alias 需要处理一下，目前场景下不会生效，导致在构建的时候会从 `node_modules` 里面找依赖，从而把整个框架代码都 bundle 进来，暂时先把 alias 后面的 `$` 去掉先，后面还有其他的 case 再添加 patch 来处理。

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
