### PR TITLE
fix(pack): analyze path can't get stats.json file

### DIFF
--- a/packages/pack/src/build.ts
+++ b/packages/pack/src/build.ts
@@ -80,9 +80,7 @@ async function buildInternal(
   handleIssues(entrypoints.issues);
 
   if (process.env.ANALYZE) {
-    await analyzeBundle(
-      bundleOptions.config.output?.path || "dist",
-    );
+    await analyzeBundle(bundleOptions.config.output?.path || "dist");
   } else {
     await project.shutdown();
   }
@@ -91,9 +89,7 @@ async function buildInternal(
   // https://github.com/vercel/next.js/blob/512d8283054407ab92b2583ecce3b253c3be7b85/packages/next/src/lib/worker.ts
 }
 
-async function analyzeBundle(
-  outputPath: string,
-): Promise<void> {
+async function analyzeBundle(outputPath: string): Promise<void> {
   const statsPath = join(outputPath, "stats.json");
 
   if (!existsSync(statsPath)) {

--- a/packages/pack/src/build.ts
+++ b/packages/pack/src/build.ts
@@ -81,9 +81,8 @@ async function buildInternal(
 
   if (process.env.ANALYZE) {
     await analyzeBundle(bundleOptions.config.output?.path || "dist");
-  } else {
-    await project.shutdown();
   }
+  await project.shutdown();
 
   // TODO: Maybe run tasks in worker is a better way, see
   // https://github.com/vercel/next.js/blob/512d8283054407ab92b2583ecce3b253c3be7b85/packages/next/src/lib/worker.ts

--- a/packages/pack/src/build.ts
+++ b/packages/pack/src/build.ts
@@ -79,13 +79,12 @@ async function buildInternal(
 
   handleIssues(entrypoints.issues);
 
-  await project.shutdown();
-
   if (process.env.ANALYZE) {
     await analyzeBundle(
-      projectPath || process.cwd(),
       bundleOptions.config.output?.path || "dist",
     );
+  } else {
+    await project.shutdown();
   }
 
   // TODO: Maybe run tasks in worker is a better way, see
@@ -93,10 +92,9 @@ async function buildInternal(
 }
 
 async function analyzeBundle(
-  projectPath: string,
   outputPath: string,
 ): Promise<void> {
-  const statsPath = join(projectPath, outputPath, "stats.json");
+  const statsPath = join(outputPath, "stats.json");
 
   if (!existsSync(statsPath)) {
     console.warn(


### PR DESCRIPTION
## Summary

umi / bigfish 进来的时候 `output.path` 已经是绝对路径了，在 umi 中使用:

```bash
ANALYZE=1 umi build
```

<img width="3804" height="2076" alt="image" src="https://github.com/user-attachments/assets/85f4fadd-cc81-47b8-8b2e-1e6b2fe81774" />


这个 analyze 目前作为一个临时解决方案，等 turbopack 的 analyze 稳定之后切换新的 analyze。

## Test Plan

不需要
