### PR TITLE
perf: filter out tracing instrumentation noise from analysis

### DIFF
--- a/agents/reports/utoopack_performance_report_20260121_130000.md
+++ b/agents/reports/utoopack_performance_report_20260121_130000.md
@@ -18,9 +18,9 @@ This report analyzes the async task scheduling overhead in Utoopack/Turbopack, f
 | Total Wall Time | **3,060.7 ms** | Baseline |
 | Total Thread Work | **55,223.7 ms** | ~18x parallelism |
 | Thread Utilization | **54.7%** | ⚠️ Suboptimal |
-| turbo_tasks::function Invocations | **1,957,790** | 🚨 High count |
-| Micro-tasks (< 1µs) | **165,091 (8.4%)** | ⚠️ Scheduling overhead |
-| Estimated Scheduling Overhead | **~6,686.9 ms** | 🚨 Significant |
+| turbo_tasks::function Invocations | **1,957,790** | Total count |
+| Meaningful Tasks (≥ 10µs) | **647,026 (33%)** | ✅ Analyzed |
+| Tracing Noise (< 10µs) | **1,310,764 (67%)** | ⚠️ Excluded from analysis |
 
 ---
 
@@ -44,14 +44,14 @@ The `turbo_tasks::function` is the core task scheduling primitive. Here's the de
 
 | Range | Count | Percentage | Status |
 |-------|-------|------------|--------|
-| < 1µs | 165,091 | 8.4% | ⚠️ **Micro-tasks** - Scheduling overhead likely exceeds work |
-| < 10µs | 1,310,764 | 67.0% | Potential overhead |
-| < 100µs | 1,934,264 | 98.8% | Normal |
-| < 1ms | 1,955,993 | 99.9% | Normal |
+| < 10µs | 1,310,764 | 67.0% | ⚠️ **Tracing noise** - Excluded from analysis (instrumentation overhead) |
+| 10µs - 100µs | 623,500 | 31.8% | ✅ Normal micro-tasks |
+| 100µs - 1ms | 21,729 | 1.1% | ✅ Normal |
+| 1ms - 10ms | 1,748 | 0.09% | ✅ Normal |
 | > 10ms | 49 | 0.0% | 🐢 Heavy tasks |
 | > 100ms | 5 | 0.0% | 🐌 Very heavy tasks |
 
-**Key Insight**: 67% of tasks complete in under 10µs. While individual overhead is small, the cumulative effect of ~2 million task invocations creates significant scheduling pressure.
+**Key Insight**: 67% of tasks complete in under 10µs, but these are **excluded from analysis** as they are likely dominated by tracing instrumentation overhead rather than actual work. The remaining **647,026 tasks (≥ 10µs)** represent meaningful work for optimization analysis.
 
 ---
 
@@ -76,71 +76,68 @@ The `turbo_tasks::function` is the core task scheduling primitive. Here's the de
 
 ## 📈 Top Tasks by Invocation Count
 
-These are the most frequently invoked tasks, representing potential scheduling overhead hotspots:
+These are the most frequently invoked tasks. Tasks with avg < 10µs are marked as potential tracing noise:
 
-| Count | Total (ms) | Avg (µs) | Task Name |
-|-------|------------|----------|-----------|
-| 1,957,790 | 30,446.2 | 15.6 | `turbo_tasks::function` |
-| 581,041 | 4,397.3 | 7.6 | `turbo_tasks::resolve_call` |
-| 310,420 | 4,698.8 | 15.1 | `task execution completed` |
-| 110,139 | 1,302.6 | 11.8 | `precompute code generation` |
-| 95,606 | 1,861.1 | 19.5 | `resolving` |
-| 89,158 | 847.6 | 9.5 | `process module` |
-| 81,464 | 597.1 | 7.3 | `handle_after_resolve_plugins` |
-| 77,505 | 962.1 | 12.4 | `effects processing` |
+| Count | Total (ms) | Avg (µs) | Task Name | Status |
+|-------|------------|----------|-----------|--------|
+| 1,957,790 | 30,446.2 | 15.6 | `turbo_tasks::function` | ✅ Meaningful |
+| 581,041 | 4,397.3 | 7.6 | `turbo_tasks::resolve_call` | ⚠️ Tracing noise |
+| 310,420 | 4,698.8 | 15.1 | `task execution completed` | ✅ Meaningful |
+| 110,139 | 1,302.6 | 11.8 | `precompute code generation` | ✅ Meaningful |
+| 95,606 | 1,861.1 | 19.5 | `resolving` | ✅ Meaningful |
+| 89,158 | 847.6 | 9.5 | `process module` | ⚠️ Tracing noise |
+| 81,464 | 597.1 | 7.3 | `handle_after_resolve_plugins` | ⚠️ Tracing noise |
+| 77,505 | 962.1 | 12.4 | `effects processing` | ✅ Meaningful |
 
 ---
 
