### PR TITLE
fix(pack): insert @utoo/style-loader as default alias

### DIFF
--- a/crates/pack-core/src/import_map.rs
+++ b/crates/pack-core/src/import_map.rs
@@ -22,6 +22,8 @@ use turbopack_node::execution_context::ExecutionContext;
 
 use crate::{config::Config, embed_js, mode::Mode, util::convert_to_project_relative};
 
+pub const UTOO_STYLE_LOADER: &str = "@utoo/style-loader";
+
 pub fn mdx_import_source_file() -> RcStr {
     unreachable!()
 }
@@ -104,6 +106,10 @@ async fn insert_shared_aliases(
         import_map.insert_singleton_alias(
             "react-refresh",
             pack_path.join("node_modules/react-refresh")?,
+        );
+        import_map.insert_singleton_alias(
+            UTOO_STYLE_LOADER,
+            pack_path.join(&format!("node_modules/{UTOO_STYLE_LOADER}"))?,
         );
     }
     // import_map.insert_singleton_alias("styled-jsx", pack_package.clone());

--- a/crates/pack-core/src/shared/webpack_rules/style_loader.rs
+++ b/crates/pack-core/src/shared/webpack_rules/style_loader.rs
@@ -8,7 +8,10 @@ use turbopack_node::transforms::webpack::WebpackLoaderItem;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::LoaderRuleItem;
 
-use crate::{config::OptionalJsonValue, import_map::get_utoopack_dependency_package};
+use crate::{
+    config::OptionalJsonValue,
+    import_map::{UTOO_STYLE_LOADER, get_utoopack_dependency_package},
+};
 
 pub async fn get_style_loader_rules(
     pack_path: FileSystemPath,
@@ -24,7 +27,7 @@ pub async fn get_style_loader_rules(
     };
 
     let style_loader = WebpackLoaderItem {
-        loader: get_utoopack_dependency_package(pack_path.clone(), rcstr!("@utoo/style-loader"))
+        loader: get_utoopack_dependency_package(pack_path.clone(), rcstr!(UTOO_STYLE_LOADER))
             .owned()
             .await?,
         options: take(


### PR DESCRIPTION
## Summary

closes: #2127 

PR https://github.com/utooland/utoo/pull/2212 支持了 `@utoo/pack` 不用 hoist 的逻辑，`@utoo/style-loader` 因为会构造出运行时相关的代码，实际上在依赖 resolve 的时候也会去根目录的 `node_modules` 里面找，因此这里我们同样需要把他 alias 到对应的产物依赖路径里面去:

<img width="1706" height="588" alt="image" src="https://github.com/user-attachments/assets/32fa9d84-840b-4027-a898-5137b71366d1" />

这里采用的方式和 alias react-refresh 逻辑相同。

## Test Plan

后续补一下这块的快照测试。
