### PR TITLE
perf(wasm): update tokio-fs-ext & opfs-project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -3391,15 +3390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6639b70a7ce854b79c70d7e83f16b5dc0137cc914f3d7d03803b513ecc67ac"
 
 [[package]]
-name = "libz-rs-sys"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
-dependencies = [
- "zlib-rs",
-]
-
-[[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.68"
 source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#2cf088153358cc4a0943cb350f05f1b884a45aba"
@@ -4159,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "opfs-project"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429d6a7299a31f350b60231b6be938c97f110c9413e6007624faa8efef0b7800"
+checksum = "4c64433ad95ae60f044e55bc0a067264270461ff41152b5509929e5e736570c7"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -8144,9 +8134,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-fs-ext"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3917b3417132eed9af87201686fb043b2f0806def11c2a4997836369c94a0b"
+checksum = "4950e63aa5b76311cb0a9d580d4202e46768abd8b2d17a739441d3dbdcbb524c"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -10939,12 +10929,6 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde_path_to_error = "0.1.16"
 simd-json           = "0.17.0"
 thiserror           = "1.0"
 tokio               = { version = "1.47.1" }
-tokio-fs-ext        = "0.6.5"
+tokio-fs-ext        = "0.6.9"
 toml                = "0.8"
 tracing             = "0.1.41"
 tracing-subscriber  = { version = "0.3.19", features = ["env-filter", "fmt"] }

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -29,7 +29,7 @@ flate2                   = "1.1.5"
 futures                  = { workspace = true }
 js-sys                   = "0.3.83"
 oneshot                  = "0.1.11"
-opfs-project             = "0.1.15"
+opfs-project             = "0.1.16"
 petgraph                 = "0.6"
 reqwest                  = { version = "0.12.22", default-features = false, features = ["json"] }
 rustc-hash               = { workspace = true }
@@ -38,7 +38,7 @@ serde-wasm-bindgen       = "0.6.5"
 serde_json               = { workspace = true }
 tar                      = "0.4.44"
 tokio                    = { workspace = true, features = ["rt", "rt-multi-thread", "time"] }
-tokio-fs-ext             = { version = "0.6.5", features = ["opfs_offload", "opfs_tracing", "opfs_watch"] }
+tokio-fs-ext             = { workspace = true, features = ["opfs_offload", "opfs_tracing", "opfs_watch"] }
 tracing                  = { workspace = true }
 tracing-subscriber       = { workspace = true }
 tracing-web              = "0.1.3"

--- a/crates/utoo-wasm/src/lib.rs
+++ b/crates/utoo-wasm/src/lib.rs
@@ -55,8 +55,10 @@ fn init_pack() {
 
 #[wasm_bindgen(js_name = "initLogFilter")]
 pub fn init_log_filter(mut filter: String) {
+    const DEFAULT_LOG_FILTER: &str = "utoo_wasm=info,pack_api=info,pack_core=info";
+
     if filter.is_empty() {
-        filter.push_str("utoo_wasm=info,pack_api=info,pack_core=info")
+        filter.push_str(DEFAULT_LOG_FILTER)
     }
     TRACING_INIT.call_once(|| {
         let filter_str = filter.clone();

--- a/crates/utoo-wasm/src/lib.rs
+++ b/crates/utoo-wasm/src/lib.rs
@@ -56,7 +56,7 @@ fn init_pack() {
 #[wasm_bindgen(js_name = "initLogFilter")]
 pub fn init_log_filter(mut filter: String) {
     if filter.is_empty() {
-        filter.push_str("pack_napi=info,pack_api=info,pack_core=info")
+        filter.push_str("utoo_wasm=info,pack_api=info,pack_core=info")
     }
     TRACING_INIT.call_once(|| {
         let filter_str = filter.clone();

--- a/packages/utoo-web/src/utoo/index.d.ts
+++ b/packages/utoo-web/src/utoo/index.d.ts
@@ -142,6 +142,10 @@ export function workerCreated(worker_id: number): void;
 export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
 export interface InitOutput {
+  readonly registerWorkerScheduler: (a: any, b: any) => void;
+  readonly workerCreated: (a: number) => void;
+  readonly initLogFilter: (a: number, b: number) => void;
+  readonly init_pack: () => void;
   readonly __wbg_direntry_free: (a: number, b: number) => void;
   readonly __wbg_get_direntry_name: (a: number) => [number, number];
   readonly __wbg_get_direntry_type: (a: number) => number;
@@ -181,10 +185,6 @@ export interface InitOutput {
   readonly project_write: (a: number, b: number, c: any) => any;
   readonly project_writeString: (a: number, b: number, c: number, d: number) => any;
   readonly project_writeSync: (a: number, b: number, c: any) => [number, number];
-  readonly initLogFilter: (a: number, b: number) => void;
-  readonly init_pack: () => void;
-  readonly registerWorkerScheduler: (a: any, b: any) => void;
-  readonly workerCreated: (a: number) => void;
   readonly rust_mi_get_default_heap: () => number;
   readonly rust_mi_get_thread_id: () => number;
   readonly rust_mi_set_default_heap: (a: number) => void;
@@ -209,18 +209,18 @@ export interface InitOutput {
   readonly wasmtaskmessage_data: (a: number) => any;
   readonly __wbg_createsyncaccesshandleoptions_free: (a: number, b: number) => void;
   readonly wasm_thread_entry_point: (a: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__h1fc3e28920f04101: (a: number, b: number) => void;
-  readonly wasm_bindgen__closure__destroy__h697219d9b2418ea3: (a: number, b: number) => void;
   readonly wasm_bindgen__convert__closures________invoke__hc572a1bf691b2f02: (a: number, b: number, c: any) => void;
   readonly wasm_bindgen__closure__destroy__h79b136ee1664aaaa: (a: number, b: number) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h1fc3e28920f04101: (a: number, b: number) => void;
+  readonly wasm_bindgen__closure__destroy__h697219d9b2418ea3: (a: number, b: number) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h12ad3f2e11ef8f1f: (a: number, b: number, c: any) => void;
+  readonly wasm_bindgen__closure__destroy__ha0c175f92395ef9a: (a: number, b: number) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h8bdf724950a20526: (a: number, b: number, c: any) => void;
+  readonly wasm_bindgen__closure__destroy__h33b24a5c45343d26: (a: number, b: number) => void;
   readonly wasm_bindgen__convert__closures_____invoke__hce460cf0a813c454: (a: number, b: number) => void;
   readonly wasm_bindgen__closure__destroy__hc14e8607e23cebd7: (a: number, b: number) => void;
   readonly wasm_bindgen__convert__closures_____invoke__h05951ccee93604a9: (a: number, b: number, c: any) => void;
   readonly wasm_bindgen__closure__destroy__hc95bb6053e4d238d: (a: number, b: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__hbd325ba31743329c: (a: number, b: number, c: any) => void;
-  readonly wasm_bindgen__closure__destroy__h87d652f0494817e1: (a: number, b: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__h12ad3f2e11ef8f1f: (a: number, b: number, c: any) => void;
-  readonly wasm_bindgen__closure__destroy__ha0c175f92395ef9a: (a: number, b: number) => void;
   readonly wasm_bindgen__convert__closures_____invoke__heb9448f3005917b6: (a: number, b: number, c: any, d: any) => void;
   readonly memory: WebAssembly.Memory;
   readonly __wbindgen_malloc: (a: number, b: number) => number;


### PR DESCRIPTION
This pull request primarily updates dependencies and makes a minor adjustment to the logging filter in the `utoo-wasm` crate. The changes ensure compatibility with newer versions of libraries and improve the clarity of log output.

Dependency updates:

* Updated `tokio-fs-ext` from version `0.6.5` to `0.6.9` in the workspace root `Cargo.toml` for improved stability and bug fixes.
* Updated `opfs-project` from `0.1.15` to `0.1.16` and changed `tokio-fs-ext` to use the workspace version in `crates/utoo-wasm/Cargo.toml`, ensuring consistency and up-to-date dependencies. [[1]](diffhunk://#diff-30f431bd515894704c2bc418a0a6de34f95a51a9aa6eeb2e78d7e0dbcf37963aL32-R32) [[2]](diffhunk://#diff-30f431bd515894704c2bc418a0a6de34f95a51a9aa6eeb2e78d7e0dbcf37963aL41-R41)

Logging improvements:

* Changed the default log filter in `init_log_filter` to use `utoo_wasm=info` instead of the removed `pack_napi=info`, ensuring log output is relevant to the current crate.

Other updates:

* Updated the `next.js` submodule to a new commit, pulling in the latest changes from that dependency.