### PR TITLE
fix(wasm): loaders resoultion

### DIFF
--- a/crates/utoo-wasm/src/errors.rs
+++ b/crates/utoo-wasm/src/errors.rs
@@ -1,0 +1,8 @@
+use wasm_bindgen::prelude::*;
+
+pub fn to_js_error<E>(e: E) -> JsError
+where
+    E: Into<anyhow::Error>,
+{
+    JsError::new(&format!("{:#?}", e.into()))
+}

--- a/crates/utoo-wasm/src/lib.rs
+++ b/crates/utoo-wasm/src/lib.rs
@@ -21,6 +21,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(feature = "utoo-pack")]
 pub(crate) mod pack;
 
+pub(crate) mod errors;
 #[cfg(feature = "utoo-pack")]
 mod opfs_offload;
 mod project;

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -10,6 +10,7 @@ use tokio_fs_ext::{DirEntry as RawDirEntry, Metadata as RawMetadata};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 
+use crate::errors::to_js_error;
 use crate::tokio_runtime::init_tokio_runtime;
 
 #[cfg(feature = "utoo-pack")]
@@ -70,8 +71,7 @@ impl Project {
             .map(|f| PackFile::new(f.path, f.content))
             .collect();
 
-        let bytes =
-            opfs_project::pack::gzip(&pack_files).map_err(|e| JsError::new(&e.to_string()))?;
+        let bytes = opfs_project::pack::gzip(&pack_files).map_err(to_js_error)?;
         Ok(js_sys::Uint8Array::from(&bytes[..]))
     }
 
@@ -86,7 +86,7 @@ impl Project {
         opfs_project::package_manager::install_deps(&package_lock, max_concurrent)
             .await
             // format anyhow backtrace for better error display in JS
-            .map_err(|e| JsError::new(&format!("{:#?}", e)))?;
+            .map_err(to_js_error)?;
         Ok(())
     }
 
