### PR TITLE
chore: update ci/cd workflow output and normalize dist_dir

### DIFF
--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pm)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pm)'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -97,6 +97,12 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/miniconda
+          sudo docker image prune --all --force
       - name: Set up QEMU
         if: matrix.settings.docker && contains(matrix.settings.target, 'aarch64')
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -33,6 +33,10 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             test: |
               set -ex &&
+              rm /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
+              apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
@@ -53,6 +57,10 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             test: |
               set -ex &&
+              rm /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
+              apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -48,6 +48,7 @@ jobs:
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
               rustup target add aarch64-unknown-linux-gnu &&
+              export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu &&
               cargo test -p pack-tests --target aarch64-unknown-linux-gnu
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
@@ -98,8 +99,6 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /usr/local/lib/node_modules
           sudo rm -rf /usr/local/share/powershell
           sudo rm -rf /usr/share/miniconda
           sudo docker image prune --all --force

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -23,7 +23,12 @@ jobs:
               cargo test -p pack-tests --target x86_64-apple-darwin
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             test: |
+              apt-get update &&
+              rustup install nightly-2025-10-27 &&
+              rustup default nightly-2025-10-27 &&
+              rustup target add x86_64-unknown-linux-gnu &&
               cargo test -p pack-tests --target x86_64-unknown-linux-gnu
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -23,11 +23,7 @@ jobs:
               cargo test -p pack-tests --target x86_64-apple-darwin
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             test: |
-              rustup install nightly-2025-10-27 &&
-              rustup default nightly-2025-10-27 &&
-              rustup target add x86_64-unknown-linux-gnu &&
               cargo test -p pack-tests --target x86_64-unknown-linux-gnu
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -33,10 +33,6 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             test: |
               set -ex &&
-              rm /etc/apk/repositories &&
-              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
-              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
-              apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
@@ -48,7 +44,6 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             test: |
               apt-get update && apt-get install -y libc6-dev-arm64-cross libgcc-s1-arm64-cross &&
-              export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
               rustup target add aarch64-unknown-linux-gnu &&
@@ -58,10 +53,6 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             test: |
               set -ex &&
-              rm /etc/apk/repositories &&
-              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
-              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
-              apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
@@ -83,16 +74,6 @@ jobs:
     name: utoopack-ci-${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        if: matrix.settings.host == 'ubuntu-latest'
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: false
       - uses: actions/checkout@v4
         with:
           submodules: false

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -89,6 +89,14 @@ jobs:
             ${{ secrets.CI_SUBMODULE }}
       - name: Init git submodules
         run: git submodule update --init --depth 1
+      - name: Free disk space
+        if: matrix.settings.host == 'ubuntu-latest'
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Set up QEMU
         if: matrix.settings.docker && contains(matrix.settings.target, 'aarch64')
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pack-integration.yml
+++ b/.github/workflows/pack-integration.yml
@@ -9,20 +9,9 @@ on:
 jobs:
   integration:
     name: Pack Integration Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
-
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pack-integration.yml
+++ b/.github/workflows/pack-integration.yml
@@ -69,7 +69,7 @@ jobs:
                 echo "----------------------------------------------------"
                 echo "Verifying example: $dir"
                 echo "----------------------------------------------------"
-                (cd "$dir" && npm run build && echo "Output dist content:" && ls -lh dist)
+                (cd "$dir" && npm run build && echo "Output dist content:" && ls -lh dist | awk 'NR>1 {print $5, $9}')
                 if [ $? -ne 0 ]; then
                   echo "Error: Build failed for example $dir"
                   exit 1

--- a/.github/workflows/pack-integration.yml
+++ b/.github/workflows/pack-integration.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   integration:
+    if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pm)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pm)'))
     name: Pack Integration Test
     runs-on: macos-latest
 

--- a/.github/workflows/pack-integration.yml
+++ b/.github/workflows/pack-integration.yml
@@ -10,7 +10,7 @@ jobs:
   integration:
     if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pm)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pm)'))
     name: Pack Integration Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -26,6 +26,20 @@ jobs:
 
       - name: Init git submodules
         run: git submodule update --init --depth 1
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/miniconda
+          sudo docker image prune --all --force
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -23,7 +23,6 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             build: |
               apt-get update && apt-get install -y libc6-dev-arm64-cross libgcc-s1-arm64-cross &&
-              export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
               rustup target add aarch64-unknown-linux-gnu &&
@@ -34,10 +33,6 @@ jobs:
             # Note: export RUSTFLAGS for musl need inject especially: https://github.com/utooland/utoo/pull/1980
             build: |
               set -ex &&
-              rm /etc/apk/repositories &&
-              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
-              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
-              apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
@@ -58,10 +53,6 @@ jobs:
             # Note: export RUSTFLAGS for musl need inject especially: https://github.com/utooland/utoo/pull/1980
             build: |
               set -ex &&
