### PR TITLE
fix(pack): temporary ESM support for @utoo/pack

### DIFF
--- a/examples/pack-esm-api/.gitignore
+++ b/examples/pack-esm-api/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.turbopack/

--- a/examples/pack-esm-api/build.mjs
+++ b/examples/pack-esm-api/build.mjs
@@ -1,0 +1,31 @@
+/**
+ * Example: build using @utoo/pack ESM JS API (no utoopack.json / CLI).
+ */
+import { build } from "@utoo/pack";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectPath = __dirname;
+
+const options = {
+  config: {
+    entry: [
+      {
+        import: "./src/index.ts",
+        html: { template: "./index.html" },
+      },
+    ],
+    output: {
+      path: "./dist",
+      filename: "[name].[contenthash:6].js",
+      chunkFilename: "[name].[contenthash:8].js",
+      clean: true,
+    },
+    sourceMaps: false,
+    optimization: { minify: false },
+  },
+};
+
+await build(options, projectPath);
+console.log("Build done: dist/");

--- a/examples/pack-esm-api/dev.mjs
+++ b/examples/pack-esm-api/dev.mjs
@@ -1,0 +1,33 @@
+/**
+ * Example: dev server using @utoo/pack ESM JS API.
+ */
+import { serve } from "@utoo/pack";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectPath = __dirname;
+
+const options = {
+  config: {
+    entry: [
+      {
+        import: "./src/index.ts",
+        html: { template: "./index.html" },
+      },
+    ],
+    output: {
+      path: "./dist",
+      filename: "[name].[contenthash:6].js",
+      chunkFilename: "[name].[contenthash:8].js",
+      clean: true,
+    },
+    sourceMaps: true,
+    optimization: { minify: false },
+  },
+};
+
+await serve(options, projectPath, undefined, {
+  logServerInfo: true,
+  port: 3000,
+});

--- a/examples/pack-esm-api/index.html
+++ b/examples/pack-esm-api/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pack ESM API Example</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="./src/index.ts"></script>
+</body>
+</html>

--- a/examples/pack-esm-api/package.json
+++ b/examples/pack-esm-api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "example-pack-esm-api",
+  "version": "1.0.0",
+  "description": "Example: bundle using @utoo/pack ESM JS API (no CLI)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs",
+    "dev": "node dev.mjs"
+  },
+  "devDependencies": {
+    "@utoo/pack": "*"
+  }
+}

--- a/examples/pack-esm-api/src/index.ts
+++ b/examples/pack-esm-api/src/index.ts
@@ -1,0 +1,1 @@
+document.getElementById("root")!.textContent = "Built with @utoo/pack ESM API";

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "examples/resolve",
         "examples/with-react",
         "examples/utooweb-demo",
-        "examples/expose-entry-exports"
+        "examples/expose-entry-exports",
+        "examples/pack-esm-api"
       ],
       "devDependencies": {
         "@biomejs/biome": "2.1.2",
@@ -111,6 +112,13 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "examples/pack-esm-api": {
+      "name": "example-pack-esm-api",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@utoo/pack": "*"
       }
     },
     "examples/react": {
@@ -8141,6 +8149,10 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/example-pack-esm-api": {
+      "resolved": "examples/pack-esm-api",
+      "link": true
     },
     "node_modules/execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "examples/resolve",
     "examples/with-react",
     "examples/utooweb-demo",
-    "examples/expose-entry-exports"
+    "examples/expose-entry-exports",
+    "examples/pack-esm-api"
   ],
   "repository": "https://github.com/utooland/utoo"
 }

--- a/packages/pack-shared/package.json
+++ b/packages/pack-shared/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build:cjs": "rm -rf cjs && tsc -p ./tsconfig.json  --module commonjs --outDir cjs",
-    "build:esm": "rm -rf esm && tsc -p ./tsconfig.json  --module esnext --outDir esm",
+    "build:esm": "rm -rf esm && tsc -p ./tsconfig.json  --module esnext --outDir esm && node ../../scripts/add-esm-extensions.cjs",
     "build": "npm run build:cjs && npm run build:esm",
     "clean": "rm -rf cjs esm",
     "prepublishOnly": "turbo run build --filter=@utoo/pack-shared"

