### PR TITLE
fix(pack-api): correctly calculate module size in webpack stats

### DIFF
--- a/crates/pack-api/src/webpack_stats.rs
+++ b/crates/pack-api/src/webpack_stats.rs
@@ -273,8 +273,14 @@ pub async fn generate_webpack_stats(
         .map(|(chunk_item, chunk_ids)| async move {
             let content_ident = chunk_item.content_ident().await?;
             let asset_path = chunk_item.asset_ident().path().await?;
-            let size_vc = content_ident.path.read().len();
-            let size: Option<u64> = *size_vc.await?;
+            let size = content_ident
+                .path
+                .read()
+                .await
+                .ok()
+                .and_then(|file_content| {
+                    file_content.as_content().map(|f| f.content().len() as u64)
+                });
             let path = asset_path.path.clone();
             Ok::<_, anyhow::Error>(WebpackStatsModule {
                 name: path.clone(),


### PR DESCRIPTION
Directly `read` on `VitualFileSystem` will cause panic.
<img width="793" height="324" alt="image" src="https://github.com/user-attachments/assets/6f29d03e-689d-4928-9468-96e4828f6e0a" />