-              rm /etc/apk/repositories &&
-              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
-              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
-              apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
@@ -83,16 +74,6 @@ jobs:
     name: utoopack-release-${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        if: matrix.settings.host == 'ubuntu-latest'
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: false
       - uses: actions/checkout@v4
         with:
           submodules: false

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -33,6 +33,10 @@ jobs:
             # Note: export RUSTFLAGS for musl need inject especially: https://github.com/utooland/utoo/pull/1980
             build: |
               set -ex &&
+              rm /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
+              apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&
@@ -53,6 +57,10 @@ jobs:
             # Note: export RUSTFLAGS for musl need inject especially: https://github.com/utooland/utoo/pull/1980
             build: |
               set -ex &&
+              rm /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/repositories &&
+              echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories &&
+              apk update &&
               apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
               rustup install nightly-2025-10-27 &&
               rustup default nightly-2025-10-27 &&

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -96,6 +96,12 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/miniconda
+          sudo docker image prune --all --force
       - name: Set up QEMU
         if: matrix.settings.docker && contains(matrix.settings.target, 'aarch64')
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -45,7 +45,12 @@ jobs:
               npm run build:binding --workspace=@utoo/pack -- --target aarch64-unknown-linux-musl
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |
+              apt-get update &&
+              rustup install nightly-2025-10-27 &&
+              rustup default nightly-2025-10-27 &&
+              rustup target add x86_64-unknown-linux-gnu &&
               npm run build:binding --workspace=@utoo/pack -- --target x86_64-unknown-linux-gnu
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -45,11 +45,7 @@ jobs:
               npm run build:binding --workspace=@utoo/pack -- --target aarch64-unknown-linux-musl
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |
-              rustup install nightly-2025-10-27 &&
-              rustup default nightly-2025-10-27 &&
-              rustup target add x86_64-unknown-linux-gnu &&
               npm run build:binding --workspace=@utoo/pack -- --target x86_64-unknown-linux-gnu
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -88,6 +88,14 @@ jobs:
             ${{ secrets.CI_SUBMODULE }}
       - name: Init git submodules
         run: git submodule update --init --depth 1
+      - name: Free disk space
+        if: matrix.settings.host == 'ubuntu-latest'
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Set up QEMU
         if: matrix.settings.docker && contains(matrix.settings.target, 'aarch64')
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -97,8 +97,6 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /usr/local/lib/node_modules
           sudo rm -rf /usr/local/share/powershell
           sudo rm -rf /usr/share/miniconda
           sudo docker image prune --all --force

--- a/.github/workflows/pm-ci.yml
+++ b/.github/workflows/pm-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pack)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pack)'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pm-e2e.yml
+++ b/.github/workflows/pm-e2e.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   e2e:
+    if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pack)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pack)'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/taplo.yml
+++ b/.github/workflows/taplo.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Install Taplo
         run: cargo install taplo-cli
       - name: Taplo
-        run: RUST_LOG=warn taplo format --check
+        run: taplo format --check

--- a/.github/workflows/taplo.yml
+++ b/.github/workflows/taplo.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Install Taplo
         run: cargo install taplo-cli
       - name: Taplo
-        run: taplo format --check
+        run: RUST_LOG=warn taplo format --check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,7 +7,7 @@
 cargo fmt --check
 
 # toml fmt check
-taplo format --check
+RUST_LOG=warn taplo format --check
 
 # biome check
 npx biome ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,16 @@ npm run test
 # Run Rust tests only
 cargo test
 
-# Run E2E tests
+# Run PM tests
+cargo test -p utoo-pm
+
+# Run Pack tests
+cargo test -p pack-tests
+
+# Update Pack tests snapshots
+UPDATE=1 cargo test -p pack-tests
+
+# Run PM E2E tests
 ./e2e/utoo-pm.sh
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ UPDATE=1 cargo test -p pack-tests
 ## 📮 Submitting Changes
 
 1.  **Create a Branch**: Use a descriptive name like `feat/awesome-feature` or `fix/bug-id`.
-2.  **Commit Messages**: Follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat: add new loader`).
+2.  **Commit Messages**: Follow [Conventional Commits](https://www.conventionalcommits.org/). Use scopes like `pm`, `pack`, or `wasm` (e.g., `feat(pack): add new loader`).
 3.  **Lint & Format**: Run `npm run biome` before committing.
 4.  **Open a PR**: Provide a clear description of your changes and link any related issues.
 

--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -630,8 +630,11 @@ impl Project {
             .unwrap_or("dist".into());
 
         let relative_dist_path = convert_to_project_relative(&dist_path, &this.project_path)?;
+        let relative_dist_path = relative_dist_path
+            .strip_prefix("./")
+            .unwrap_or(&relative_dist_path);
 
-        Ok(Vc::cell(relative_dist_path))
+        Ok(Vc::cell(relative_dist_path.into()))
     }
 
     #[turbo_tasks::function]
@@ -1010,7 +1013,7 @@ impl Project {
                 let dist_path = Path::new(&this.project_path).join(&*dist_dir);
 
                 if let Err(e) = clean_directory(&dist_path) {
-                    tracing::warn!("Failed to clean dist directory: {}", e);
+                    tracing::debug!("Failed to clean dist directory: {}", e);
                 }
             }
             let client_root = self.client_root().owned().await?;


### PR DESCRIPTION
This PR updates the integration workflow to only show file sizes and names in the dist directory, and normalizes the dist_dir output in the pack-api by removing the ./ prefix.