### PR TITLE
chore(wasm): remove useless tailwind polyfill

### DIFF
--- a/packages/utoo-web/cli/umd.js
+++ b/packages/utoo-web/cli/umd.js
@@ -93,10 +93,6 @@ const config = {
   },
   plugins: [
     new NodeProtocolUrlPlugin(),
-    new webpack.NormalModuleReplacementPlugin(
-      /tailwindcss\/lib\/lib\/load-config\.js/,
-      path.resolve(__dirname, './mocks/load-config.js')
-    ),
     new webpack.ProvidePlugin({
       process: stdLibBrowser.process,
       Buffer: stdLibBrowser.buffer,


### PR DESCRIPTION
This pull request makes a minor update to the Webpack configuration in `packages/utoo-web/cli/umd.js` by removing the replacement of the `tailwindcss/lib/lib/load-config.js` module with a mock. This simplifies the plugin setup and may allow the original Tailwind CSS configuration loader to be used as intended.