@@ -95,9 +95,7 @@ impl Project {
     pub async fn build(&self) -> Result<JsValue, JsError> {
         use turbopack_core::error::PrettyPrintError;
 
-        self.init_pack_project()
-            .await
-            .map_err(|e| JsError::new(&PrettyPrintError(&e).to_string()))?;
+        self.init_pack_project().await.map_err(to_js_error)?;
 
         let pack_project = match self.pack_project.read().as_ref() {
             Some(pack_project) => pack_project.clone(),
@@ -111,9 +109,9 @@ impl Project {
                     .spawn(async move { pack_project.build().await })
             })
             .await
-            .map_err(JsError::from)?
+            .map_err(to_js_error)?
             .map_or_else(
-                |e| Err(JsError::new(&PrettyPrintError(&e).to_string())),
+                |e| Err(to_js_error(e)),
                 |turbopack_result| {
                     use serde::Serialize;
 
@@ -121,7 +119,7 @@ impl Project {
                         .serialize(
                             &serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true),
                         )
-                        .map_err(JsError::from)
+                        .map_err(|e| JsError::new(&e.to_string()))
                 },
             )
     }
@@ -178,12 +176,18 @@ impl Project {
 
     #[wasm_bindgen]
     pub async fn read(&self, path: &str) -> Result<Vec<u8>, JsError> {
-        opfs_project::read(path).await.map_err(JsError::from)
+        opfs_project::read(path)
+            .await
+            .with_context(|| format!("Failed to read file: {}", path))
+            .map_err(to_js_error)
     }
 
     #[wasm_bindgen(js_name = readToString)]
     pub async fn read_to_string(&self, path: &str) -> Result<String, JsError> {
-        let buf = opfs_project::read(path).await.map_err(JsError::from)?;
+        let buf = opfs_project::read(path)
+            .await
+            .with_context(|| format!("Failed to read file: {}", path))
+            .map_err(to_js_error)?;
         Ok(unsafe { String::from_utf8_unchecked(buf) })
     }
 
@@ -191,7 +195,8 @@ impl Project {
     pub async fn write(&self, path: &str, content: &[u8]) -> Result<(), JsError> {
         opfs_project::write(path, content)
             .await
-            .map_err(JsError::from)?;
+            .with_context(|| format!("Failed to write file: {}", path))
+            .map_err(to_js_error)?;
         Ok(())
     }
 
@@ -199,19 +204,24 @@ impl Project {
     pub async fn write_string(&self, path: &str, content: &str) -> Result<(), JsError> {
         opfs_project::write(path, content)
             .await
-            .map_err(JsError::from)?;
+            .with_context(|| format!("Failed to write file: {}", path))
+            .map_err(to_js_error)?;
         Ok(())
     }
 
     #[wasm_bindgen(js_name = readDir)]
     pub async fn read_dir(&self, path: &str) -> Result<Vec<DirEntry>, JsError> {
-        let read_dir = opfs_project::read_dir(path).await.map_err(JsError::from)?;
+        let read_dir = opfs_project::read_dir(path)
+            .await
+            .with_context(|| format!("Failed to read directory: {}", path))
+            .map_err(to_js_error)?;
 
         let ret = read_dir
             .into_iter()
             .map(DirEntry::try_from)
             .collect::<Result<Vec<_>, std::io::Error>>()
-            .map_err(JsError::from)?;
+            .with_context(|| format!("Failed to process directory entries: {}", path))
+            .map_err(to_js_error)?;
 
         Ok(ret)
     }
@@ -220,7 +230,8 @@ impl Project {
     pub async fn create_dir(&self, path: &str) -> Result<(), JsError> {
         opfs_project::create_dir(path)
             .await
-            .map_err(JsError::from)?;
+            .with_context(|| format!("Failed to create directory: {}", path))
+            .map_err(to_js_error)?;
         Ok(())
     }
 
@@ -228,13 +239,17 @@ impl Project {
     pub async fn create_dir_all(&self, path: &str) -> Result<(), JsError> {
         opfs_project::create_dir_all(path)
             .await
-            .map_err(JsError::from)?;
+            .with_context(|| format!("Failed to create directory recursively: {}", path))
+            .map_err(to_js_error)?;
         Ok(())
     }
 
     #[wasm_bindgen(js_name = copyFile)]
     pub async fn copy_file(&self, src: &str, dst: &str) -> Result<(), JsError> {
-        opfs_project::copy(src, dst).await.map_err(JsError::from)?;
+        opfs_project::copy(src, dst)
+            .await
+            .with_context(|| format!("Failed to copy file from {} to {}", src, dst))
+            .map_err(to_js_error)?;
         Ok(())
     }
 
@@ -242,7 +257,8 @@ impl Project {
     pub async fn remove_file(&self, path: &str) -> Result<(), JsError> {
         opfs_project::remove_file(path)
             .await
-            .map_err(JsError::from)?;
+            .with_context(|| format!("Failed to remove file: {}", path))
+            .map_err(to_js_error)?;
         Ok(())
     }
 
@@ -251,11 +267,13 @@ impl Project {
         if recursive {
             opfs_project::remove_dir_all(path)
                 .await
-                .map_err(JsError::from)?;
+                .with_context(|| format!("Failed to remove directory recursively: {}", path))
+                .map_err(to_js_error)?;
         } else {
             opfs_project::remove_dir(path)
                 .await
-                .map_err(JsError::from)?;
+                .with_context(|| format!("Failed to remove directory: {}", path))
+                .map_err(to_js_error)?;
         }
 
         Ok(())
@@ -266,7 +284,8 @@ impl Project {
         opfs_project::metadata(path)
             .await
             .and_then(Metadata::try_from)
-            .map_err(JsError::from)
+            .with_context(|| format!("Failed to get metadata: {}", path))
+            .map_err(to_js_error)
     }
 }
 
@@ -309,8 +328,9 @@ impl TryFrom<RawDirEntry> for DirEntry {
 #[wasm_bindgen(inspectable)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Metadata {
-    r#type: DirEntryType,
-    file_size: u64,
+    #[wasm_bindgen]
+    pub r#type: DirEntryType,
+    pub file_size: u64,
 }
 
 impl TryFrom<RawMetadata> for Metadata {

--- a/packages/utoo-web/src/sabcom.ts
+++ b/packages/utoo-web/src/sabcom.ts
@@ -10,6 +10,7 @@ export const SAB_OP_MKDIR = 4;
 export const SAB_OP_RM = 5;
 export const SAB_OP_RMDIR = 6;
 export const SAB_OP_COPY_FILE = 7;
+export const SAB_OP_STAT = 8;
 
 // Layout:
 // 0: State (Int32)
@@ -146,6 +147,9 @@ export const handleSabRequest = async (
       const { src, dst } = JSON.parse(path);
       await fs.copyFile(src, dst);
       sabHost.writeResponse("ok");
+    } else if (op === SAB_OP_STAT) {
+      const metadata = await fs.metadata(path);
+      sabHost.writeResponse(JSON.stringify(metadata));
     } else {
       sabHost.writeError("Unknown op");
     }

--- a/packages/utoo-web/src/serviceWorker.ts
+++ b/packages/utoo-web/src/serviceWorker.ts
@@ -70,7 +70,7 @@ async function readFileFromProject(projectPath: string): Promise<Response> {
       headers: {
         "Content-Type": mimeType,
         ...(mimeType === "text/html"
-          ? { "Cross-Origin-Embedder-Policy": "require-corp" }
+          ? { "Cross-Origin-Embedder-Policy": "credentialless" }
           : {}),
       },
     });

--- a/packages/utoo-web/src/utoo/index.d.ts
+++ b/packages/utoo-web/src/utoo/index.d.ts
@@ -43,6 +43,8 @@ export class Metadata {
   toString(): string;
   free(): void;
   [Symbol.dispose](): void;
+  type: DirEntryType;
+  file_size: bigint;
 }
 export class Project {
   free(): void;
@@ -106,10 +108,14 @@ export interface InitOutput {
   readonly __wbg_direntry_free: (a: number, b: number) => void;
   readonly __wbg_get_direntry_name: (a: number) => [number, number];
   readonly __wbg_get_direntry_type: (a: number) => number;
+  readonly __wbg_get_metadata_file_size: (a: number) => bigint;
+  readonly __wbg_get_metadata_type: (a: number) => number;
   readonly __wbg_metadata_free: (a: number, b: number) => void;
   readonly __wbg_project_free: (a: number, b: number) => void;
   readonly __wbg_set_direntry_name: (a: number, b: number, c: number) => void;
   readonly __wbg_set_direntry_type: (a: number, b: number) => void;
+  readonly __wbg_set_metadata_file_size: (a: number, b: bigint) => void;
+  readonly __wbg_set_metadata_type: (a: number, b: number) => void;
   readonly project_build: (a: number) => any;
   readonly project_copyFile: (a: number, b: number, c: number, d: number, e: number) => any;
   readonly project_createDir: (a: number, b: number, c: number) => any;
@@ -166,13 +172,13 @@ export interface InitOutput {
   readonly __wbindgen_export_7: WebAssembly.Table;
   readonly __externref_drop_slice: (a: number, b: number) => void;
   readonly __externref_table_dealloc: (a: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__h2ce973260553dde0: (a: number, b: number) => void;
-  readonly closure115_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure114980_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure117532_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure114991_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure113_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure114994_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure117543_externref_shim: (a: number, b: number, c: any) => void;
   readonly wasm_bindgen__convert__closures_____invoke__heac94dfe74335608: (a: number, b: number) => void;
-  readonly closure114983_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure117662_externref_shim: (a: number, b: number, c: any, d: any) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h2ce973260553dde0: (a: number, b: number) => void;
+  readonly closure117673_externref_shim: (a: number, b: number, c: any, d: any) => void;
   readonly __wbindgen_thread_destroy: (a?: number, b?: number, c?: number) => void;
   readonly __wbindgen_start: (a: number) => void;
 }

--- a/packages/utoo-web/src/webpackLoaders/worker/cjs.ts
+++ b/packages/utoo-web/src/webpackLoaders/worker/cjs.ts
@@ -171,16 +171,6 @@ const loadModule = (
     let searchPaths = searchPathsCache[context];
     if (!searchPaths) {
       searchPaths = [];
-      // @ts-ignore
-      const cwd = self.process?.cwd?.() || self.workerData?.cwd || "/";
-      const isInsideNodeModules =
-        context.includes("/node_modules/") ||
-        context.includes("\\node_modules\\");
-
-      if (isInsideNodeModules) {
-        searchPaths.push(path.join(cwd, "node_modules"));
-      }
-
       let currentDir = context;
       while (true) {
         if (path.basename(currentDir) !== "node_modules") {
@@ -220,10 +210,14 @@ const loadModule = (
             ];
             for (const candidate of candidates) {
               if (existsSync(candidate) && !statSync(candidate).isDirectory()) {
-                resolvedId = candidate;
-                moduleCode = fs.readFileSync(candidate, "utf8") as string;
-                moduleId = candidate;
-                break;
+                try {
+                  resolvedId = candidate;
+                  moduleCode = fs.readFileSync(candidate, "utf8") as string;
+                  moduleId = candidate;
+                  break;
+                } catch (e) {
+                  // ignore
+                }
               }
             }
           }
@@ -235,10 +229,14 @@ const loadModule = (
         for (const ext of extensions) {
           const p = nodeModulesPath + ext;
           if (existsSync(p) && !statSync(p).isDirectory()) {
-            resolvedId = p;
-            moduleCode = fs.readFileSync(p, "utf8") as string;
-            moduleId = p;
-            break;
+            try {
+              resolvedId = p;
+              moduleCode = fs.readFileSync(p, "utf8") as string;
+              moduleId = p;
+              break;
+            } catch (e) {
+              // ignore
+            }
           }
         }
       }
@@ -261,10 +259,14 @@ const loadModule = (
     for (const ext of extensions) {
       const p = relativeId + ext;
       if (existsSync(p) && !statSync(p).isDirectory()) {
-        resolvedId = p; // Use relative path for FS ops
-        moduleCode = fs.readFileSync(p, "utf8") as string;
-        moduleId = id; // Keep original absolute path as module ID
-        break;
+        try {
+          resolvedId = p; // Use relative path for FS ops
+          moduleCode = fs.readFileSync(p, "utf8") as string;
+          moduleId = id; // Keep original absolute path as module ID
+          break;
+        } catch (e) {
+          // ignore
+        }
       }
     }
   }
@@ -275,10 +277,15 @@ const loadModule = (
     for (const ext of extensions) {
       const p = resolvedId + ext;
       if (existsSync(p) && !statSync(p).isDirectory()) {
-        resolvedId = p;
-        moduleCode = fs.readFileSync(p, "utf8") as string;
-        moduleId = p;
-        break;
+        try {
+          resolvedId = p;
+          moduleCode = fs.readFileSync(p, "utf8") as string;
+          moduleId = p;
+          break;
+        } catch (e) {
+          console.error(`[Debug] Failed to read file ${p}:`, e);
+          // ignore
+        }
       }
     }
   }
@@ -290,7 +297,7 @@ const loadModule = (
   }
 
   console.error(
-    `Worker: Dependency ${id} (resolved: ${resolvedId}) not found.`,
+    `Worker: Dependency ${id} (resolved: ${resolvedId}) not found. Context: ${context}`,
   );
   return {};
 };


### PR DESCRIPTION
This pull request improves error handling and robustness across the Rust WASM backend and the web frontend, especially in file system operations and module loading. The main changes include centralizing error formatting for JS interop in Rust, enhancing error context in file operations, adding new stat support in the web worker protocol, and making module resolution more resilient to file read errors.

**Rust WASM backend improvements:**

* Centralized JS error conversion: Added a `to_js_error` helper in `errors.rs` for consistent and detailed error formatting when converting Rust errors to `JsError` for JS interop, and refactored all error handling in `project.rs` to use this helper. This also includes adding contextual messages for file and directory operations to improve debugging. [[1]](diffhunk://#diff-3bcf1b0dc9028ccb2a41d2e1281f80960e8340347b21bacca871bb7fd385d729R1-R8) [[2]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdR13) [[3]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL73-R74) [[4]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL89-R89) [[5]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL98-R98) [[6]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL114-R122) [[7]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL181-R224) [[8]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL223-R261) [[9]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL254-R276) [[10]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL269-R288)
* Metadata struct improvements: Made the fields of the `Metadata` struct public and annotated them for JS access, improving compatibility with JS consumers.

**Web worker protocol and file system:**

* Added stat operation: Introduced `SAB_OP_STAT` to the shared array buffer protocol and implemented stat handling in `handleSabRequest`, enabling the frontend to query file metadata. [[1]](diffhunk://#diff-1623cc16ba9f246733e7439b3ae37f30762d01eab140c38a18c33a83e8b0fdf9R13) [[2]](diffhunk://#diff-1623cc16ba9f246733e7439b3ae37f30762d01eab140c38a18c33a83e8b0fdf9R150-R152)
* Changed COEP header in service worker: Updated the `Cross-Origin-Embedder-Policy` from `require-corp` to `credentialless` for HTML responses, aligning with modern browser requirements.

**Module resolution robustness:**

* Improved error handling in module loading: Wrapped file read operations in try-catch blocks during module resolution to prevent crashes if a file cannot be read, and enhanced debug logging for missing dependencies. Also, removed unused logic for determining node_modules search paths. [[1]](diffhunk://#diff-2643f66eb3b4b583073b4f450433e30a7f05efafea0db4fc6014735c4af9dd2dL174-L183) [[2]](diffhunk://#diff-2643f66eb3b4b583073b4f450433e30a7f05efafea0db4fc6014735c4af9dd2dR213-R220) [[3]](diffhunk://#diff-2643f66eb3b4b583073b4f450433e30a7f05efafea0db4fc6014735c4af9dd2dR232-R239) [[4]](diffhunk://#diff-2643f66eb3b4b583073b4f450433e30a7f05efafea0db4fc6014735c4af9dd2dR262-R269) [[5]](diffhunk://#diff-2643f66eb3b4b583073b4f450433e30a7f05efafea0db4fc6014735c4af9dd2dR280-R288) [[6]](diffhunk://#diff-2643f66eb3b4b583073b4f450433e30a7f05efafea0db4fc6014735c4af9dd2dL293-R300)