### PR TITLE
refactor(worker): use initSync for direct module init

### DIFF
--- a/packages/utoo-web/src/webpackLoaders/worker.ts
+++ b/packages/utoo-web/src/webpackLoaders/worker.ts
@@ -39,7 +39,7 @@ export function startLoaderWorker() {
     try {
       initSync({ module, memory });
     } catch (err) {
-      console.log(err);
+      console.error(err);
       throw err;
     }
 

--- a/packages/utoo-web/src/webpackLoaders/worker.ts
+++ b/packages/utoo-web/src/webpackLoaders/worker.ts
@@ -1,5 +1,6 @@
-import initWasm, {
+import {
   Fs,
+  initSync,
   recvTaskMessageInWorker,
   sendTaskMessage,
   workerCreated,
@@ -28,17 +29,19 @@ declare let self: DedicatedWorkerGlobalScope & {
 };
 
 export function startLoaderWorker() {
-  self.onmessage = async (event) => {
+  self.onmessage = (event) => {
     let [module, memory, meta] = event.data as [
       WebAssembly.Module,
       WebAssembly.Memory,
       LoaderRunnerMeta,
     ];
 
-    await initWasm(module, memory).catch((err: Error) => {
+    try {
+      initSync({ module, memory });
+    } catch (err) {
       console.log(err);
       throw err;
-    });
+    }
 
     self.workerData = {
       threadId: meta.workerData.threadId,


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/utooland/utoo/blob/next/README.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Since the `WebAssembly.Module` is already available when the worker receives the message (passed via `event.data`), we can directly use `initSync` for synchronous initialization instead of async `initWasm`. 

This eliminates unnecessary async overhead and simplifies the code by removing the async branch that was designed for lazy module loading.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Tested locally by running the demo project. Awaiting GitHub CI test results for further validation.