### PR TITLE
ci: update release workflows to handle prerelease tags

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -185,11 +185,19 @@ jobs:
           # npm config set provenance true
           echo "${VERSION}" &&
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc &&
+
+          TAG="latest"
+          if [[ "$VERSION" == *"-"* ]]; then
+            PRERELEASE="${VERSION#*-}"
+            TAG="${PRERELEASE%%.*}"
+          fi
+          echo "Publishing with tag: $TAG"
+
           npm version --workspace=@utoo/pack "${VERSION}" &&
           npm version --workspace=@utoo/pack-cli "${VERSION}" &&
           npm install --workspace=@utoo/pack-cli @utoo/pack --save-exact &&
-          npm publish --workspace=@utoo/pack --access public &&
-          npm publish --workspace=@utoo/pack-cli --access public
+          npm publish --workspace=@utoo/pack --access public --tag "${TAG}" &&
+          npm publish --workspace=@utoo/pack-cli --access public --tag "${TAG}"
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/utooweb-release.yml
+++ b/.github/workflows/utooweb-release.yml
@@ -55,8 +55,15 @@ jobs:
           echo "${VERSION}" &&
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc &&
 
+          TAG="latest"
+          if [[ "$VERSION" == *"-"* ]]; then
+            PRERELEASE="${VERSION#*-}"
+            TAG="${PRERELEASE%%.*}"
+          fi
+          echo "Publishing with tag: $TAG"
+
           npm version --workspace=@utoo/web "${VERSION}" &&
-          npm publish --workspace=@utoo/web --access public
+          npm publish --workspace=@utoo/web --access public --tag "${TAG}"
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request updates the npm publish workflow for both the `pack` and `web` packages to automatically assign the appropriate npm dist-tag based on the version being published. This ensures that prerelease versions (e.g., beta, alpha) are published with the correct tag instead of always using `latest`.

**Release workflow improvements:**

* In both `.github/workflows/pack-release.yml` and `.github/workflows/utooweb-release.yml`, the publish step now determines the npm dist-tag (`latest` for stable releases, or the prerelease identifier like `beta` for prereleases) based on the version string. The tag is then passed to the `npm publish` command to ensure correct tagging on npm. [[1]](diffhunk://#diff-aca3291f6fc7e09209775f607a7cfa0f0c3b6696cad8bb9bfcc81970f7a27be4R188-R200) [[2]](diffhunk://#diff-87aea2ba085be1c53c8fb97115b441b3443d48cc3973d66728a4a7d34b184d30R58-R66)