### PR TITLE
fix(pack): correctly remove body scripts from html entry template

### DIFF
--- a/packages/pack/src/utils/html-entry.ts
+++ b/packages/pack/src/utils/html-entry.ts
@@ -22,6 +22,11 @@ export function processHtmlEntry(config: ConfigComplete, projectPath: string) {
           const src = script.getAttribute("src");
           if (src && !src.startsWith("http") && !src.startsWith("//")) {
             const scriptPath = path.join(path.dirname(entry.import), src);
+            // Remove the origin script tag from the DOM
+            if (script.parentNode) {
+              script.parentNode.removeChild(script);
+            }
+
             newEntries.push({
               import: scriptPath,
               html: {
@@ -30,10 +35,6 @@ export function processHtmlEntry(config: ConfigComplete, projectPath: string) {
                 filename: path.basename(entry.import),
               },
             });
-            // Remove the script tag from the DOM
-            if (script.parentNode) {
-              script.parentNode.removeChild(script);
-            }
           }
         });
 


### PR DESCRIPTION
This pull request makes a minor adjustment to how script tags are handled in the `processHtmlEntry` function. The change moves the removal of the original script tag earlier in the code, ensuring that the tag is deleted before new entries are added.

* Refactored script tag removal logic in `processHtmlEntry` so that the script tag is removed from the DOM immediately after its path is processed, rather than after the new entry is added. (`packages/pack/src/utils/html-entry.ts`) [[1]](diffhunk://#diff-bb60f28199705815e073f6198d341d5bfe92577efc0a04bfdb8e27b7b8304e93R25-R29) [[2]](diffhunk://#diff-bb60f28199705815e073f6198d341d5bfe92577efc0a04bfdb8e27b7b8304e93L33-L36)