### PR TITLE
fix(pack): function :global() transform error under css modules

### DIFF
--- a/crates/pack-tests/tests/snapshot/style/css_modules/input/normal_css_modules/style.module.css
+++ b/crates/pack-tests/tests/snapshot/style/css_modules/input/normal_css_modules/style.module.css
@@ -6,4 +6,4 @@
 .title {
   color: #333;
   font-size: 24px;
-} 
+}

--- a/crates/pack-tests/tests/snapshot/style/css_modules/input/normal_css_modules/style.module.less
+++ b/crates/pack-tests/tests/snapshot/style/css_modules/input/normal_css_modules/style.module.less
@@ -7,3 +7,16 @@
   border: none;
   border-radius: 4px;
 }
+
+.message {
+  color: red;
+  &:global(.left) {
+      .message-main, .message-context {
+          font-size: 15px;
+      }
+  }
+
+  :global(.right) {
+    font-size: 16px;
+  }
+}

--- a/crates/pack-tests/tests/snapshot/style/css_modules/output/crates_pack-tests_tests_snapshot_style_css_modules_input_317327a4.js
+++ b/crates/pack-tests/tests/snapshot/style/css_modules/output/crates_pack-tests_tests_snapshot_style_css_modules_input_317327a4.js
@@ -41,6 +41,7 @@ __turbopack_context__.v({
 
 __turbopack_context__.v({
   "button": "style-module-less-module__n1Cx1q__button",
+  "message": "style-module-less-module__n1Cx1q__message",
 });
 }),
 565, ((__turbopack_context__) => {

--- a/crates/pack-tests/tests/snapshot/style/css_modules/output/crates_pack-tests_tests_snapshot_style_css_modules_input_db4c60c6.css
+++ b/crates/pack-tests/tests/snapshot/style/css_modules/output/crates_pack-tests_tests_snapshot_style_css_modules_input_db4c60c6.css
@@ -60,6 +60,18 @@
   padding: 10px 20px;
 }
 
+.style-module-less-module__n1Cx1q__message {
+  color: red;
+}
+
+.style-module-less-module__n1Cx1q__message:global(.left) .message-main, .style-module-less-module__n1Cx1q__message:global(.left) .message-context {
+  font-size: 15px;
+}
+
+.style-module-less-module__n1Cx1q__message :global(.right) {
+  font-size: 16px;
+}
+
 /* [project]/crates/pack-tests/tests/snapshot/style/css_modules/input/normal_css_modules/style.module.sass.module.css [client] (css) */
 .style-module-sass-module__qgbigG__card {
   border-radius: 8px;


### PR DESCRIPTION
## Summary

修复一下 `:global()` 在 nested css、nested less 下的 transform 行为。

主要应该是 lightning-css 侧的改动。

目前先添加了测试。


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
