### PR TITLE
fix(pm): preserve git+ prefix in lockfile resolved URL

### DIFF
--- a/crates/ruborist/src/resolver/git.rs
+++ b/crates/ruborist/src/resolver/git.rs
@@ -132,7 +132,7 @@ fn validate_package_name(name: &str) -> Result<()> {
 fn read_cached_git_result(
     package_dir: &Path,
     sha: &str,
-    original_url: &str,
+    resolved_url: &str,
 ) -> Result<GitCloneResult> {
     let pkg_bytes = std::fs::read(package_dir.join("package.json"))
         .context("failed to read cached package.json")?;
@@ -146,9 +146,9 @@ fn read_cached_git_result(
         manifest.version = "0.0.0".to_string();
     }
 
-    let resolved_url = format!("{}#{}", original_url, sha);
+    let pinned_url = format!("{}#{}", resolved_url, sha);
     manifest.dist = Dist {
-        tarball: Some(resolved_url.clone()),
+        tarball: Some(pinned_url.clone()),
         integrity: None,
         ..Default::default()
     };
@@ -158,7 +158,7 @@ fn read_cached_git_result(
 
     Ok(GitCloneResult::new(
         package_dir.to_path_buf(),
-        resolved_url,
+        pinned_url,
         manifest,
     ))
 }
@@ -255,7 +255,7 @@ fn clone_repo_blocking(
     cache_dir: &Path,
     clone_url: &str,
     commit_ish: Option<&str>,
-    original_url: &str,
+    resolved_url: &str,
     name: &str,
 ) -> Result<GitCloneResult> {
     // Validate the caller-supplied name before using it in any path operation.
@@ -274,7 +274,7 @@ fn clone_repo_blocking(
         let sha = commit_ish.unwrap();
         let package_dir = cache_dir.join(name).join(sha);
         if package_dir.join("_resolved").exists() {
-            match read_cached_git_result(&package_dir, sha, original_url) {
+            match read_cached_git_result(&package_dir, sha, resolved_url) {
                 Ok(result) => {
                     tracing::debug!(
                         "Git cache hit: {}@{} (SHA: {})",
@@ -382,7 +382,7 @@ fn clone_repo_blocking(
     // Using the full commit SHA as the version directory avoids collisions
     // with registry versions and between different commits of the same repo.
     let package_dir = cache_dir.join(&name).join(&commit_hex);
-    let resolved_url = format!("{}#{}", original_url, commit_hex);
+    let pinned_url = format!("{}#{}", resolved_url, commit_hex);
     let resolved_marker = package_dir.join("_resolved");
 
     // Fill in git-specific manifest fields.
@@ -390,7 +390,7 @@ fn clone_repo_blocking(
     // identify the source. `has_install_script` is computed from `scripts`
     // because package.json doesn't carry this pre-computed flag.
     manifest.dist = Dist {
-        tarball: Some(resolved_url.clone()),
+        tarball: Some(pinned_url.clone()),
         integrity: None,
         ..Default::default()
     };
@@ -399,7 +399,7 @@ fn clone_repo_blocking(
     }));
 
     if resolved_marker.exists() {
-        return Ok(GitCloneResult::new(package_dir, resolved_url, manifest));
+        return Ok(GitCloneResult::new(package_dir, pinned_url, manifest));
     }
 
     // Extract into a per-process unique staging directory, then atomically
@@ -439,7 +439,7 @@ fn clone_repo_blocking(
         }
     }
 
-    Ok(GitCloneResult::new(package_dir, resolved_url, manifest))
+    Ok(GitCloneResult::new(package_dir, pinned_url, manifest))
 }
 
 // ============================================================================
@@ -459,7 +459,7 @@ fn clone_repo_blocking(
 ///
 /// # Arguments
 /// * `cache_dir` - Root cache directory
-/// * `url` - Git URL, optionally with `git+` prefix
+/// * `url` - Git URL with `git+` prefix (e.g. `git+https://github.com/foo/bar.git`)
 /// * `commit_ish` - Optional branch, tag, or commit SHA to check out
 /// * `name` - Package name (from the dependency edge)
 /// * `clone_cache` - Shared dedup cache for concurrent clone operations
@@ -470,9 +470,7 @@ pub async fn ensure_repo_cached(
     name: &str,
     clone_cache: &GitCloneCache,
 ) -> Result<Arc<GitCloneResult>> {
-    // The caller should pass a clone-ready URL (no `git+` prefix) via
-    // PackageSpec::clone_url(). We still strip defensively in case raw URLs
-    // are threaded through.
+    // Strip the `git+` prefix to get a clone-ready URL.
     let canonical_url = url.strip_prefix("git+").unwrap_or(url);
     let key = format!("{}#{}", canonical_url, commit_ish.unwrap_or("HEAD"));
 
@@ -485,7 +483,7 @@ pub async fn ensure_repo_cached(
     };
 
     let clone_url = canonical_url.to_string();
-    let original_url = url.to_string();
+    let resolved_url = url.to_string();
     let cache_dir = cache_dir.to_path_buf();
     let commit_ish_owned = commit_ish.map(|s| s.to_string());
     let name_owned = name.to_string();
@@ -496,7 +494,7 @@ pub async fn ensure_repo_cached(
                 &cache_dir,
                 &clone_url,
                 commit_ish_owned.as_deref(),
-                &original_url,
+                &resolved_url,
                 &name_owned,
             )
             .map(Arc::new)
@@ -530,15 +528,13 @@ pub(crate) async fn resolve_non_registry_dep(
     clone_cache: &GitCloneCache,
 ) -> anyhow::Result<ResolvedPackage> {
     let (url, commit_ish) = match spec {
-        PackageSpec::Git { commit_ish, .. } => {
-            (spec.clone_url().unwrap().to_string(), commit_ish.clone())
-        }
+        PackageSpec::Git { url, commit_ish } => (url.clone(), commit_ish.clone()),
         PackageSpec::GitHub {
             owner,
             repo,
             commit_ish,
         } => (
-            format!("https://github.com/{owner}/{repo}.git"),
+            format!("git+https://github.com/{owner}/{repo}.git"),
             commit_ish.clone(),
         ),
         // Exhaustive enumeration — new PackageSpec variants will cause a

--- a/e2e/pm/git-deps/package.json
+++ b/e2e/pm/git-deps/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "e2e-git-deps",
+  "version": "1.0.0",
+  "private": true,
+  "description": "e2e test for git dependency resolution",
+  "dependencies": {
+    "abbrev": "github:npm/abbrev-js",
+    "ini": "git+https://github.com/npm/ini.git#v5.0.0",
+    "isexe": "isaacs/isexe#v3.1.1"
+  }
+}

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -111,8 +111,45 @@ fi
 echo -e "${GREEN}PASS: cowsay global install successful${NC}"
 
 
-# Case 8: reinstall ant-design
-echo -e "${YELLOW}Case 8: Clone and install ant-design${NC} by npmjs.org"
+# Case 8: git dependency install
+echo -e "${YELLOW}Case 8: git dependency install${NC}"
+cd e2e/pm/git-deps
+rm -rf node_modules package-lock.json
+utoo install --ignore-scripts || { echo -e "${RED}FAIL: utoo install failed for git-deps${NC}"; exit 1; }
+if [ ! -d "node_modules" ]; then
+    echo -e "${RED}FAIL: node_modules directory not created${NC}"
+    exit 1
+fi
+# github:owner/repo shorthand
+if [ ! -d "node_modules/abbrev" ]; then
+    echo -e "${RED}FAIL: abbrev (github: shorthand) not installed${NC}"
+    exit 1
+fi
+# git+https:// with tag ref
+if [ ! -d "node_modules/ini" ]; then
+    echo -e "${RED}FAIL: ini (git+https with tag) not installed${NC}"
+    exit 1
+fi
+# bare owner/repo shorthand with tag
+if [ ! -d "node_modules/isexe" ]; then
+    echo -e "${RED}FAIL: isexe (bare github shorthand) not installed${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS: git dependency install successful${NC}"
+
+# Case 8.1: git dependency warm install (cache hit)
+echo -e "${YELLOW}Case 8.1: git dependency warm install${NC}"
+rm -rf node_modules package-lock.json
+utoo install --ignore-scripts || { echo -e "${RED}FAIL: utoo warm install failed for git-deps${NC}"; exit 1; }
+if [ ! -d "node_modules/abbrev" ] || [ ! -d "node_modules/ini" ] || [ ! -d "node_modules/isexe" ]; then
+    echo -e "${RED}FAIL: git deps missing after warm install${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS: git dependency warm install successful${NC}"
+cd ../../..
+
+# Case 9: reinstall ant-design
+echo -e "${YELLOW}Case 9: Clone and install ant-design${NC} by npmjs.org"
 cd e2e/pm/ant-design/ant-design
 git clean -dfx
 echo "Installing dependencies for ant-design by npmjs.org..."


### PR DESCRIPTION
## Summary

- `resolve_non_registry_dep` stripped the `git+` prefix before passing URLs to `ensure_repo_cached`, causing lockfile `resolved` fields to contain bare `https://` URLs
- Install phase `is_git_url()` misidentified these as HTTP tarballs → gzip decompression failure
- Fix: pass URLs with `git+` prefix from the caller, strip internally only for the actual git clone operation
- Adds e2e tests covering all three git dep formats: `github:owner/repo`, `git+https://...#tag`, `owner/repo#tag`

```

用户声明 → "ini": "git+https://github.com/npm/ini.git#v5.0.0"                                                                                                                                                                            
   
  BFS 解析（PackageSpec::from）→ PackageSpec::Git { url: "git+https://...", commit_ish: "v5.0.0" }                                                                                                                                         
                                                                  
  resolve_non_registry_dep() 提取 URL 传给 ensure_repo_cached()：
  - Git 变体：调 spec.clone_url()，这个方法为了方便 git clone 主动剥掉了 git+ → "https://github.com/npm/ini.git"
  - GitHub 变体：直接拼 "https://github.com/{owner}/{repo}.git" — 从来就没有 git+

  clone_repo_blocking() 用这个 URL 拼 lockfile 的 resolved：
  format!("{}#{}", original_url, commit_hex)
  → "https://github.com/npm/ini.git#63c421e..."  // 没有 git+

  安装阶段 is_git_url() 检查 resolved URL：
  "https://..." → Protocol::Http → 不是 git → 当 tarball 下载 → gzip 解压失败

  根因：resolve_non_registry_dep 用了 clone_url() 来提取 URL，这个方法的职责是给 git clone 用所以剥掉了 git+，但这个 URL 同时也被透传到了 lockfile 的 resolved 字段。一个 URL 承担了两个用途（clone + lockfile），而这两个场景对 git+
  前缀的需求恰好相反。

  修复：让调用方传入带 git+ 的完整 URL，ensure_repo_cached 内部各取所需——剥离后的 canonical_url 给 clone 用，原始的 resolved_url 给 lockfile 用。
```

## Test plan

- [x] Cold install: all three git dep formats resolve and install correctly
- [x] Warm install: cache hit path works with `git+` prefixed resolved URLs
- [x] Lockfile `resolved` fields all carry `git+https://...#sha` format
- [x] `cargo build` / `cargo fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)