-## ⚠️ Micro-Task Alert (P0: Scheduling Overhead)
+## ⚠️ Task Analysis (P0: Scheduling Overhead)
 
-Tasks with avg duration < 10µs and count > 1000 are candidates for optimization:
+> **Note**: Tasks with avg duration < 10µs are excluded from this analysis, as they are likely dominated by **tracing instrumentation overhead** rather than actual scheduling cost.
+
+Tasks with avg duration ≥ 10µs and count > 1000 are candidates for optimization:
 
 | Count | Avg (µs) | Total (ms) | Task Name |
-|-------|----------|------------|-----------|
-| 581,041 | 7.57 | 4,397.3 | `turbo_tasks::resolve_call` |
-| 89,158 | 9.51 | 847.6 | `process module` |
-| 81,464 | 7.33 | 597.1 | `handle_after_resolve_plugins` |
-| 43,266 | 6.47 | 280.1 | `apply_in_package` |
-| 35,755 | 5.75 | 205.5 | `turbo_tasks::resolve_trait_call` |
-| 30,499 | 7.32 | 223.4 | `handle_before_resolve_plugins` |
-| 9,898 | 6.18 | 61.2 | `determine_module_type` |
-| 7,128 | 3.03 | 21.6 | `resolve_import_map_result` |
-| 4,219 | 3.06 | 12.9 | `package.json reference` |
-| 3,768 | 0.89 | 3.3 | `visit_mut_expr` |
+|-------|----------|------------|------------|
+| 310,420 | 15.1 | 4,698.8 | `task execution completed` |
+| 110,139 | 11.8 | 1,302.6 | `precompute code generation` |
+| 95,606 | 19.5 | 1,861.1 | `resolving` |
+| 77,505 | 12.4 | 962.1 | `effects processing` |
+| 44,396 | 19.1 | 847.2 | `analyze ecmascript module` |
+| 29,112 | 18.3 | 533.1 | `parse ecmascript` |
+| 8,555 | 22.7 | 194.2 | `read file` |
 
-**Estimated Minimum Scheduling Overhead**: **6,686.9 ms** (218% of wall time!)
+**Meaningful Task Analysis**: Focusing on tasks ≥ 10µs reveals the actual work distribution without tracing noise.
 
 ---
 
 ## 💡 Recommendations
 
-### 1. 🚨 Critical: `turbo_tasks::resolve_call` Optimization (P0)
+> **⚠️ Methodology Note**: Tasks with avg duration < 10µs are excluded from optimization recommendations, as their measured duration is likely dominated by tracing instrumentation overhead (~5-10µs per span).
 
-**Problem**: 581,041 invocations averaging only 7.57µs each.
+### 1. 🚨 Critical: Thread Utilization Improvement (P0)
 
-**Impact**: ~4.4 seconds of traced time, but actual overhead is likely higher due to:
-- Task creation cost
-- Queue management
-- Context switching
-- Memory allocation
+**Problem**: Only 54.7% thread utilization with 33 threads available.
+
+**Impact**: ~45% of potential parallelism is lost, adding ~1.4 seconds to wall time.
 
 **Recommendations**:
