### PR TITLE
perf(wasm): sync init wasm in thread worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -944,7 +944,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2814,7 +2814,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3218,7 +3218,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5068,7 +5068,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5105,7 +5105,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5572,7 +5572,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6279,6 +6279,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -8164,7 +8165,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tokio"
 version = "1.47.1"
-source = "git+https://github.com/utooland/tokio.git#0b9f7720e2b65634e0fb7d7d8be9073fc21d96a1"
+source = "git+https://github.com/utooland/tokio.git#863a78f4869e327c88997156e6bb852e069589b3"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8207,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "2.5.0"
-source = "git+https://github.com/utooland/tokio.git#0b9f7720e2b65634e0fb7d7d8be9073fc21d96a1"
+source = "git+https://github.com/utooland/tokio.git#863a78f4869e327c88997156e6bb852e069589b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8287,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "tokio-util"
 version = "0.7.16"
-source = "git+https://github.com/utooland/tokio.git#0b9f7720e2b65634e0fb7d7d8be9073fc21d96a1"
+source = "git+https://github.com/utooland/tokio.git#863a78f4869e327c88997156e6bb852e069589b3"
 dependencies = [
  "bytes",
  "futures-core",
@@ -10062,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "wasm_thread"
 version = "0.3.3"
-source = "git+https://github.com/utooland/wasm_thread.git#1155d645aedfdbe55f8ea336a9e8a8150239beb0"
+source = "git+https://github.com/utooland/wasm_thread.git#fd53c2f5a20e9f899d9216dee045472f50d97219"
 dependencies = [
  "futures",
  "js-sys",

--- a/packages/utoo-web/src/threadWorker.ts
+++ b/packages/utoo-web/src/threadWorker.ts
@@ -1,7 +1,7 @@
-import initWasm from "./utoo";
+import { initSync } from "./utoo";
 
 declare let self: WorkerGlobalScope;
 
 // this is for wasm_thread to spawn new worker thread.
-// see: https://github.com/utooland/wasm_thread/blob/94438ff771ee0a6a55d79e49a655707970acb615/src/wasm32/js/web_worker.js#L10
-(self as any).wasm_bindgen = initWasm;
+// https://github.com/utooland/wasm_thread/blob/fd53c2f5a20e9f899d9216dee045472f50d97219/src/wasm32/js/web_worker.sync.js#L10
+(self as any).wasm_bindgen = initSync;


### PR DESCRIPTION
Fellow https://github.com/utooland/utoo/pull/2540
This pull request makes a minor update to how WebAssembly initialization is handled in the `threadWorker.ts` file. The change replaces the asynchronous initialization function with a synchronous one to better support worker thread spawning.

* Replaced the default import `initWasm` with the synchronous initialization function `initSync` from `utoo`, and updated the assignment of `wasm_bindgen` accordingly in `threadWorker.ts`.