### PR TITLE
fix(multi-entries-heavy): correct devdependencies -> devDependencies

### DIFF
--- a/examples/multi-entries-heavy/package.json
+++ b/examples/multi-entries-heavy/package.json
@@ -15,7 +15,7 @@
     "react-dom": "18.2.0",
     "three": "^0.153.0"
   },
-  "devdependencies": {
+  "devDependencies": {
     "@utoo/pack-cli": "*",
     "serve": "^14.2.4"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,10 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "three": "^0.153.0"
+      },
+      "devDependencies": {
+        "@utoo/pack-cli": "*",
+        "serve": "^14.2.4"
       }
     },
     "examples/multi-entries-heavy/node_modules/react": {


### PR DESCRIPTION
So npm includes pack-cli in lockfile and turbo respects build order.

Close #2613.
