### PR TITLE
docs: update API docs with FileSystemObserver and OPFS info

### DIFF
--- a/packages/utoo-web/API.md
+++ b/packages/utoo-web/API.md
@@ -4,11 +4,21 @@
 
 ## Core Concepts
 
-1. **Real File System**: The project lives in the browser's Origin Private File System (OPFS). `Project` provides a Node.js-like `fs` interface.
+1. **Real File System**: The project lives in the browser's [Origin Private File System (OPFS)](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system). `Project` provides a Node.js-like `fs` interface.
 2. **Project Main Worker**: The `Project` instance runs in a Web Worker. The main thread object is a proxy, keeping the UI responsive.
 3. **Thread Worker**: Heavy tasks (bundling, compilation) run in a dedicated Web Worker powered by a ported `tokio` runtime.
 4. **Loader Worker**: Executes Webpack loaders in a dedicated worker with Node.js polyfills.
 5. **Service Worker**: Acts as a local server to intercept requests and serve built files for preview.
+
+## File Watching & Incremental Builds
+
+`@utoo/web` leverages the modern [FileSystemObserver API](https://github.com/whatwg/fs/blob/main/proposals/FileSystemObserver.md) to implement efficient file system watching directly in the browser. This is crucial for supporting Turbopack's incremental build capabilities.
+
+1.  **FileSystemObserver Integration**: The `tokio-fs-ext` crate (used by `utoo-wasm`) provides a `watch` module that wraps the `FileSystemObserver` API. This allows the Rust code to receive notifications about file changes in the Origin Private File System (OPFS).
+2.  **Offloading to Turbopack**: When a file change is detected, the event is propagated through the `OpfsOffload` layer to the Turbopack engine running in the WASM environment.
+3.  **Incremental Compilation**: Turbopack's architecture is built on a reactive graph. When it receives a file change event, it invalidates only the affected parts of the dependency graph. This triggers a re-computation (rebuild) of only the changed modules and their dependents, resulting in extremely fast updates, similar to Hot Module Replacement (HMR) in native development environments.
+
+This architecture ensures that `@utoo/web` delivers a responsive development experience even for large projects running entirely within the browser.
 
 ---
 

--- a/packages/utoo-web/API_zh-CN.md
+++ b/packages/utoo-web/API_zh-CN.md
@@ -4,11 +4,21 @@
 
 ## 核心概念
 
-1. **Real File System**：项目存在于浏览器的源私有文件系统（OPFS）中。`Project` 类提供类似 Node.js `fs` 的接口。
+1. **Real File System**：项目存在于浏览器的[源私有文件系统（OPFS）](https://developer.mozilla.org/zh-CN/docs/Web/API/File_System_API/Origin_private_file_system)中。`Project` 类提供类似 Node.js `fs` 的接口。
 2. **Project Main Worker**：`Project` 实例运行在 Web Worker 中。主线程对象是代理，保持 UI 响应。
 3. **Thread Worker**：重度任务（打包、编译）在专用的 Web Worker 中运行，由移植的 `tokio` 运行时驱动。
 4. **Loader Worker**：在带有 Node.js polyfills 的专用 Worker 中执行 Webpack loaders。
 5. **Service Worker**：充当本地服务器，拦截请求并提供构建文件以供预览。
+
+## 文件监听与增量构建
+
+`@utoo/web` 利用现代的 [FileSystemObserver API](https://github.com/whatwg/fs/blob/main/proposals/FileSystemObserver.md) 在浏览器中直接实现高效的文件系统监听。这对于支持 Turbopack 的增量构建能力至关重要。
+
+1.  **FileSystemObserver 集成**：`tokio-fs-ext` crate（由 `utoo-wasm` 使用）提供了一个 `watch` 模块，封装了 `FileSystemObserver` API。这使得 Rust 代码能够接收关于源私有文件系统（OPFS）中文件更改的通知。
+2.  **卸载到 Turbopack**：当检测到文件更改时，事件通过 `OpfsOffload` 层传播到在 WASM 环境中运行的 Turbopack 引擎。
+3.  **增量编译**：Turbopack 的架构建立在响应式图之上。当它接收到文件更改事件时，它仅使依赖图中受影响的部分失效。这触发了仅针对更改的模块及其依赖项的重新计算（重建），从而实现极快的更新，类似于原生开发环境中的热模块替换（HMR）。
+
+这种架构确保了 `@utoo/web` 即使对于完全在浏览器中运行的大型项目也能提供响应迅速的开发体验。
 
 ---
 


### PR DESCRIPTION
This pull request updates the API documentation for `@utoo/web` in both English and Chinese. The main focus is to document the new file watching and incremental build capabilities powered by the FileSystemObserver API and Turbopack integration.

**Documentation improvements:**

* Added a new section explaining how `@utoo/web` uses the FileSystemObserver API for efficient file system watching in the browser, enabling fast incremental builds via Turbopack. [[1]](diffhunk://#diff-a9df005ef041370eb775d1d3362d3ded906314b4cb6e8b25e4182d6258b596c2L7-R22) [[2]](diffhunk://#diff-2b365e78e2c03d1aebf4375c93adbc002d55962bb7df1a00a9820f7eaf05f481L7-R22)
* Included relevant links to external documentation for OPFS and FileSystemObserver API in both English and Chinese docs. [[1]](diffhunk://#diff-a9df005ef041370eb775d1d3362d3ded906314b4cb6e8b25e4182d6258b596c2L7-R22) [[2]](diffhunk://#diff-2b365e78e2c03d1aebf4375c93adbc002d55962bb7df1a00a9820f7eaf05f481L7-R22)