--- a/packages/pack-shared/src/styledString.ts
+++ b/packages/pack-shared/src/styledString.ts
@@ -1,8 +1,11 @@
-import { bold, green, magenta, red } from "picocolors";
+import picocolors from "picocolors";
 import {
   decodeMagicIdentifier,
   MAGIC_IDENTIFIER_REGEX,
 } from "./magicIdentifier";
+
+// picocolors is a CommonJS module, so we need to import it as a default import
+const { bold, green, magenta, red } = picocolors;
 
 export type StyledString =
   | {

--- a/packages/pack/package.json
+++ b/packages/pack/package.json
@@ -74,7 +74,7 @@
     "build": "npm run build:binding && npm run build:cjs && npm run build:esm",
     "build:js": "npm run build:cjs && npm run build:esm",
     "build:cjs": "rm -rf cjs && tsc -p ./tsconfig.json --module commonjs --outDir cjs && cp src/*.d.ts cjs/",
-    "build:esm": "rm -rf esm && tsc -p ./tsconfig.json --module esnext --outDir esm && cp src/*.d.ts esm/",
+    "build:esm": "rm -rf esm && tsc -p ./tsconfig.json --module esnext --outDir esm && cp src/*.d.ts esm/ && node ../../scripts/add-esm-extensions.cjs && node scripts/inject-esm-dirname.cjs",
     "build:local": "npm run build:binding:local && npx turbo run build --filter=@utoo/pack-shared && npm run build:cjs && npm run build:esm && cp src/*.node cjs/ && cp src/*.node esm/",
     "artifacts": "napi artifacts --dir ./src --dist npm",
     "build:binding": "napi build src --platform --release -p pack-napi --cargo-cwd ../../ --cargo-name pack_napi --features plugin --js binding.js --dts binding.d.ts",

--- a/packages/pack/scripts/inject-esm-dirname.cjs
+++ b/packages/pack/scripts/inject-esm-dirname.cjs
@@ -1,28 +1,63 @@
 /**
- * ESM 构建后为 esm/utils/common.js 注入 __dirname（基于 import.meta.url），
- * 以便 getPackPath() 在 ESM 下能正确解析 pack 根目录。
- * 必须在 add-esm-extensions 之后执行。
+ * After ESM build, inject __dirname (from import.meta.url) into every .js file
+ * under esm/ that references __dirname, so ESM output works in Node where __dirname is undefined.
+ * Must run after add-esm-extensions.
+ *
+ * TODO: this is a temporary workaround. Once utoo/pack can act as a mature
+ * library bundler with built-in support for __dirname/import.meta.url handling,
+ * replace this script with the built-in mechanism instead of post-processing ESM output.
  */
 const fs = require("fs");
 const path = require("path");
 
-const commonPath = path.join(__dirname, "../esm/utils/common.js");
-let content = fs.readFileSync(commonPath, "utf8");
+const esmDir = path.join(__dirname, "../esm");
 
-const dirnameInject = [
-  'import { fileURLToPath } from "node:url";',
-  "const __dirname = path.dirname(fileURLToPath(import.meta.url));",
-].join("\n");
-
-// 在首个 import 之后插入（紧跟 "import path from ..." 那一行之后）
-const firstImportEnd = content.indexOf("\n", content.indexOf('import path from'));
-if (firstImportEnd === -1) {
-  throw new Error("inject-esm-dirname: could not find first import in common.js");
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      walk(full);
+    } else if (e.name.endsWith(".js")) {
+      // binding.js must stay as CommonJS-only and should not be post-processed.
+      if (e.name === "binding.js") continue;
+      injectDirnameIfNeeded(full);
+    }
+  }
 }
-content =
-  content.slice(0, firstImportEnd + 1) +
-  dirnameInject +
-  "\n" +
-  content.slice(firstImportEnd + 1);
 
