### PR TITLE
fix(pack): postcss use path as external

### DIFF
--- a/crates/pack-core/src/import_map.rs
+++ b/crates/pack-core/src/import_map.rs
@@ -363,7 +363,7 @@ pub async fn get_utoopack_dependency_package(
     #[cfg(not(feature = "test"))]
     {
         let project_root = pack_path.root().owned().await?;
-        let path = if dependency == "loader-runner" {
+        let path = if dependency == "loader-runner" || dependency == "postcss" {
             dependency_path_to_root
                 .path
                 .clone()


### PR DESCRIPTION

## Summary

follow pr: https://github.com/utooland/utoo/pull/2274

这里 postcss 应该也是当作一个 external module 在处理，否则会 external 时期解析不到:

<img width="1060" height="664" alt="截屏2025-11-03 20 52 34" src="https://github.com/user-attachments/assets/6fbb52c4-2e2f-41e1-8b76-98611d01157e" />

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
