### PR TITLE
fix(pack): just ignore .d.ts file when bundle

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -277,7 +277,15 @@ pub async fn get_client_module_options_context(
     let target_browsers = env.runtime_versions();
 
     let mut client_rules = get_client_transforms_rules(config).await?;
-    let foreign_client_rules = get_client_transforms_rules(config).await?;
+    let mut foreign_client_rules = get_client_transforms_rules(config).await?;
+
+    // Ignore .d.ts files - they are TypeScript declaration files and should not be bundled
+    let ignore_dts_rule = ModuleRule::new(
+        turbopack::module_options::RuleCondition::ResourcePathEndsWith(".d.ts".to_string()),
+        vec![turbopack::module_options::ModuleRuleEffect::Ignore],
+    );
+    client_rules.push(ignore_dts_rule.clone());
+    foreign_client_rules.push(ignore_dts_rule);
 
     client_rules.push(get_auto_css_modules_rule());
 

--- a/crates/pack-tests/tests/snapshot/typescript/dts_export/config.json
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_export/config.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+        "entry": [
+            {
+                "import": "input/index.ts",
+                "name": "main"
+            }
+        ],
+        "optimization": {
+            "minify": false
+        }
+    }
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_export/input/index.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_export/input/index.ts
@@ -1,0 +1,1 @@
+export * from './types.d.ts';

--- a/crates/pack-tests/tests/snapshot/typescript/dts_export/input/types.d.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_export/input/types.d.ts
@@ -1,0 +1,1 @@
+export type MyType = string;

--- a/crates/pack-tests/tests/snapshot/typescript/dts_export/output/crates_pack-tests_tests_snapshot_typescript_dts_export_input_index_ts_3420c2bb.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_export/output/crates_pack-tests_tests_snapshot_typescript_dts_export_input_index_ts_3420c2bb.js
@@ -1,0 +1,16 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([typeof document === "object" ? document.currentScript : undefined,
+54, ((__turbopack_context__) => {
+"use strict";
+
+;
+__turbopack_context__.s([]);
+}),
+6, ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__54__ = __turbopack_context__.i(54);
+__turbopack_context__.s([]);
+}),
+]);
+
+//# sourceMappingURL=crates_pack-tests_tests_snapshot_typescript_dts_export_input_index_ts_3420c2bb.js.map

--- a/crates/pack-tests/tests/snapshot/typescript/dts_export/output/crates_pack-tests_tests_snapshot_typescript_dts_export_input_index_ts_3420c2bb.js.map
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_export/output/crates_pack-tests_tests_snapshot_typescript_dts_export_input_index_ts_3420c2bb.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}}]
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_export/output/main.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_export/output/main.js
@@ -1,0 +1,5 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["crates_pack-tests_tests_snapshot_typescript_dts_export_input_index_ts_3420c2bb.js"],"runtimeModuleIds":[6]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/typescript/dts_export/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_export/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}


### PR DESCRIPTION
## Summary

closes: #2259 

turbopack 这里的行为比较奇怪，会在 `export *` 的 case 下把 `.d.ts` 文件内容 bundle 进来：

<img width="2498" height="1332" alt="image" src="https://github.com/user-attachments/assets/7b609ca6-6374-46ba-8cdf-3271980ad73f" />

测试 webpack + tsloader 不会有类似的情况，因为 umi / 业务侧代码会有写类似的写法，所以 utoopack 先暂时把 `.d.ts` 在 bundle 的时候给 ignore 掉避免出现 panic 的情况。


## Test Plan

参考添加的快照测试
