### PR TITLE
perf(wasm): comlink transfer

### DIFF
--- a/packages/utoo-web/package.json
+++ b/packages/utoo-web/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@utoo/pack-shared": "^0.0.7",
-    "buffer-backed-object": "^1.0.1",
     "comlink": "^4.4.2",
     "micromatch": "^4.0.8",
     "systemjs": "^6.15.1"

--- a/packages/utoo-web/src/internalProject.ts
+++ b/packages/utoo-web/src/internalProject.ts
@@ -1,3 +1,4 @@
+import * as comlink from "comlink";
 import {
   Binding,
   PackFile,
@@ -66,6 +67,7 @@ class InternalEndpoint implements ProjectEndpoint {
       ret = await ProjectInternal.readToString(path);
     } else {
       ret = await ProjectInternal.read(path);
+      return comlink.transfer(ret, [ret.buffer]);
     }
     return ret as any;
   }
@@ -148,7 +150,8 @@ class InternalEndpoint implements ProjectEndpoint {
 
   async gzip(files: PackFile[]) {
     await this.wasmInit!;
-    return await ProjectInternal.gzip(files);
+    const ret = await ProjectInternal.gzip(files);
+    return comlink.transfer(ret, [ret.buffer]);
   }
 
   async sigMd5(content: Uint8Array) {

--- a/packages/utoo-web/src/project.ts
+++ b/packages/utoo-web/src/project.ts
@@ -119,6 +119,13 @@ export class Project implements ProjectEndpoint {
     encoding?: "utf8",
   ) {
     await this.#mount;
+    if (content instanceof Uint8Array) {
+      return await this.remote.writeFile(
+        path,
+        comlink.transfer(content, [content.buffer]),
+        encoding,
+      );
+    }
     return await this.remote.writeFile(path, content, encoding);
   }
 
@@ -162,12 +169,15 @@ export class Project implements ProjectEndpoint {
 
   public async gzip(files: PackFile[]): Promise<Uint8Array> {
     await this.#mount;
-    return await this.remote.gzip(files);
+    const buffers = files.map((f) => f.content.buffer);
+    return await this.remote.gzip(comlink.transfer(files, buffers));
   }
 
   public async sigMd5(content: Uint8Array): Promise<string> {
     await this.#mount;
-    return await this.remote.sigMd5(content);
+    return await this.remote.sigMd5(
+      comlink.transfer(content, [content.buffer]),
+    );
   }
 
   public static fork(

--- a/packages/utoo-web/src/sabcom.ts
+++ b/packages/utoo-web/src/sabcom.ts
@@ -1,10 +1,3 @@
-import {
-  BigUint64,
-  BufferBackedObject,
-  Float64,
-  Uint8,
-} from "buffer-backed-object";
-
 export const SAB_STATE_IDLE = 0;
 export const SAB_STATE_REQUEST = 1;
 export const SAB_STATE_RESPONSE = 2;
@@ -22,14 +15,21 @@ export const SAB_OP_STAT = 8;
 export const STAT_TYPE_FILE = 0;
 export const STAT_TYPE_DIR = 1;
 
-const StatDescriptor = {
-  type: Uint8(),
-  size: BigUint64(),
-  atimeMs: Float64(),
-  mtimeMs: Float64(),
-  ctimeMs: Float64(),
-  birthtimeMs: Float64(),
-};
+// Stat struct layout (starts at byte 12)
+// type: Uint8 (1 byte) -> offset 0
+// padding: 7 bytes
+// size: BigUint64 (8 bytes) -> offset 8
+// atimeMs: Float64 (8 bytes) -> offset 16
+// mtimeMs: Float64 (8 bytes) -> offset 24
+// ctimeMs: Float64 (8 bytes) -> offset 32
+// birthtimeMs: Float64 (8 bytes) -> offset 40
+
+const STAT_OFFSET_TYPE = 0;
+const STAT_OFFSET_SIZE = 8;
+const STAT_OFFSET_ATIME = 16;
+const STAT_OFFSET_MTIME = 24;
+const STAT_OFFSET_CTIME = 32;
+const STAT_OFFSET_BIRTHTIME = 40;
 
 // Layout:
 // 0: State (Int32)
@@ -40,14 +40,12 @@ const StatDescriptor = {
 export class SabComHost {
   private int32: Int32Array;
   private uint8: Uint8Array;
-  public statStruct: any;
+  private dataView: DataView;
 
   constructor(private sab: SharedArrayBuffer) {
     this.int32 = new Int32Array(sab);
     this.uint8 = new Uint8Array(sab);
-    this.statStruct = BufferBackedObject(sab as any, StatDescriptor, {
-      byteOffset: 12,
-    });
+    this.dataView = new DataView(sab);
   }
 
   readRequest() {
@@ -76,7 +74,22 @@ export class SabComHost {
     Atomics.notify(this.int32, 0);
   }
 
-  writeStatResponse() {
+  writeStat(
+    type: number,
+    size: bigint,
+    atimeMs: number,
+    mtimeMs: number,
+    ctimeMs: number,
+    birthtimeMs: number,
+  ) {
+    const base = 12;
+    this.dataView.setUint8(base + STAT_OFFSET_TYPE, type);
+    this.dataView.setBigUint64(base + STAT_OFFSET_SIZE, size, true);
+    this.dataView.setFloat64(base + STAT_OFFSET_ATIME, atimeMs, true);
+    this.dataView.setFloat64(base + STAT_OFFSET_MTIME, mtimeMs, true);
+    this.dataView.setFloat64(base + STAT_OFFSET_CTIME, ctimeMs, true);
+    this.dataView.setFloat64(base + STAT_OFFSET_BIRTHTIME, birthtimeMs, true);
+
     Atomics.store(this.int32, 0, SAB_STATE_RESPONSE);
     Atomics.notify(this.int32, 0);
   }
@@ -85,7 +98,7 @@ export class SabComHost {
 export class SabComClient {
   private int32: Int32Array;
   private uint8: Uint8Array;
-  public statStruct: any;
+  private dataView: DataView;
 
   constructor(
     private sab: SharedArrayBuffer,
@@ -93,9 +106,7 @@ export class SabComClient {
   ) {
     this.int32 = new Int32Array(sab);
     this.uint8 = new Uint8Array(sab);
-    this.statStruct = BufferBackedObject(sab as any, StatDescriptor, {
-      byteOffset: 12,
-    });
+    this.dataView = new DataView(sab);
   }
 
   call(op: number, data: string) {
@@ -137,7 +148,16 @@ export class SabComClient {
       const msg = new TextDecoder().decode(this.uint8.slice(12, 12 + len));
       throw new Error(msg);
     }
-    return this.statStruct;
+
+    const base = 12;
+    return {
+      type: this.dataView.getUint8(base + STAT_OFFSET_TYPE),
+      size: this.dataView.getBigUint64(base + STAT_OFFSET_SIZE, true),
+      atimeMs: this.dataView.getFloat64(base + STAT_OFFSET_ATIME, true),
+      mtimeMs: this.dataView.getFloat64(base + STAT_OFFSET_MTIME, true),
+      ctimeMs: this.dataView.getFloat64(base + STAT_OFFSET_CTIME, true),
+      birthtimeMs: this.dataView.getFloat64(base + STAT_OFFSET_BIRTHTIME, true),
+    };
   }
 }
 
@@ -206,15 +226,14 @@ export const handleSabRequest = async (
         ? (metadata as any).toJSON()
         : metadata;
 
-      sabHost.statStruct.type =
-        json.type === "directory" ? STAT_TYPE_DIR : STAT_TYPE_FILE;
-      sabHost.statStruct.size = BigInt(json.file_size || 0);
-      sabHost.statStruct.atimeMs = Number(json.atimeMs || 0);
-      sabHost.statStruct.mtimeMs = Number(json.mtimeMs || 0);
-      sabHost.statStruct.ctimeMs = Number(json.ctimeMs || 0);
-      sabHost.statStruct.birthtimeMs = Number(json.birthtimeMs || 0);
+      const type = json.type === "directory" ? STAT_TYPE_DIR : STAT_TYPE_FILE;
+      const size = BigInt(json.file_size || 0);
+      const atimeMs = Number(json.atimeMs || 0);
+      const mtimeMs = Number(json.mtimeMs || 0);
+      const ctimeMs = Number(json.ctimeMs || 0);
+      const birthtimeMs = Number(json.birthtimeMs || 0);
 
-      sabHost.writeStatResponse();
+      sabHost.writeStat(type, size, atimeMs, mtimeMs, ctimeMs, birthtimeMs);
     } else {
       sabHost.writeError("Unknown op");
     }

--- a/packages/utoo-web/src/sabcom.ts
+++ b/packages/utoo-web/src/sabcom.ts
@@ -15,6 +15,11 @@ export const SAB_OP_STAT = 8;
 export const STAT_TYPE_FILE = 0;
 export const STAT_TYPE_DIR = 1;
 
+export const SAB_INDEX_STATE = 0;
+export const SAB_INDEX_OP = 1;
+export const SAB_INDEX_DATA_LEN = 2;
+export const SAB_DATA_OFFSET = 12;
+
 // Stat struct layout (starts at byte 12)
 // type: Uint8 (1 byte) -> offset 0
 // padding: 7 bytes
@@ -49,9 +54,11 @@ export class SabComHost {
   }
 
   readRequest() {
-    const op = this.int32[1];
-    const len = this.int32[2];
-    const data = new TextDecoder().decode(this.uint8.slice(12, 12 + len));
+    const op = this.int32[SAB_INDEX_OP];
+    const len = this.int32[SAB_INDEX_DATA_LEN];
+    const data = new TextDecoder().decode(
+      this.uint8.slice(SAB_DATA_OFFSET, SAB_DATA_OFFSET + len),
+    );
     return { op, data };
   }
 
@@ -60,18 +67,18 @@ export class SabComHost {
       data = new TextEncoder().encode(data);
     }
     // TODO: Check size overflow
-    this.int32[2] = data.length;
-    this.uint8.set(data, 12);
-    Atomics.store(this.int32, 0, SAB_STATE_RESPONSE);
-    Atomics.notify(this.int32, 0);
+    this.int32[SAB_INDEX_DATA_LEN] = data.length;
+    this.uint8.set(data, SAB_DATA_OFFSET);
+    Atomics.store(this.int32, SAB_INDEX_STATE, SAB_STATE_RESPONSE);
+    Atomics.notify(this.int32, SAB_INDEX_STATE);
   }
 
   writeError(message: string) {
     const data = new TextEncoder().encode(message);
-    this.int32[2] = data.length;
-    this.uint8.set(data, 12);
-    Atomics.store(this.int32, 0, SAB_STATE_ERROR);
-    Atomics.notify(this.int32, 0);
+    this.int32[SAB_INDEX_DATA_LEN] = data.length;
+    this.uint8.set(data, SAB_DATA_OFFSET);
+    Atomics.store(this.int32, SAB_INDEX_STATE, SAB_STATE_ERROR);
+    Atomics.notify(this.int32, SAB_INDEX_STATE);
   }
 
   writeStat(
@@ -82,7 +89,7 @@ export class SabComHost {
     ctimeMs: number,
     birthtimeMs: number,
   ) {
-    const base = 12;
+    const base = SAB_DATA_OFFSET;
     this.dataView.setUint8(base + STAT_OFFSET_TYPE, type);
     this.dataView.setBigUint64(base + STAT_OFFSET_SIZE, size, true);
     this.dataView.setFloat64(base + STAT_OFFSET_ATIME, atimeMs, true);
@@ -90,8 +97,8 @@ export class SabComHost {
     this.dataView.setFloat64(base + STAT_OFFSET_CTIME, ctimeMs, true);
     this.dataView.setFloat64(base + STAT_OFFSET_BIRTHTIME, birthtimeMs, true);
 
-    Atomics.store(this.int32, 0, SAB_STATE_RESPONSE);
-    Atomics.notify(this.int32, 0);
+    Atomics.store(this.int32, SAB_INDEX_STATE, SAB_STATE_RESPONSE);
+    Atomics.notify(this.int32, SAB_INDEX_STATE);
   }
 }
 
@@ -111,45 +118,49 @@ export class SabComClient {
 
   call(op: number, data: string) {
     const encoded = new TextEncoder().encode(data);
-    this.int32[1] = op;
-    this.int32[2] = encoded.length;
-    this.uint8.set(encoded, 12);
+    this.int32[SAB_INDEX_OP] = op;
+    this.int32[SAB_INDEX_DATA_LEN] = encoded.length;
+    this.uint8.set(encoded, SAB_DATA_OFFSET);
 
-    Atomics.store(this.int32, 0, SAB_STATE_REQUEST);
+    Atomics.store(this.int32, SAB_INDEX_STATE, SAB_STATE_REQUEST);
     this.notifyHost();
 
-    Atomics.wait(this.int32, 0, SAB_STATE_REQUEST);
+    Atomics.wait(this.int32, SAB_INDEX_STATE, SAB_STATE_REQUEST);
 
-    const state = Atomics.load(this.int32, 0);
+    const state = Atomics.load(this.int32, SAB_INDEX_STATE);
     if (state === SAB_STATE_ERROR) {
-      const len = this.int32[2];
-      const msg = new TextDecoder().decode(this.uint8.slice(12, 12 + len));
+      const len = this.int32[SAB_INDEX_DATA_LEN];
+      const msg = new TextDecoder().decode(
+        this.uint8.slice(SAB_DATA_OFFSET, SAB_DATA_OFFSET + len),
+      );
       throw new Error(msg);
     }
 
-    const len = this.int32[2];
-    return this.uint8.slice(12, 12 + len);
+    const len = this.int32[SAB_INDEX_DATA_LEN];
+    return this.uint8.slice(SAB_DATA_OFFSET, SAB_DATA_OFFSET + len);
   }
 
   callStat(path: string) {
     const encoded = new TextEncoder().encode(path);
-    this.int32[1] = SAB_OP_STAT;
-    this.int32[2] = encoded.length;
-    this.uint8.set(encoded, 12);
+    this.int32[SAB_INDEX_OP] = SAB_OP_STAT;
+    this.int32[SAB_INDEX_DATA_LEN] = encoded.length;
+    this.uint8.set(encoded, SAB_DATA_OFFSET);
 
-    Atomics.store(this.int32, 0, SAB_STATE_REQUEST);
+    Atomics.store(this.int32, SAB_INDEX_STATE, SAB_STATE_REQUEST);
     this.notifyHost();
 
-    Atomics.wait(this.int32, 0, SAB_STATE_REQUEST);
+    Atomics.wait(this.int32, SAB_INDEX_STATE, SAB_STATE_REQUEST);
 
-    const state = Atomics.load(this.int32, 0);
+    const state = Atomics.load(this.int32, SAB_INDEX_STATE);
     if (state === SAB_STATE_ERROR) {
-      const len = this.int32[2];
-      const msg = new TextDecoder().decode(this.uint8.slice(12, 12 + len));
+      const len = this.int32[SAB_INDEX_DATA_LEN];
+      const msg = new TextDecoder().decode(
+        this.uint8.slice(SAB_DATA_OFFSET, SAB_DATA_OFFSET + len),
+      );
       throw new Error(msg);
     }
 
-    const base = 12;
+    const base = SAB_DATA_OFFSET;
     return {
       type: this.dataView.getUint8(base + STAT_OFFSET_TYPE),
       size: this.dataView.getBigUint64(base + STAT_OFFSET_SIZE, true),

--- a/packages/utoo-web/src/utoo/index.d.ts
+++ b/packages/utoo-web/src/utoo/index.d.ts
@@ -175,11 +175,11 @@ export interface InitOutput {
   readonly __wbindgen_export_7: WebAssembly.Table;
   readonly __externref_drop_slice: (a: number, b: number) => void;
   readonly __externref_table_dealloc: (a: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__h2ce973260553dde0: (a: number, b: number) => void;
-  readonly closure117648_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure149_externref_shim: (a: number, b: number, c: any) => void;
   readonly closure115096_externref_shim: (a: number, b: number, c: any) => void;
   readonly closure115099_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure117648_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure149_externref_shim: (a: number, b: number, c: any) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h2ce973260553dde0: (a: number, b: number) => void;
   readonly wasm_bindgen__convert__closures_____invoke__heac94dfe74335608: (a: number, b: number) => void;
   readonly closure117778_externref_shim: (a: number, b: number, c: any, d: any) => void;
   readonly __wbindgen_thread_destroy: (a?: number, b?: number, c?: number) => void;


### PR DESCRIPTION
This pull request refactors the SharedArrayBuffer (SAB) communication layer in `utoo-web` to remove the dependency on `buffer-backed-object`, implements manual struct layout and parsing for file stat operations, and improves binary data transfer efficiency using `comlink.transfer`. The most significant changes are the manual handling of stat struct serialization/deserialization, the removal of a dependency, and consistent use of transferable objects for performance.

**SharedArrayBuffer (SAB) communication refactor:**

* Removed the use of `buffer-backed-object` for stat struct handling in `sabcom.ts`, replacing it with manual struct layout using `DataView` and explicit offset constants for stat fields. This change eliminates an external dependency and gives more control over memory layout and performance. [[1]](diffhunk://#diff-1623cc16ba9f246733e7439b3ae37f30762d01eab140c38a18c33a83e8b0fdf9L1-L7) [[2]](diffhunk://#diff-1623cc16ba9f246733e7439b3ae37f30762d01eab140c38a18c33a83e8b0fdf9L25-R37) [[3]](diffhunk://#diff-1623cc16ba9f246733e7439b3ae37f30762d01eab140c38a18c33a83e8b0fdf9L43-R61)
* Rewrote stat read/write logic in both `SabComHost` and `SabComClient` to use manual field access via `DataView`, ensuring correct serialization and deserialization of stat information over SAB. [[1]](diffhunk://#diff-1623cc16ba9f246733e7439b3ae37f30762d01eab140c38a18c33a83e8b0fdf9L65-R171) [[2]](diffhunk://#diff-1623cc16ba9f246733e7439b3ae37f30762d01eab140c38a18c33a83e8b0fdf9L209-R247)

**Dependency management:**

* Removed the `buffer-backed-object` package from `package.json`, as it is no longer needed after the refactor.

**Binary data transfer improvements:**

* Updated internal project and project endpoint methods (`internalProject.ts`, `project.ts`) to use `comlink.transfer` for efficient zero-copy transfer of `Uint8Array` buffers between threads/workers, particularly for file read/write, gzip, and signature operations. [[1]](diffhunk://#diff-df68f5652d02172a9b1b24a0863849e0eb94287c808409a72ecb6bcfa3954c46R1) [[2]](diffhunk://#diff-df68f5652d02172a9b1b24a0863849e0eb94287c808409a72ecb6bcfa3954c46R70) [[3]](diffhunk://#diff-df68f5652d02172a9b1b24a0863849e0eb94287c808409a72ecb6bcfa3954c46L151-R154) [[4]](diffhunk://#diff-134ee57c67e43daeebdac7f9982664ab41a036e66d3c1055c89013a5d7f18f66R122-R128) [[5]](diffhunk://#diff-134ee57c67e43daeebdac7f9982664ab41a036e66d3c1055c89013a5d7f18f66L165-R180)

These changes improve performance, reduce dependencies, and make the SAB communication code more explicit and maintainable.