### PR TITLE
chore: adjust hmr events tracing from info to debug

### DIFF
--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -571,6 +571,7 @@ pub fn project_entrypoints_subscribe(
     )
 }
 
+#[tracing::instrument(level = "debug", name = "get HMR events", skip(project, func))]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_hmr_events(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -617,10 +618,6 @@ pub fn project_hmr_events(
                     }
                     Ok((Some(update.clone()), issues.clone(), diagnostics.clone()))
                 }
-                .instrument(tracing::info_span!(
-                    "HMR subscription",
-                    identifier = %outer_identifier
-                ))
             }
         },
         move |ctx| {


### PR DESCRIPTION
## Summary

Before:

<img width="2580" height="1744" alt="image" src="https://github.com/user-attachments/assets/d58da4de-a468-4806-8de7-88724d42ee2d" />


After:

<img width="2468" height="728" alt="image" src="https://github.com/user-attachments/assets/57a7a79c-e4a7-4de6-8b8e-09d47ff62bf5" />


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
