### PR TITLE
fix(pack): library output stats & chunk path

### DIFF
--- a/crates/pack-api/src/library.rs
+++ b/crates/pack-api/src/library.rs
@@ -11,10 +11,12 @@ use qstring::QString;
 use tracing::{Instrument, trace_span};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, JoinIterExt, ResolvedVc, ValueToString, Vc};
+use turbo_tasks_fs::{File, FileContent};
 use turbopack::{
     ModuleAssetContext, module_options::ModuleOptionsContext, transition::TransitionOptions,
 };
 use turbopack_core::{
+    asset::AssetContent,
     chunk::{
         ChunkGroupResult, ChunkingContext, EvaluatableAsset, EvaluatableAssets,
         availability_info::AvailabilityInfo,
@@ -31,12 +33,14 @@ use turbopack_core::{
         origin::{PlainResolveOrigin, ResolveOrigin, ResolveOriginExt},
         parse::Request,
     },
+    virtual_output::VirtualOutputAsset,
 };
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
 use crate::{
     endpoint::{Endpoint, EndpointOutput, EndpointOutputPaths},
     project::Project,
+    webpack_stats::generate_webpack_stats,
 };
 
 #[turbo_tasks::value]
@@ -331,6 +335,24 @@ impl Endpoint for LibraryEndpoint {
                 server_entry_path: dist_root.to_string(),
                 server_paths: vec![],
                 client_paths: vec![],
+            };
+
+            let should_create_webpack_stats = *this.project.should_create_webpack_stats().await?;
+
+            let output_assets = if !should_create_webpack_stats {
+                output_assets
+            } else {
+                let webpack_stats = generate_webpack_stats(output_assets, this.project.dist_root());
+                let webpack_stats_read = webpack_stats.await?;
+                let dist_root_owned = this.project.dist_root().owned().await?;
+                let stats_json = simd_json::serde::to_string(&*webpack_stats_read)?;
+                let stats_output = VirtualOutputAsset::new(
+                    dist_root_owned.join("stats.json")?,
+                    AssetContent::file(FileContent::from(File::from(stats_json)).cell()),
+                )
+                .to_resolved()
+                .await?;
+                output_assets.concatenate(*ResolvedVc::cell(vec![ResolvedVc::upcast(stats_output)]))
             };
 
             Ok(EndpointOutput {

--- a/crates/pack-api/src/webpack_stats.rs
+++ b/crates/pack-api/src/webpack_stats.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use pack_core::library::ecmascript::EcmascriptLibraryEvaluateChunk;
 use qstring::QString;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
@@ -162,6 +163,34 @@ pub async fn get_asset_intermediate_info(
             id: chunk_ident.clone(),
             ..Default::default()
         });
+    }
+
+    if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptLibraryEvaluateChunk>(asset) {
+        let entry_path_full = chunk.path().await?;
+        let entry_path = dist_root
+            .await?
+            .get_relative_path_to(&entry_path_full)
+            .unwrap_or_else(|| entry_path_full.path.clone());
+        local_chunks.push(WebpackStatsChunk {
+            size: asset_len,
+            files: vec![entry_path.clone()],
+            id: entry_path.clone(),
+            ..Default::default()
+        });
+
+        let entry_name: RcStr = QString::from(chunk.ident().await?.query.as_str())
+            .get("name")
+            .unwrap_or(remove_extension_from_str(entry_path.as_str()))
+            .into();
+
+        local_entrypoints.push((
+            entry_name.clone(),
+            WebpackStatsEntrypoint {
+                name: entry_name,
+                chunks: vec![entry_path.clone()],
+                assets: vec![WebpackStatsEntrypointAssets { name: entry_path }],
+            },
+        ));
     }
 
     let local_asset = WebpackStatsAsset {

--- a/crates/pack-core/src/emit.rs
+++ b/crates/pack-core/src/emit.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
 #[turbo_tasks::function]
 pub async fn emit_assets(
     assets: Vc<ExpandedOutputAssets>,
-    _node_root: FileSystemPath,
+    node_root: FileSystemPath,
     client_relative_path: FileSystemPath,
     client_output_path: FileSystemPath,
 ) -> Result<()> {
@@ -24,16 +24,18 @@ pub async fn emit_assets(
         .iter()
         .copied()
         .map(|asset| {
+            let node_root = node_root.clone();
             let client_relative_path = client_relative_path.clone();
             let client_output_path = client_output_path.clone();
 
             async move {
                 let path = asset.path();
                 let span = tracing::trace_span!("emit asset", name = %path.to_string().await?);
-                // We allow to write output out of dist path, this is different with next.js
                 async move {
                     let path = path.await?;
-                    Ok(if path.is_inside_ref(&client_relative_path) {
+                    Ok(if path.is_inside_ref(&node_root) {
+                        Some(emit(*asset))
+                    } else if path.is_inside_ref(&client_relative_path) {
                         // Client assets are emitted to the client output path, which is prefixed
                         // with _next. We need to rebase them to remove that
                         // prefix.
@@ -43,7 +45,7 @@ pub async fn emit_assets(
                             client_output_path,
                         ))
                     } else {
-                        Some(emit(*asset))
+                        None
                     })
                 }
                 .instrument(span)

--- a/crates/pack-core/src/library/chunking_context.rs
+++ b/crates/pack-core/src/library/chunking_context.rs
@@ -430,11 +430,17 @@ impl ChunkingContext for LibraryChunkingContext {
 
         let output_root = &self.output_root;
 
-        let output_name =
-            ident_to_output_filename(ident, self.root_path.clone(), extension.clone())
-                .owned()
-                .await?
-                .to_string();
+        let output_name = ident_to_output_filename(
+            ident,
+            self.root_path.clone(),
+            extension.clone(),
+            self.filename
+                .as_ref()
+                .and_then(|f| f.rsplit_once("/").map(|p| RcStr::from(p.0))),
+        )
+        .owned()
+        .await?
+        .to_string();
 
         let mut filename = if evaluate {
             output_name
@@ -757,10 +763,23 @@ async fn ident_to_output_filename(
     ident: Vc<AssetIdent>,
     context_path: FileSystemPath,
     expected_extension: RcStr,
+    filename_prefix: Option<RcStr>,
 ) -> Result<Vc<RcStr>> {
     let ident = &*ident.await?;
+
     let mut name = if let Some(inner) = context_path.get_path_to(&ident.path) {
-        escape_file_path(inner)
+        let (parent, file_name) = match inner.rsplit_once("/") {
+            Some((parent, file_name)) => (Some(parent), file_name),
+            None => (None, inner),
+        };
+        if let Some(filename_prefix) = filename_prefix
+            && let Some(parent) = parent
+            && filename_prefix == parent
+        {
+            format!("{}/{}", parent, escape_file_path(file_name))
+        } else {
+            escape_file_path(inner)
+        }
     } else {
         escape_file_path(&ident.path.to_string())
     };

--- a/crates/pack-core/src/library/ecmascript/chunk.rs
+++ b/crates/pack-core/src/library/ecmascript/chunk.rs
@@ -102,7 +102,7 @@ impl EcmascriptLibraryEvaluateChunk {
         writedoc!(
             code,
             r#"
-                ((__TURBOPACK__) => {{
+                ((__UTOOPACK__) => {{
             "#,
         )?;
 
@@ -180,7 +180,7 @@ impl EcmascriptLibraryEvaluateChunk {
     }
 
     #[turbo_tasks::function]
-    async fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
+    pub async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.ident.owned().await?;
 
         ident.add_modifier(rcstr!("ecmascript library evaluate chunk"));
@@ -193,7 +193,7 @@ impl EcmascriptLibraryEvaluateChunk {
         let this = self.await?;
         Ok(SourceMapAsset::new(
             Vc::upcast(*this.chunking_context),
-            self.ident_for_path(),
+            self.ident(),
             Vc::upcast(self),
         ))
     }
@@ -212,7 +212,7 @@ impl OutputAsset for EcmascriptLibraryEvaluateChunk {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let ident = self.ident_for_path();
+        let ident = self.ident();
         Ok(this
             .chunking_context
             .chunk_path(Some(Vc::upcast(self)), ident, None, ".js".into()))

--- a/crates/pack-core/src/library/runtime/runtime_code.rs
+++ b/crates/pack-core/src/library/runtime/runtime_code.rs
@@ -48,7 +48,7 @@ pub async fn get_library_runtime_code(
     writedoc!(
         code,
         r#"            
-            if (!Array.isArray(__TURBOPACK__)) {{
+            if (!Array.isArray(__UTOOPACK__)) {{
                 return;
             }}
 
@@ -93,8 +93,8 @@ pub async fn get_library_runtime_code(
     writedoc!(
         code,
         r#"
-            const chunksToRegister = __TURBOPACK__;
-            __TURBOPACK__ = {{ push: registerChunk }};
+            const chunksToRegister = __UTOOPACK__;
+            __UTOOPACK__ = {{ push: registerChunk }};
             chunksToRegister.forEach(registerChunk);
         "#
     )?;

--- a/crates/pack-tests/tests/snapshot/concatenate_modules/library-shared/output/main.js
+++ b/crates/pack-tests/tests/snapshot/concatenate_modules/library-shared/output/main.js
@@ -1,4 +1,4 @@
-((__TURBOPACK__) => {
+((__UTOOPACK__) => {
 // Dummy runtime
 })([["main.js", {
 

--- a/crates/pack-tests/tests/snapshot/dynamic_import/library-chunk/output/main.js
+++ b/crates/pack-tests/tests/snapshot/dynamic_import/library-chunk/output/main.js
@@ -1,4 +1,4 @@
-((__TURBOPACK__) => {
+((__UTOOPACK__) => {
 // Dummy runtime
 })([["main.js", {
 

--- a/crates/pack-tests/tests/snapshot/runtime/library_build_runtime/output/main.js
+++ b/crates/pack-tests/tests/snapshot/runtime/library_build_runtime/output/main.js
@@ -1,6 +1,6 @@
-((__TURBOPACK__) => {
+((__UTOOPACK__) => {
             
-if (!Array.isArray(__TURBOPACK__)) {
+if (!Array.isArray(__UTOOPACK__)) {
     return;
 }
 
@@ -797,8 +797,8 @@ let BACKEND;
         return resolver.promise;
     }
 })();
-const chunksToRegister = __TURBOPACK__;
-__TURBOPACK__ = { push: registerChunk };
+const chunksToRegister = __UTOOPACK__;
+__UTOOPACK__ = { push: registerChunk };
 chunksToRegister.forEach(registerChunk);
 function factory () {
     const runtimeModuleIds = ["11"];

--- a/crates/pack-tests/tests/snapshot/umd/async-module/output/main.js
+++ b/crates/pack-tests/tests/snapshot/umd/async-module/output/main.js
@@ -1,4 +1,4 @@
-((__TURBOPACK__) => {
+((__UTOOPACK__) => {
 // Dummy runtime
 })([["main.js", {
 

--- a/crates/pack-tests/tests/snapshot/umd/basic/output/main.js
+++ b/crates/pack-tests/tests/snapshot/umd/basic/output/main.js
@@ -1,4 +1,4 @@
-((__TURBOPACK__) => {
+((__UTOOPACK__) => {
 // Dummy runtime
 })([["main.js", {
 


### PR DESCRIPTION
1. fix the bad magic mangle for symbol `__TURBOPACK__`
2. generate `stats.json` for `library` output
3. keep the `output.filename` dir prefix, emit chunks in that dir