### PR TITLE
fix(pm): registry

### DIFF
--- a/crates/pm/src/model/package_lock.rs
+++ b/crates/pm/src/model/package_lock.rs
@@ -9,6 +9,14 @@ use crate::{
     service::dependency_graph::{DependencyGraphService, DependencyType, PackageNode},
 };
 
+/// Represents a license field that can be either a string or an array of strings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum License {
+    String(String),
+    Array(Vec<String>),
+}
+
 /// Represents package information in package-lock.json
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct LockPackage {
@@ -21,7 +29,7 @@ pub struct LockPackage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub integrity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub license: Option<String>,
+    pub license: Option<License>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<HashMap<String, String>>,
     #[serde(rename = "devDependencies", skip_serializing_if = "Option::is_none")]
@@ -381,5 +389,64 @@ mod tests {
 
         package.version = None;
         assert_eq!(package.get_version(), "unknown");
+    }
+
+    #[test]
+    fn test_license_field_parsing() {
+        // Test string license
+        let json_string = r#"{
+            "version": "1.0.0",
+            "license": "MIT"
+        }"#;
+        let package: LockPackage = serde_json::from_str(json_string).unwrap();
+        assert!(package.license.is_some());
+        match package.license.unwrap() {
+            License::String(s) => assert_eq!(s, "MIT"),
+            License::Array(_) => panic!("Expected License::String"),
+        }
+
+        // Test array license
+        let json_array = r#"{
+            "version": "1.0.0",
+            "license": ["MIT", "Apache-2.0"]
+        }"#;
+        let package: LockPackage = serde_json::from_str(json_array).unwrap();
+        assert!(package.license.is_some());
+        match package.license.unwrap() {
+            License::Array(arr) => {
+                assert_eq!(arr.len(), 2);
+                assert_eq!(arr[0], "MIT");
+                assert_eq!(arr[1], "Apache-2.0");
+            }
+            License::String(_) => panic!("Expected License::Array"),
+        }
+
+        // Test no license
+        let json_no_license = r#"{
+            "version": "1.0.0"
+        }"#;
+        let package: LockPackage = serde_json::from_str(json_no_license).unwrap();
+        assert!(package.license.is_none());
+
+        // Test serialization of string license
+        let package_with_string = LockPackage {
+            version: Some("1.0.0".to_string()),
+            license: Some(License::String("MIT".to_string())),
+            ..LockPackage::default()
+        };
+        let serialized = serde_json::to_string(&package_with_string).unwrap();
+        assert!(serialized.contains(r#""license":"MIT""#));
+
+        // Test serialization of array license
+        let package_with_array = LockPackage {
+            version: Some("1.0.0".to_string()),
+            license: Some(License::Array(vec![
+                "MIT".to_string(),
+                "Apache-2.0".to_string(),
+            ])),
+            ..LockPackage::default()
+        };
+        let serialized = serde_json::to_string(&package_with_array).unwrap();
+        assert!(serialized.contains(r#""license":["MIT","Apache-2.0"]"#));
     }
 }

--- a/crates/pm/src/service/registry.rs
+++ b/crates/pm/src/service/registry.rs
@@ -308,11 +308,24 @@ impl RegistryService {
             let dist_tags = &versions_info_arc.versions.dist_tags;
             let version_list = &versions_info_arc.versions.version_list;
 
-            let target_version = match dist_tags.get(spec) {
-                Some(version) => version.to_string(),
-                None => match semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec)
+            // First check if spec is a dist-tag
+            let target_version = if let Some(version) = dist_tags.get(spec) {
+                version.to_string()
+            } else {
+                // Not a dist-tag, do semver matching
+                // Check if 'latest' dist-tag satisfies the spec (npm behavior)
+                let version = if let Some(latest) = dist_tags.get("latest")
+                    && semver::matches(spec, latest)
                 {
-                    Some(version) => version.to_string(),
+                    tracing::debug!("Using dist-tags 'latest' version {latest} for {name}@{spec}");
+                    Some(latest.to_string())
+                } else {
+                    semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec)
+                        .map(|v| v.to_string())
+                };
+
+                match version {
+                    Some(v) => v,
                     None => {
                         tracing::debug!(
                             "No matching version found for {}@{} from {} available versions",
@@ -324,7 +337,7 @@ impl RegistryService {
                             "No matching version found for {name}@{spec}"
                         ));
                     }
-                },
+                }
             };
 
             tracing::debug!("Resolved target version for {name}@{spec}: {target_version}");
@@ -491,8 +504,8 @@ mod tests {
             ("beta", "2.0.0-beta.1"),
             ("alpha", "2.0.0-alpha.1"),
             ("next", "1.3.0"),
-            // Test semver fallback when dist-tag doesn't exist
-            ("^1.0.0", "1.3.0"), // Should match highest semver (1.3.0 is higher than 1.2.3)
+            // Test semver matching with latest priority (npm behavior)
+            ("^1.0.0", "1.2.3"), // Should use latest (1.2.3) since it satisfies ^1.0.0
             ("~1.1.0", "1.1.0"), // Should match exact semver
             ("1.0.0", "1.0.0"),  // Should match exact version
         ];
@@ -614,6 +627,103 @@ mod tests {
         }
     }
 
