### PR TITLE
fix: invalid wasm runtime export object

### DIFF
--- a/crates/mako/src/plugins/wasm_runtime.rs
+++ b/crates/mako/src/plugins/wasm_runtime.rs
@@ -91,7 +91,7 @@ impl Plugin for WasmRuntimePlugin {
                 ));
 
                 wasm_import_object_code.push_str(&format!(
-                    "\"{module}\": {{ {names} }}",
+                    "\"{module}\": {{ {names} }},",
                     module = key,
                     names = value
                         .iter()


### PR DESCRIPTION
As below:
<img width="1814" height="884" alt="image" src="https://github.com/user-attachments/assets/1ae0f84e-d138-41d3-874c-0fc287bf2651" />