### PR TITLE
fix(pack): order of stasts.json assets

### DIFF
--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -365,7 +365,9 @@ impl Endpoint for AppEndpoint {
             };
 
             let output_assets = if *self.project().should_create_webpack_stats().await? {
-                let webpack_stats = generate_webpack_stats(output_assets).await?;
+                let output_assets_vec = output_assets.await?;
+                let webpack_stats =
+                    generate_webpack_stats(output_assets_vec.iter().copied()).await?;
                 let stats_output = VirtualOutputAsset::new(
                     dist_root.join("stats.json")?,
                     AssetContent::file(

--- a/crates/pack-api/src/webpack_stats.rs
+++ b/crates/pack-api/src/webpack_stats.rs
@@ -1,215 +1,178 @@
-use std::sync::Arc;
-
-use anyhow::{Error, Result};
-use parking_lot::Mutex;
+use anyhow::Result;
 use qstring::QString;
 use rustc_hash::FxHashSet;
+use tracing::instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
 use turbopack::css::chunk::CssChunk;
 use turbopack_browser::ecmascript::{EcmascriptBrowserChunk, EcmascriptBrowserEvaluateChunk};
 use turbopack_core::{
     chunk::{Chunk, ChunkItem, ChunkableModule},
-    output::{OutputAsset, OutputAssets},
+    output::OutputAsset,
 };
 
-#[turbo_tasks::function]
-pub async fn generate_webpack_stats(output_assets: Vc<OutputAssets>) -> Result<Vc<WebpackStats>> {
-    let assets: Arc<Mutex<Vec<WebpackStatsAsset>>> = Arc::new(Mutex::new(vec![]));
-    let chunks: Arc<Mutex<Vec<WebpackStatsChunk>>> = Arc::new(Mutex::new(vec![]));
-    #[allow(clippy::type_complexity)]
-    let chunk_items: Arc<Mutex<FxIndexMap<Vc<Box<dyn ChunkItem>>, FxIndexSet<RcStr>>>> =
-        Arc::new(Mutex::new(FxIndexMap::default()));
-    let modules: Arc<Mutex<Vec<WebpackStatsModule>>> = Arc::new(Mutex::new(vec![]));
-    let entrypoints: Arc<Mutex<FxIndexMap<RcStr, WebpackStatsEntrypoint>>> =
-        Arc::new(Mutex::new(FxIndexMap::default()));
+#[instrument(level = "info", name = "generate webpack stats", skip_all)]
+pub async fn generate_webpack_stats<I>(entry_assets: I) -> Result<WebpackStats>
+where
+    I: IntoIterator<Item = ResolvedVc<Box<dyn OutputAsset>>>,
+{
+    let mut assets = vec![];
+    let mut chunks = vec![];
+    let mut chunk_items: FxIndexMap<Vc<Box<dyn ChunkItem>>, FxIndexSet<RcStr>> =
+        FxIndexMap::default();
+    let mut modules = vec![];
+    let mut entrypoints: FxIndexMap<RcStr, WebpackStatsEntrypoint> = FxIndexMap::default();
+
+    let entry_assets = entry_assets.into_iter().collect::<Vec<_>>();
 
     // Collect all assets including referenced assets (async chunks)
-    let initial_assets = output_assets.await?;
-    let mut all_assets = vec![];
-    let mut visited = FxHashSet::default();
-    let mut queue: Vec<_> = initial_assets.iter().copied().collect();
-
-    while let Some(asset) = queue.pop() {
-        if visited.insert(asset) {
-            all_assets.push(asset);
-            let references = asset.references().await?;
-            queue.extend(references.iter().copied());
+    let asset_children = {
+        let mut asset_children =
+            FxIndexMap::with_capacity_and_hasher(entry_assets.len(), Default::default());
+        let mut visited =
+            FxHashSet::with_capacity_and_hasher(entry_assets.len(), Default::default());
+        let mut queue = entry_assets.clone();
+        while let Some(asset) = queue.pop() {
+            if visited.insert(asset) {
+                let references = asset.references().await?;
+                asset_children.insert(asset, references.clone());
+                queue.extend(references);
+            }
         }
+        asset_children
+    };
+
+    // Iterate over all collected assets
+    for asset in asset_children.keys().copied() {
+        let asset_len = asset.size_bytes().await?.unwrap_or_default();
+
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBrowserEvaluateChunk>(asset)
+        {
+            let entry_path = chunk.path().await?.path.clone();
+            chunks.push(WebpackStatsChunk {
+                size: asset_len,
+                files: vec![entry_path.clone()],
+                id: entry_path.clone(),
+                ..Default::default()
+            });
+
+            chunk
+                .evaluatable_assets()
+                .await?
+                .iter()
+                .for_each(|evaluatable_asset| {
+                    let item = evaluatable_asset
+                        .as_chunk_item(chunk.module_graph(), chunk.chunking_context());
+                    chunk_items
+                        .entry(item)
+                        .or_default()
+                        .insert(entry_path.clone());
+                });
+
+            let entry_referenced_assets = chunk.chunks_data().await?;
+            let mut entry_chunks = entry_referenced_assets
+                .iter()
+                .map(async |asset| Ok(asset.await?.path.as_str().into()))
+                .try_join()
+                .await?;
+            entry_chunks.push(entry_path.clone());
+
+            let mut entry_assets_list = entry_referenced_assets
+                .iter()
+                .map(|asset| async move {
+                    Ok(WebpackStatsEntrypointAssets {
+                        name: asset.await?.path.as_str().into(),
+                    })
+                })
+                .try_join()
+                .await?;
+            entry_assets_list.push(WebpackStatsEntrypointAssets {
+                name: entry_path.clone(),
+            });
+
+            let entry_name: RcStr = QString::from(chunk.ident().await?.query.as_str())
+                .get("name")
+                .unwrap_or(remove_extension_from_str(entry_path.as_str()))
+                .into();
+            entrypoints.insert(
+                entry_name.clone(),
+                WebpackStatsEntrypoint {
+                    name: entry_name.clone(),
+                    chunks: entry_chunks,
+                    assets: entry_assets_list,
+                },
+            );
+        }
+
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBrowserChunk>(asset) {
+            let chunk_ident = &chunk.path().await?.path;
+            chunks.push(WebpackStatsChunk {
+                size: asset_len,
+                files: vec![chunk_ident.clone()],
+                id: chunk_ident.clone(),
+                ..Default::default()
+            });
+
+            chunk
+                .chunk()
+                .chunk_items()
+                .await?
+                .into_iter()
+                .for_each(|item| {
+                    chunk_items
+                        .entry(**item)
+                        .or_default()
+                        .insert(chunk_ident.clone());
+                });
+        }
+
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<CssChunk>(asset) {
+            let chunk_ident = &chunk.path().await?.path;
+            chunks.push(WebpackStatsChunk {
+                size: asset_len,
+                files: vec![chunk_ident.clone()],
+                id: chunk_ident.clone(),
+                ..Default::default()
+            });
+        }
+
+        let path = &asset.path().await?.path;
+        assets.push(WebpackStatsAsset {
+            ty: "asset".into(),
+            name: path.clone(),
+            chunks: vec![path.clone()],
+            size: asset_len,
+            ..Default::default()
+        });
     }
 
-    all_assets
-        .iter()
-        .map(|asset| {
-            let chunks = chunks.clone();
-            let chunk_items = chunk_items.clone();
-            let entrypoints = entrypoints.clone();
-            let assets = assets.clone();
-            async move {
-                let asset_len = asset.size_bytes().await?.unwrap_or_default();
-
-                if let Some(chunk) =
-                    ResolvedVc::try_downcast_type::<EcmascriptBrowserEvaluateChunk>(*asset)
-                {
-                    let entry_path = chunk.path().await?.path.clone();
-                    {
-                        let mut chunks = chunks.lock();
-                        chunks.push(WebpackStatsChunk {
-                            size: asset_len,
-                            files: vec![entry_path.clone()],
-                            id: entry_path.clone(),
-                            ..Default::default()
-                        });
-                    }
-
-                    chunk
-                        .evaluatable_assets()
-                        .await?
-                        .iter()
-                        .for_each(|evaluatable_asset| {
-                            let item = evaluatable_asset
-                                .as_chunk_item(chunk.module_graph(), chunk.chunking_context());
-                            {
-                                let mut chunk_items = chunk_items.lock();
-                                chunk_items
-                                    .entry(item)
-                                    .or_default()
-                                    .insert(entry_path.clone());
-                            }
-                        });
-
-                    let entry_referenced_assets = (*chunk).chunks_data().await?;
-                    let mut entry_chunks = entry_referenced_assets
-                        .iter()
-                        .map(async |asset| Ok(asset.await?.path.as_str().into()))
-                        .try_join()
-                        .await?;
-                    entry_chunks.push(entry_path.clone());
-
-                    let mut entry_assets = entry_referenced_assets
-                        .iter()
-                        .map(|asset| async move {
-                            Ok(WebpackStatsEntrypointAssets {
-                                name: asset.await?.path.as_str().into(),
-                            })
-                        })
-                        .try_join()
-                        .await?;
-                    entry_assets.push(WebpackStatsEntrypointAssets {
-                        name: entry_path.clone(),
-                    });
-
-                    let entry_name: RcStr = QString::from((*chunk).ident().await?.query.as_str())
-                        .get("name")
-                        .unwrap_or(remove_extension_from_str(entry_path.as_str()))
-                        .into();
-                    {
-                        let mut entrypoints = entrypoints.lock();
-                        entrypoints.insert(
-                            entry_name.clone(),
-                            WebpackStatsEntrypoint {
-                                name: entry_name.clone(),
-                                chunks: entry_chunks,
-                                assets: entry_assets,
-                            },
-                        );
-                    }
-                }
-
-                if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBrowserChunk>(*asset)
-                {
-                    let chunk_ident = &chunk.path().await?.path;
-                    {
-                        let mut chunks = chunks.lock();
-                        chunks.push(WebpackStatsChunk {
-                            size: asset_len,
-                            files: vec![chunk_ident.clone()],
-                            id: chunk_ident.clone(),
-                            ..Default::default()
-                        });
-                    }
-
-                    chunk
-                        .chunk()
-                        .chunk_items()
-                        .await?
-                        .into_iter()
-                        .for_each(|item| {
-                            let mut chunk_items = chunk_items.lock();
-                            chunk_items
-                                .entry(**item)
-                                .or_default()
-                                .insert(chunk_ident.clone());
-                        });
-                }
-
-                if let Some(chunk) = ResolvedVc::try_downcast_type::<CssChunk>(*asset) {
-                    let chunk_ident = &chunk.path().await?.path;
-                    {
-                        let mut chunks = chunks.lock();
-                        chunks.push(WebpackStatsChunk {
-                            size: asset_len,
-                            files: vec![chunk_ident.clone()],
-                            id: chunk_ident.clone(),
-                            ..Default::default()
-                        });
-                    }
-                }
-
-                let path = &asset.path().await?.path;
-                {
-                    let mut assets = assets.lock();
-                    assets.push(WebpackStatsAsset {
-                        ty: "asset".into(),
-                        name: path.clone(),
-                        chunks: vec![path.clone()],
-                        size: asset_len,
-                        ..Default::default()
-                    });
-                }
-                Ok::<(), Error>(())
-            }
-        })
-        .try_join()
-        .await?;
-
-    let chunk_items = Arc::into_inner(chunk_items).unwrap().into_inner();
-    chunk_items
-        .iter()
-        .map(|(chunk_item, chunks)| async {
-            // For virtual file system or other read errors, use None as size
-            // This prevents the build from failing when dealing with virtual files
-            let size = chunk_item
-                .content_ident()
-                .await?
-                .path
-                .read()
-                .len()
-                .await
-                .ok()
-                .and_then(|v| *v);
-            let path = chunk_item.asset_ident().path().await?.path.clone();
-            {
-                let mut modules = modules.lock();
-                modules.push(WebpackStatsModule {
-                    name: path.clone(),
-                    id: path.clone(),
-                    chunks: chunks.iter().cloned().collect(),
-                    size,
-                });
-            }
-            Ok(())
-        })
-        .try_join()
-        .await?;
+    for (chunk_item, chunk_ids) in chunk_items {
+        // For virtual file system or other read errors, use None as size
+        // This prevents the build from failing when dealing with virtual files
+        let size = chunk_item
+            .content_ident()
+            .await?
+            .path
+            .read()
+            .len()
+            .await
+            .ok()
+            .and_then(|v| *v);
+        let path = chunk_item.asset_ident().path().await?.path.clone();
+        modules.push(WebpackStatsModule {
+            name: path.clone(),
+            id: path.clone(),
+            chunks: chunk_ids.iter().cloned().collect(),
+            size,
+        });
+    }
 
     Ok(WebpackStats {
-        assets: Arc::into_inner(assets).unwrap().into_inner(),
-        entrypoints: Arc::into_inner(entrypoints).unwrap().into_inner(),
-        chunks: Arc::into_inner(chunks).unwrap().into_inner(),
-        modules: Arc::into_inner(modules).unwrap().into_inner(),
-    }
-    .cell())
+        assets,
+        entrypoints,
+        chunks,
+        modules,
+    })
 }
 
 fn remove_extension_from_str(filename: &str) -> &str {

--- a/crates/pack-tests/tests/snapshot/async_chunk/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/async_chunk/output/stats.json
@@ -2,6 +2,30 @@
   "assets": [
     {
       "type": "asset",
+      "name": "main.js",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "main.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js",
+      "info": {},
+      "size": 1092,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+      ]
+    },
+    {
+      "type": "asset",
       "name": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js.map",
       "info": {},
       "size": 0,
@@ -10,6 +34,18 @@
       "cached": false,
       "chunks": [
         "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js",
+      "info": {},
+      "size": 797,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
       ]
     },
     {
@@ -34,42 +70,6 @@
       "cached": false,
       "chunks": [
         "main.js.map"
-      ]
-    },
-    {
-      "type": "asset",
-      "name": "main.js",
-      "info": {},
-      "size": 0,
-      "emitted": false,
-      "compared_for_emit": false,
-      "cached": false,
-      "chunks": [
-        "main.js"
-      ]
-    },
-    {
-      "type": "asset",
-      "name": "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js",
-      "info": {},
-      "size": 797,
-      "emitted": false,
-      "compared_for_emit": false,
-      "cached": false,
-      "chunks": [
-        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
-      ]
-    },
-    {
-      "type": "asset",
-      "name": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js",
-      "info": {},
-      "size": 1092,
-      "emitted": false,
-      "compared_for_emit": false,
-      "cached": false,
-      "chunks": [
-        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
       ]
     }
   ],
@@ -108,11 +108,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js",
-      "size": 797,
+      "id": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js",
+      "size": 1092,
       "hash": "",
       "files": [
-        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
       ]
     },
     {
@@ -120,31 +120,15 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js",
-      "size": 1092,
+      "id": "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js",
+      "size": 797,
       "hash": "",
       "files": [
-        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
       ]
     }
   ],
   "modules": [
-    {
-      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/node_modules/foo/index.js",
-      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/node_modules/foo/index.js",
-      "chunks": [
-        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
-      ],
-      "size": 56
-    },
-    {
-      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
-      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
-      "chunks": [
-        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
-      ],
-      "size": 110
-    },
     {
       "name": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
       "id": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
@@ -170,12 +154,28 @@
       "size": 18
     },
     {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/index.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
+      ],
+      "size": 110
+    },
+    {
       "name": "crates/pack-tests/tests/snapshot/async_chunk/input/import.js",
       "id": "crates/pack-tests/tests/snapshot/async_chunk/input/import.js",
       "chunks": [
         "crates_pack-tests_tests_snapshot_async_chunk_input_4c1df917.js"
       ],
       "size": 91
+    },
+    {
+      "name": "crates/pack-tests/tests/snapshot/async_chunk/input/node_modules/foo/index.js",
+      "id": "crates/pack-tests/tests/snapshot/async_chunk/input/node_modules/foo/index.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_async_chunk_input_3b55c753.js"
+      ],
+      "size": 56
     },
     {
       "name": "crates/pack-tests/tests/snapshot/async_chunk/input/import.js",


### PR DESCRIPTION
## Summary

修复 `stats.json` 中的 assets 顺序不稳定的问题: 

https://github.com/utooland/utoo/actions/runs/19497553543/job/55803396277?pr=2320

参考了 next.js 的处理，这里先不用并发了，看 trace 这块性能差异不是很明显


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