+    /// Test that 'latest' dist-tag is preferred when it satisfies the semver requirement
+    #[tokio::test]
+    async fn test_latest_dist_tag_priority() {
+        // Create a scenario where:
+        // - latest points to 1.5.0
+        // - version_list has 1.0.0, 1.5.0, 1.9.0
+        // - User requests ^1.0.0
+        // Expected: Should use 1.5.0 (latest) even though 1.9.0 is the max_satisfying version
+
+        let mut dist_tags = HashMap::new();
+        dist_tags.insert("latest".to_string(), "1.5.0".to_string());
+
+        let versions = Versions {
+            version_list: vec![
+                "1.0.0".to_string(),
+                "1.5.0".to_string(),
+                "1.9.0".to_string(),
+            ],
+            dist_tags: dist_tags.clone(),
+        };
+
+        let versions_info = VersionsInfo {
+            versions,
+            etag: Some("test-etag".to_string()),
+            last_updated: 1234567890,
+        };
+
+        // Test: ^1.0.0 should use latest (1.5.0) instead of max_satisfying (1.9.0)
+        let result = test_resolve_with_dist_tags(&versions_info, "test-package", "^1.0.0").await;
+        match result {
+            Ok(resolved) => {
+                assert_eq!(resolved.version, "1.5.0");
+                println!("✓ Latest dist-tag (1.5.0) was preferred over max_satisfying (1.9.0) for ^1.0.0");
+            }
+            Err(e) => {
+                panic!("Failed to resolve with latest dist-tag priority: {e}");
+            }
+        }
+
+        // Test: ^2.0.0 should use max_satisfying since latest doesn't satisfy
+        let mut dist_tags2 = HashMap::new();
+        dist_tags2.insert("latest".to_string(), "1.5.0".to_string());
+
+        let versions2 = Versions {
+            version_list: vec![
+                "1.5.0".to_string(),
+                "2.0.0".to_string(),
+                "2.1.0".to_string(),
+            ],
+            dist_tags: dist_tags2,
+        };
+
+        let versions_info2 = VersionsInfo {
+            versions: versions2,
+            etag: Some("test-etag".to_string()),
+            last_updated: 1234567890,
+        };
+
+        let result2 = test_resolve_with_dist_tags(&versions_info2, "test-package", "^2.0.0").await;
+        match result2 {
+            Ok(resolved) => {
+                assert_eq!(resolved.version, "2.1.0");
+                println!("✓ Latest (1.5.0) doesn't satisfy ^2.0.0, correctly used max_satisfying (2.1.0)");
+            }
+            Err(e) => {
+                panic!("Failed to resolve when latest doesn't satisfy: {e}");
+            }
+        }
+
+        // Test: No latest tag should fall back to max_satisfying
+        let versions3 = Versions {
+            version_list: vec![
+                "1.0.0".to_string(),
+                "1.5.0".to_string(),
+                "1.9.0".to_string(),
+            ],
+            dist_tags: HashMap::new(),
+        };
+
+        let versions_info3 = VersionsInfo {
+            versions: versions3,
+            etag: Some("test-etag".to_string()),
+            last_updated: 1234567890,
+        };
+
+        let result3 = test_resolve_with_dist_tags(&versions_info3, "test-package", "^1.0.0").await;
+        match result3 {
+            Ok(resolved) => {
+                assert_eq!(resolved.version, "1.9.0");
+                println!("✓ No latest tag, correctly used max_satisfying (1.9.0)");
+            }
+            Err(e) => {
+                panic!("Failed to resolve without latest tag: {e}");
+            }
+        }
+    }
+
     /// Test error cases
     #[tokio::test]
     async fn test_resolve_errors() {
@@ -665,16 +775,29 @@ mod tests {
             return Err(anyhow::anyhow!("No versions found for package: {name}"));
         }
 
-        let target_version = match dist_tags.get(spec) {
-            Some(version) => version.to_string(),
-            None => match semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec) {
-                Some(version) => version.to_string(),
+        // First check if spec is a dist-tag
+        let target_version = if let Some(version) = dist_tags.get(spec) {
+            version.to_string()
+        } else {
+            // Not a dist-tag, do semver matching
+            // Check if 'latest' dist-tag satisfies the spec (npm behavior)
+            let version = if let Some(latest) = dist_tags.get("latest")
+                && semver::matches(spec, latest)
+            {
+                Some(latest.to_string())
+            } else {
+                semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec)
+                    .map(|v| v.to_string())
+            };
+
+            match version {
+                Some(v) => v,
                 None => {
                     return Err(anyhow::anyhow!(
                         "No matching version found for {name}@{spec}"
                     ));
                 }
-            },
+            }
         };
 
         // Create a mock resolved package

