### PR TITLE
fix(pack): non-hoist less-loader not found

### DIFF
--- a/crates/pack-core/src/import_map.rs
+++ b/crates/pack-core/src/import_map.rs
@@ -364,15 +364,25 @@ pub async fn get_utoopack_dependency_package(
 
     let dependency_path_to_root = &source.ident().path().owned().await?.parent();
 
-    Ok(Vc::cell(
-        dependency_path_to_root
-            .path
-            // This is a hack for special node_modules structure like pnpm
-            // for example: require("node_modules/.pnpm/loader-runner@4.3.0/node_modules/loader-runner/lib/LoaderRunner.js") can't be resolve,
-            // but require(".pnpm/loader-runner@4.3.0/node_modules/loader-runner/lib/LoaderRunner.js)" can be
-            .replacen("node_modules/", "", 1)
-            .into(),
-    ))
+    #[cfg(not(feature = "test"))]
+    {
+        let project_root = pack_path.root().owned().await?;
+        let relative_path = match project_root.get_relative_path_to(dependency_path_to_root) {
+            Some(relative) => relative,
+            None => dependency_path_to_root.path.clone(),
+        };
+        Ok(Vc::cell(relative_path.into()))
+    }
+    #[cfg(feature = "test")]
+    {
+        Ok(Vc::cell(
+            dependency_path_to_root
+                .path
+                .clone()
+                .replacen("node_modules/", "", 1)
+                .into(),
+        ))
+    }
 }
 
 pub fn get_client_resolved_map(

--- a/crates/pack-core/src/shared/webpack_rules/mod.rs
+++ b/crates/pack-core/src/shared/webpack_rules/mod.rs
@@ -9,11 +9,9 @@ use turbopack::module_options::{
     WebpackLoaderBuiltinConditionSet, WebpackLoaderBuiltinConditionSetMatch, WebpackLoadersOptions,
 };
 use turbopack_core::resolve::{ExternalTraced, ExternalType, options::ImportMapping};
-use turbopack_core::resolve::{ResolveResult, ResolveResultItem};
 
 use crate::{
     config::Config,
-    import_map::get_utoopack_dependency_package,
     shared::webpack_rules::{
         less::get_less_loader_rules, sass::get_sass_loader_rules,
         style_loader::get_style_loader_rules,
@@ -168,14 +166,11 @@ pub async fn webpack_loader_options(
 
 #[turbo_tasks::function]
 async fn loader_runner_package_mapping(pack_path: FileSystemPath) -> Result<Vc<ImportMapping>> {
-    Ok(
-        ImportMapping::Direct(ResolveResult::primary(ResolveResultItem::External {
-            name: get_utoopack_dependency_package(pack_path, rcstr!("loader-runner"))
-                .owned()
-                .await?,
-            ty: ExternalType::CommonJs,
-            traced: ExternalTraced::Untraced,
-        }))
-        .cell(),
-    )
+    Ok(ImportMapping::PrimaryAlternativeExternal {
+        name: Some(rcstr!("loader-runner")),
+        ty: ExternalType::CommonJs,
+        traced: ExternalTraced::Untraced,
+        lookup_dir: pack_path,
+    }
+    .cell())
 }

--- a/packages/pack/package.json
+++ b/packages/pack/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",
-    "@swc/helpers": "^0.5.15",
     "@types/babel__code-frame": "7.0.2",
     "@types/node": "^20.3.0",
     "styled-jsx": "^5.1.6",


### PR DESCRIPTION
## Summary

修复当 `@utoo/pack` 的 less-loader 没被 hosit 的情况下路径找不到的问题:

如果没有被 hoist，那么 less-loader 的路径会变成 `node_modules/@utoo/pack/node_modules/less-loader`，在 utoopack 的 loader-runner 实际 require 的路径会变成: `require("@utoo/pack/node_modules/less-loader")` 这种 case 的 require less-loader 会被当作 subpath 处理:

<img width="2636" height="1276" alt="image" src="https://github.com/user-attachments/assets/3f245e79-cfb8-4dc3-b812-b7570b03653f" />

因此这里统一处理成相对路径来处理，对于 loader-runner 则通过带 pack_path 的 external 方式来处理，具体参考代码变更。

## Test Plan

无测试变更，测试需要对于这种情况做一些适配保障测试能正常运行。