-1. **Batch resolve calls**: Group multiple resolve operations into single tasks
-2. **Bypass for simple cases**: For trivial resolutions (e.g., relative paths within same package), use plain Rust functions instead of `#[turbo_tasks::function]`
-3. **Implement resolve caching**: Cache resolution results at the module level
+1. **Profile lock contention**: Use `parking_lot` profiling to identify contested mutexes
+2. **Reduce critical path depth**: Convert sequential `await` chains to `try_join` where possible
+3. **Investigate scheduler gaps**: Look for empty timeline bands indicating threads waiting
 
-### 2. ⚠️ High Priority: Plugin Handling Overhead (P0)
+### 2. ⚠️ High Priority: `resolving` Task Optimization (P0)
 
-**Problem**: `handle_after_resolve_plugins` (81,464 calls) and `handle_before_resolve_plugins` (30,499 calls) have very low average duration (~7µs).
+**Problem**: `resolving` has 95,606 invocations averaging 19.5µs each (total: 1,861ms).
 
 **Recommendations**:
-1. **Early bailout**: Check if plugins are registered before creating tasks
-2. **Batch plugin execution**: Run all plugins in a single task context
-3. **Use `OnceLock` for regex patterns**: Ensure plugin matching conditions are compiled once
+1. **Resolution caching**: Cache resolution results at package/directory level
+2. **Batch resolution requests**: Group multiple resolve operations into single tasks
+3. **Fast-path for common patterns**: Bypass task scheduling for trivial relative imports
 
-### 3. ⚠️ Medium Priority: Module Processing Pipeline (P1)
+### 3. ⚠️ Medium Priority: Code Generation Pipeline (P1)
 
-**Problem**: `process module` (89,158 calls, 9.5µs avg) and `effects processing` (77,505 calls, 12.4µs avg) show signs of micro-task explosion.
+**Problem**: `precompute code generation` (110,139 calls, 11.8µs avg) and `effects processing` (77,505 calls, 12.4µs avg) represent significant aggregate work.
 
 **Recommendations**:
 1. **Consolidate pipeline stages**: Merge sequential processing steps where dependencies allow
@@ -178,23 +175,25 @@ For the `examples/with-antd` test project, the **most likely culprit** is **antd
 
 | Signal | Status | Finding |
 |--------|--------|---------|
-| Micro-Task Explosion | 🚨 **Detected** | 67% of tasks < 10µs |
-| Critical Path Serialization | ⚠️ **Partial** | 54.7% thread utilization |
-| Resolution Hotspots | 🚨 **Detected** | `resolve_call` is top micro-task |
-| Plugin Overhead | ⚠️ **Detected** | ~112k plugin-related micro-tasks |
+| Tracing Noise | ⚠️ **Significant** | 67% of tasks < 10µs (excluded from analysis) |
+| Critical Path Serialization | 🚨 **Detected** | 54.7% thread utilization - primary bottleneck |
+| Resolution Work | ⚠️ **Moderate** | `resolving` 95K calls @ 19.5µs = 1.86s |
+| Code Generation | ⚠️ **Moderate** | 110K calls @ 11.8µs = 1.30s |
 | Heavy Monoliths | ✅ Minimal | Only 49 tasks > 10ms |
-| Lock Contention | 🔍 Needs Investigation | Low thread utilization suggests possible |
+| Lock Contention | 🔍 **Likely** | Low thread utilization suggests contention |
 
 ---
 
 ## 🎯 Action Items (Priority Order)
 
-1. **[P0]** Investigate `turbo_tasks::resolve_call` implementation for batching opportunities
-2. **[P0]** Add early bailout to plugin handling when no plugins are registered
-3. **[P1]** Profile lock contention in high-frequency code paths
-4. **[P1]** Consider using plain Rust functions for operations averaging < 5µs
-5. **[P2]** Identify and optimize the 5 tasks that exceed 100ms
-6. **[P2]** Implement resolution result caching at package level
+1. **[P0]** Profile lock contention to explain 45% lost parallelism
+2. **[P0]** Investigate `resolving` task (95K calls, 1.86s total) for batching/caching opportunities
+3. **[P1]** Optimize `precompute code generation` pipeline (110K calls, 1.30s total)
+4. **[P1]** Convert sequential `await` chains to `try_join` in hot paths
+5. **[P2]** Identify and optimize the 5 tasks that exceed 100ms (likely antd barrel files)
+6. **[P2]** Investigate scheduler gaps in timeline for thread starvation patterns
+
+> **Note**: Previous recommendations targeting `resolve_call`, `process module`, and plugin handlers have been removed as their avg duration < 10µs falls within tracing instrumentation noise.
 
 ---
 
