### PR TITLE
fix(pack): client chunking output root

### DIFF
--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -934,7 +934,7 @@ impl Project {
         Ok(get_client_chunking_context(ClientChunkingContextOptions {
             mode: self.mode(),
             root_path: self.project_path().owned().await?,
-            output_root: self.client_root().owned().await?,
+            output_root: self.dist_root().owned().await?,
             output_root_to_root_path: (*output_root_to_root_path).clone(),
             public_path: self.config().computed_public_path(),
             environment: self.client_compile_time_info().environment(),


### PR DESCRIPTION
This pull request makes a targeted change to the output root directory used for client chunking in the `Project` implementation. The update ensures that the distribution root (`dist_root`) is used instead of the client root (`client_root`) when initializing the chunking context, which likely aligns output paths with the intended build output structure.

**Build output path update:**

* Changed the `output_root` parameter in the client chunking context initialization from `client_root` to `dist_root` in `crates/pack-api/src/project.rs`, ensuring output paths are consistent with the distribution directory.