### PR TITLE
fix(pack): rollback to ipc loader pool

### DIFF
--- a/crates/pack-napi/Cargo.toml
+++ b/crates/pack-napi/Cargo.toml
@@ -86,7 +86,7 @@ turbopack                         = { workspace = true }
 turbopack-core                    = { workspace = true }
 turbopack-ecmascript-hmr-protocol = { workspace = true }
 turbopack-ecmascript-plugins      = { workspace = true, optional = true }
-turbopack-node                    = { workspace = true, default-features = false, features = ["worker_pool"] }
+turbopack-node                    = { workspace = true, default-features = false, features = ["process_pool"] }
 turbopack-trace-server            = { workspace = true }
 turbopack-trace-utils             = { workspace = true }
 

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -447,7 +447,8 @@ pub async fn project_shutdown(
 ) {
     project.turbo_tasks.stop_and_wait().await;
     project_on_exit_internal(&project).await;
-    turbopack_node::worker_pool::shutdown();
+    // FIXME
+    // turbopack_node::worker_pool::shutdown();
 }
 
 #[napi(object)]


### PR DESCRIPTION
The `worker_threads` pool causes forever hanging now.