### PR TITLE
fix(pack): loader resolve path

### DIFF
--- a/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/issues/Error evaluating Node.js code-7dd645.txt
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/issues/Error evaluating Node.js code-7dd645.txt
@@ -1,0 +1,16 @@
+error - [transform] /crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/input/test.txt  Error evaluating Node.js code
+  
+  Error: Cannot find module './test-file-loader.js'
+  Require stack:
+  - WORKSPACE_ROOT/packages/pack/.turbopack/[turbopack]_runtime.js
+  - WORKSPACE_ROOT/packages/pack/.turbopack/webpack-loaders.js
+      [at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)]
+      [at Function.resolve (node:internal/modules/helpers:145:19)]
+      [at externalRequire.resolve (WORKSPACE_ROOT/packages/pack/.turbopack/[turbopack]_runtime.js:533:20)]
+      [at WORKSPACE_ROOT/packages/pack/.turbopack/__8b1e0af0.js:385:86]
+      [at <anonymous>]
+      [at WORKSPACE_ROOT/packages/pack/.turbopack/__8b1e0af0.js:384:41]
+      [at <anonymous>]
+      [at transform (WORKSPACE_ROOT/packages/pack/.turbopack/__8b1e0af0.js:133:12)]
+      [at run (WORKSPACE_ROOT/packages/pack/.turbopack/__c7ae8543.js:443:37)]
+      [at run (WORKSPACE_ROOT/packages/pack/.turbopack/__c7ae8543.js:464:25)]

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/output/crates_pack-tests_tests_snapshot_fe2230b9.js
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/output/crates_pack-tests_tests_snapshot_fe2230b9.js
@@ -15,7 +15,9 @@ __turbopack_context__.s([
 }),
 6, ((__turbopack_context__, module, exports) => {
 
-module.exports = "Got a buffer of 11 bytes";
+const e = new Error("Could not parse module '[project]/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/input/test.txt.js', file not found");
+e.code = 'MODULE_UNPARSABLE';
+throw e;
 }),
 23, ((__turbopack_context__) => {
 "use strict";

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/output/crates_pack-tests_tests_snapshot_fe2230b9.js.map
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/output/crates_pack-tests_tests_snapshot_fe2230b9.js.map
@@ -3,6 +3,5 @@
   "sources": [],
   "sections": [
     {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/node_modules/react/jsx-runtime.js"],"sourcesContent":["export function jsx() {\n  return 'purposefully empty stub for react/jsx-runtime.js'\n}\nexport function jsxs() {\n  return 'purposefully empty stub for react/jsx-runtime.js'\n}\n"],"names":[],"mappings":"AAAO,SAAS;IACd,OAAO;AACT;AACO,SAAS;IACd,OAAO;AACT","ignoreList":[0]}},
-    {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/input/test.txt.js"],"sourcesContent":["module.exports = \"Got a buffer of 11 bytes\""],"names":[],"mappings":"AAAA,OAAO,OAAO,GAAG"}},
-    {"offset": {"line": 22, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/input/index.tsx"],"sourcesContent":["import dataText from './test.txt';\n\nexport default function App() {\n    return <div>{dataText}</div>;\n}"],"names":[],"mappings":";AAAA;;;AAEe,SAAS;IACpB,qBAAO,gDAAC;kBAAK,6CAAQ;;AACzB"}}]
+    {"offset": {"line": 24, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/webpack-loaders/custom-loader/input/index.tsx"],"sourcesContent":["import dataText from './test.txt';\n\nexport default function App() {\n    return <div>{dataText}</div>;\n}"],"names":[],"mappings":";AAAA;;;AAEe,SAAS;IACpB,qBAAO,gDAAC;kBAAK,6CAAQ;;AACzB"}}]
 }


### PR DESCRIPTION
## Summary

Updated PR: https://github.com/utooland/next.js/pull/72

## Test Plan


有个相对路径的测试 Case 会挂掉，符合目前的预期