### PR TITLE
fix(pack): add node_modules to watch ignore options

### DIFF
--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -82,6 +82,15 @@ pub struct WatchOptions {
     /// Enable polling at a certain interval if the native file watching doesn't work (e.g.
     /// docker).
     pub poll_interval: Option<Duration>,
+
+    /// Paths to ignore when watching for file changes.
+    /// By default, ignores: node_modules
+    #[serde(default = "default_ignored_paths")]
+    pub ignored: Vec<RcStr>,
+}
+
+fn default_ignored_paths() -> Vec<RcStr> {
+    vec!["node_modules".into()]
 }
 
 #[turbo_tasks::value]
@@ -588,16 +597,20 @@ impl Project {
             }
         }
 
-        if denied_paths.is_empty() {
+        // Get watched ignored paths from configuration
+        let watched_ignored = self.watch.ignored.clone();
+
+        if denied_paths.is_empty() && watched_ignored.is_empty() {
             Ok(DiskFileSystem::new(
                 PROJECT_FILESYSTEM_NAME.into(),
                 self.root_path.clone(),
             ))
         } else {
-            Ok(DiskFileSystem::new_with_denied_paths(
+            Ok(DiskFileSystem::new_with_watched_ignored(
                 PROJECT_FILESYSTEM_NAME.into(),
                 self.root_path.clone(),
                 denied_paths,
+                watched_ignored,
             ))
         }
     }

--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -89,7 +89,7 @@ pub struct WatchOptions {
     pub ignored: Vec<RcStr>,
 }
 
-fn default_ignored_paths() -> Vec<RcStr> {
+pub fn default_ignored_paths() -> Vec<RcStr> {
     vec!["node_modules".into()]
 }
 

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -82,6 +82,10 @@ pub struct NapiWatchOptions {
     /// Enable polling at a certain interval if the native file watching doesn't work (e.g.
     /// docker).
     pub poll_interval_ms: Option<f64>,
+
+    /// Paths to ignore when watching for file changes.
+    /// By default, ignores: node_modules
+    pub ignored: Option<Vec<String>>,
 }
 
 #[napi(object)]
@@ -178,6 +182,12 @@ impl From<NapiWatchOptions> for WatchOptions {
                 .poll_interval_ms
                 .filter(|interval| !interval.is_nan() && interval.is_finite() && *interval > 0.0)
                 .map(|interval| Duration::from_secs_f64(interval / 1000.0)),
+            ignored: val
+                .ignored
+                .unwrap_or_else(|| vec!["node_modules".to_string()])
+                .into_iter()
+                .map(|s| s.into())
+                .collect(),
         }
     }
 }

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -184,10 +184,8 @@ impl From<NapiWatchOptions> for WatchOptions {
                 .map(|interval| Duration::from_secs_f64(interval / 1000.0)),
             ignored: val
                 .ignored
-                .unwrap_or_else(|| vec!["node_modules".to_string()])
-                .into_iter()
-                .map(|s| s.into())
-                .collect(),
+                .map(|v| v.into_iter().map(|s| s.into()).collect())
+                .unwrap_or_else(pack_api::project::default_ignored_paths),
         }
     }
 }

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -140,6 +140,11 @@ pub struct SchemaWatchOptions {
     /// Enable polling at a certain interval if the native file watching doesn't work (e.g. docker).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub poll_interval: Option<u64>,
+
+    /// Paths to ignore when watching for file changes.
+    /// By default, ignores: node_modules
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignored: Option<Vec<String>>,
 }
 
 /// Environment variables for build-time injection

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -57,6 +57,11 @@ export interface NapiWatchOptions {
    * docker).
    */
   pollIntervalMs?: number
+  /**
+   * Paths to ignore when watching for file changes.
+   * By default, ignores: node_modules
+   */
+  ignored?: Array<string>
 }
 export interface NapiProjectOptions {
   /**


### PR DESCRIPTION
## Summary

在 linux gun 场景里面使用 devServer 的时候监听 `node_modules` 里面的文件变更会有比较大的性能损失。

目前 webpack 默认不监听 node_modules 中的依赖文件变更。

ref: https://github.com/utooland/next.js/pull/97


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
