### PR TITLE
fix(pack): copy should enable pass not found directory

### DIFF
--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -1190,10 +1190,8 @@ impl Project {
                         assets.push(ResolvedVc::upcast(asset.to_resolved().await?));
                     }
                     _ => {
-                        return Err(anyhow::anyhow!(
-                            "Unsupported entry type for copy: {:?}",
-                            entry_type
-                        ));
+                        // skip
+                        continue;
                     }
                 }
             }

--- a/crates/pack-tests/tests/snapshot/basic/copy/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/copy/config.json
@@ -14,7 +14,8 @@
           "from": "./input/reset.css",
           "to": "./reset.css"
         },
-       "public"
+       "public",
+       "not_found_directory"
       ]
     },
     "stats": true


### PR DESCRIPTION
## Summary

output.copy 如果传一个找不到的文件，直接 skip 掉，直接的处理 panic 了.


## Test Plan

添加了一个小的测试
