### PR TITLE
fix(wasm): gzip && md5

### DIFF
--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -58,9 +58,14 @@ impl Project {
     /// Calculate MD5 hash of byte content (async for better thread scheduling)
     #[wasm_bindgen(js_name = sigMd5)]
     pub async fn sig_md5(content: Vec<u8>) -> Result<String, JsError> {
-        let result = tokio::task::spawn_blocking(move || opfs_project::pack::sig_md5(&content))
-            .await
-            .map_err(|e| JsError::new(&format!("Task failed: {}", e)))?;
+        let rt = TOKIO_RUNTIME.get().expect("tokio runtime not found");
+
+        let result = rt
+            .spawn(tokio::task::spawn_blocking(move || {
+                opfs_project::pack::sig_md5(&content)
+            }))
+            .await?
+            .map_err(to_js_error)?;
         Ok(result)
     }
 
@@ -85,9 +90,13 @@ impl Project {
             .map(|f| PackFile::new(f.path, f.content))
             .collect();
 
-        let bytes = tokio::task::spawn_blocking(move || opfs_project::pack::gzip(&pack_files))
-            .await
-            .map_err(|e| JsError::new(&format!("Task failed: {}", e)))?
+        let rt = TOKIO_RUNTIME.get().expect("tokio runtime not found");
+
+        let bytes = rt
+            .spawn(tokio::task::spawn_blocking(move || {
+                opfs_project::pack::gzip(&pack_files)
+            }))
+            .await??
             .map_err(to_js_error)?;
         Ok(js_sys::Uint8Array::from(&bytes[..]))
     }
@@ -143,12 +152,9 @@ impl Project {
             None => return Err(JsError::new("invalid pack project")),
         };
 
-        TOKIO_RUNTIME
-            .with(|rt| {
-                rt.get()
-                    .expect("tokio runtime not found")
-                    .spawn(async move { pack_project.build().await })
-            })
+        let rt = TOKIO_RUNTIME.get().expect("tokio runtime not found");
+
+        rt.spawn(async move { pack_project.build().await })
             .await
             .map_err(to_js_error)?
             .map_or_else(
@@ -206,12 +212,9 @@ impl Project {
                 ..Default::default()
             };
 
-            let pack_context = TOKIO_RUNTIME
-                .with(|rt| {
-                    rt.get()
-                        .expect("tokio runtime not found")
-                        .spawn(PackProject::initialize(options))
-                })
+            let rt = TOKIO_RUNTIME.get().expect("tokio runtime not found");
+            let pack_context = rt
+                .spawn(PackProject::initialize(options))
                 .await
                 .context("fail to initialize pack project")??;
 

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -61,10 +61,10 @@ impl Project {
         let rt = TOKIO_RUNTIME.get().ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
 
         let result = rt
-            .spawn(tokio::task::spawn_blocking(move || {
+            .spawn_blocking(move || {
                 opfs_project::pack::sig_md5(&content)
-            }))
-            .await?
+            })
+            .await
             .map_err(to_js_error)?;
         Ok(result)
     }

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -212,7 +212,7 @@ impl Project {
                 ..Default::default()
             };
 
-            let rt = TOKIO_RUNTIME.get().expect("tokio runtime not found");
+            let rt = TOKIO_RUNTIME.get().ok_or_else(|| anyhow::anyhow!("tokio runtime not initialized"))?;
             let pack_context = rt
                 .spawn(PackProject::initialize(options))
                 .await

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -58,12 +58,12 @@ impl Project {
     /// Calculate MD5 hash of byte content (async for better thread scheduling)
     #[wasm_bindgen(js_name = sigMd5)]
     pub async fn sig_md5(content: Vec<u8>) -> Result<String, JsError> {
-        let rt = TOKIO_RUNTIME.get().ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
+        let rt = TOKIO_RUNTIME
+            .get()
+            .ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
 
         let result = rt
-            .spawn_blocking(move || {
-                opfs_project::pack::sig_md5(&content)
-            })
+            .spawn_blocking(move || opfs_project::pack::sig_md5(&content))
             .await
             .map_err(to_js_error)?;
         Ok(result)
@@ -90,13 +90,13 @@ impl Project {
             .map(|f| PackFile::new(f.path, f.content))
             .collect();
 
-        let rt = TOKIO_RUNTIME.get().ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
+        let rt = TOKIO_RUNTIME
+            .get()
+            .ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
 
         let bytes = rt
-            .spawn(tokio::task::spawn_blocking(move || {
-                opfs_project::pack::gzip(&pack_files)
-            }))
-            .await??
+            .spawn_blocking(move || opfs_project::pack::gzip(&pack_files))
+            .await?
             .map_err(to_js_error)?;
         Ok(js_sys::Uint8Array::from(&bytes[..]))
     }
@@ -152,7 +152,9 @@ impl Project {
             None => return Err(JsError::new("invalid pack project")),
         };
 
-        let rt = TOKIO_RUNTIME.get().ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
+        let rt = TOKIO_RUNTIME
+            .get()
+            .ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
 
         rt.spawn(async move { pack_project.build().await })
             .await
@@ -212,7 +214,9 @@ impl Project {
                 ..Default::default()
             };
 
-            let rt = TOKIO_RUNTIME.get().ok_or_else(|| anyhow::anyhow!("tokio runtime not initialized"))?;
+            let rt = TOKIO_RUNTIME
+                .get()
+                .ok_or_else(|| anyhow::anyhow!("tokio runtime not initialized"))?;
             let pack_context = rt
                 .spawn(PackProject::initialize(options))
                 .await

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -152,7 +152,7 @@ impl Project {
             None => return Err(JsError::new("invalid pack project")),
         };
 
-        let rt = TOKIO_RUNTIME.get().expect("tokio runtime not found");
+        let rt = TOKIO_RUNTIME.get().ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
 
         rt.spawn(async move { pack_project.build().await })
             .await

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -58,7 +58,7 @@ impl Project {
     /// Calculate MD5 hash of byte content (async for better thread scheduling)
     #[wasm_bindgen(js_name = sigMd5)]
     pub async fn sig_md5(content: Vec<u8>) -> Result<String, JsError> {
-        let rt = TOKIO_RUNTIME.get().expect("tokio runtime not found");
+        let rt = TOKIO_RUNTIME.get().ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
 
         let result = rt
             .spawn(tokio::task::spawn_blocking(move || {

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -90,7 +90,7 @@ impl Project {
             .map(|f| PackFile::new(f.path, f.content))
             .collect();
 
-        let rt = TOKIO_RUNTIME.get().expect("tokio runtime not found");
+        let rt = TOKIO_RUNTIME.get().ok_or_else(|| JsError::new("tokio runtime not initialized"))?;
 
         let bytes = rt
             .spawn(tokio::task::spawn_blocking(move || {

--- a/crates/utoo-wasm/src/tokio_runtime.rs
+++ b/crates/utoo-wasm/src/tokio_runtime.rs
@@ -2,35 +2,26 @@ use std::{
     cell::OnceCell,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        LazyLock,
+        OnceLock,
     },
     time::Duration,
 };
 
 use tokio::runtime;
 
-thread_local! {
-    pub static TOKIO_RUNTIME: OnceCell<runtime::Runtime> = const { OnceCell::new() };
-}
+pub static TOKIO_RUNTIME: OnceLock<runtime::Runtime> = OnceLock::new();
 
 pub fn init_tokio_runtime(worker_url: String) {
-    TOKIO_RUNTIME.with(|ctx| {
-        ctx.get_or_init(|| {
-            runtime::Builder::new_multi_thread()
-                /* *
-                 * The default dlmalloc is a single global allocator,
-                 * it will block threads scheduling,
-                 * see https://web.dev/articles/scaling-multithreaded-webassembly-applications#heap_management_mallocfree
-                 */
-                .disable_lifo_slot()
-                .thread_name_fn(|| {
-                    static ATOMIC_ID: AtomicUsize = AtomicUsize::new(1);
-                    let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                    format!("tokio-runtime-worker-{id}")
-                })
-                .wasm_bindgen_shim_url(worker_url.clone())
-                .build()
-                .unwrap()
-        });
-    })
+    TOKIO_RUNTIME.get_or_init(|| {
+        runtime::Builder::new_multi_thread()
+            .disable_lifo_slot()
+            .thread_name_fn(|| {
+                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(1);
+                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+                format!("tokio-runtime-worker-{id}")
+            })
+            .wasm_bindgen_shim_url(worker_url.clone())
+            .build()
+            .unwrap()
+    });
 }

--- a/crates/utoo-wasm/src/tokio_runtime.rs
+++ b/crates/utoo-wasm/src/tokio_runtime.rs
@@ -22,6 +22,6 @@ pub fn init_tokio_runtime(worker_url: String) {
             })
             .wasm_bindgen_shim_url(worker_url.clone())
             .build()
-            .unwrap()
+            .expect("Failed to build tokio runtime")
     });
 }

--- a/packages/utoo-web/src/project/InternalProject.ts
+++ b/packages/utoo-web/src/project/InternalProject.ts
@@ -77,9 +77,7 @@ class InternalEndpoint implements ProjectEndpoint {
     if (encoding === "utf8") {
       ret = await ProjectInternal.readToString(path);
     } else {
-      ret = await ProjectInternal.read(path);
-      const copied = ret.slice(0);
-      return comlink.transfer(copied, [copied.buffer]);
+      return await ProjectInternal.read(path);
     }
     return ret as any;
   }
@@ -162,9 +160,7 @@ class InternalEndpoint implements ProjectEndpoint {
 
   async gzip(files: PackFile[]) {
     await this.wasmInit!;
-    const ret = await ProjectInternal.gzip(files);
-    const copied = ret.slice(0);
-    return comlink.transfer(copied, [copied.buffer]);
+    return await ProjectInternal.gzip(files);
   }
 
   async sigMd5(content: Uint8Array) {

--- a/packages/utoo-web/src/project/Project.ts
+++ b/packages/utoo-web/src/project/Project.ts
@@ -126,11 +126,7 @@ export class Project implements ProjectEndpoint {
   ) {
     await this.#mount;
     if (content instanceof Uint8Array) {
-      return await this.remote.writeFile(
-        path,
-        comlink.transfer(content, [content.buffer]),
-        encoding,
-      );
+      return await this.remote.writeFile(path, content, encoding);
     }
     return await this.remote.writeFile(path, content, encoding);
   }
@@ -175,15 +171,12 @@ export class Project implements ProjectEndpoint {
 
   public async gzip(files: PackFile[]): Promise<Uint8Array> {
     await this.#mount;
-    const buffers = files.map((f) => f.content.buffer);
-    return await this.remote.gzip(comlink.transfer(files, buffers));
+    return await this.remote.gzip(files);
   }
 
   public async sigMd5(content: Uint8Array): Promise<string> {
     await this.#mount;
-    return await this.remote.sigMd5(
-      comlink.transfer(content, [content.buffer]),
-    );
+    return await this.remote.sigMd5(content);
   }
 
   public static fork(

--- a/packages/utoo-web/src/utoo/index.d.ts
+++ b/packages/utoo-web/src/utoo/index.d.ts
@@ -185,13 +185,13 @@ export interface InitOutput {
   readonly __wbindgen_free: (a: number, b: number, c: number) => void;
   readonly __wbindgen_export_7: WebAssembly.Table;
   readonly __externref_drop_slice: (a: number, b: number) => void;
-  readonly closure117912_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure115367_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure106_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure115550_externref_shim: (a: number, b: number, c: any) => void;
   readonly wasm_bindgen__convert__closures_____invoke__h2ce973260553dde0: (a: number, b: number) => void;
+  readonly closure118092_externref_shim: (a: number, b: number, c: any) => void;
   readonly wasm_bindgen__convert__closures_____invoke__h13262edabaa325f0: (a: number, b: number) => void;
-  readonly closure115364_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure104_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure118047_externref_shim: (a: number, b: number, c: any, d: any) => void;
+  readonly closure115547_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure118226_externref_shim: (a: number, b: number, c: any, d: any) => void;
   readonly __wbindgen_thread_destroy: (a?: number, b?: number, c?: number) => void;
   readonly __wbindgen_start: (a: number) => void;
 }

--- a/packages/utoo-web/src/utoo/index.d.ts
+++ b/packages/utoo-web/src/utoo/index.d.ts
@@ -185,13 +185,13 @@ export interface InitOutput {
   readonly __wbindgen_free: (a: number, b: number, c: number) => void;
   readonly __wbindgen_export_7: WebAssembly.Table;
   readonly __externref_drop_slice: (a: number, b: number) => void;
-  readonly closure106_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure115550_externref_shim: (a: number, b: number, c: any) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__h2ce973260553dde0: (a: number, b: number) => void;
-  readonly closure118092_externref_shim: (a: number, b: number, c: any) => void;
   readonly wasm_bindgen__convert__closures_____invoke__h13262edabaa325f0: (a: number, b: number) => void;
-  readonly closure115547_externref_shim: (a: number, b: number, c: any) => void;
-  readonly closure118226_externref_shim: (a: number, b: number, c: any, d: any) => void;
+  readonly closure115507_externref_shim: (a: number, b: number, c: any) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h2ce973260553dde0: (a: number, b: number) => void;
+  readonly closure106_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure118049_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure115504_externref_shim: (a: number, b: number, c: any) => void;
+  readonly closure118183_externref_shim: (a: number, b: number, c: any, d: any) => void;
   readonly __wbindgen_thread_destroy: (a?: number, b?: number, c?: number) => void;
   readonly __wbindgen_start: (a: number) => void;
 }


### PR DESCRIPTION
This pull request refactors how the Tokio runtime is accessed and initialized in the `utoo-wasm` crate. The main improvements are simplifying the runtime management by switching from a thread-local `OnceCell` to a global `OnceLock`, and updating all usages to match this new approach. This reduces code complexity and potential issues with thread-local state.

**Tokio runtime management refactor:**

* Replaced the thread-local `OnceCell` (`TOKIO_RUNTIME`) with a global `OnceLock` in `tokio_runtime.rs`, making the runtime globally accessible and simplifying initialization logic.
* Updated the `init_tokio_runtime` function to use the new global `OnceLock` instead of a thread-local context.

**Updates to runtime usage in project methods:**

* Refactored all usages of `TOKIO_RUNTIME` in `project.rs` to use the global `OnceLock` instead of the previous thread-local approach, including in `sig_md5`, `gzip`, `build`, and `PackProject::initialize` calls. [[1]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL61-R68) [[2]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL88-R99) [[3]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL146-R157) [[4]](diffhunk://#diff-311ea80d6df6888a14e1962a54ad3271a11dc5e06e03009987d7bd8825ad7ebdL209-L214)