### PR TITLE
feat: expose serviceWorkerOptions and cwd option from project instance

### DIFF
--- a/packages/utoo-web/src/project.ts
+++ b/packages/utoo-web/src/project.ts
@@ -20,7 +20,9 @@ const ConnectedPorts = new Set<MessagePort>();
 export class Project implements ProjectEndpoint {
   #mount: Promise<void>;
 
-  private serviceWorkerOptions?: ServiceWorkerOptions;
+  public readonly serviceWorkerOptions?: ServiceWorkerOptions;
+
+  public readonly cwd: string;
 
   private remote: comlink.Remote<
     ProjectEndpoint & {
@@ -41,6 +43,7 @@ export class Project implements ProjectEndpoint {
     } = options;
 
     this.serviceWorkerOptions = serviceWorker;
+    this.cwd = cwd;
 
     const { port1, port2 } = new MessageChannel();
 

--- a/packages/utoo-web/src/project.ts
+++ b/packages/utoo-web/src/project.ts
@@ -42,8 +42,8 @@ export class Project implements ProjectEndpoint {
       logFilter,
     } = options;
 
-    this.serviceWorkerOptions = serviceWorker;
     this.cwd = cwd;
+    this.serviceWorkerOptions = serviceWorker;
 
     const { port1, port2 } = new MessageChannel();
 

--- a/packages/utoo-web/src/project.ts
+++ b/packages/utoo-web/src/project.ts
@@ -20,9 +20,9 @@ const ConnectedPorts = new Set<MessagePort>();
 export class Project implements ProjectEndpoint {
   #mount: Promise<void>;
 
-  public readonly serviceWorkerOptions?: ServiceWorkerOptions;
-
   public readonly cwd: string;
+
+  public readonly serviceWorkerOptions?: ServiceWorkerOptions;
 
   private remote: comlink.Remote<
     ProjectEndpoint & {


### PR DESCRIPTION
serviceWorkerOptions 和 cwd 导出来，方便 ai-pages 封装 sdk 时获取一些初始化时的上下文配置