### PR TITLE
fix(pack): fix test snaptshot node_root

### DIFF
--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -640,7 +640,7 @@ impl Project {
         let pack_relative = if this.pack_path.starts_with(&*this.root_path) {
             this.pack_path.strip_prefix(&*this.root_path).unwrap()
         } else {
-            this.pack_path.as_str()
+            "./"
         };
         let pack_relative = pack_relative
             .strip_prefix(MAIN_SEPARATOR)

--- a/crates/pack-tests/tests/snapshot/public_path/basic/output/main.js
+++ b/crates/pack-tests/tests/snapshot/public_path/basic/output/main.js
@@ -8,7 +8,7 @@ if (!Array.isArray(globalThis.TURBOPACK)) {
 }
 
 const CHUNK_BASE_PATH = "https://cdn.example.com/assets/";
-const RELATIVE_ROOT_PATH = "../../../../../../..";
+const RELATIVE_ROOT_PATH = "..";
 const RUNTIME_PUBLIC_PATH = "https://cdn.example.com/assets/";
 const CHUNK_SUFFIX = "";
 /**

--- a/crates/pack-tests/tests/snapshot/public_path/runtime/output/main.js
+++ b/crates/pack-tests/tests/snapshot/public_path/runtime/output/main.js
@@ -8,7 +8,7 @@ if (!Array.isArray(globalThis.TURBOPACK)) {
 }
 
 const CHUNK_BASE_PATH = "__RUNTIME_PUBLIC_PATH__";
-const RELATIVE_ROOT_PATH = "../../../../../../..";
+const RELATIVE_ROOT_PATH = "..";
 const RUNTIME_PUBLIC_PATH = "__RUNTIME_PUBLIC_PATH__";
 const CHUNK_SUFFIX = "";
 /**

--- a/crates/pack-tests/tests/snapshot/runtime/app_build_runtime/output/main.js
+++ b/crates/pack-tests/tests/snapshot/runtime/app_build_runtime/output/main.js
@@ -8,7 +8,7 @@ if (!Array.isArray(globalThis.TURBOPACK)) {
 }
 
 const CHUNK_BASE_PATH = "/";
-const RELATIVE_ROOT_PATH = "../../../../../../..";
+const RELATIVE_ROOT_PATH = "..";
 const RUNTIME_PUBLIC_PATH = "/";
 const CHUNK_SUFFIX = "";
 /**

--- a/crates/pack-tests/tests/snapshot/runtime/app_dev_runtime/output/main.js
+++ b/crates/pack-tests/tests/snapshot/runtime/app_dev_runtime/output/main.js
@@ -8,7 +8,7 @@ if (!Array.isArray(globalThis.TURBOPACK)) {
 }
 
 const CHUNK_BASE_PATH = "/";
-const RELATIVE_ROOT_PATH = "../../../../../../..";
+const RELATIVE_ROOT_PATH = "..";
 const RUNTIME_PUBLIC_PATH = "/";
 const CHUNK_SUFFIX = "";
 /**

--- a/crates/pack-tests/tests/snapshot/runtime/library_build_runtime/output/main.js
+++ b/crates/pack-tests/tests/snapshot/runtime/library_build_runtime/output/main.js
@@ -6,7 +6,7 @@ if (!Array.isArray(__TURBOPACK__)) {
 
 const CHUNK_BASE_PATH = "";
 const CHUNK_SUFFIX_PATH = "";
-const RELATIVE_ROOT_PATH = "../../../../../../..";
+const RELATIVE_ROOT_PATH = "..";
 const RUNTIME_PUBLIC_PATH = "";
 /**
  * This file contains runtime types and functions that are shared between all


### PR DESCRIPTION
Avoid long output path for nodejs server (`.turbopack`) when `pack_path` is not relative to `root_path`
<img width="792" height="426" alt="image" src="https://github.com/user-attachments/assets/1fad9305-69db-41af-a5fa-52d2e13c22d1" />
