### PR TITLE
feat(webpackCompat): compat define object config

### DIFF
--- a/packages/pack/src/webpackCompat.ts
+++ b/packages/pack/src/webpackCompat.ts
@@ -159,7 +159,21 @@ function compatFromWebpackPlugin<R>(
 
 compatDefine.pluginName = "DefinePlugin";
 function compatDefine(maybeWebpackPluginInstance: MaybeWebpackPluginInstance) {
-  return maybeWebpackPluginInstance?.definitions;
+  const definitions = maybeWebpackPluginInstance?.definitions;
+  if (!definitions || typeof definitions !== "object") {
+    return definitions;
+  }
+
+  const processedDefinitions: Record<string, any> = {};
+  for (const [key, value] of Object.entries(definitions)) {
+    if (typeof value === "object" && value !== null) {
+      processedDefinitions[key] = JSON.stringify(value);
+    } else {
+      processedDefinitions[key] = value;
+    }
+  }
+
+  return processedDefinitions;
 }
 
 function compatExternals(


### PR DESCRIPTION
## Summary

在 webpack 配置适配模式下，添加一下 define 的处理，假设用户传递进来的 define 配置如下:

```ts
enum WorkspaceResourceEnum {
  CARD = 'card',
  RUNTIME_CONFIG = 'runtime_config',
  MEMBER = 'member',
  KNOWLEDGE = 'knowledge',
}

export default defineConfig({
  define: {
    WorkspaceResourceEnum: WorkspaceResourceEnum
  }
})
```

这种 object 写法在 turbopack 那边是没办法处理的，需要把这个 case JSON.stringify。

参考 utoopack 在 umi 框架对 process.env 这个 define 做的处理: https://github.com/umijs/umi/blob/master/packages/bundler-utoopack/src/config.ts#L14

这里对其他的 case 做一下统一的适配。


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
