### PR TITLE
chore(deps): upgrade tokio-fs-ext and opfs-project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4205,9 +4205,9 @@ dependencies = [
 
 [[package]]
 name = "opfs-project"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00e54f510b0be0af18906fb0f9bce2957cbea7cac161e82f13d7c9dbc98b18a"
+checksum = "7b1eeed1d8b7ee17f0bc5631404f0ddd4f7b610548147d31029cce98dc020421"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4938,7 +4938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -8184,9 +8184,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-fs-ext"
-version = "0.6.10"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d40184a3ebace868985529617fa92e871096ca74cdb41fb870341d0266fde87"
+checksum = "b3a15b2ea3a517a0d27eeea0c5e43605490ea5722983351973a67756d68a5900"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_path_to_error = "0.1.16"
 simd-json           = "0.17.0"
 thiserror           = "1.0"
 tokio               = { version = "1.47.1" }
-tokio-fs-ext        = "0.6.10"
+tokio-fs-ext        = "0.7.0"
 toml                = "0.8"
 tracing             = "0.1.41"
 tracing-subscriber  = { version = "0.3.19", features = ["env-filter", "fmt"] }

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -29,7 +29,7 @@ flate2                   = "1.1.5"
 futures                  = { workspace = true }
 js-sys                   = "0.3.83"
 oneshot                  = "0.1.11"
-opfs-project             = "0.2.1"
+opfs-project             = "0.2.2"
 petgraph                 = "0.6"
 reqwest                  = { version = "0.12.22", default-features = false, features = ["json"] }
 rustc-hash               = { workspace = true }

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -162,13 +162,29 @@ impl Project {
     pub async fn install(
         package_lock: String,
         max_concurrent_downloads: Option<usize>,
+        omit: Vec<String>,
     ) -> Result<(), JsError> {
         use opfs_project::package_lock::PackageLock;
+        use opfs_project::{InstallOptions, OmitType};
 
         let lock = PackageLock::from_json(&package_lock)
             .map_err(|e| JsError::new(&format!("Failed to parse package-lock.json: {}", e)))?;
 
-        opfs_project::install(&lock, max_concurrent_downloads)
+        let omit = omit
+            .into_iter()
+            .filter_map(|s| match s.as_str() {
+                "dev" => Some(OmitType::Dev),
+                "optional" => Some(OmitType::Optional),
+                _ => None,
+            })
+            .collect();
+
+        let options = Some(InstallOptions {
+            max_concurrent_downloads,
+            omit,
+        });
+
+        opfs_project::install(&lock, options)
             .await
             .map_err(to_js_error)
     }

--- a/packages/utoo-web/src/project/ForkedProject.ts
+++ b/packages/utoo-web/src/project/ForkedProject.ts
@@ -1,6 +1,7 @@
 import * as comlink from "comlink";
 import {
   DepsOptions,
+  InstallOptions,
   PackFile,
   ProjectEndpoint,
   RawStats,
@@ -18,8 +19,8 @@ export class ForkedProject implements ProjectEndpoint {
     return await this.endpoint.deps(options);
   }
 
-  public async install(packageLock: string, maxConcurrentDownloads?: number) {
-    return await this.endpoint.install(packageLock, maxConcurrentDownloads);
+  public async install(packageLock: string, options?: InstallOptions) {
+    return await this.endpoint.install(packageLock, options);
   }
 
   public async build() {

--- a/packages/utoo-web/src/project/InternalProject.ts
+++ b/packages/utoo-web/src/project/InternalProject.ts
@@ -1,5 +1,6 @@
 import {
   DepsOptions,
+  InstallOptions,
   PackFile,
   ProjectEndpoint,
   ProjectOptions,
@@ -47,9 +48,13 @@ class InternalEndpoint implements ProjectEndpoint {
     );
   }
 
-  async install(packageLock: string, maxConcurrentDownloads?: number) {
+  async install(packageLock: string, options?: InstallOptions) {
     await this.wasmInit!;
-    await ProjectInternal.install(packageLock, maxConcurrentDownloads);
+    await ProjectInternal.install(
+      packageLock,
+      options?.maxConcurrentDownloads,
+      options?.omit ?? [],
+    );
     return;
   }
 

--- a/packages/utoo-web/src/project/Project.ts
+++ b/packages/utoo-web/src/project/Project.ts
@@ -4,6 +4,7 @@ import {
   BuildOutput,
   DepsOptions,
   Dirent,
+  InstallOptions,
   PackFile,
   ProjectEndpoint,
   ProjectOptions,
@@ -102,9 +103,9 @@ export class Project implements ProjectEndpoint {
     return await this.remote.deps(options);
   }
 
-  public async install(packageLock: string, maxConcurrentDownloads?: number) {
+  public async install(packageLock: string, options?: InstallOptions) {
     await this.#mount;
-    return await this.remote.install(packageLock, maxConcurrentDownloads);
+    return await this.remote.install(packageLock, options);
   }
 
   public async build(): Promise<BuildOutput> {

--- a/packages/utoo-web/src/types.ts
+++ b/packages/utoo-web/src/types.ts
@@ -107,12 +107,17 @@ export interface DepsOptions {
   concurrency?: number | null;
 }
 
+export type OmitType = "dev" | "optional";
+
+export interface InstallOptions {
+  maxConcurrentDownloads?: number;
+  /** Dependency types to omit. Default: [] */
+  omit?: OmitType[];
+}
+
 export interface ProjectEndpoint {
   deps: (options?: DepsOptions) => Promise<string>;
-  install: (
-    packageLock: string,
-    maxConcurrentDownloads?: number,
-  ) => Promise<void>;
+  install: (packageLock: string, options?: InstallOptions) => Promise<void>;
   build: () => Promise<BuildOutput>;
   readFile(path: string): Promise<Uint8Array>;
   readFile(path: string, encoding?: "utf8"): Promise<string>;

--- a/packages/utoo-web/src/utoo/index.d.ts
+++ b/packages/utoo-web/src/utoo/index.d.ts
@@ -81,7 +81,7 @@ export class Project {
   /**
    * Install dependencies - downloads tgz files only, extracts on-demand when files are read
    */
-  static install(package_lock: string, max_concurrent_downloads?: number | null): Promise<void>;
+  static install(package_lock: string, max_concurrent_downloads: number | null | undefined, omit: string[]): Promise<void>;
   static setCwd(path: string): void;
   /**
    * Calculate MD5 hash of byte content (async for better thread scheduling)
@@ -169,7 +169,7 @@ export interface InitOutput {
   readonly project_deps: (a: number, b: number, c: number) => any;
   readonly project_gzip: (a: any) => any;
   readonly project_init: (a: number, b: number) => void;
-  readonly project_install: (a: number, b: number, c: number) => any;
+  readonly project_install: (a: number, b: number, c: number, d: number, e: number) => any;
   readonly project_metadata: (a: number, b: number) => any;
   readonly project_metadataSync: (a: number, b: number) => [number, number, number];
   readonly project_read: (a: number, b: number) => any;
@@ -212,18 +212,18 @@ export interface InitOutput {
   readonly wasmtaskmessage_data: (a: number) => any;
   readonly __wbg_createsyncaccesshandleoptions_free: (a: number, b: number) => void;
   readonly wasm_thread_entry_point: (a: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__h05951ccee93604a9: (a: number, b: number, c: any) => void;
-  readonly wasm_bindgen__closure__destroy__hc95bb6053e4d238d: (a: number, b: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__hd01d906c585a4882: (a: number, b: number) => void;
-  readonly wasm_bindgen__closure__destroy__h4f7407a77b90c2b4: (a: number, b: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__h12ad3f2e11ef8f1f: (a: number, b: number, c: any) => void;
-  readonly wasm_bindgen__closure__destroy__ha0c175f92395ef9a: (a: number, b: number) => void;
   readonly wasm_bindgen__convert__closures________invoke__hc572a1bf691b2f02: (a: number, b: number, c: any) => void;
   readonly wasm_bindgen__closure__destroy__h79b136ee1664aaaa: (a: number, b: number) => void;
-  readonly wasm_bindgen__convert__closures_____invoke__h2858c75136ebca17: (a: number, b: number, c: any) => void;
-  readonly wasm_bindgen__closure__destroy__he6d1c6bf29fdb02d: (a: number, b: number) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h05951ccee93604a9: (a: number, b: number, c: any) => void;
+  readonly wasm_bindgen__closure__destroy__hc95bb6053e4d238d: (a: number, b: number) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h1b2c409774bafc2f: (a: number, b: number, c: any) => void;
+  readonly wasm_bindgen__closure__destroy__h9945bfb90329f05c: (a: number, b: number) => void;
   readonly wasm_bindgen__convert__closures_____invoke__h56a508b165bb0698: (a: number, b: number) => void;
   readonly wasm_bindgen__closure__destroy__hb10b6a816b65033c: (a: number, b: number) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__h12ad3f2e11ef8f1f: (a: number, b: number, c: any) => void;
+  readonly wasm_bindgen__closure__destroy__ha0c175f92395ef9a: (a: number, b: number) => void;
+  readonly wasm_bindgen__convert__closures_____invoke__hd01d906c585a4882: (a: number, b: number) => void;
+  readonly wasm_bindgen__closure__destroy__h4f7407a77b90c2b4: (a: number, b: number) => void;
   readonly wasm_bindgen__convert__closures_____invoke__heb9448f3005917b6: (a: number, b: number, c: any, d: any) => void;
   readonly memory: WebAssembly.Memory;
   readonly __wbindgen_malloc: (a: number, b: number) => number;


### PR DESCRIPTION
Upgrades `tokio-fs-ext` to 0.7.0 and `opfs-project` to 0.2.2. Also updates the `next.js` submodule.