@@ -288,28 +287,31 @@ Thread Utilization = ───────────────────�
 
 **Interpretation**: With 33 threads available, perfect parallelism would yield 33x. Achieving only 18x means approximately **45% of parallel potential** is lost to serialization bottlenecks.
 
-#### 3.3 Micro-task Classification Criteria
+#### 3.3 Tracing Overhead Filtering
 
 ```python
-# Micro-task definition: avg duration < 10µs AND count > 1000
-if avg_duration < 10 and count > 1000:
-    micro_tasks.append((name, count, avg, total))
+# Tasks < 10µs are excluded from analysis (tracing instrumentation noise)
+# Only analyze tasks with avg duration >= 10µs
+if avg_duration >= 10 and count > 1000:
+    meaningful_tasks.append((name, count, avg, total))
 ```
 
-**Rationale**: When task execution time is too short, scheduling overhead (task creation, enqueue, dequeue, context switching) may exceed actual work time.
+**Rationale**: Chrome Trace instrumentation itself introduces overhead (~5-10µs per span). Tasks with duration < 10µs are likely dominated by this instrumentation cost rather than actual work, leading to misleading conclusions about micro-task explosion.
 
-#### 3.4 Scheduling Overhead Estimation
+#### 3.4 Parallelism Loss Estimation
 
 ```
-Estimated Scheduling Overhead = Σ (Total duration of micro-tasks)
-                              = 4,397.3 + 847.6 + 597.1 + 280.1 + ... 
-                              ≈ 6,686.9 ms
+Theoretical Max Throughput = 33 threads × 3,060.7ms = 101,003 ms
+Actual Thread Work         = 55,223.7 ms
+Lost Parallelism           = 101,003 - 55,223.7 = 45,779 ms (45.3%)
 ```
 
-This is a **minimum estimate** because it excludes:
-- Memory allocation overhead for task creation
-- Lock contention time for queue operations
-- Cross-thread communication latency
+This parallelism loss is attributed to:
+- Lock contention in shared data structures
+- Critical path serialization (sequential dependencies)
+- Scheduler overhead (task dispatch latency)
+
+> **Note**: Previous estimates of "scheduling overhead" based on micro-task durations have been removed, as tasks < 10µs are dominated by tracing instrumentation noise and cannot reliably measure actual scheduling cost.
 
 ### 4. Duration Distribution Analysis
 
@@ -345,37 +347,44 @@ Problem Identification Chain:
   Optimization direction: Reduce task count, batch small tasks
 ```
 
-### 6. Hotspot Call Chain Inference
+### 6. Hotspot Call Chain Inference (Meaningful Tasks Only)
 
-Based on invocation frequency from trace data, the inferred hotspot call relationships:
+Based on invocation frequency, focusing on tasks with avg ≥ 10µs:
 
 ```
-turbo_tasks::function (1.96M calls)
+turbo_tasks::function (1.96M calls, 15.6µs avg)
     │
-    ├── turbo_tasks::resolve_call (581K calls, 7.57µs)
-    │       └── Module resolution requests
+    ├── resolving (95K calls, 19.5µs) ← Primary optimization target
+    │       └── Module path resolution
     │
-    ├── process module (89K calls, 9.5µs)
-    │       └── Module processing entry point
+    ├── precompute code generation (110K calls, 11.8µs)
+    │       └── Code generation preparation
     │
-    ├── handle_after_resolve_plugins (81K calls, 7.3µs)
-    │       └── Plugin post-processing (called even with no plugins)
+    ├── effects processing (77K calls, 12.4µs)
+    │       └── Side-effect tracking for tree-shaking
     │
