### PR TITLE
chore(cli): rename 'utoopack' -> 'up' in docs and sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Utoo is a modern, high-performance frontend toolchain designed to provide a unif
 
 - **[`utoo`](crates/pm)** (alias **`ut`**): High-performance Rust package manager (Fast, Parallel, `npm` compatible).
 - **[`@utoo/pack`](packages/pack)**: Next-gen bundler powered by **Turbopack** (HMR, TS/JSX, Less/Sass, and more).
- - **[`@utoo/pack-cli`](packages/pack-cli)**: Command-line interface for the bundler (dev server, build, inspect). A lightweight wrapper to run `up` commands.
+- **[`@utoo/pack-cli`](packages/pack-cli)**: Command-line interface for the bundler (dev server, build, inspect). A lightweight wrapper to run `up` commands.
 - **[`@utoo/web`](packages/utoo-web)**: Web-compatible version of the toolchain (WASM, Browser-based bundling).
 
 ## 🚀 Quick Start

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Utoo is a modern, high-performance frontend toolchain designed to provide a unif
 
 - **[`utoo`](crates/pm)** (alias **`ut`**): High-performance Rust package manager (Fast, Parallel, `npm` compatible).
 - **[`@utoo/pack`](packages/pack)**: Next-gen bundler powered by **Turbopack** (HMR, TS/JSX, Less/Sass, and more).
+ - **[`@utoo/pack-cli`](packages/pack-cli)**: Command-line interface for the bundler (dev server, build, inspect). A lightweight wrapper to run `up` commands.
 - **[`@utoo/web`](packages/utoo-web)**: Web-compatible version of the toolchain (WASM, Browser-based bundling).
 
 ## 🚀 Quick Start
@@ -56,9 +57,9 @@ utoo x create-react   # Execute a package (npx style, or use `ut x`)
 
 #### Bundling
 ```bash
-utoopack dev          # Start dev server with HMR
-utoopack build        # Production build
-utoopack build --webpack # Build using webpack.config.js
+up dev          # Start dev server with HMR
+up build        # Production build
+up build --webpack # Build using webpack.config.js
 ```
 
 ## ✨ Key Features

--- a/packages/pack-cli/README.md
+++ b/packages/pack-cli/README.md
@@ -15,7 +15,7 @@ npm install -g @utoo/pack-cli
 Start the development server with Hot Module Replacement (HMR):
 
 ```bash
-utoopack dev
+up dev
 ```
 
 ### Production Build
@@ -23,7 +23,7 @@ utoopack dev
 Build your project for production:
 
 ```bash
-utoopack build
+up build
 ```
 
 ### Webpack Compatibility Mode
@@ -31,16 +31,16 @@ utoopack build
 If you have an existing `webpack.config.js`, you can run `@utoo/pack` in compatibility mode:
 
 ```bash
-utoopack build --webpack
+up build --webpack
 # or
-utoopack dev --webpack
+up dev --webpack
 ```
 
 ## 🛠️ Commands
 
-- `utoopack dev`: Start development server.
-- `utoopack build`: Build for production.
-- `utoopack help`: Show help for all commands.
+- `up dev`: Start development server.
+- `up build`: Build for production.
+- `up help`: Show help for all commands.
 
 ## 📄 License
 

--- a/packages/pack/README.md
+++ b/packages/pack/README.md
@@ -77,7 +77,7 @@ async function startDev() {
 ### Usage via CLI
 
 ```bash
-utoopack build --webpack
+up build --webpack
 ```
 
 ### Programmatic Usage


### PR DESCRIPTION
This pull request updates documentation to clarify the usage of the new `@utoo/pack-cli` package and standardizes the CLI commands to use the new `up` alias instead of `utoopack`. The changes help users understand the new entry point and streamline command usage across the toolchain.

**Documentation updates for CLI usage:**

* Added `@utoo/pack-cli` as the official command-line interface for the bundler, describing it as a lightweight wrapper for running `up` commands.
* Standardized all CLI command examples in `README.md` and `packages/pack-cli/README.md` to use `up` (e.g., `up dev`, `up build`, `up build --webpack`) instead of `utoopack`, and updated the command descriptions accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R62) [[2]](diffhunk://#diff-02956c7dfd673e075d1efe89b1f5c5560ad7c63e7051c99dde0293f7f8005304L18-R43) [[3]](diffhunk://#diff-8478c02fdb8f70c3115dc1db873062904e87860037d091df5466c3f7707e2b2aL80-R80)