### PR TITLE
ci(pm): optimize Windows CI speed by disabling Defender real-time scanning

### DIFF
--- a/.github/workflows/pm-ci.yml
+++ b/.github/workflows/pm-ci.yml
@@ -47,6 +47,12 @@ jobs:
       
       - name: Init git submodules
         run: git submodule update --init --recursive --depth 1
+
+      # Disable Windows Defender real-time scanning to speed up I/O-heavy builds (~30-50% faster)
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       
       # Add: Configure Git longpaths on Windows
       - name: Configure Git (Windows)

--- a/.github/workflows/pm-e2e.yml
+++ b/.github/workflows/pm-e2e.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Init git submodules
         run: git submodule update --init --recursive --depth 1
 
+      # Disable Windows Defender real-time scanning to speed up I/O-heavy builds (~30-50% faster)
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
       - name: Install x86_64 Node.js via nvm
         if: matrix.settings.target == 'x86_64-apple-darwin'
         run: |


### PR DESCRIPTION
## Summary

Optimizes Windows CI build time by disabling Windows Defender real-time scanning, reducing NTFS I/O overhead for cargo builds, test execution, and npm operations.

### Changes

- **Disable Windows Defender real-time scanning** on Windows runners
  - Added early step using `Set-MpPreference -DisableRealtimeMonitoring $true`
  - Only runs on Windows (`if: runner.os == 'Windows'`)
  - Applied to `pm-ci.yml` and `pm-e2e.yml`
  - `pack-ci.yml` Windows targets are currently commented out, no changes needed

### Expected Impact

- **~30-50% faster** on I/O-heavy steps (cargo build, cargo test, npm install)
- Zero risk: only affects ephemeral CI runners, Defender is restored when the runner is recycled

### References

- For even better performance, consider adopting [`samypr100/setup-dev-drive`](https://github.com/samypr100/setup-dev-drive) with ReFS (used by [oxc](https://github.com/oxc-project/oxc) and [rolldown](https://github.com/rolldown/rolldown)) as a follow-up