### PR TITLE
feat(pack): support provide plugin

### DIFF
--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -780,6 +780,7 @@ impl Project {
             (*self.config.target().await?).clone(),
             Vc::cell(define_env),
             self.config.mode(),
+            self.config.provider_config(),
         ))
     }
 

--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -24,7 +24,7 @@ use turbopack_core::{
     },
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, DefinableNameSegment,
-        FreeVarReferences,
+        FreeVarReference, FreeVarReferences,
     },
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment},
     file_source::FileSource,
@@ -40,8 +40,8 @@ use turbopack_node::{
 use crate::{
     client::runtime_entry::RuntimeEntries,
     config::{
-        Config, default_max_chunk_count_per_group, default_max_merge_chunk_size,
-        default_min_chunk_size,
+        Config, ProviderConfig, ProviderConfigValue, default_max_chunk_count_per_group,
+        default_max_merge_chunk_size, default_min_chunk_size,
     },
     embed_js::embed_file_path,
     import_map::{
@@ -103,22 +103,51 @@ async fn client_defines(define_env: Vc<EnvMap>) -> Result<Vc<CompileTimeDefines>
 }
 
 #[turbo_tasks::function]
-async fn client_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarReferences>> {
-    Ok(free_var_references!(
-        ..defines(&*define_env.await?).into_iter() //
-                                                   //FIXME: keep original request when compiling target node
-                                                   //, Buffer = FreeVarReference::EcmaScriptModule {
-                                                   //     request: "node:buffer".into(),
-                                                   //     lookup_path: None,
-                                                   //     export: Some("Buffer".into()),
-                                                   // },
-                                                   // process = FreeVarReference::EcmaScriptModule {
-                                                   //     request: "node:process".into(),
-                                                   //     lookup_path: None,
-                                                   //     export: Some("default".into()),
-                                                   // }
-    )
-    .cell())
+async fn client_free_vars(
+    define_env: Vc<EnvMap>,
+    provider_config: Vc<ProviderConfig>,
+) -> Result<Vc<FreeVarReferences>> {
+    let mut free_vars = free_var_references!(..defines(&*define_env.await?).into_iter());
+
+    // Add provider configurations as FreeVarReference::EcmaScriptModule
+    // This implements webpack's ProvidePlugin behavior
+    let provider = provider_config.await?;
+    for (var_name, value) in provider.iter() {
+        let (request, export) = match value {
+            ProviderConfigValue::Module(module_name) => {
+                // Simple module import: { $: 'jquery' } -> import $ from 'jquery'
+                (module_name.clone(), Some(rcstr!("default")))
+            }
+            ProviderConfigValue::NamedExport(parts) => {
+                // Named export import: { Buffer: ['buffer', 'Buffer'] }
+                // -> import { Buffer } from 'buffer'
+                let request = if let Some(r) = parts.get(0) {
+                    r.clone()
+                } else {
+                    continue;
+                };
+                let export = parts.get(1).cloned().or(Some(rcstr!("default")));
+                (request, export)
+            }
+        };
+
+        // Support nested variable names like "process.env"
+        let name_segments: Vec<DefinableNameSegment> = var_name
+            .split('.')
+            .map(|s| DefinableNameSegment::Name(s.into()))
+            .collect();
+
+        free_vars.0.insert(
+            name_segments,
+            FreeVarReference::EcmaScriptModule {
+                request,
+                lookup_path: None,
+                export,
+            },
+        );
+    }
+
+    Ok(free_vars.cell())
 }
 
 #[turbo_tasks::function]
@@ -126,6 +155,7 @@ pub async fn get_client_compile_time_info(
     browserslist_query: RcStr,
     define_env: Vc<EnvMap>,
     mode: Vc<Mode>,
+    provider_config: Vc<ProviderConfig>,
 ) -> Result<Vc<CompileTimeInfo>> {
     let mut define_env = (*define_env.await?).clone();
     define_env.extend([(
@@ -149,7 +179,11 @@ pub async fn get_client_compile_time_info(
             .await?,
     )
     .defines(client_defines(define_env).to_resolved().await?)
-    .free_var_references(client_free_vars(define_env).to_resolved().await?)
+    .free_var_references(
+        client_free_vars(define_env, provider_config)
+            .to_resolved()
+            .await?,
+    )
     .cell()
     .await
 }

--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -121,7 +121,7 @@ async fn client_free_vars(
             ProviderConfigValue::NamedExport(parts) => {
                 // Named export import: { Buffer: ['buffer', 'Buffer'] }
                 // -> import { Buffer } from 'buffer'
-                let request = if let Some(r) = parts.get(0) {
+                let request = if let Some(r) = parts.first() {
                     r.clone()
                 } else {
                     continue;

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -116,6 +116,21 @@ pub struct DevServer {
     pub hot: Option<bool>,
 }
 
+/// Provider configuration item - can be a module name string or [module, export] tuple.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+)]
+#[serde(untagged)]
+pub enum ProviderConfigValue {
+    /// Simple module import: "jquery" -> import $ from 'jquery'
+    Module(RcStr),
+    /// Named export import: ["buffer", "Buffer"] -> import { Buffer } from 'buffer'
+    NamedExport(Vec<RcStr>),
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct ProviderConfig(FxIndexMap<RcStr, ProviderConfigValue>);
+
 #[turbo_tasks::value(serialization = "custom", eq = "manual")]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, OperationValue)]
 #[serde(rename_all = "camelCase")]
@@ -129,6 +144,7 @@ pub struct Config {
     target: Option<RcStr>,
     source_maps: Option<bool>,
     define: Option<FxIndexMap<String, JsonValue>>,
+    provider: Option<FxIndexMap<RcStr, ProviderConfigValue>>,
     images: Option<ImageConfig>,
     styles: Option<StyleConfig>,
     optimization: Option<OptimizationConfig>,
@@ -1046,6 +1062,11 @@ impl Config {
             .collect();
 
         Vc::cell(define_env)
+    }
+
+    #[turbo_tasks::function]
+    pub fn provider_config(&self) -> Vc<ProviderConfig> {
+        Vc::cell(self.provider.clone().unwrap_or_default())
     }
 
     #[turbo_tasks::function]

--- a/crates/pack-tests/tests/snapshot/node_modules/buffer-dep/index.js
+++ b/crates/pack-tests/tests/snapshot/node_modules/buffer-dep/index.js
@@ -1,0 +1,5 @@
+exports.Buffer = {
+  from: function (str) {
+    return { data: str };
+  },
+};

--- a/crates/pack-tests/tests/snapshot/node_modules/jquery/index.js
+++ b/crates/pack-tests/tests/snapshot/node_modules/jquery/index.js
@@ -1,0 +1,3 @@
+module.exports = function $(selector) {
+  return { selector };
+};

--- a/crates/pack-tests/tests/snapshot/provider/basic/config.json
+++ b/crates/pack-tests/tests/snapshot/provider/basic/config.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "optimization": {
+      "minify": false,
+      "moduleIds": "named" 
+    },
+    "provider": {
+      "$": "jquery",
+      "Buffer": ["buffer-dep", "Buffer"]
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/provider/basic/input/index.js
+++ b/crates/pack-tests/tests/snapshot/provider/basic/input/index.js
@@ -1,0 +1,6 @@
+// Test ProvidePlugin functionality
+// $ should be automatically imported from 'jquery'
+// Buffer should be automatically imported from 'buffer'
+
+console.log($('#app'));
+console.log(Buffer.from('hello'));

--- a/crates/pack-tests/tests/snapshot/provider/basic/output/crates_pack-tests_tests_snapshot_64485ac0.js
+++ b/crates/pack-tests/tests/snapshot/provider/basic/output/crates_pack-tests_tests_snapshot_64485ac0.js
@@ -1,0 +1,32 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/crates/pack-tests/tests/snapshot/node_modules/jquery/index.js [client] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+module.exports = function $(selector) {
+    return {
+        selector
+    };
+};
+}),
+"[project]/crates/pack-tests/tests/snapshot/node_modules/buffer-dep/index.js [client] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+exports.Buffer = {
+    from: function(str) {
+        return {
+            data: str
+        };
+    }
+};
+}),
+"[project]/crates/pack-tests/tests/snapshot/provider/basic/input/index.js [client] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+// Test ProvidePlugin functionality
+// $ should be automatically imported from 'jquery'
+// Buffer should be automatically imported from 'buffer'
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$jquery$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = /*#__PURE__*/ __turbopack_context__.i("[project]/crates/pack-tests/tests/snapshot/node_modules/jquery/index.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$buffer$2d$dep$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = /*#__PURE__*/ __turbopack_context__.i("[project]/crates/pack-tests/tests/snapshot/node_modules/buffer-dep/index.js [client] (ecmascript)");
+console.log((0, __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$jquery$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__["default"])('#app'));
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$buffer$2d$dep$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__["Buffer"].from('hello'));
+}),
+]);
+
+//# sourceMappingURL=crates_pack-tests_tests_snapshot_64485ac0.js.map

--- a/crates/pack-tests/tests/snapshot/provider/basic/output/crates_pack-tests_tests_snapshot_64485ac0.js.map
+++ b/crates/pack-tests/tests/snapshot/provider/basic/output/crates_pack-tests_tests_snapshot_64485ac0.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 3, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/node_modules/jquery/index.js"],"sourcesContent":["module.exports = function $(selector) {\n  return { selector };\n};\n"],"names":[],"mappings":"AAAA,OAAO,OAAO,GAAG,SAAS,EAAE,QAAQ;IAClC,OAAO;QAAE;IAAS;AACpB","ignoreList":[0]}},
+    {"offset": {"line": 11, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/node_modules/buffer-dep/index.js"],"sourcesContent":["exports.Buffer = {\n  from: function (str) {\n    return { data: str };\n  },\n};\n"],"names":[],"mappings":"AAAA,QAAQ,MAAM,GAAG;IACf,MAAM,SAAU,GAAG;QACjB,OAAO;YAAE,MAAM;QAAI;IACrB;AACF","ignoreList":[0]}},
+    {"offset": {"line": 21, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/provider/basic/input/index.js"],"sourcesContent":["// Test ProvidePlugin functionality\n// $ should be automatically imported from 'jquery'\n// Buffer should be automatically imported from 'buffer'\n\nconsole.log($('#app'));\nconsole.log(Buffer.from('hello'));\n"],"names":[],"mappings":"AAAA,mCAAmC;AACnC,mDAAmD;AACnD,wDAAwD;AAE5C;AACA;AADZ,QAAQ,GAAG,CAAC,IAAA,sLAAC,EAAC;AACd,QAAQ,GAAG,CAAC,4LAAM,CAAC,IAAI,CAAC"}}]
+}

--- a/crates/pack-tests/tests/snapshot/provider/basic/output/main.js
+++ b/crates/pack-tests/tests/snapshot/provider/basic/output/main.js
@@ -1,0 +1,5 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["crates_pack-tests_tests_snapshot_64485ac0.js"],"runtimeModuleIds":["[project]/crates/pack-tests/tests/snapshot/provider/basic/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/provider/basic/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/provider/basic/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/packages/pack/docs/features-list.json
+++ b/packages/pack/docs/features-list.json
@@ -179,7 +179,7 @@
       "children": [
         {
           "featureLevel2": "",
-          "featureStatus": "🟠",
+          "featureStatus": "✅",
           "featureDetails": "[Webpack `ProvidePlugin`](https://webpack.js.org/plugins/provide-plugin/#root)",
           "remarks": ""
         }

--- a/packages/pack/docs/features-list.md
+++ b/packages/pack/docs/features-list.md
@@ -27,7 +27,7 @@
 |  | `node` | 🟠 |  |  |
 | Sourcemap |  | ✅ | [Webpack `devtool` configuration](https://webpack.js.org/configuration/devtool/) |  |
 | Define |  | ✅ | [Webpack `DefinePlugin`](https://webpack.js.org/plugins/define-plugin/) |  |
-| Providers |  | 🟠 | [Webpack `ProvidePlugin`](https://webpack.js.org/plugins/provide-plugin/#root) |  |
+| Providers |  | ✅ | [Webpack `ProvidePlugin`](https://webpack.js.org/plugins/provide-plugin/#root) |  |
 | Optimization | `concatenateModules` | ✅ | [Webpack `optimization.concatenateModules`](https://webpack.js.org/configuration/optimization/#optimizationconcatenatemodules) |  |
 |  | `moduleIds` | ✅ | [Webpack `optimization.moduleIds`](https://webpack.js.org/configuration/optimization/#optimizationmoduleids) | Supports "names" or "deterministic" |
 |  | `minify` | ✅ | [Webpack `optimization.minimize`](https://webpack.js.org/configuration/optimization/#optimizationminimize) |  |

--- a/packages/pack/src/types.ts
+++ b/packages/pack/src/types.ts
@@ -115,6 +115,22 @@ export interface ExternalAdvanced {
 
 export type ExternalConfig = string | ExternalAdvanced;
 
+/**
+ * Provider configuration for automatic module imports.
+ * Similar to webpack's ProvidePlugin.
+ *
+ * @example
+ * ```ts
+ * provider: {
+ *   // Provides `$` as `import $ from 'jquery'`
+ *   $: 'jquery',
+ *   // Provides `Buffer` as `import { Buffer } from 'buffer'`
+ *   Buffer: ['buffer', 'Buffer'],
+ * }
+ * ```
+ */
+export type ProviderConfig = Record<string, string | [string, string]>;
+
 export interface ConfigComplete {
   entry: EntryOptions[];
   mode?: "production" | "development";
@@ -139,6 +155,7 @@ export interface ConfigComplete {
   target?: string;
   sourceMaps?: boolean;
   define?: Record<string, string>;
+  provider?: ProviderConfig;
   optimization?: {
     moduleIds?: "named" | "deterministic";
     minify?: boolean;

--- a/packages/pack/src/webpackCompat.ts
+++ b/packages/pack/src/webpackCompat.ts
@@ -70,6 +70,7 @@ export function compatOptionsFromWebpack(
       sourceMaps: compatSourceMaps(devtool),
       optimization: compatOptimization(optimization),
       define: compatFromWebpackPlugin(plugins, compatDefine),
+      provider: compatFromWebpackPlugin(plugins, compatProvider),
       stats: compatStats(stats),
     },
     buildId: webpackConfig.name,
@@ -191,6 +192,34 @@ function compatDefine(maybeWebpackPluginInstance: MaybeWebpackPluginInstance) {
   }
 
   return processedDefinitions;
+}
+
+compatProvider.pluginName = "ProvidePlugin";
+function compatProvider(
+  maybeWebpackPluginInstance: MaybeWebpackPluginInstance,
+): ConfigComplete["provider"] {
+  const definitions = maybeWebpackPluginInstance?.definitions;
+  if (!definitions || typeof definitions !== "object") {
+    return undefined;
+  }
+
+  const provider: ConfigComplete["provider"] = {};
+  for (const [key, value] of Object.entries(definitions)) {
+    if (typeof value === "string") {
+      // Simple module import: { $: 'jquery' }
+      provider[key] = value;
+    } else if (Array.isArray(value)) {
+      if (value.length === 1) {
+        // e.g. { process: ['process/browser'] } for default import
+        provider[key] = value[0];
+      } else if (value.length >= 2) {
+        // Named export import: { Buffer: ['buffer', 'Buffer'] }
+        provider[key] = [value[0], value[1]];
+      }
+    }
+  }
+
+  return Object.keys(provider).length > 0 ? provider : undefined;
 }
 
 function compatExternals(

--- a/packages/pack/tsconfig.json
+++ b/packages/pack/tsconfig.json
@@ -9,9 +9,6 @@
     "strict": true,
     "skipLibCheck": true,
     "lib": ["dom", "dom.iterable", "esnext"],
-    "paths": {
-      "@utoo/pack-shared": ["../pack-shared/src/index.ts"]
-    }
   },
   "include": ["src"],
   "exclude": ["es", "cjs"]


### PR DESCRIPTION
## Summary

支持 `config.provide` 来兼容 webpack plugin: https://webpack.js.org/plugins/provide-plugin/

mako 配置: https://makojs.dev/docs/config#providers 

配置写法:

```ts
export default {
   utoopack: {
      provide: {
         $: 'jquery',
         Buffer: ['buffer', 'Buffer'],
      }
   }
}
```


## Test Plan

参考快照测试