--- a/crates/pm/src/service/registry.rs
+++ b/crates/pm/src/service/registry.rs
@@ -269,6 +269,43 @@ impl RegistryService {
         }
     }
 
+    /// Resolve target version from dist-tags and version list
+    /// This is the core version resolution logic that matches npm's behavior
+    fn resolve_target_version(
+        dist_tags: &HashMap<String, String>,
+        version_list: &[String],
+        spec: &str,
+    ) -> Result<String> {
+        if version_list.is_empty() {
+            return Err(anyhow::anyhow!("No versions available"));
+        }
+
+        // First check if spec is a dist-tag
+        if let Some(version) = dist_tags.get(spec) {
+            return Ok(version.to_string());
+        }
+
+        // Not a dist-tag, do semver matching
+        // Check if 'latest' dist-tag satisfies the spec (npm behavior)
+        let version = if let Some(latest) = dist_tags.get("latest")
+            && semver::matches(spec, latest)
+        {
+            tracing::debug!("Using dist-tags 'latest' version {latest} for spec {spec}");
+            Some(latest.to_string())
+        } else {
+            semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec)
+                .map(|v| v.to_string())
+        };
+
+        version.ok_or_else(|| {
+            anyhow::anyhow!(
+                "No matching version found for spec '{}' from {} available versions",
+                spec,
+                version_list.len()
+            )
+        })
+    }
+
     // Note: get_version_manifest_by_full_versions has been replaced with the new cache-first architecture:
     // - get_target_version_by_cache: gets version from cache
     // - get_target_version_by_full_manifest: gets version from network
@@ -304,42 +341,11 @@ impl RegistryService {
             // 2. Resolve package versions using new caching architecture
             let versions_info_arc = Self::resolve_package_versions(name).await?;
 
-            // 3. Check dist-tags (Arc auto-derefs)
+            // 3. Resolve target version using extracted logic
             let dist_tags = &versions_info_arc.versions.dist_tags;
             let version_list = &versions_info_arc.versions.version_list;
 
-            // First check if spec is a dist-tag
-            let target_version = if let Some(version) = dist_tags.get(spec) {
-                version.to_string()
-            } else {
-                // Not a dist-tag, do semver matching
-                // Check if 'latest' dist-tag satisfies the spec (npm behavior)
-                let version = if let Some(latest) = dist_tags.get("latest")
-                    && semver::matches(spec, latest)
-                {
-                    tracing::debug!("Using dist-tags 'latest' version {latest} for {name}@{spec}");
-                    Some(latest.to_string())
-                } else {
-                    semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec)
-                        .map(|v| v.to_string())
-                };
-
-                match version {
-                    Some(v) => v,
-                    None => {
-                        tracing::debug!(
-                            "No matching version found for {}@{} from {} available versions",
-                            name,
-                            spec,
-                            version_list.len()
-                        );
-                        return Err(anyhow::anyhow!(
-                            "No matching version found for {name}@{spec}"
-                        ));
-                    }
-                }
-            };
-
+            let target_version = Self::resolve_target_version(dist_tags, version_list, spec)?;
             tracing::debug!("Resolved target version for {name}@{spec}: {target_version}");
 
             // 5. Get specific version manifest using three-tier caching
