### PR TITLE
fix(wasm): not throw error when build issues happened

### DIFF
--- a/packages/pack-shared/src/issue.ts
+++ b/packages/pack-shared/src/issue.ts
@@ -114,10 +114,15 @@ export function handleIssues(issues: Issue[], forceColor = true) {
   }
 
   if (topLevelErrors.size !== 0) {
-    throw new Error(
+    console.error(
       `Utoopack build failed with ${topLevelErrors.size} errors:\n${[...topLevelErrors].join("\n")}`,
     );
   }
+
+  return {
+    errors: [...topLevelErrors],
+    warnings: [...topLevelWarnings],
+  };
 }
 
 function isRelevantWarning(issue: Issue): boolean {


### PR DESCRIPTION
Throwing an error is not as expected, just printing in console.