### PR TITLE
fix(pack): use `loader-runner` relative path as external

### DIFF
--- a/crates/pack-core/src/import_map.rs
+++ b/crates/pack-core/src/import_map.rs
@@ -359,11 +359,18 @@ pub async fn get_utoopack_dependency_package(
     #[cfg(not(feature = "test"))]
     {
         let project_root = pack_path.root().owned().await?;
-        let relative_path = match project_root.get_relative_path_to(dependency_path_to_root) {
-            Some(relative) => relative,
-            None => dependency_path_to_root.path.clone(),
+        let path = if dependency == "loader-runner" {
+            dependency_path_to_root
+                .path
+                .clone()
+                .replacen("node_modules/", "", 1)
+                .into()
+        } else {
+            project_root
+                .get_relative_path_to(dependency_path_to_root)
+                .unwrap_or_else(|| dependency_path_to_root.path.clone())
         };
-        Ok(Vc::cell(relative_path.into()))
+        Ok(Vc::cell(path))
     }
     #[cfg(feature = "test")]
     {

--- a/crates/pack-core/src/shared/webpack_rules/mod.rs
+++ b/crates/pack-core/src/shared/webpack_rules/mod.rs
@@ -8,10 +8,13 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
     WebpackLoaderBuiltinConditionSet, WebpackLoaderBuiltinConditionSetMatch, WebpackLoadersOptions,
 };
-use turbopack_core::resolve::{ExternalTraced, ExternalType, options::ImportMapping};
+use turbopack_core::resolve::{
+    ExternalTraced, ExternalType, ResolveResult, ResolveResultItem, options::ImportMapping,
+};
 
 use crate::{
     config::Config,
+    import_map::get_utoopack_dependency_package,
     shared::webpack_rules::{
         less::get_less_loader_rules, sass::get_sass_loader_rules,
         style_loader::get_style_loader_rules,
@@ -166,11 +169,14 @@ pub async fn webpack_loader_options(
 
 #[turbo_tasks::function]
 async fn loader_runner_package_mapping(pack_path: FileSystemPath) -> Result<Vc<ImportMapping>> {
-    Ok(ImportMapping::PrimaryAlternativeExternal {
-        name: Some(rcstr!("loader-runner")),
-        ty: ExternalType::CommonJs,
-        traced: ExternalTraced::Untraced,
-        lookup_dir: pack_path,
-    }
-    .cell())
+    Ok(
+        ImportMapping::Direct(ResolveResult::primary(ResolveResultItem::External {
+            name: get_utoopack_dependency_package(pack_path, rcstr!("loader-runner"))
+                .owned()
+                .await?,
+            ty: ExternalType::CommonJs,
+            traced: ExternalTraced::Untraced,
+        }))
+        .cell(),
+    )
 }


### PR DESCRIPTION
## Summary

ref pr: https://github.com/utooland/utoo/pull/2273

`loader-runner` 的 external 路径需要传一个真实的路径，否则在 pnpm 下会解析不到。


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
