### PR TITLE
feat(pack): allow emit seperate css when building library

### DIFF
--- a/crates/pack-core/src/library/chunking_context.rs
+++ b/crates/pack-core/src/library/chunking_context.rs
@@ -8,13 +8,13 @@ use turbo_tasks::{
     NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::FileSystemPath;
-use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher, encode_hex};
+use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher, encode_hex, hash_xxh3_hash64};
 use turbopack_browser::chunking_context::{
     match_content_hash_placeholder, match_name_placeholder, replace_content_hash_placeholder,
     replace_name_placeholder,
 };
 use turbopack_core::{
-    asset::Asset,
+    asset::{Asset, AssetContent},
     chunk::{
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingConfig, ChunkingConfigs,
         ChunkingContext, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets, MinifyType,
@@ -137,6 +137,11 @@ impl LibraryChunkingContextBuilder {
         self
     }
 
+    pub fn chunk_filename(mut self, chunk_filename: RcStr) -> Self {
+        self.chunking_context.chunk_filename = Some(chunk_filename);
+        self
+    }
+
     pub fn asset_base_path(mut self, asset_base_path: Option<RcStr>) -> Self {
         self.chunking_context.asset_base_path = asset_base_path;
         self
@@ -205,6 +210,8 @@ pub struct LibraryChunkingContext {
     debug_ids: bool,
     /// Evaluate chunk filename template
     filename: Option<RcStr>,
+    /// Non evaluate chunk filename template
+    chunk_filename: Option<RcStr>,
 }
 
 impl LibraryChunkingContext {
@@ -233,6 +240,7 @@ impl LibraryChunkingContext {
                 export_usage: None,
                 unused_references: None,
                 filename: Default::default(),
+                chunk_filename: Default::default(),
                 runtime_root,
                 runtime_export,
                 enable_module_merging: false,
@@ -400,7 +408,7 @@ impl ChunkingContext for LibraryChunkingContext {
     #[turbo_tasks::function]
     async fn chunk_path(
         &self,
-        _asset: Option<Vc<Box<dyn Asset>>>,
+        asset: Option<Vc<Box<dyn Asset>>>,
         ident: Vc<AssetIdent>,
         _prefix: Option<RcStr>,
         extension: RcStr,
@@ -411,24 +419,64 @@ impl ChunkingContext for LibraryChunkingContext {
             .iter()
             .any(|m| m.contains("evaluate"));
 
-        if !evaluate {
-            bail!(
-                "library should only generate a single evaluate chunk, please enable inline features of styles.inlineCss and images.inlineLimit in config"
-            )
-        }
+        let output_root = &self.output_root;
 
-        let root_path = &self.output_root;
-        let mut name = ident_to_output_filename(ident, self.root_path.clone(), extension.clone())
-            .owned()
-            .await?;
+        let output_name =
+            ident_to_output_filename(ident, self.root_path.clone(), extension.clone())
+                .owned()
+                .await?
+                .to_string();
+
+        let mut filename = if evaluate {
+            output_name
+        } else {
+            match asset {
+                Some(asset) => {
+                    let filename_template = self.chunk_filename.clone();
+                    match filename_template {
+                        Some(filename) => {
+                            let query = QString::from(ident.await?.query.as_str());
+
+                            let name = query.get("name").unwrap_or(output_name.as_str());
+
+                            let mut filename = filename.to_string();
+
+                            if match_name_placeholder(&filename) {
+                                filename = replace_name_placeholder(&filename, name);
+                            }
+
+                            if match_content_hash_placeholder(&filename) {
+                                let content = asset.content().await?;
+                                if let AssetContent::File(file) = &*content {
+                                    let content_hash = hash_xxh3_hash64(&file.await?);
+                                    filename = replace_content_hash_placeholder(
+                                        &filename,
+                                        &format!("{content_hash:016x}"),
+                                    );
+                                } else {
+                                    bail!(
+                                        "chunk_path requires an asset with file content when content \
+                                     hashing is enabled"
+                                    );
+                                }
+                            };
+
+                            filename
+                        }
+                        None => output_name,
+                    }
+                }
+                None => output_name,
+            }
+        };
 
         // Check if the name already ends with the extension
-        if !name.ends_with(&*extension) {
+        if !filename.ends_with(&*extension) {
             // If doesn't end with extension, add the provided extension
-            name = format!("{name}{extension}").into();
+            filename = format!("{filename}{extension}");
         }
 
-        root_path.join(&name).map(|p| p.cell())
+        output_root.join(&filename).map(|p| p.cell())
     }
 
     #[turbo_tasks::function]

--- a/crates/pack-core/src/library/contexts.rs
+++ b/crates/pack-core/src/library/contexts.rs
@@ -113,10 +113,14 @@ pub async fn get_library_chunking_context(
     .unused_references(unused_references.to_resolved().await?)
     .nested_async_availability(*nested_async_chunking.await?);
 
-    if !mode.is_development()
-        && let Some(filename) = &output.filename
-    {
-        builder = builder.filename(filename.clone());
+    if !mode.is_development() {
+        if let Some(filename) = &output.filename {
+            builder = builder.filename(filename.clone());
+        }
+
+        if let Some(chunk_filename) = &output.chunk_filename {
+            builder = builder.chunk_filename(chunk_filename.clone());
+        }
     }
 
     if mode.is_development() {


### PR DESCRIPTION
This pull request adds support for customizable chunk filenames in the library chunking context, allowing users to specify a separate filename template for non-evaluate chunks. The changes introduce a new `chunk_filename` field, update the builder pattern to support it, and modify the chunk path logic to use this template when appropriate.

**Chunk filename customization:**

* Added a new `chunk_filename` field to the `LibraryChunkingContext` struct to store a non-evaluate chunk filename template. [[1]](diffhunk://#diff-da7f5baadd17e2f8fb3ef99a64659f41d8757f9beea4c7ec8a64ab64b803bc04R213-R214) [[2]](diffhunk://#diff-da7f5baadd17e2f8fb3ef99a64659f41d8757f9beea4c7ec8a64ab64b803bc04R243)
* Updated the `LibraryChunkingContextBuilder` with a new `.chunk_filename()` method to set the chunk filename template.
* Modified the chunk path resolution logic in the `ChunkingContext` implementation to use the `chunk_filename` template for non-evaluate chunks, including support for name and content hash placeholders. [[1]](diffhunk://#diff-da7f5baadd17e2f8fb3ef99a64659f41d8757f9beea4c7ec8a64ab64b803bc04L403-R411) [[2]](diffhunk://#diff-da7f5baadd17e2f8fb3ef99a64659f41d8757f9beea4c7ec8a64ab64b803bc04L414-R482)

**Integration with library context creation:**

* Updated `get_library_chunking_context` to set both `filename` and `chunk_filename` on the builder when in production mode, based on the output configuration.

**Hashing utility import:**

* Imported the `hash_xxh3_hash64` function to support content hash replacement in chunk filenames.