### PR TITLE
feat(pm): configurable cache dir

### DIFF
--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -14,7 +14,7 @@ use cmd::update::update;
 use cmd::view::view;
 use cmd::{clean::clean, deps::build_workspace};
 use helper::auto_update::init_auto_update;
-use util::config::{set_legacy_peer_deps, set_omit, set_registry};
+use util::config::{set_cache_dir, set_legacy_peer_deps, set_omit, set_registry};
 use util::logger::{get_log_file_path, init_tracing, log_time, log_time_end};
 use util::save_type::{OmitType, PackageAction, SaveType, parse_save_type};
 
@@ -57,6 +57,9 @@ struct Cli {
 
     #[arg(long, global = true)]
     registry: Option<String>,
+
+    #[arg(long, global = true)]
+    cache_dir: Option<String>,
 
     #[arg(long, global = true, action = clap::ArgAction::SetTrue)]
     legacy_peer_deps: Option<bool>,
@@ -293,6 +296,9 @@ async fn async_main() -> Result<()> {
 
     // global registry
     set_registry(cli.registry).await;
+
+    // set cache directory
+    set_cache_dir(cli.cache_dir).await;
 
     // set legacy_peer_deps when set --legacy
     if cli.legacy_peer_deps == Some(true) {

--- a/crates/pm/src/util/cache.rs
+++ b/crates/pm/src/util/cache.rs
@@ -264,4 +264,73 @@ mod tests {
         assert_eq!(to_delete.len(), 0);
         Ok(())
     }
+
+    #[test]
+    fn test_get_cache_dir_uses_config() {
+        // Test that get_cache_dir delegates to config module
+        let result = get_cache_dir();
+
+        // Should return a valid path
+        assert!(result.is_absolute() || result.starts_with("~") || result.starts_with("."));
+    }
+
+    #[test]
+    fn test_get_package_versions_cache_file() {
+        let result = get_package_versions_cache_file("lodash");
+
+        // Should contain package name and versions.json
+        assert!(result.to_string_lossy().contains("lodash"));
+        assert!(result.to_string_lossy().ends_with("versions.json"));
+    }
+
+    #[test]
+    fn test_get_package_versions_cache_file_scoped() {
+        let result = get_package_versions_cache_file("@types/node");
+
+        // Should handle scoped packages correctly
+        assert!(result.to_string_lossy().contains("@types/node"));
+        assert!(result.to_string_lossy().ends_with("versions.json"));
+    }
+
+    #[test]
+    fn test_get_package_manifest_cache_file() {
+        let result = get_package_manifest_cache_file("lodash", "4.17.21");
+
+        // Should contain package name, manifests directory, and version.json
+        assert!(result.to_string_lossy().contains("lodash"));
+        assert!(result.to_string_lossy().contains("manifests"));
+        assert!(result.to_string_lossy().ends_with("4.17.21.json"));
+    }
+
+    #[test]
+    fn test_get_package_manifest_cache_file_scoped() {
+        let result = get_package_manifest_cache_file("@types/node", "18.0.0");
+
+        // Should handle scoped packages correctly
+        assert!(result.to_string_lossy().contains("@types/node"));
+        assert!(result.to_string_lossy().contains("manifests"));
+        assert!(result.to_string_lossy().ends_with("18.0.0.json"));
+    }
+
+    #[tokio::test]
+    async fn test_cache_file_structure_consistency() -> anyhow::Result<()> {
+        // Test that cache file paths are consistent
+        let pkg_name = "express";
+        let version = "4.18.2";
+
+        let versions_file = get_package_versions_cache_file(pkg_name);
+        let manifest_file = get_package_manifest_cache_file(pkg_name, version);
+
+        // Both should be under the same cache directory
+        let cache_dir = get_cache_dir();
+        assert!(versions_file.starts_with(&cache_dir));
+        assert!(manifest_file.starts_with(&cache_dir));
+
+        // Manifest should be under the same package directory as versions
+        let pkg_dir = cache_dir.join(pkg_name);
+        assert!(versions_file.starts_with(&pkg_dir));
+        assert!(manifest_file.starts_with(&pkg_dir));
+
+        Ok(())
+    }
 }

--- a/crates/pm/src/util/cache.rs
+++ b/crates/pm/src/util/cache.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use tokio::fs;
 
+use super::config;
+
 pub fn parse_pattern(pattern: &str) -> (String, String) {
     // for @scope/pkg@version
     if pattern.starts_with('@') {
@@ -83,7 +85,7 @@ pub async fn collect_matching_versions(
 }
 
 pub fn get_cache_dir() -> PathBuf {
-    dirs::home_dir().unwrap().join(".cache/nm")
+    config::get_cache_dir()
 }
 
 pub fn get_package_versions_cache_file(package_name: &str) -> PathBuf {

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -17,7 +17,6 @@ use std::os::unix::ffi::OsStrExt;
 mod linux_clone {
     use anyhow::{Context, Result};
     use std::os::unix::io::AsRawFd;
-    use std::os::unix::fs::OpenOptionsExt;
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::fs;
@@ -41,19 +40,11 @@ mod linux_clone {
     // Copy a single file using FICLONE
     async fn copy_file_with_ficlone(src: &Path, dst: &Path) -> Result<()> {
         let src_file = tokio::fs::File::open(src).await?;
-
-        // Get source file metadata to preserve permissions
         let src_metadata = src_file.metadata().await?;
-        let src_mode = src_metadata.permissions().mode();
+        let src_permissions = src_metadata.permissions();
 
-        // Create destination file with the same permissions
-        let dst_file = tokio::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(src_mode)
-            .open(dst)
-            .await?;
+        // Create destination file
+        let dst_file = tokio::fs::File::create(dst).await?;
 
         let src_fd = src_file.as_raw_fd();
         let dst_fd = dst_file.as_raw_fd();
@@ -76,26 +67,21 @@ mod linux_clone {
             return Err(anyhow::anyhow!("FICLONE not supported: {}", e));
         }
 
+        // Preserve permissions after successful copy
+        fs::set_permissions(dst, src_permissions).await?;
+
         Ok(())
     }
 
     // Copy a single file using copy_file_range
     async fn copy_file_with_range(src: &Path, dst: &Path) -> Result<()> {
         let src_file = tokio::fs::File::open(src).await?;
-
-        // Get source file metadata to preserve permissions
         let metadata = src_file.metadata().await?;
         let file_size = metadata.len() as usize;
-        let src_mode = metadata.permissions().mode();
+        let src_permissions = metadata.permissions();
 
-        // Create destination file with the same permissions
-        let dst_file = tokio::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(src_mode)
-            .open(dst)
-            .await?;
+        // Create destination file
+        let dst_file = tokio::fs::File::create(dst).await?;
 
         let src_fd = src_file.as_raw_fd();
         let dst_fd = dst_file.as_raw_fd();
@@ -120,6 +106,9 @@ mod linux_clone {
             COPY_FILE_RANGE_SUPPORTED.store(false, Ordering::Relaxed);
             return Err(anyhow::anyhow!("copy_file_range not supported: {}", e));
         }
+
+        // Preserve permissions after successful copy
+        fs::set_permissions(dst, src_permissions).await?;
 
         Ok(())
     }
@@ -154,6 +143,11 @@ mod linux_clone {
                 dst.display()
             )
         })?;
+
+        // Preserve permissions for regular copy fallback
+        let src_metadata = fs::metadata(src).await?;
+        fs::set_permissions(dst, src_metadata.permissions()).await?;
+
         Ok(())
     }
 
@@ -748,6 +742,136 @@ mod tests {
             let result =
                 linux_clone::clone_dir(temp.path().join("not_a_dir").as_ref(), &dst_dir).await;
             assert!(result.is_err());
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_fast_copy_preserves_permissions() -> Result<()> {
+            use std::os::unix::fs::PermissionsExt;
+
+            let temp = TempDir::new()?;
+            let src_dir = temp.path().join("src");
+            let dst_dir = temp.path().join("dst");
+
+            // Create source directory with an executable file
+            fs::create_dir(&src_dir).await?;
+            let src_file = src_dir.join("executable.sh");
+            fs::write(&src_file, b"#!/bin/bash\necho 'test'").await?;
+
+            // Set executable permissions (0o755)
+            let mut perms = fs::metadata(&src_file).await?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&src_file, perms).await?;
+
+            // Verify source file has correct permissions
+            let src_metadata = fs::metadata(&src_file).await?;
+            assert_eq!(src_metadata.permissions().mode() & 0o777, 0o755);
+
+            // Use clone_dir to trigger fast_copy_file path (no _hasInstallScript flag)
+            linux_clone::clone_dir(&src_dir, &dst_dir).await?;
+
+            // Verify destination file has same permissions
+            let dst_file = dst_dir.join("executable.sh");
+            let dst_metadata = fs::metadata(&dst_file).await?;
+            assert_eq!(
+                dst_metadata.permissions().mode() & 0o777,
+                0o755,
+                "Destination file should preserve executable permissions"
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_fast_copy_preserves_read_only_permissions() -> Result<()> {
+            use std::os::unix::fs::PermissionsExt;
+
+            let temp = TempDir::new()?;
+            let src_dir = temp.path().join("src");
+            let dst_dir = temp.path().join("dst");
+
+            // Create source directory with a read-only file
+            fs::create_dir(&src_dir).await?;
+            let src_file = src_dir.join("readonly.txt");
+            fs::write(&src_file, b"read only content").await?;
+
+            // Set read-only permissions (0o444)
+            let mut perms = fs::metadata(&src_file).await?.permissions();
+            perms.set_mode(0o444);
+            fs::set_permissions(&src_file, perms).await?;
+
+            // Verify source file has correct permissions
+            let src_metadata = fs::metadata(&src_file).await?;
+            assert_eq!(src_metadata.permissions().mode() & 0o777, 0o444);
+
+            // Use clone_dir to trigger fast_copy_file path
+            linux_clone::clone_dir(&src_dir, &dst_dir).await?;
+
+            // Verify destination file has same permissions
+            let dst_file = dst_dir.join("readonly.txt");
+            let dst_metadata = fs::metadata(&dst_file).await?;
+            assert_eq!(
+                dst_metadata.permissions().mode() & 0o777,
+                0o444,
+                "Destination file should preserve read-only permissions"
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_clone_dir_preserves_executable_in_subdirs() -> Result<()> {
+            use std::os::unix::fs::PermissionsExt;
+
+            let temp = TempDir::new()?;
+            let src_dir = temp.path().join("src");
+            let dst_dir = temp.path().join("dst");
+
+            // Create directory structure with executable files
+            create_test_structure(
+                &src_dir,
+                &[
+                    ("bin", None),
+                    ("bin/script.sh", Some(b"#!/bin/bash\necho 'hello'")),
+                    ("lib", None),
+                    ("lib/data.txt", Some(b"data")),
+                ],
+            )
+            .await?;
+
+            // Set executable permission on script.sh
+            let script_path = src_dir.join("bin/script.sh");
+            let mut perms = fs::metadata(&script_path).await?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).await?;
+
+            // Set read-only permission on data.txt
+            let data_path = src_dir.join("lib/data.txt");
+            let mut perms = fs::metadata(&data_path).await?.permissions();
+            perms.set_mode(0o644);
+            fs::set_permissions(&data_path, perms).await?;
+
+            // Clone directory
+            linux_clone::clone_dir(&src_dir, &dst_dir).await?;
+
+            // Verify script.sh has executable permissions
+            let dst_script = dst_dir.join("bin/script.sh");
+            let dst_script_metadata = fs::metadata(&dst_script).await?;
+            assert_eq!(
+                dst_script_metadata.permissions().mode() & 0o777,
+                0o755,
+                "Executable file should preserve permissions in subdirectories"
+            );
+
+            // Verify data.txt has correct permissions
+            let dst_data = dst_dir.join("lib/data.txt");
+            let dst_data_metadata = fs::metadata(&dst_data).await?;
+            assert_eq!(
+                dst_data_metadata.permissions().mode() & 0o777,
+                0o644,
+                "Regular file should preserve permissions in subdirectories"
+            );
 
             Ok(())
         }

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -17,6 +17,7 @@ use std::os::unix::ffi::OsStrExt;
 mod linux_clone {
     use anyhow::{Context, Result};
     use std::os::unix::io::AsRawFd;
+    use std::os::unix::fs::OpenOptionsExt;
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::fs;
@@ -40,7 +41,19 @@ mod linux_clone {
     // Copy a single file using FICLONE
     async fn copy_file_with_ficlone(src: &Path, dst: &Path) -> Result<()> {
         let src_file = tokio::fs::File::open(src).await?;
-        let dst_file = tokio::fs::File::create(dst).await?;
+
+        // Get source file metadata to preserve permissions
+        let src_metadata = src_file.metadata().await?;
+        let src_mode = src_metadata.permissions().mode();
+
+        // Create destination file with the same permissions
+        let dst_file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(src_mode)
+            .open(dst)
+            .await?;
 
         let src_fd = src_file.as_raw_fd();
         let dst_fd = dst_file.as_raw_fd();
@@ -69,13 +82,23 @@ mod linux_clone {
     // Copy a single file using copy_file_range
     async fn copy_file_with_range(src: &Path, dst: &Path) -> Result<()> {
         let src_file = tokio::fs::File::open(src).await?;
-        let dst_file = tokio::fs::File::create(dst).await?;
+
+        // Get source file metadata to preserve permissions
+        let metadata = src_file.metadata().await?;
+        let file_size = metadata.len() as usize;
+        let src_mode = metadata.permissions().mode();
+
+        // Create destination file with the same permissions
+        let dst_file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(src_mode)
+            .open(dst)
+            .await?;
 
         let src_fd = src_file.as_raw_fd();
         let dst_fd = dst_file.as_raw_fd();
-
-        let metadata = src_file.metadata().await?;
-        let file_size = metadata.len() as usize;
 
         // Use spawn_blocking to avoid blocking the async runtime
         let result = tokio::task::spawn_blocking(move || {

--- a/crates/pm/src/util/config.rs
+++ b/crates/pm/src/util/config.rs
@@ -173,6 +173,15 @@ static REGISTRY: LazyLock<ConfigValue<String>> =
 static LEGACY_PEER_DEPS: LazyLock<ConfigValue<bool>> =
     LazyLock::new(|| ConfigValue::new("legacy-peer-deps", true));
 
+static CACHE_DIR: LazyLock<ConfigValue<String>> = LazyLock::new(|| {
+    let default_cache = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".cache/nm")
+        .to_string_lossy()
+        .to_string();
+    ConfigValue::new("cache-dir", default_cache)
+});
+
 static IS_NPM_REGISTRY: OnceLock<bool> = OnceLock::new();
 
 fn is_npm_registry_url(url: &str) -> bool {
@@ -239,4 +248,27 @@ pub fn set_omit(value: HashSet<OmitType>) {
 
 pub fn get_omit() -> HashSet<OmitType> {
     OMIT.get().cloned().unwrap_or_default()
+}
+
+pub async fn set_cache_dir(cache_dir: Option<String>) {
+    // Priority: CLI argument > UTOO_CACHE_DIR env > config > default
+    let final_cache_dir = if let Some(dir) = cache_dir {
+        Some(dir)
+    } else if let Ok(env_dir) = std::env::var("UTOO_CACHE_DIR")
+        && !env_dir.is_empty()
+    {
+        Some(env_dir)
+    } else {
+        // Read from config file if no CLI arg or env var
+        Config::load(false)
+            .await
+            .ok()
+            .and_then(|config| config.get("cache-dir").ok().flatten())
+    };
+
+    CACHE_DIR.set(final_cache_dir);
+}
+
+pub fn get_cache_dir() -> PathBuf {
+    PathBuf::from(CACHE_DIR.get_sync())
 }

--- a/crates/pm/src/util/config.rs
+++ b/crates/pm/src/util/config.rs
@@ -272,3 +272,66 @@ pub async fn set_cache_dir(cache_dir: Option<String>) {
 pub fn get_cache_dir() -> PathBuf {
     PathBuf::from(CACHE_DIR.get_sync())
 }
+
+#[cfg(test)]
+mod cache_dir_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_cache_dir_default() {
+        // Test default cache directory
+        let default_cache = dirs::home_dir()
+            .unwrap()
+            .join(".cache/nm")
+            .to_string_lossy()
+            .to_string();
+
+        // Create a fresh ConfigValue to simulate first access
+        let cache_config = ConfigValue::new("cache-dir", default_cache.clone());
+        let result = cache_config.get_sync();
+
+        assert_eq!(result, default_cache);
+    }
+
+    #[test]
+    fn test_config_value_parser_string() {
+        let config = ConfigValue::new("test-key", "default-value".to_string());
+        let parsed = config.parse_config_value("custom-value");
+        assert_eq!(parsed, "custom-value");
+    }
+
+    #[test]
+    fn test_config_value_parser_bool() {
+        let config = ConfigValue::new("test-bool", false);
+        assert!(config.parse_config_value("true"));
+        assert!(config.parse_config_value("TRUE"));
+        assert!(config.parse_config_value("True"));
+        assert!(!config.parse_config_value("false"));
+        assert!(!config.parse_config_value("anything"));
+    }
+
+    #[tokio::test]
+    async fn test_cache_dir_from_config_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let config_path = temp_dir.path().join("config.toml");
+
+        // Create a config file with cache-dir setting
+        let custom_path = "/tmp/config-cache-test";
+        let config_content = format!(
+            r#"
+[values]
+cache-dir = "{}"
+"#,
+            custom_path
+        );
+        std::fs::write(&config_path, config_content)?;
+
+        // Load config from file
+        let config = Config::load_from_path(&config_path).await?;
+        let cache_dir = config.get("cache-dir")?.unwrap();
+
+        assert_eq!(cache_dir, custom_path);
+        Ok(())
+    }
+}


### PR DESCRIPTION
1. Added new `cache_dir` configuration to support custom global storage path
2. Fixed permission issue when `fast-copy` fails across filesystems