@@ -762,7 +768,7 @@ mod tests {
     }
 
     /// Helper function to test dist-tags matching logic
-    /// This simulates the logic from RegistryService::resolve_package
+    /// This directly calls the real resolve_target_version method
     async fn test_resolve_with_dist_tags(
         versions_info: &VersionsInfo,
         name: &str,
@@ -771,34 +777,8 @@ mod tests {
         let dist_tags = &versions_info.versions.dist_tags;
         let version_list = &versions_info.versions.version_list;
 
-        if version_list.is_empty() {
-            return Err(anyhow::anyhow!("No versions found for package: {name}"));
-        }
-
-        // First check if spec is a dist-tag
-        let target_version = if let Some(version) = dist_tags.get(spec) {
-            version.to_string()
-        } else {
-            // Not a dist-tag, do semver matching
-            // Check if 'latest' dist-tag satisfies the spec (npm behavior)
-            let version = if let Some(latest) = dist_tags.get("latest")
-                && semver::matches(spec, latest)
-            {
-                Some(latest.to_string())
-            } else {
-                semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec)
-                    .map(|v| v.to_string())
-            };
-
-            match version {
-                Some(v) => v,
-                None => {
-                    return Err(anyhow::anyhow!(
-                        "No matching version found for {name}@{spec}"
-                    ));
-                }
-            }
-        };
+        // Call the real method from RegistryService
+        let target_version = RegistryService::resolve_target_version(dist_tags, version_list, spec)?;
 
         // Create a mock resolved package
         Ok(ResolvedPackage {

--- a/crates/pm/src/service/registry.rs
+++ b/crates/pm/src/service/registry.rs
@@ -287,15 +287,17 @@ impl RegistryService {
 
         // Not a dist-tag, do semver matching
         // Check if 'latest' dist-tag satisfies the spec (npm behavior)
-        let version = if let Some(latest) = dist_tags.get("latest")
-            && semver::matches(spec, latest)
-        {
-            tracing::debug!("Using dist-tags 'latest' version {latest} for spec {spec}");
-            Some(latest.to_string())
-        } else {
-            semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec)
-                .map(|v| v.to_string())
-        };
+        let version = dist_tags
+            .get("latest")
+            .filter(|latest| semver::matches(spec, latest))
+            .map(|latest| {
+                tracing::debug!("Using dist-tags 'latest' version {latest} for spec {spec}");
+                latest.to_string()
+            })
+            .or_else(|| {
+                semver::max_satisfying(version_list.iter().map(|s| s.as_str()), spec)
+                    .map(|v| v.to_string())
+            });
 
         version.ok_or_else(|| {
             anyhow::anyhow!(
@@ -665,7 +667,9 @@ mod tests {
         match result {
             Ok(resolved) => {
                 assert_eq!(resolved.version, "1.5.0");
-                println!("✓ Latest dist-tag (1.5.0) was preferred over max_satisfying (1.9.0) for ^1.0.0");
+                println!(
+                    "✓ Latest dist-tag (1.5.0) was preferred over max_satisfying (1.9.0) for ^1.0.0"
+                );
             }
             Err(e) => {
                 panic!("Failed to resolve with latest dist-tag priority: {e}");
@@ -695,7 +699,9 @@ mod tests {
         match result2 {
             Ok(resolved) => {
                 assert_eq!(resolved.version, "2.1.0");
-                println!("✓ Latest (1.5.0) doesn't satisfy ^2.0.0, correctly used max_satisfying (2.1.0)");
+                println!(
+                    "✓ Latest (1.5.0) doesn't satisfy ^2.0.0, correctly used max_satisfying (2.1.0)"
+                );
             }
             Err(e) => {
                 panic!("Failed to resolve when latest doesn't satisfy: {e}");
@@ -778,7 +784,8 @@ mod tests {
         let version_list = &versions_info.versions.version_list;
 
         // Call the real method from RegistryService
-        let target_version = RegistryService::resolve_target_version(dist_tags, version_list, spec)?;
+        let target_version =
+            RegistryService::resolve_target_version(dist_tags, version_list, spec)?;
 
         // Create a mock resolved package
         Ok(ResolvedPackage {


### PR DESCRIPTION
* Added support for license field as string[] (exp: `pause-stream`)
* Default to using `latest` tag during resolve