### PR TITLE
fix(pack): copy assets has wrong path under stats.json

### DIFF
--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -368,10 +368,12 @@ impl Endpoint for AppEndpoint {
 
             let output_assets = if *self.project().should_create_webpack_stats().await? {
                 let output_assets_vec = output_assets.await?;
+                let dist_root = self.project().dist_root().owned().await?;
+                let dist_root_clone = dist_root.clone();
                 let webpack_stats =
-                    generate_webpack_stats(output_assets_vec.iter().copied()).await?;
+                    generate_webpack_stats(output_assets_vec.iter().copied(), dist_root).await?;
                 let stats_output = VirtualOutputAsset::new(
-                    dist_root.join("stats.json")?,
+                    dist_root_clone.join("stats.json")?,
                     AssetContent::file(
                         File::from(serde_json::to_string_pretty(&webpack_stats)?).into(),
                     ),

--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -369,11 +369,11 @@ impl Endpoint for AppEndpoint {
             let output_assets = if *self.project().should_create_webpack_stats().await? {
                 let output_assets_vec = output_assets.await?;
                 let dist_root = self.project().dist_root().owned().await?;
-                let dist_root_clone = dist_root.clone();
                 let webpack_stats =
-                    generate_webpack_stats(output_assets_vec.iter().copied(), dist_root).await?;
+                    generate_webpack_stats(output_assets_vec.iter().copied(), dist_root.clone())
+                        .await?;
                 let stats_output = VirtualOutputAsset::new(
-                    dist_root_clone.join("stats.json")?,
+                    dist_root.join("stats.json")?,
                     AssetContent::file(
                         File::from(serde_json::to_string_pretty(&webpack_stats)?).into(),
                     ),

--- a/crates/pack-api/src/webpack_stats.rs
+++ b/crates/pack-api/src/webpack_stats.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashSet;
 use tracing::instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack::css::chunk::CssChunk;
 use turbopack_browser::ecmascript::{EcmascriptBrowserChunk, EcmascriptBrowserEvaluateChunk};
 use turbopack_core::{
@@ -12,7 +13,10 @@ use turbopack_core::{
 };
 
 #[instrument(level = "info", name = "generate webpack stats", skip_all)]
-pub async fn generate_webpack_stats<I>(entry_assets: I) -> Result<WebpackStats>
+pub async fn generate_webpack_stats<I>(
+    entry_assets: I,
+    dist_root: FileSystemPath,
+) -> Result<WebpackStats>
 where
     I: IntoIterator<Item = ResolvedVc<Box<dyn OutputAsset>>>,
 {
@@ -48,7 +52,10 @@ where
 
         if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBrowserEvaluateChunk>(asset)
         {
-            let entry_path = chunk.path().await?.path.clone();
+            let entry_path_full = chunk.path().await?;
+            let entry_path = dist_root
+                .get_relative_path_to(&entry_path_full)
+                .unwrap_or_else(|| entry_path_full.path.clone());
             chunks.push(WebpackStatsChunk {
                 size: asset_len,
                 files: vec![entry_path.clone()],
@@ -72,17 +79,29 @@ where
             let entry_referenced_assets = chunk.chunks_data().await?;
             let mut entry_chunks = entry_referenced_assets
                 .iter()
-                .map(async |asset| Ok(asset.await?.path.as_str().into()))
+                .map(|asset| {
+                    let asset = *asset;
+                    async move {
+                        let chunk_data = asset.await?;
+                        // ChunkData.path is already a relative path string
+                        Ok(chunk_data.path.as_str().into())
+                    }
+                })
                 .try_join()
                 .await?;
             entry_chunks.push(entry_path.clone());
 
             let mut entry_assets_list = entry_referenced_assets
                 .iter()
-                .map(|asset| async move {
-                    Ok(WebpackStatsEntrypointAssets {
-                        name: asset.await?.path.as_str().into(),
-                    })
+                .map(|asset| {
+                    let asset = *asset;
+                    async move {
+                        let chunk_data = asset.await?;
+                        // ChunkData.path is already a relative path string
+                        Ok(WebpackStatsEntrypointAssets {
+                            name: chunk_data.path.as_str().into(),
+                        })
+                    }
                 })
                 .try_join()
                 .await?;
@@ -105,7 +124,10 @@ where
         }
 
         if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBrowserChunk>(asset) {
-            let chunk_ident = &chunk.path().await?.path;
+            let chunk_path_full = chunk.path().await?;
+            let chunk_ident = dist_root
+                .get_relative_path_to(&chunk_path_full)
+                .unwrap_or_else(|| chunk_path_full.path.clone());
             chunks.push(WebpackStatsChunk {
                 size: asset_len,
                 files: vec![chunk_ident.clone()],
@@ -127,7 +149,10 @@ where
         }
 
         if let Some(chunk) = ResolvedVc::try_downcast_type::<CssChunk>(asset) {
-            let chunk_ident = &chunk.path().await?.path;
+            let chunk_path_full = chunk.path().await?;
+            let chunk_ident = dist_root
+                .get_relative_path_to(&chunk_path_full)
+                .unwrap_or_else(|| chunk_path_full.path.clone());
             chunks.push(WebpackStatsChunk {
                 size: asset_len,
                 files: vec![chunk_ident.clone()],
@@ -136,7 +161,12 @@ where
             });
         }
 
-        let path = &asset.path().await?.path;
+        let asset_path_full = asset.path().await?;
+        let path = dist_root
+            .get_relative_path_to(&asset_path_full)
+            .unwrap_or_else(|| asset_path_full.path.clone());
+        // Remove leading "./" prefix if present
+        let path = path.strip_prefix("./").map(|s| s.into()).unwrap_or(path);
         assets.push(WebpackStatsAsset {
             ty: "asset".into(),
             name: path.clone(),

--- a/crates/pack-tests/tests/snapshot/basic/copy/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/copy/config.json
@@ -16,6 +16,7 @@
         },
        "public"
       ]
-    }
+    },
+    "stats": true
   }
 }

--- a/crates/pack-tests/tests/snapshot/basic/copy/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/basic/copy/output/stats.json
@@ -1,0 +1,161 @@
+{
+  "assets": [
+    {
+      "type": "asset",
+      "name": "logo.svg",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "logo.svg"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "ant.svg",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "ant.svg"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "reset.css",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "reset.css"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "reset2.css",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "reset2.css"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "main.js",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "main.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js",
+      "info": {},
+      "size": 309,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js.map",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "main.js.map",
+      "info": {},
+      "size": 0,
+      "emitted": false,
+      "compared_for_emit": false,
+      "cached": false,
+      "chunks": [
+        "main.js.map"
+      ]
+    }
+  ],
+  "entrypoints": {
+    "main": {
+      "name": "main",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js",
+        "main.js"
+      ],
+      "assets": [
+        {
+          "name": "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js"
+        },
+        {
+          "name": "main.js"
+        }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "main.js",
+      "size": 0,
+      "hash": "",
+      "files": [
+        "main.js"
+      ]
+    },
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js",
+      "size": 309,
+      "hash": "",
+      "files": [
+        "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "name": "crates/pack-tests/tests/snapshot/basic/copy/input/index.js",
+      "id": "crates/pack-tests/tests/snapshot/basic/copy/input/index.js",
+      "chunks": [
+        "main.js"
+      ],
+      "size": 28
+    },
+    {
+      "name": "crates/pack-tests/tests/snapshot/basic/copy/input/index.js",
+      "id": "crates/pack-tests/tests/snapshot/basic/copy/input/index.js",
+      "chunks": [
+        "crates_pack-tests_tests_snapshot_basic_copy_input_index_df61b525.js"
+      ],
+      "size": 28
+    }
+  ]
+}


### PR DESCRIPTION


## Summary

`stats.json` 中 copy 资源的路径会出现问题，之前为了处理目录的 copy，这里需要做一点适配。

这个 path 需要相对于 `dist_root` 而不是 `project_root`.

 Before:

<img width="1240" height="450" alt="image" src="https://github.com/user-attachments/assets/25200fd1-defc-44a3-a443-a8d45dc729e2" />

After:

<img width="1300" height="508" alt="image" src="https://github.com/user-attachments/assets/32386c92-38a0-4abf-b024-0a8053cf973d" />


## Test Plan

参考快照测试

同时在我本地用 ant-design-pro 模版测试过了:

<img width="1304" height="1380" alt="image" src="https://github.com/user-attachments/assets/b9eaf942-e354-4412-83b2-5cb874c67436" />
