### PR TITLE
ci: allow fork PRs to run CI

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   biome:
     runs-on: macos-latest

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,20 +6,16 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: false
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pm)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pm)'))
@@ -86,15 +89,8 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: false
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
       - name: Free disk space
         if: matrix.settings.host == 'ubuntu-latest'
         run: |

--- a/.github/workflows/pack-integration.yml
+++ b/.github/workflows/pack-integration.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pm)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pm)'))
@@ -15,17 +18,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: false
-
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
 
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
 
       - name: Free disk space
         run: |

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -84,15 +84,8 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: false
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
       - name: Free disk space
         if: matrix.settings.host == 'ubuntu-latest'
         run: |

--- a/.github/workflows/pm-ci.yml
+++ b/.github/workflows/pm-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pack)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pack)'))
@@ -41,17 +44,9 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: false
-      
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
       
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
       
       # Add: Configure Git longpaths on Windows
       - name: Configure Git (Windows)

--- a/.github/workflows/pm-e2e.yml
+++ b/.github/workflows/pm-e2e.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     if: (github.event_name == 'push' && !contains(github.event.head_commit.message, '(pack)')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '(pack)'))
@@ -26,17 +29,9 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: false
-
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
 
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
 
       - name: Install x86_64 Node.js via nvm
         if: matrix.settings.target == 'x86_64-apple-darwin'

--- a/.github/workflows/pm-release.yml
+++ b/.github/workflows/pm-release.yml
@@ -110,13 +110,8 @@ jobs:
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: rustup target add aarch64-unknown-linux-gnu
 
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
 
       - name: Build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/taplo.yml
+++ b/.github/workflows/taplo.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   taplo:
     runs-on: ubuntu-latest

--- a/.github/workflows/utooweb-ci.yml
+++ b/.github/workflows/utooweb-ci.yml
@@ -6,21 +6,17 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: utooweb-ci-build-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: false
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/utooweb-release.yml
+++ b/.github/workflows/utooweb-release.yml
@@ -11,15 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: false
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CI_SUBMODULE }}
       - name: Init git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init --recursive --depth 1
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "next.js"]
 	path = next.js
-	url = git@github.com:utooland/next.js.git
+	url = https://github.com/utooland/next.js.git
   branch = utoo


### PR DESCRIPTION
This PR updates CI workflows to allow fork PRs to run CI. 
Changes:
- Switched next.js submodule to HTTPS to allow public access without SSH secrets.
- Added 'permissions: contents: read' to all CI workflows.
- Optimized submodule initialization to use --recursive and --depth 1.