-fs.writeFileSync(commonPath, content, "utf8");
+function injectDirnameIfNeeded(filePath) {
+  let content = fs.readFileSync(filePath, "utf8");
+  if (!content.includes("__dirname")) return;
+
+  // Already has our __dirname definition
+  if (/const\s+__dirname\s*=\s*path\.dirname\(fileURLToPath\(import\.meta\.url\)\)/.test(content))
+    return;
+
+  const lines = content.split("\n");
+  let lastImportIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*import\s/.test(lines[i])) lastImportIndex = i;
+  }
+
+  const needsPath = !/from\s+["'](?:node:)?path["']/.test(content);
+  const needsFileURLToPath = !content.includes("fileURLToPath");
+
+  const injectLines = [];
+  if (needsFileURLToPath) injectLines.push('import { fileURLToPath } from "node:url";');
+  if (needsPath) injectLines.push('import path from "path";');
+  injectLines.push("const __dirname = path.dirname(fileURLToPath(import.meta.url));");
+
+  const insertAt = lastImportIndex >= 0 ? lastImportIndex + 1 : 0;
+  const before = lines.slice(0, insertAt).join("\n");
+  const after = lines.slice(insertAt).join("\n");
+  content = before + "\n" + injectLines.join("\n") + "\n" + after;
+
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+if (!fs.existsSync(esmDir)) {
+  console.error("inject-esm-dirname: esm dir not found:", esmDir);
+  process.exit(1);
+}
+walk(esmDir);

--- a/packages/pack/scripts/inject-esm-dirname.cjs
+++ b/packages/pack/scripts/inject-esm-dirname.cjs
@@ -1,0 +1,28 @@
+/**
+ * ESM 构建后为 esm/utils/common.js 注入 __dirname（基于 import.meta.url），
+ * 以便 getPackPath() 在 ESM 下能正确解析 pack 根目录。
+ * 必须在 add-esm-extensions 之后执行。
+ */
+const fs = require("fs");
+const path = require("path");
+
+const commonPath = path.join(__dirname, "../esm/utils/common.js");
+let content = fs.readFileSync(commonPath, "utf8");
+
+const dirnameInject = [
+  'import { fileURLToPath } from "node:url";',
+  "const __dirname = path.dirname(fileURLToPath(import.meta.url));",
+].join("\n");
+
+// 在首个 import 之后插入（紧跟 "import path from ..." 那一行之后）
+const firstImportEnd = content.indexOf("\n", content.indexOf('import path from'));
+if (firstImportEnd === -1) {
+  throw new Error("inject-esm-dirname: could not find first import in common.js");
+}
+content =
+  content.slice(0, firstImportEnd + 1) +
+  dirnameInject +
+  "\n" +
+  content.slice(firstImportEnd + 1);
+
+fs.writeFileSync(commonPath, content, "utf8");

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -14,7 +14,7 @@ import { nanoid } from "nanoid";
 import type { Socket } from "net";
 import path from "path";
 import { Duplex } from "stream";
-import ws from "ws";
+import { WebSocket, WebSocketServer } from "ws";
 import { BundleOptions } from "../config/types";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import {
@@ -30,7 +30,7 @@ import { validateEntryPaths } from "../utils/validateEntry";
 import { projectFactory } from "./project";
 import { Project, Update as TurbopackUpdate } from "./types";
 
-const wsServer = new ws.Server({ noServer: true });
+const wsServer = new WebSocketServer({ noServer: true });
 
 const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random());
 
@@ -150,10 +150,10 @@ export async function createHotReloader(
   let hmrEventHappened = false;
   let hmrHash = 0;
 
-  const clients = new Set<ws>();
-  const clientStates = new WeakMap<ws, ClientState>();
+  const clients = new Set<WebSocket>();
+  const clientStates = new WeakMap<WebSocket, ClientState>();
 
-  function sendToClient(client: ws, payload: HMR_ACTION_TYPES) {
+  function sendToClient(client: WebSocket, payload: HMR_ACTION_TYPES) {
     client.send(JSON.stringify(payload));
   }
 
@@ -192,7 +192,7 @@ export async function createHotReloader(
     sendEnqueuedMessagesDebounce();
   }
 
-  async function subscribeToHmrEvents(client: ws, id: string) {
+  async function subscribeToHmrEvents(client: WebSocket, id: string) {
     const state = clientStates.get(client);
     if (!state || state.subscriptions.has(id)) {
       return;
@@ -227,7 +227,7 @@ export async function createHotReloader(
     }
   }
 
-  function unsubscribeFromHmrEvents(client: ws, id: string) {
+  function unsubscribeFromHmrEvents(client: WebSocket, id: string) {
     const state = clientStates.get(client);
     if (!state) {
       return;

--- a/packages/pack/src/core/project.ts
+++ b/packages/pack/src/core/project.ts
@@ -1,3 +1,4 @@
+import { resolve } from "path";
 import { isDeepStrictEqual } from "util";
 import type {
   HmrIdentifiers,
@@ -16,7 +17,7 @@ import {
   TurbopackRuleConfigCollection,
   TurbopackRuleConfigItem,
 } from "../config/types";
-import { rustifyEnv } from "../utils/common";
+import { getPackPath, rustifyEnv } from "../utils/common";
 import { runLoaderWorkerPool } from "./loaderWorkerPool";
 import {
   Endpoint,
@@ -326,10 +327,7 @@ export function projectFactory() {
     constructor(nativeProject: { __napiType: "Project" }) {
       this._nativeProject = nativeProject;
       if (typeof binding.registerWorkerScheduler === "function") {
-        runLoaderWorkerPool(
-          binding,
-          require.resolve("@utoo/pack/cjs/binding.js"),
-        );
+        runLoaderWorkerPool(binding, resolve(getPackPath(), "./binding.js"));
       }
     }
 

--- a/packages/pack/src/utils/common.ts
+++ b/packages/pack/src/utils/common.ts
@@ -23,6 +23,11 @@ export function blockStdout() {
   }
 }
 
+/**
+ * Pack 根目录（pack 包所在目录）。
+ * - CJS：使用 __dirname。
+ * - ESM：在构建后由脚本注入 __dirname（基于 import.meta.url），此处仅用 __dirname 以保持 CJS 产物不含 import.meta，避免 Node 将 .js 判为 ESM。
+ */
 export function getPackPath() {
   return path.resolve(__dirname, "..");
 }

--- a/packages/pack/src/utils/mkcert.ts
+++ b/packages/pack/src/utils/mkcert.ts
@@ -2,11 +2,8 @@ import { execSync } from "node:child_process";
 import { createPrivateKey, X509Certificate } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { WritableStream } from "node:stream/web";
 import os from "os";
-
-const { WritableStream } = require("node:stream/web") as {
-  WritableStream: typeof global.WritableStream;
-};
 
 const MKCERT_VERSION = "v1.4.4";
 

--- a/scripts/add-esm-extensions.cjs
+++ b/scripts/add-esm-extensions.cjs
@@ -1,0 +1,37 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+// Usage: node add-esm-extensions.cjs [esmDir]
+// Run from package root (e.g. packages/pack); default esmDir = "esm"
+const ESM_DIR = path.resolve(process.cwd(), process.argv[2] || "esm");
+
+function addJsExtension(content) {
+  // Relative import/export: ./path or ../path without extension -> add .js (Node ESM requires it)
+  return content.replace(
+    /(from\s+['"]|export\s+\*\s+from\s+['"])(\.\.?\/[^'"]+)(['"])/g,
+    (_, prefix, specifier, quote) => {
+      if (/\.(js|mjs|cjs|json|node)$/i.test(specifier)) return prefix + specifier + quote;
+      return prefix + specifier + ".js" + quote;
+    }
+  );
+}
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full);
+    else if (e.name.endsWith(".js")) {
+      const content = fs.readFileSync(full, "utf8");
+      fs.writeFileSync(full, addJsExtension(content), "utf8");
+    }
+  }
+}
+
+if (!fs.existsSync(ESM_DIR)) {
+  console.error("esm dir not found:", ESM_DIR);
+  process.exit(1);
+}
+walk(ESM_DIR);


### PR DESCRIPTION
Temporary ESM support for `@utoo/pack`:

- **ESM**: add .js extensions via script, inject `__dirname` in common.js from `import.meta.url`
- **CJS**: `getPackPath()` use `__dirname` only to avoid `import.meta` (fix Node treating .js as ESM)
- Add pack-esm-api example and `scripts/add-esm-extensions.cjs`

Ref https://github.com/utooland/utoo/issues/2610

Made with [Cursor](https://cursor.com)