### PR TITLE
fix(pack): stats.json assets and chunks should include async chunk

### DIFF
--- a/crates/pack-api/src/webpack_stats.rs
+++ b/crates/pack-api/src/webpack_stats.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::{Error, Result};
 use parking_lot::Mutex;
 use qstring::QString;
+use rustc_hash::FxHashSet;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
 use turbopack::css::chunk::CssChunk;
@@ -23,8 +24,21 @@ pub async fn generate_webpack_stats(output_assets: Vc<OutputAssets>) -> Result<V
     let entrypoints: Arc<Mutex<FxIndexMap<RcStr, WebpackStatsEntrypoint>>> =
         Arc::new(Mutex::new(FxIndexMap::default()));
 
-    let output_assets = &*output_assets.await?;
-    output_assets
+    // Collect all assets including referenced assets (async chunks)
+    let initial_assets = output_assets.await?;
+    let mut all_assets = vec![];
+    let mut visited = FxHashSet::default();
+    let mut queue: Vec<_> = initial_assets.iter().copied().collect();
+
+    while let Some(asset) = queue.pop() {
+        if visited.insert(asset) {
+            all_assets.push(asset);
+            let references = asset.references().await?;
+            queue.extend(references.iter().copied());
+        }
+    }
+
+    all_assets
         .iter()
         .map(|asset| {
             let chunks = chunks.clone();

--- a/crates/pack-tests/tests/snapshot/async_chunk/config.json
+++ b/crates/pack-tests/tests/snapshot/async_chunk/config.json
@@ -11,6 +11,7 @@
         },
         "output": {
             "path": "output"
-        }
+        },
+        "stats": true
     }
 }

--- a/crates/pack-tests/tests/snapshot/async_chunk/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/async_chunk/output/stats.json
@@ -1,0 +1,189 @@
+{
+  "assets": [
+    {
+      "type": "asset",
+      "name": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js.map",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js.map",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "main.js.map",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "main.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "main.js",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "main.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js",
+      "info": {},
+      "size": 797,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js",
+      "info": {},
+      "size": 1092,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+      ]
+    }
+  ],
+  "entrypoints": {
+    "main": {
+      "name": "main",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js",
+        "main.js"
+      ],
+      "assets": [
+        {
+          "name": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+        },
+        {
+          "name": "main.js"
+        }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "main.js",
+      "size": 0,
+      "hash": "",
+      "files": [
+        "main.js"
+      ]
+    },
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js",
+      "size": 797,
+      "hash": "",
+      "files": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
+      ]
+    },
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js",
+      "size": 1092,
+      "hash": "",
+      "files": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/node_modules/foo/index.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/node_modules/foo/index.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
+      ],
+      "size": 56
+    },
+    {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+      ],
+      "size": 110
+    },
+    {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
+      "chunks": [
+        "main.js"
+      ],
+      "size": 110
+    },
+    {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/node_modules/bar/index.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/node_modules/bar/index.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+      ],
+      "size": 56
+    },
+    {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/shared.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/shared.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+      ],
+      "size": 18
+    },
+    {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/import.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/import.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+      ],
+      "size": 91
+    },
+    {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/import.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/import.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
+      ],
+      "size": 91
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

修复 `stats.json` 文件的 assets、chunks 对象不统计 async chunk 的问题。

Before: 

<img width="1862" height="714" alt="image" src="https://github.com/user-attachments/assets/68ad5e61-a8e3-4b62-b872-b30822e9c8b0" />


After:

<img width="1968" height="1392" alt="image" src="https://github.com/user-attachments/assets/e6a35a2f-2186-4ef7-ae35-6756a35af55f" />


## Test Plan

参考快照测试的 `stats.json` 文件，其中 `crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js` 是个 dynamic chunk。
