### PR TITLE
feat(web): add Project.checkCompatibility API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8876,6 +8876,7 @@ dependencies = [
  "serde_json",
  "shrink-to-fit",
  "smallvec",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tracing",

--- a/packages/utoo-web/src/project/Project.ts
+++ b/packages/utoo-web/src/project/Project.ts
@@ -16,6 +16,7 @@ import {
   ServiceWorkerOptions,
   Stats,
 } from "../types";
+import { checkCompatibility } from "./checkCompatibility";
 import { ForkedProject } from "./ForkedProject";
 
 let ProjectWorker: Worker;
@@ -250,5 +251,9 @@ export class Project implements ProjectEndpoint {
     );
 
     return new ForkedProject(channel.port1);
+  }
+
+  public static checkCompatibility() {
+    return checkCompatibility();
   }
 }

--- a/packages/utoo-web/src/project/checkCompatibility.ts
+++ b/packages/utoo-web/src/project/checkCompatibility.ts
@@ -1,0 +1,42 @@
+export function checkCompatibility(): {
+  compatible: boolean;
+  minimalVersion: { chrome: number };
+  details: {
+    sharedArrayBuffer: boolean;
+    atomics: boolean;
+    worker: boolean;
+    serviceWorker: boolean;
+    opfs: boolean;
+    fileSystemObserver: boolean;
+  };
+  missing: string[];
+} {
+  const details = {
+    sharedArrayBuffer:
+      typeof SharedArrayBuffer !== "undefined" && crossOriginIsolated,
+    atomics: typeof Atomics !== "undefined",
+    worker: typeof Worker !== "undefined",
+    serviceWorker: "serviceWorker" in navigator,
+    opfs: "storage" in navigator && "getDirectory" in navigator.storage,
+    fileSystemObserver: "FileSystemObserver" in window,
+  };
+
+  const missing: string[] = [];
+
+  if (!details.sharedArrayBuffer) missing.push("SharedArrayBuffer (COOP/COEP)");
+  if (!details.atomics) missing.push("Atomics");
+  if (!details.worker) missing.push("Worker");
+  if (!details.serviceWorker) missing.push("ServiceWorker");
+  if (!details.opfs) missing.push("OPFS");
+  if (!details.fileSystemObserver) missing.push("FileSystemObserver");
+
+  const compatible = missing.length === 0;
+  const minimalVersion = { chrome: 137 };
+
+  return {
+    compatible,
+    minimalVersion,
+    details,
+    missing,
+  };
+}


### PR DESCRIPTION
This PR adds a static `checkCompatibility` method to the `Project` class in `@utoo/web`.

It verifies if the browser environment supports essential features like:
- SharedArrayBuffer (with crossOriginIsolated)
- Atomics
- Worker
- ServiceWorker
- OPFS
- FileSystemObserver

This allows applications to fail fast or show warnings if the environment is not compatible.
