### PR TITLE
feat(pack): flatten utoopack.json structure and update CLI to support…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4403,6 +4403,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "turbopack-node",
 ]
 
 [[package]]

--- a/crates/pack-cli/build.rs
+++ b/crates/pack-cli/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // This is a workaround for Cargo workspace feature unification.
+    // When building the entire workspace, `turbopack-node`'s `worker_pool` feature
+    // is enabled (e.g., by `pack-napi`), which pulls in Node.js N-API symbols.
+    // Since `pack-cli` is a standalone binary and not a Node.js addon, these symbols
+    // are missing at link time. This flag tells the linker to resolve them at
+    // runtime instead of failing the build.
+    println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
+}

--- a/crates/pack-cli/src/lib.rs
+++ b/crates/pack-cli/src/lib.rs
@@ -29,10 +29,10 @@ pub struct Command {
     pub watch: Option<bool>,
 
     #[arg(short, long)]
-    pub project_dir: String,
+    pub project_path: Option<String>,
 
     #[arg(short, long)]
-    pub root_dir: Option<String>,
+    pub root_path: Option<String>,
 }
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -44,16 +44,6 @@ pub enum Mode {
 #[derive(Debug, Default, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PartialProjectOptions {
-    /// A root path from which all files must be nested under. Trying to access
-    /// a file outside this root will fail. Think of this as a chroot.
-    pub root_path: Option<RcStr>,
-
-    /// A path inside the root_path which contains the app/pages directories.
-    pub project_path: Option<RcStr>,
-
-    /// The contents of next.config.js, serialized to JSON.
-    pub config: Option<serde_json::Value>,
-
     /// A map of environment variables to use when compiling code.
     pub process_env: Option<Vec<(RcStr, RcStr)>>,
 
@@ -69,6 +59,9 @@ pub struct PartialProjectOptions {
 
     /// Absolute path for `@utoo/pack`.
     pub pack_path: Option<RcStr>,
+
+    #[serde(flatten)]
+    pub config: serde_json::Value,
 }
 
 pub async fn initialize_project_container(

--- a/crates/pack-cli/src/main.rs
+++ b/crates/pack-cli/src/main.rs
@@ -4,7 +4,7 @@
 use clap::Parser;
 use dunce::canonicalize;
 use pack_api::project::{ProjectOptions, WatchOptions};
-use serde_json::{Value, json};
+use serde_json::Value;
 use std::{cell::RefCell, fs::File, path::PathBuf, time::Instant};
 use turbo_rcstr::RcStr;
 
@@ -30,13 +30,13 @@ fn main() {
 
     let watch = dev && args.watch.is_some_and(|watch| watch);
 
-    let project_path: RcStr = canonicalize(args.project_dir)
+    let project_path: RcStr = canonicalize(args.project_path.unwrap_or_else(|| ".".to_string()))
         .unwrap()
         .to_str()
         .unwrap()
         .into();
 
-    let root_dir = args.root_dir.map(RcStr::from);
+    let root_path = args.root_path.map(RcStr::from);
 
     thread_local! {
         static LAST_SWC_ATOM_GC_TIME: RefCell<Option<Instant>> = const { RefCell::new(None) };
@@ -114,17 +114,12 @@ fn main() {
                 serde_json::from_reader(&mut project_options_file).unwrap();
             let mode = if dev { "development" } else { "production" };
 
-            partial_project_options.config = partial_project_options.config.as_mut().map_or(
-                Some(json!(format!(r#"{{ "mode": {mode}}}"#,))),
-                |mut config| {
-                    if let Value::Object(map) = &mut config {
-                        map.insert("mode".to_string(), mode.into());
-                    }
-                    Some(config.take())
-                },
-            );
+            if let Value::Object(map) = &mut partial_project_options.config {
+                map.insert("mode".to_string(), mode.into());
+            }
+
             let project_options = ProjectOptions {
-                root_path: root_dir
+                root_path: root_path
                     .as_ref()
                     .map(|r| {
                         canonicalize(PathBuf::from(&r))
@@ -133,16 +128,9 @@ fn main() {
                             .unwrap()
                             .into()
                     })
-                    .or(partial_project_options.root_path.as_ref().map(|r| {
-                        canonicalize(PathBuf::from(&project_path).join(r))
-                            .unwrap()
-                            .to_str()
-                            .unwrap()
-                            .into()
-                    }))
                     .unwrap_or_else(|| project_path.clone()),
                 project_path,
-                config: partial_project_options.config.unwrap().to_string().into(),
+                config: partial_project_options.config.to_string().into(),
                 process_env: partial_project_options.process_env.unwrap_or_default(),
                 define_env: partial_project_options.define_env.unwrap_or_default(),
 

--- a/crates/pack-schema/Cargo.toml
+++ b/crates/pack-schema/Cargo.toml
@@ -10,7 +10,8 @@ name = "pack-schema"
 path = "src/main.rs"
 
 [dependencies]
-pack-core  = { path = "../pack-core" }
-schemars   = { workspace = true }
-serde      = { workspace = true }
-serde_json = { workspace = true }
+pack-core      = { path = "../pack-core" }
+schemars       = { workspace = true }
+serde          = { workspace = true }
+serde_json     = { workspace = true }
+turbopack-node = { workspace = true, default-features = false, features = ["process_pool"] }

--- a/crates/pack-schema/build.rs
+++ b/crates/pack-schema/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // This is a workaround for Cargo workspace feature unification.
+    // When building the entire workspace, `turbopack-node`'s `worker_pool` feature
+    // is enabled (e.g., by `pack-napi`), which pulls in Node.js N-API symbols.
+    // Since `pack-cli` is a standalone binary and not a Node.js addon, these symbols
+    // are missing at link time. This flag tells the linker to resolve them at
+    // runtime instead of failing the build.
+    println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
+}

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -7,26 +7,38 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectOptions {
-    /// Root path of the project
+    /// A root path from which all files must be nested under.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Root path of the project")]
     pub root_path: Option<String>,
 
-    /// Project path relative to root
+    /// A path inside the root_path which contains the app directories.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Project path relative to root")]
     pub project_path: Option<String>,
 
-    /// Main configuration object
-    #[schemars(description = "Main configuration object")]
-    pub config: SchemaConfig,
-}
+    /// A map of environment variables to use when compiling code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_env: Option<HashMap<String, String>>,
 
-/// Main configuration structure that mirrors pack_core::config::Config
-/// All fields are derived from the original Config structure in pack-core
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct SchemaConfig {
+    /// Whether to run in development mode
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dev: Option<bool>,
+
+    /// The build id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_id: Option<String>,
+
+    /// Absolute path for @utoo/pack
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pack_path: Option<String>,
+
+    /// Filesystem watcher options.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watch: Option<SchemaWatchOptions>,
+
+    /// A map of environment variables which should get injected at compile time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub define_env: Option<SchemaDefineEnv>,
+
     /// Build mode (development, production)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Build mode")]
@@ -106,6 +118,61 @@ pub struct SchemaConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Enable Node.js polyfills for browser builds")]
     pub node_polyfill: Option<bool>,
+
+    /// Enable build statistics
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Enable build statistics")]
+    pub stats: Option<bool>,
+
+    /// Development server configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Development server configuration")]
+    pub dev_server: Option<SchemaDevServer>,
+}
+
+/// Filesystem watcher options
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaWatchOptions {
+    /// Whether to watch the filesystem for file changes.
+    pub enable: bool,
+
+    /// Enable polling at a certain interval if the native file watching doesn't work (e.g. docker).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub poll_interval: Option<u64>,
+}
+
+/// Environment variables for build-time injection
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaDefineEnv {
+    /// Client-side environment variables
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client: Option<Vec<SchemaEnvVar>>,
+    /// Edge-side environment variables
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edge: Option<Vec<SchemaEnvVar>>,
+    /// Node.js environment variables
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nodejs: Option<Vec<SchemaEnvVar>>,
+}
+
+/// Environment variable pair
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SchemaEnvVar {
+    /// Variable name
+    pub name: String,
+    /// Variable value
+    pub value: String,
+}
+
+/// Development server configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaDevServer {
+    /// Enable hot module replacement
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hot: Option<bool>,
 }
 
 /// Entry point configuration
@@ -125,6 +192,44 @@ pub struct SchemaEntryOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Library configuration for this entry")]
     pub library: Option<SchemaLibraryOptions>,
+
+    /// HTML generation configuration for this entry
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "HTML generation configuration for this entry")]
+    pub html: Option<SchemaHtmlConfig>,
+}
+
+/// HTML generation configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaHtmlConfig {
+    /// Path to the HTML template file
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+
+    /// Inline HTML template content
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template_content: Option<String>,
+
+    /// Output filename for the generated HTML
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+
+    /// Title for the generated HTML
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    /// Where to inject scripts (true, false, "body", "head")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inject: Option<serde_json::Value>,
+
+    /// Script loading strategy ("blocking", "defer", "module")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub script_loading: Option<String>,
+
+    /// Meta tags configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// Library output configuration
@@ -269,6 +374,18 @@ pub struct SchemaOptimizationConfig {
         description = "Whether to bunle wasm as asset. Defaults to false. When false, WASM files will be output as static assets."
     )]
     pub wasm_as_asset: Option<bool>,
+
+    /// Whether to remove unused exports
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remove_unused_exports: Option<bool>,
+
+    /// Whether to remove unused imports
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remove_unused_imports: Option<bool>,
+
+    /// Whether to enable nested async chunking
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nested_async_chunking: Option<bool>,
 }
 
 /// Module ID generation strategy
@@ -473,12 +590,58 @@ pub struct SchemaModuleConfig {
     /// Module rules configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Module rules configuration")]
-    pub rules: Option<HashMap<String, serde_json::Value>>,
+    pub rules: Option<HashMap<String, SchemaModuleRule>>,
 
     /// Module conditions configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Module conditions configuration")]
     pub conditions: Option<HashMap<String, SchemaConfigConditionItem>>,
+}
+
+/// Module rule configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SchemaModuleRule {
+    /// Shorthand for a single loader
+    Shorthand(String),
+    /// Full rule configuration
+    Full(SchemaRuleConfigItem),
+    /// Multiple rule configurations
+    Array(Vec<SchemaModuleRuleItem>),
+}
+
+/// Item in a module rule array
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SchemaModuleRuleItem {
+    /// Shorthand for a single loader
+    Shorthand(String),
+    /// Full rule configuration
+    Full(SchemaRuleConfigItem),
+}
+
+/// Full module rule configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaRuleConfigItem {
+    /// Loaders to apply
+    pub loaders: Vec<SchemaLoaderItem>,
+    /// Rename the module as another extension
+    #[serde(default, alias = "as")]
+    pub rename_as: Option<String>,
+    /// Condition for applying the rule
+    #[serde(default)]
+    pub condition: Option<SchemaConfigConditionItem>,
+}
+
+/// Loader configuration item
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SchemaLoaderItem {
+    /// Loader name
+    LoaderName(String),
+    /// Loader with options
+    LoaderOptions(serde_json::Value),
 }
 
 /// Configuration condition item
@@ -664,11 +827,15 @@ mod tests {
         let schema_str = serde_json::to_string(&schema).unwrap();
 
         // Check for key configuration fields
-        assert!(schema_str.contains("config"));
+        assert!(schema_str.contains("rootPath"));
+        assert!(schema_str.contains("projectPath"));
         assert!(schema_str.contains("entry"));
         assert!(schema_str.contains("externals"));
         assert!(schema_str.contains("optimization"));
         assert!(schema_str.contains("concatenateModules"));
+        assert!(schema_str.contains("watch"));
+        assert!(schema_str.contains("defineEnv"));
+        assert!(schema_str.contains("html"));
     }
 
     #[test]
@@ -726,26 +893,24 @@ mod tests {
         {
           "rootPath": "../../",
           "projectPath": "./",
-          "config": {
-            "entry": [
-              {
-                "import": "./index.js"       
-              }
-            ],
-            "output": {
-              "path": "./dist",
-              "filename": "[name].[contenthash:6].js",
-              "chunkFilename": "[name].[contenthash:8].js",
-              "clean": true
-            },
-            "optimization": {
-              "moduleIds": "named",
-              "minify": false,
-              "concatenateModules": true
-            },
-            "externals": {
-              "foo": "bar"
+          "entry": [
+            {
+              "import": "./index.js"       
             }
+          ],
+          "output": {
+            "path": "./dist",
+            "filename": "[name].[contenthash:6].js",
+            "chunkFilename": "[name].[contenthash:8].js",
+            "clean": true
+          },
+          "optimization": {
+            "moduleIds": "named",
+            "minify": false,
+            "concatenateModules": true
+          },
+          "externals": {
+            "foo": "bar"
           }
         }
         "#;
@@ -753,13 +918,13 @@ mod tests {
         let config: ProjectOptions = serde_json::from_str(json).unwrap();
         assert_eq!(config.root_path, Some("../../".to_string()));
         assert_eq!(config.project_path, Some("./".to_string()));
-        assert!(config.config.entry.is_some());
-        assert!(config.config.output.is_some());
-        assert!(config.config.optimization.is_some());
-        assert!(config.config.externals.is_some());
+        assert!(config.entry.is_some());
+        assert!(config.output.is_some());
+        assert!(config.optimization.is_some());
+        assert!(config.externals.is_some());
 
         // Test concatenateModules configuration
-        let optimization = config.config.optimization.as_ref().unwrap();
+        let optimization = config.optimization.as_ref().unwrap();
         assert_eq!(optimization.concatenate_modules, Some(true));
     }
 
@@ -768,43 +933,73 @@ mod tests {
         // Test with concatenateModules: true
         let json_true = r#"
         {
-          "config": {
-            "optimization": {
-              "concatenateModules": true
-            }
+          "optimization": {
+            "concatenateModules": true
           }
         }
         "#;
         let config: ProjectOptions = serde_json::from_str(json_true).unwrap();
-        let optimization = config.config.optimization.as_ref().unwrap();
+        let optimization = config.optimization.as_ref().unwrap();
         assert_eq!(optimization.concatenate_modules, Some(true));
 
         // Test with concatenateModules: false
         let json_false = r#"
         {
-          "config": {
-            "optimization": {
-              "concatenateModules": false
-            }
+          "optimization": {
+            "concatenateModules": false
           }
         }
         "#;
         let config: ProjectOptions = serde_json::from_str(json_false).unwrap();
-        let optimization = config.config.optimization.as_ref().unwrap();
+        let optimization = config.optimization.as_ref().unwrap();
         assert_eq!(optimization.concatenate_modules, Some(false));
 
         // Test without concatenateModules (should be None)
         let json_none = r#"
         {
-          "config": {
-            "optimization": {
-              "minify": true
-            }
+          "optimization": {
+            "minify": true
           }
         }
         "#;
         let config: ProjectOptions = serde_json::from_str(json_none).unwrap();
-        let optimization = config.config.optimization.as_ref().unwrap();
+        let optimization = config.optimization.as_ref().unwrap();
         assert_eq!(optimization.concatenate_modules, None);
+    }
+
+    #[test]
+    fn test_module_rules_deserialization() {
+        let json = r#"
+        {
+          "module": {
+            "rules": {
+              "*.txt": {
+                "loaders": ["./test-file-loader.js"],
+                "as": "*.js"
+              },
+              "*.svg": "svg-loader"
+            }
+          }
+        }
+        "#;
+        let config: ProjectOptions = serde_json::from_str(json).unwrap();
+        let rules = config.module.as_ref().unwrap().rules.as_ref().unwrap();
+
+        // Check full rule
+        let txt_rule = rules.get("*.txt").unwrap();
+        if let SchemaModuleRule::Full(full) = txt_rule {
+            assert_eq!(full.rename_as, Some("*.js".to_string()));
+            assert_eq!(full.loaders.len(), 1);
+        } else {
+            panic!("Expected Full rule for *.txt");
+        }
+
+        // Check shorthand rule
+        let svg_rule = rules.get("*.svg").unwrap();
+        if let SchemaModuleRule::Shorthand(s) = svg_rule {
+            assert_eq!(s, "svg-loader");
+        } else {
+            panic!("Expected Shorthand rule for *.svg");
+        }
     }
 }

--- a/examples/define/utoopack.json
+++ b/examples/define/utoopack.json
@@ -1,27 +1,26 @@
 {
   "$schema": "../../packages/pack/config_schema.json",
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "define": {
-      "AAA": "\"aaa\"",
-      "BBB": "\"bbb\"",
-      "CCC": "1"
-    },
-    "entry": [
-      {
-        "import": "./index.html"
+  "define": {
+    "AAA": "\"aaa\"",
+    "BBB": "\"bbb\"",
+    "CCC": "1"
+  },
+  "entry": [
+    {
+      "import": "./src/index.ts",
+      "html": {
+        "template": "./index.html"
       }
-    ],
-    "output": {
-      "path": "./dist",
-      "filename": "[name].[contenthash:6].js",
-      "chunkFilename": "[name].[contenthash:8].js",
-      "clean": true
-    },
-    "sourceMaps": false,
-    "optimization": {
-      "minify": false
     }
+  ],
+  "output": {
+    "path": "./dist",
+    "filename": "[name].[contenthash:6].js",
+    "chunkFilename": "[name].[contenthash:8].js",
+    "clean": true
+  },
+  "sourceMaps": false,
+  "optimization": {
+    "minify": false
   }
 }

--- a/examples/externals/utoopack.json
+++ b/examples/externals/utoopack.json
@@ -1,63 +1,64 @@
 {
   "$schema": "../../packages/pack/config_schema.json",
-  "config": {
-    "stats": true,
-    "entry": [
-      {
-        "import": "./index.html"
+  "stats": true,
+  "entry": [
+    {
+      "import": "./index.js",
+      "html": {
+        "template": "./index.html"
       }
-    ],
-    "output": {
-      "path": "./dist",
-      "filename": "[name].[contenthash:6].js",
-      "chunkFilename": "[name].[contenthash:8].js",
-      "clean": true
+    }
+  ],
+  "output": {
+    "path": "./dist",
+    "filename": "[name].[contenthash:6].js",
+    "chunkFilename": "[name].[contenthash:8].js",
+    "clean": true
+  },
+  "optimization": {
+    "moduleIds": "named",
+    "minify": false
+  },
+  "externals": {
+    "foo": "bar",
+    "foo_require": "commonjs bar",
+    "foo_require2": {
+      "root": "bar_require2",
+      "type": "commonjs"
     },
-    "optimization": {
-      "moduleIds": "named",
-      "minify": false
+    "foo_import": "esm bar",
+    "foo_import2": {
+      "root": "bar_import2",
+      "type": "esm"
     },
-    "externals": {
-      "foo": "bar",
-      "foo_require": "commonjs bar",
-      "foo_require2": {
-        "root": "bar_require2",
-        "type": "commonjs"
-      },
-      "foo_import": "esm bar",
-      "foo_import2": {
-        "root": "bar_import2",
-        "type": "esm"
-      },
-      "foo_script": "script bar_script1@https://example.com/lib/script.js",
-      "foo_script2": {
-        "root": "bar_script2",
-        "type": "script",
-        "script": "https://example.com/lib/script2.js"
-      },
-      "antd": {
-        "root": "antd",
-        "subPath": {
-          "exclude": [
-            "style"
-          ],
-          "rules": [
-            {
-              "regex": "/(version|message|notification)$/",
-              "target": "$1"
-            },
-            {
-              "regex": "/^\/(?:es|lib)\/([a-z\\-]+)$/",
-              "target": "$1",
-              "targetConverter": "PascalCase"
-            },
-            {
-              "regex": "/^\/(?:es|lib)\/([a-z-]+)\/([A-Z][a-zA-Z-]+)$/",
-              "target": "$1/$2",
-              "targetConverter": "PascalCase"
-            }
-          ]
-        }
+    "foo_script": "script bar_script1@https://example.com/lib/script.js",
+    "foo_script2": {
+      "root": "bar_script2",
+      "type": "script",
+      "script": "https://example.com/lib/script2.js"
+    },
+    "antd": {
+      "root": "antd",
+      "subPath": {
+        "exclude": [
+          "style"
+        ],
+        "rules": [
+          {
+            "regex": "/(version|message|notification)$/",
+            "target": "$1"
+          },
+          {
+            "regex": "/^/(?:es|lib)/([a-z\\-]+)$/",
+            "target": "$1",
+            "targetConverter": "PascalCase"
+          },
+          {
+            "regex": "/^/(?:es|lib)/([a-z-]+)/([A-Z][a-zA-Z-]+)$/",
+            "target": "$1/$2",
+            "targetConverter": "PascalCase"
+          }
+        ]
       }
     }
   }

--- a/examples/multi-entries-heavy/utoopack.json
+++ b/examples/multi-entries-heavy/utoopack.json
@@ -1,15 +1,14 @@
 {
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "entry": [
-      {
-        "import": "./index.html"
+  "entry": [
+    {
+      "import": "./src/entry-0.js",
+      "html": {
+        "template": "./index.html"
       }
-    ],
-    "output": {
-      "path": "./dist"
-    },
-    "stats": true
-  }
+    }
+  ],
+  "output": {
+    "path": "./dist"
+  },
+  "stats": true
 }

--- a/examples/react/utoopack.json
+++ b/examples/react/utoopack.json
@@ -1,50 +1,49 @@
 {
   "$schema": "../../packages/pack/config_schema.json",
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "entry": [
-      {
-        "import": "./index.html",
-        "name": "index"
-      }
-    ],
-    "output": {
-      "path": "./dist",
-      "clean": true,
-      "copy": [
-        {
-          "from": "./static/index.css",
-          "to": "./index.css"
-        }
-      ]
-    },
-    "optimization": {
-      "minify": false
-    },
-    "module": {
-      "rules": {
-        "*.txt": {
-          "loaders": [
-            "./test-file-loader.js"
-          ],
-          "as": "*.js"
-        },
-        "#svg": {
-          "loaders": [
-            "@svgr/webpack"
-          ],
-          "as": "*.js"
-        }
+  "entry": [
+    {
+      "import": "./src/index.tsx",
+      "html": {
+        "template": "./index.html"
       },
-      "conditions": {
-        "#svg": {
-          "path": {
-            "type": "regex",
-            "value": {
-              "source": ".*\\.svg$",
-              "flags": "i"
-            }
+      "name": "index"
+    }
+  ],
+  "output": {
+    "path": "./dist",
+    "clean": true,
+    "copy": [
+      {
+        "from": "./static/index.css",
+        "to": "./index.css"
+      }
+    ]
+  },
+  "optimization": {
+    "minify": false
+  },
+  "module": {
+    "rules": {
+      "*.txt": {
+        "loaders": [
+          "./test-file-loader.js"
+        ],
+        "as": "*.js"
+      },
+      "#svg": {
+        "loaders": [
+          "@svgr/webpack"
+        ],
+        "as": "*.js"
+      }
+    },
+    "conditions": {
+      "#svg": {
+        "path": {
+          "type": "regex",
+          "value": {
+            "source": ".*\\.svg$",
+            "flags": "i"
           }
         }
       }

--- a/examples/resolve/utoopack.json
+++ b/examples/resolve/utoopack.json
@@ -1,24 +1,23 @@
 {
   "$schema": "../../packages/pack/config_schema.json",
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "output": {
-      "clean": true
-    },
-    "entry": [
-      {
-        "import": "./index.html",
-        "name": "alias-demo"
-      }
-    ],
-    "resolve": {
-      "alias": {
-        "hello-a": "./src/a.ts"
-      }
-    },
-    "optimization": {
-      "minify": false
+  "output": {
+    "clean": true
+  },
+  "entry": [
+    {
+      "import": "./src/index.ts",
+      "html": {
+        "template": "./index.html"
+      },
+      "name": "alias-demo"
     }
+  ],
+  "resolve": {
+    "alias": {
+      "hello-a": "./src/a.ts"
+    }
+  },
+  "optimization": {
+    "minify": false
   }
 }

--- a/examples/split-chunks/utoopack.json
+++ b/examples/split-chunks/utoopack.json
@@ -1,23 +1,22 @@
 {
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "entry": [
-      {
-        "import": "./index.html"
+  "entry": [
+    {
+      "import": "./index.js",
+      "html": {
+        "template": "./index.html"
       }
-    ],
-    "output": {
-      "path": "./dist",
-      "clean": true
-    },
-    "optimization": {
-      "splitChunks": {
-        "js": {
-          "minChunkSize": 2000,
-          "maxChunkCountPerGroup": 1,
-          "maxMergeChunkSize": 20000
-        }
+    }
+  ],
+  "output": {
+    "path": "./dist",
+    "clean": true
+  },
+  "optimization": {
+    "splitChunks": {
+      "js": {
+        "minChunkSize": 2000,
+        "maxChunkCountPerGroup": 1,
+        "maxMergeChunkSize": 20000
       }
     }
   }

--- a/examples/with-antd/utoopack.json
+++ b/examples/with-antd/utoopack.json
@@ -1,34 +1,33 @@
 {
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "entry": [
-      {
-        "import": "./index.html"
+  "entry": [
+    {
+      "import": "./src/index.tsx",
+      "html": {
+        "template": "./index.html"
       }
-    ],
-    "styles": {
-      "less": {
-        "javascriptEnabled": true
+    }
+  ],
+  "styles": {
+    "less": {
+      "javascriptEnabled": true
+    }
+  },
+  "output": {
+    "path": "./dist",
+    "filename": "[name].[contenthash:8].js",
+    "chunkFilename": "[name].[contenthash:8].js",
+    "clean": true
+  },
+  "optimization": {
+    "minify": false,
+    "moduleIds": "named",
+    "splitChunks": {
+      "js": {
+        "minChunkSize": 50000,
+        "maxChunkCountPerGroup": 40,
+        "maxMergeChunkSize": 200000
       }
-    },
-    "output": {
-      "path": "./dist",
-      "filename": "[name].[contenthash:8].js",
-      "chunkFilename": "[name].[contenthash:8].js",
-      "clean": true
-    },
-    "optimization": {
-      "minify": false,
-      "moduleIds": "named",
-      "splitChunks": {
-        "js": {
-          "minChunkSize": 50000,
-          "maxChunkCountPerGroup": 40,
-          "maxMergeChunkSize": 200000
-        }
-      }
-    },
-    "stats": true
-  }
+    }
+  },
+  "stats": true
 }

--- a/examples/with-less/utoopack.json
+++ b/examples/with-less/utoopack.json
@@ -1,25 +1,26 @@
 {
   "$schema": "../../packages/pack/config_schema.json",
-  "config": {
-    "entry": [
-      {
-        "import": "./index.html"
+  "entry": [
+    {
+      "import": "./src/index.ts",
+      "html": {
+        "template": "./index.html"
       }
-    ],
-    "optimization": {
-      "minify": false
-    },
-    "styles": {
-      "less": {
-        "javascriptEnabled": true
-      }
-    },
-    "output": {
-      "path": "./dist",
-      "filename": "[name].[contenthash:8]",
-      "chunkFilename": "[name].[contenthash:8]",
-      "clean": true
-    },
-    "stats": true
-  }
+    }
+  ],
+  "optimization": {
+    "minify": false
+  },
+  "styles": {
+    "less": {
+      "javascriptEnabled": true
+    }
+  },
+  "output": {
+    "path": "./dist",
+    "filename": "[name].[contenthash:8]",
+    "chunkFilename": "[name].[contenthash:8]",
+    "clean": true
+  },
+  "stats": true
 }

--- a/examples/with-library/utoopack.json
+++ b/examples/with-library/utoopack.json
@@ -1,42 +1,38 @@
 {
   "$schema": "../../packages/pack/config_schema.json",
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "entry": [
-      {
-        "name": "library",
-        "import": "./src/index.ts",
-        "library": {
-          "name": "MyLibrary",
-          "export": [
-            "default",
-            "value"
-          ]
-        }
+  "entry": [
+    {
+      "name": "library",
+      "import": "./src/index.ts",
+      "library": {
+        "name": "MyLibrary",
+        "export": [
+          "default",
+          "value"
+        ]
       }
-    ],
-    "output": {
-      "path": "./dist",
-      "filename": "[name].[contenthash:8].js",
-      "clean": true
+    }
+  ],
+  "output": {
+    "path": "./dist",
+    "filename": "[name].[contenthash:8].js",
+    "clean": true
+  },
+  "html": {
+    "title": "with-library"
+  },
+  "optimization": {
+    "moduleIds": "named",
+    "minify": false
+  },
+  "externals": {
+    "react": {
+      "root": "React",
+      "commonjs": "react"
     },
-    "html": {
-      "title": "with-library"
-    },
-    "optimization": {
-      "moduleIds": "named",
-      "minify": false
-    },
-    "externals": {
-      "react": {
-        "root": "React",
-        "commonjs": "react"
-      },
-      "react-dom": {
-        "root": "ReactDOM",
-        "commonjs": "react-dom"
-      }
+    "react-dom": {
+      "root": "ReactDOM",
+      "commonjs": "react-dom"
     }
   }
 }

--- a/examples/with-sass/utoopack.json
+++ b/examples/with-sass/utoopack.json
@@ -1,17 +1,16 @@
 {
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "entry": [
-      {
-        "import": "./index.html"
+  "entry": [
+    {
+      "import": "./src/index.ts",
+      "html": {
+        "template": "./index.html"
       }
-    ],
-    "output": {
-      "path": "./dist",
-      "filename": "[name].[contenthash:8]",
-      "chunkFilename": "[name].[contenthash:8]",
-      "clean": true
     }
+  ],
+  "output": {
+    "path": "./dist",
+    "filename": "[name].[contenthash:8]",
+    "chunkFilename": "[name].[contenthash:8]",
+    "clean": true
   }
 }

--- a/examples/with-style-loader/utoopack.json
+++ b/examples/with-style-loader/utoopack.json
@@ -1,27 +1,23 @@
 {
   "$schema": "../../packages/pack/config_schema.json",
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "entry": [
-      {
-        "import": "./src/index.ts",
-        "library": {
-          "name": "with-style-loader"
-        }
+  "entry": [
+    {
+      "import": "./src/index.ts",
+      "library": {
+        "name": "with-style-loader"
       }
-    ],
-    "output": {
-      "path": "./dist"
-    },
-    "html": {
-      "title": "with-style-loader"
-    },
-    "styles": {
-      "inlineCss": {}
-    },
-    "optimization": {
-      "minify": false
     }
+  ],
+  "output": {
+    "path": "./dist"
+  },
+  "html": {
+    "title": "with-style-loader"
+  },
+  "styles": {
+    "inlineCss": {}
+  },
+  "optimization": {
+    "minify": false
   }
 }

--- a/examples/with-tailwind/utoopack.json
+++ b/examples/with-tailwind/utoopack.json
@@ -1,19 +1,18 @@
 {
   "$schema": "../../packages/pack/config_schema.json",
-  "rootPath": "../../",
-  "projectPath": "./",
-  "config": {
-    "entry": [
-      {
-        "name": "index",
-        "import": "./index.html"
+  "entry": [
+    {
+      "name": "index",
+      "import": "./src/index.jsx",
+      "html": {
+        "template": "./index.html"
       }
-    ],
-    "output": {
-      "clean": true
-    },
-    "optimization": {
-      "minify": false
     }
+  ],
+  "output": {
+    "clean": true
+  },
+  "optimization": {
+    "minify": false
   }
 }

--- a/packages/pack-cli/src/utils/common.ts
+++ b/packages/pack-cli/src/utils/common.ts
@@ -8,11 +8,13 @@ export const commonFlags = {
     char: "p",
     description: "Set the project path",
     required: false,
+    aliases: ["projectPath"],
   }),
   root: Flags.string({
     char: "r",
     description: "Set the root path",
     required: false,
+    aliases: ["rootPath"],
   }),
   webpack: Flags.boolean({
     name: "webpack",
@@ -42,11 +44,31 @@ export function resolveBuildOptions(flags: {
   if (webpack) {
     projectOptions = { webpackMode: true } as utooPack.WebpackConfig;
   } else {
-    projectOptions = JSON.parse(
+    const rawOptions = JSON.parse(
       fs.readFileSync(path.resolve(cwd, project || "", "utoopack.json"), {
         encoding: "utf-8",
       }),
-    ) as utooPack.BundleOptions;
+    );
+    const {
+      processEnv,
+      defineEnv,
+      watch,
+      dev,
+      buildId,
+      packPath,
+      rootPath: _rootPath,
+      projectPath: _projectPath,
+      ...config
+    } = rawOptions;
+    projectOptions = {
+      config,
+      processEnv,
+      defineEnv,
+      watch,
+      dev,
+      buildId,
+      packPath,
+    } as utooPack.BundleOptions;
   }
 
   return { projectPath, rootPath, projectOptions };

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -3,180 +3,241 @@
   "title": "ProjectOptions",
   "description": "Top-level project options configuration This represents the root structure of utoopack.json",
   "type": "object",
-  "required": [
-    "config"
-  ],
   "properties": {
-    "config": {
-      "description": "Main configuration object",
-      "allOf": [
+    "buildId": {
+      "description": "The build id.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "cacheHandler": {
+      "description": "Cache handler configuration",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "define": {
+      "description": "Define variables for build-time replacement",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    },
+    "defineEnv": {
+      "description": "A map of environment variables which should get injected at compile time.",
+      "anyOf": [
         {
-          "$ref": "#/definitions/SchemaConfig"
+          "$ref": "#/definitions/SchemaDefineEnv"
+        },
+        {
+          "type": "null"
         }
       ]
     },
-    "projectPath": {
-      "description": "Project path relative to root",
+    "dev": {
+      "description": "Whether to run in development mode",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "devServer": {
+      "description": "Development server configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaDevServer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "entry": {
+      "description": "Entry points for the build",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/SchemaEntryOptions"
+      }
+    },
+    "experimental": {
+      "description": "Experimental features",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaExperimentalConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "externals": {
+      "description": "External dependencies configuration",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/SchemaExternalConfig"
+      }
+    },
+    "images": {
+      "description": "Image processing configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaImageConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "mode": {
+      "description": "Build mode",
       "type": [
         "string",
         "null"
       ]
     },
-    "rootPath": {
-      "description": "Root path of the project",
+    "module": {
+      "description": "Module configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaModuleConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nodePolyfill": {
+      "description": "Enable Node.js polyfills for browser builds",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "optimization": {
+      "description": "Build optimization settings",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaOptimizationConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "output": {
+      "description": "Output configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaOutputConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "packPath": {
+      "description": "Absolute path for @utoo/pack",
       "type": [
         "string",
         "null"
+      ]
+    },
+    "persistentCaching": {
+      "description": "Enable persistent caching",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "processEnv": {
+      "description": "A map of environment variables to use when compiling code.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "projectPath": {
+      "description": "A path inside the root_path which contains the app directories.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "resolve": {
+      "description": "Resolve configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaResolveConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "rootPath": {
+      "description": "A root path from which all files must be nested under.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "sourceMaps": {
+      "description": "Enable source maps",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "stats": {
+      "description": "Enable build statistics",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "styles": {
+      "description": "Style processing configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaStyleConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "target": {
+      "description": "Target environment",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "watch": {
+      "description": "Filesystem watcher options.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaWatchOptions"
+        },
+        {
+          "type": "null"
+        }
       ]
     }
   },
   "definitions": {
-    "SchemaConfig": {
-      "description": "Main configuration structure that mirrors pack_core::config::Config All fields are derived from the original Config structure in pack-core",
-      "type": "object",
-      "properties": {
-        "cacheHandler": {
-          "description": "Cache handler configuration",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "define": {
-          "description": "Define variables for build-time replacement",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        },
-        "entry": {
-          "description": "Entry points for the build",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/SchemaEntryOptions"
-          }
-        },
-        "experimental": {
-          "description": "Experimental features",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SchemaExperimentalConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "externals": {
-          "description": "External dependencies configuration",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/definitions/SchemaExternalConfig"
-          }
-        },
-        "images": {
-          "description": "Image processing configuration",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SchemaImageConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "mode": {
-          "description": "Build mode",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "module": {
-          "description": "Module configuration",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SchemaModuleConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "optimization": {
-          "description": "Build optimization settings",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SchemaOptimizationConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "output": {
-          "description": "Output configuration",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SchemaOutputConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "persistentCaching": {
-          "description": "Enable persistent caching",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "resolve": {
-          "description": "Resolve configuration",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SchemaResolveConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "sourceMaps": {
-          "description": "Enable source maps",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "styles": {
-          "description": "Style processing configuration",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SchemaStyleConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "target": {
-          "description": "Target environment",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
     "SchemaConfigConditionItem": {
       "description": "Configuration condition item",
       "type": "object",
@@ -238,20 +299,80 @@
       ]
     },
     "SchemaCopyItem": {
-      "description": "Copy item configuration",
-      "type": "object",
-      "required": [
-        "from",
-        "to"
-      ],
-      "properties": {
-        "from": {
-          "description": "Source path to copy from",
+      "description": "Copy item configuration Can be either a string (source path) or an object with from and optional to",
+      "anyOf": [
+        {
+          "description": "String variant: source path (destination will be same as source)",
           "type": "string"
         },
-        "to": {
-          "description": "Destination path to copy to",
-          "type": "string"
+        {
+          "description": "Object variant: source path and optional destination path",
+          "type": "object",
+          "required": [
+            "from"
+          ],
+          "properties": {
+            "from": {
+              "description": "Source path to copy from",
+              "type": "string"
+            },
+            "to": {
+              "description": "Destination path to copy to (optional, defaults to same as from)",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "SchemaDefineEnv": {
+      "description": "Environment variables for build-time injection",
+      "type": "object",
+      "properties": {
+        "client": {
+          "description": "Client-side environment variables",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemaEnvVar"
+          }
+        },
+        "edge": {
+          "description": "Edge-side environment variables",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemaEnvVar"
+          }
+        },
+        "nodejs": {
+          "description": "Node.js environment variables",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemaEnvVar"
+          }
+        }
+      }
+    },
+    "SchemaDevServer": {
+      "description": "Development server configuration",
+      "type": "object",
+      "properties": {
+        "hot": {
+          "description": "Enable hot module replacement",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },
@@ -262,6 +383,17 @@
         "import"
       ],
       "properties": {
+        "html": {
+          "description": "HTML generation configuration for this entry",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaHtmlConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "import": {
           "description": "Import path for the entry point",
           "type": "string"
@@ -283,6 +415,24 @@
             "string",
             "null"
           ]
+        }
+      }
+    },
+    "SchemaEnvVar": {
+      "description": "Environment variable pair",
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "description": "Variable name",
+          "type": "string"
+        },
+        "value": {
+          "description": "Variable value",
+          "type": "string"
         }
       }
     },
@@ -515,6 +665,58 @@
         }
       }
     },
+    "SchemaHtmlConfig": {
+      "description": "HTML generation configuration",
+      "type": "object",
+      "properties": {
+        "filename": {
+          "description": "Output filename for the generated HTML",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inject": {
+          "description": "Where to inject scripts (true, false, \"body\", \"head\")"
+        },
+        "meta": {
+          "description": "Meta tags configuration",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "scriptLoading": {
+          "description": "Script loading strategy (\"blocking\", \"defer\", \"module\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "template": {
+          "description": "Path to the HTML template file",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "templateContent": {
+          "description": "Inline HTML template content",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Title for the generated HTML",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
     "SchemaImageConfig": {
       "description": "Image configuration",
       "type": "object",
@@ -552,6 +754,18 @@
           ]
         }
       }
+    },
+    "SchemaLoaderItem": {
+      "description": "Loader configuration item",
+      "anyOf": [
+        {
+          "description": "Loader name",
+          "type": "string"
+        },
+        {
+          "description": "Loader with options"
+        }
+      ]
     },
     "SchemaModularizeImportPackageConfig": {
       "description": "Modularize import package configuration",
@@ -617,7 +831,9 @@
             "object",
             "null"
           ],
-          "additionalProperties": true
+          "additionalProperties": {
+            "$ref": "#/definitions/SchemaModuleRule"
+          }
         }
       }
     },
@@ -627,6 +843,47 @@
       "enum": [
         "named",
         "deterministic"
+      ]
+    },
+    "SchemaModuleRule": {
+      "description": "Module rule configuration",
+      "anyOf": [
+        {
+          "description": "Shorthand for a single loader",
+          "type": "string"
+        },
+        {
+          "description": "Full rule configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaRuleConfigItem"
+            }
+          ]
+        },
+        {
+          "description": "Multiple rule configurations",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SchemaModuleRuleItem"
+          }
+        }
+      ]
+    },
+    "SchemaModuleRuleItem": {
+      "description": "Item in a module rule array",
+      "anyOf": [
+        {
+          "description": "Shorthand for a single loader",
+          "type": "string"
+        },
+        {
+          "description": "Full rule configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaRuleConfigItem"
+            }
+          ]
+        }
       ]
     },
     "SchemaOptimizationConfig": {
@@ -668,6 +925,13 @@
             }
           ]
         },
+        "nestedAsyncChunking": {
+          "description": "Whether to enable nested async chunking",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "noMangling": {
           "description": "Whether to disable name mangling",
           "type": [
@@ -696,6 +960,20 @@
             }
           ]
         },
+        "removeUnusedExports": {
+          "description": "Whether to remove unused exports",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "removeUnusedImports": {
+          "description": "Whether to remove unused imports",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "splitChunks": {
           "description": "Split chunks configuration",
           "type": [
@@ -718,6 +996,13 @@
         },
         "treeShaking": {
           "description": "Whether to enable tree shaking",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "wasmAsAsset": {
+          "description": "Whether to bunle wasm as asset. Defaults to false. When false, WASM files will be output as static assets.",
           "type": [
             "boolean",
             "null"
@@ -855,6 +1140,42 @@
         }
       }
     },
+    "SchemaRuleConfigItem": {
+      "description": "Full module rule configuration",
+      "type": "object",
+      "required": [
+        "loaders"
+      ],
+      "properties": {
+        "condition": {
+          "description": "Condition for applying the rule",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaConfigConditionItem"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "loaders": {
+          "description": "Loaders to apply",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SchemaLoaderItem"
+          }
+        },
+        "renameAs": {
+          "description": "Rename the module as another extension",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
     "SchemaSplitChunkConfig": {
       "description": "Split chunk configuration",
       "type": "object",
@@ -928,6 +1249,28 @@
           }
         }
       ]
+    },
+    "SchemaWatchOptions": {
+      "description": "Filesystem watcher options",
+      "type": "object",
+      "required": [
+        "enable"
+      ],
+      "properties": {
+        "enable": {
+          "description": "Whether to watch the filesystem for file changes.",
+          "type": "boolean"
+        },
+        "pollInterval": {
+          "description": "Enable polling at a certain interval if the native file watching doesn't work (e.g. docker).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request refactors the configuration structure for the pack CLI and its schema, simplifying how project and root paths are handled and flattening the main configuration object. It also updates all example configuration files to match the new format and improves CLI flag handling for project and root paths. The changes aim to make configuration more intuitive and reduce ambiguity between root/project paths and the main config.

**Configuration Structure Refactor:**

* The `utoopack.json` format is flattened: `rootPath`, `projectPath`, and nested `config` are removed from the top level, with all configuration options now directly at the root. All example config files are updated accordingly. [[1]](diffhunk://#diff-7afe3191f0285a5a56d37cb2c5c524957dec6092f6aebc1e5497d48aa6c6a13eL3-R13) [[2]](diffhunk://#diff-e31d19c959d90dd185eab7ecc92a0899e7c79d905acf6d84a275ca24b54e3502L3-R9) [[3]](diffhunk://#diff-92903d7e54989902b77666267150b8b0be46fe9049d795eac457bc35588497efL2-L15) [[4]](diffhunk://#diff-6d027d9de6f3c5b08b2db488bce848b266ece8cc3a0a29b19cf7279c067b15a2L3-R8) [[5]](diffhunk://#diff-2a706f8f3749d32f4c76d0713cf47495cbd11522db11c10d0af74c2bad149128L3-R11) [[6]](diffhunk://#diff-8495fcb9621501cf07891c25d987cd4c3ae79ab71d420887269d02617598babdL2-R7) [[7]](diffhunk://#diff-2d53687ab7b8ca9207cfd0e85727931527270ad66e480cb4f2c69eb68277a3b8L2-R7) [[8]](diffhunk://#diff-923198563b10d8633775ba937fdc2be99126d4085f3288e4d33f61b5c1cdc963L3-R8) [[9]](diffhunk://#diff-1e57ac6984fc0039065abb7b5f5c20710b2ee603683db8b4e37a10756d7ec554L3-L5) [[10]](diffhunk://#diff-a0517ed3fe18647edc20a9db37fec1af62f5f4f5ed48a23f8261837731d00ef1L2-R7) [[11]](diffhunk://#diff-ae9fc496d10f8de12289eeb230ef1f6fc2baef7512cca87189b708ab40bcbfd3L3-L5) [[12]](diffhunk://#diff-0b81d1168ee01fbff858f0fc35326d132ad732f88452257088d45728e6e6de7aL3-R9)

* The Rust CLI and schema definitions are updated: `project_path` and `root_path` are now optional and renamed in CLI argument parsing; the main config is flattened into a single `serde_json::Value` field, and related logic in `main.rs` is refactored to match. [[1]](diffhunk://#diff-c0345783dd102f845b5466fabcc9368c25621082e95ae9bfff7ef035ef3e6679L32-R35) [[2]](diffhunk://#diff-c0345783dd102f845b5466fabcc9368c25621082e95ae9bfff7ef035ef3e6679L47-L56) [[3]](diffhunk://#diff-c0345783dd102f845b5466fabcc9368c25621082e95ae9bfff7ef035ef3e6679R62-R64) [[4]](diffhunk://#diff-f9d48c7051bf18e7b611da12ba62b8237d7637889c57f96c05658b006aa627bdL33-R39) [[5]](diffhunk://#diff-f9d48c7051bf18e7b611da12ba62b8237d7637889c57f96c05658b006aa627bdL117-R122) [[6]](diffhunk://#diff-f9d48c7051bf18e7b611da12ba62b8237d7637889c57f96c05658b006aa627bdL136-R133) [[7]](diffhunk://#diff-814363896928d1e3a83127e29b1ccb1668cb026d39078b49e48a8db66c4506e4L10-R27)

**Schema and Type Improvements:**

* The JSON schema for project options is updated to remove required nested `config`, and instead uses `allOf` to merge with `SchemaConfig`. New top-level properties (`processEnv`, `dev`, `buildId`, `packPath`) are added for better type safety and clarity.

**CLI Flag and Utility Enhancements:**

* CLI flags for project and root paths now support aliases (`projectPath`, `rootPath`), improving usability and backward compatibility.

* The CLI utility logic in `common.ts` is refactored to parse the new flattened config structure and correctly extract environment and build options.

**Build System Adjustment:**

* A workaround is added to `build.rs` for macOS linker issues when building the CLI in workspaces, ensuring compatibility when Node.js symbols are missing.