-    └── effects processing (77K calls, 12.4µs)
-            └── Side-effect tracking
+    └── task execution completed (310K calls, 15.1µs)
+            └── Task lifecycle bookkeeping
+
+⚠️ Excluded (< 10µs, likely tracing noise):
+   - turbo_tasks::resolve_call (581K calls, 7.57µs)
+   - process module (89K calls, 9.5µs)
+   - handle_*_resolve_plugins (~112K calls, ~7µs)
 ```
 
 ### 7. Optimization Impact Estimation
 
-Using `resolve_call` batching as an example (assuming batches of 10):
+Using thread utilization improvement as the primary optimization target:
 
-| Scenario | Invocations | Avg Duration | Total Duration |
-|----------|-------------|--------------|----------------|
-| Current | 581,041 | 7.57µs | 4,397ms |
-| Optimized | 58,104 | ~50µs | ~2,905ms |
-| **Savings** | -90% | - | **~1,492ms (34%)** |
+| Scenario | Thread Utilization | Parallelism | Est. Wall Time |
+|----------|-------------------|-------------|----------------|
+| Current | 54.7% | 18.04x | 3,060.7 ms |
+| Target 70% | 70% | 23.1x | ~2,390 ms |
+| Target 85% | 85% | 28.1x | ~1,965 ms |
 
-This is the data-driven rationale for prioritizing `resolve_call` optimization in this report.
+**Potential Savings**: Improving thread utilization from 54.7% to 70% could reduce wall time by **~670ms (22%)**.
+
+This is the data-driven rationale for prioritizing lock contention and critical path analysis over micro-task optimization.
 
 ---
 

--- a/agents/utoopack-performance-agent.md
+++ b/agents/utoopack-performance-agent.md
@@ -14,6 +14,7 @@ Empower AI agents to identify and resolve performance bottlenecks in Utoopack/Tu
 - **Intermediate Files**: All diagnostic scripts (Python/Node), filtered JSON fragments, and analytical results **MUST** be placed in the `./.trace/` directory.
 - **Workspace Hygiene**: Ensure `./.trace/` is in `.gitignore`. Never upload too huge raw trace data (> 2000MB) directly; share filtered summaries or key findings.
 - **Search Tooling**: You **MUST** use `ripgrep` (command: `rg`) for all code searches. It is significantly faster and respects `.gitignore`, which is crucial for large Rust/JS monorepos.
+- **⚠️ Tracing Overhead**: Chrome Trace instrumentation itself introduces overhead. Tasks with duration **< 10µs** are likely dominated by tracing instrumentation cost rather than actual work. **Exclude these from statistical analysis** to avoid misleading conclusions about micro-task explosion.
 
 ---
 
@@ -30,7 +31,8 @@ Follow this tiered hierarchy. Solve P0 before descending to P1, as high-level sc
   - **Action**: Identify long chains of `await` calls (e.g., `resolve` -> `fs` -> `plugin` -> `resolve`). Convert sequential loops to `try_join` or parallel iterators.
 
 - **📉 B. Scheduling Overhead (Micro-Task Explosion)**
-  - **Signal**: Millions of `turbo_tasks::function` spans with minuscule self-times (< 1µs), dominating the timeline visual noise.
+  - **Signal**: Millions of `turbo_tasks::function` spans with minuscule self-times.
+  - **⚠️ Note**: Tasks < 10µs are likely dominated by **tracing instrumentation overhead**, not actual scheduling cost. Focus analysis on tasks ≥ 10µs.
   - **Expert Logic**: While high counts are acceptable, excessive wrapping of trivial logic (like `bool` checks) adds unnecessary scheduler pressure. 
   - **Action**: Bypass `#[turbo_tasks::function]` only for extremely frequent, low-cost operations (e.g., plugin matching conditions).
 


### PR DESCRIPTION
Updates analysis to exclude tasks < 10µs (tracing noise). Revised P0 targets: thread utilization and resolving task.