### PR TITLE
feat(wasm): add decodeURIComponent in sw proxy

### DIFF
--- a/packages/utoo-web/src/serviceWorker.ts
+++ b/packages/utoo-web/src/serviceWorker.ts
@@ -34,7 +34,8 @@ self.addEventListener("message", (event) => {
 
 self.addEventListener("fetch", async (event: FetchEvent) => {
   await _promise;
-  const { url, referrer } = event.request;
+  let { url, referrer } = event.request;
+  url = decodeURIComponent(url);
   if (
     new URL(url).pathname.startsWith(_serviceWorkerScope) ||
     (referrer && new URL(referrer).pathname.startsWith(_serviceWorkerScope))


### PR DESCRIPTION
This is useful for when using `@utoo/web` in different browser tabs with a same `cwd` but fetch resources with `../`. 
We can encode to `../` to `..%2F`