### PR TITLE
fix: resolve typescript errors in dev command

### DIFF
--- a/packages/pack/src/commands/dev.ts
+++ b/packages/pack/src/commands/dev.ts
@@ -6,6 +6,7 @@ import path from "path";
 import send from "send";
 import { Duplex, Writable } from "stream";
 import url from "url";
+import { ConfigComplete } from "../config/types";
 import { resolveBundleOptions, WebpackConfig } from "../config/webpackCompat";
 import { createHotReloader } from "../core/hmr";
 import { BundleOptions } from "../core/types";
@@ -42,7 +43,9 @@ async function serveInternal(
     await xcodeProfilingReady();
   }
 
-  const cfgDevServer = options.config?.devServer || {};
+  const cfgDevServer =
+    options.config?.devServer ||
+    ({} as NonNullable<ConfigComplete["devServer"]>);
 
   const serverOpts: StartServerOptions = {
     hostname: serverOptions?.hostname || cfgDevServer.host || "localhost",


### PR DESCRIPTION
This pull request makes a minor update to the `dev.ts` command, specifically improving type safety when accessing the `devServer` configuration. The change ensures that the `cfgDevServer` variable is always treated as a non-nullable object, which can help prevent runtime errors due to undefined values.

Configuration type safety:

* Updated the assignment of `cfgDevServer` in `dev.ts` to use a non-nullable type assertion, ensuring it always defaults to a valid object if not provided.
* Added an import for `ConfigComplete` from `../config/types` to support the improved type assertion.