### PR TITLE
refactor(pm): add catalog config support and rename init_project_root

### DIFF
--- a/crates/pm/src/cmd/update.rs
+++ b/crates/pm/src/cmd/update.rs
@@ -1,10 +1,10 @@
 use crate::service::update::clean_package_lock;
-use crate::{cmd::install::install, helper::workspace::update_cwd_to_root};
+use crate::{cmd::install::install, helper::workspace::init_project_root};
 use anyhow::{Context, Result};
 
 pub async fn update(ignore_scripts: bool) -> Result<()> {
     let cwd = std::env::current_dir().context("Failed to get current directory")?;
-    let root_path = update_cwd_to_root(&cwd).await?;
+    let root_path = init_project_root(&cwd).await?;
 
     // Clean package-lock.json
     tracing::debug!("Cleaning package-lock.json...");

--- a/crates/pm/src/helper/workspace.rs
+++ b/crates/pm/src/helper/workspace.rs
@@ -66,8 +66,11 @@ pub async fn find_project_path(cwd: &Path) -> Result<PathBuf> {
         .await
 }
 
-/// Update current working directory to project root (with workspaces).
-pub async fn update_cwd_to_root(cwd: &Path) -> Result<PathBuf> {
+/// Resolve the workspace root and change into it.
+///
+/// This is the standard entry point for commands that operate on the
+/// project root (install, update, deps, etc.).
+pub async fn init_project_root(cwd: &Path) -> Result<PathBuf> {
     let root_dir = find_root_path(cwd).await?;
     if !compare_paths(cwd, &root_dir) {
         tracing::debug!(
@@ -76,6 +79,7 @@ pub async fn update_cwd_to_root(cwd: &Path) -> Result<PathBuf> {
         );
         env::set_current_dir(&root_dir).context("Failed to change to root directory")?;
     }
+
     Ok(root_dir)
 }
 
@@ -178,9 +182,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_cwd_to_root_in_root() {
+    async fn test_init_project_root_in_root() {
         let (_temp_dir, root_path) = setup_test_workspace().await;
-        update_cwd_to_root(&root_path).await.unwrap();
+        init_project_root(&root_path).await.unwrap();
         let result = update_cwd_to_project(&root_path).await.unwrap();
         assert!(compare_paths(&result, &root_path));
     }

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -42,7 +42,7 @@ use crate::constants::cmd::{
     WHOAMI_NAME,
 };
 use crate::constants::{APP_ABOUT, APP_NAME, APP_VERSION};
-use crate::helper::workspace::update_cwd_to_root;
+use crate::helper::workspace::init_project_root;
 
 fn detect_shell_from_env() -> Option<clap_complete::Shell> {
     // Most common on Unix-like systems.
@@ -481,7 +481,7 @@ async fn async_main() -> Result<()> {
                 }
             } else {
                 let cwd = std::env::current_dir()?;
-                let root_path = update_cwd_to_root(&cwd).await?;
+                let root_path = init_project_root(&cwd).await?;
                 install(ignore_scripts, &root_path).await?;
                 log_time_end("All packages installed");
             }
@@ -519,7 +519,7 @@ async fn async_main() -> Result<()> {
         }
         Some(Commands::Deps { workspace_only }) => {
             let cwd = std::env::current_dir()?;
-            let root_path = update_cwd_to_root(&cwd).await?;
+            let root_path = init_project_root(&cwd).await?;
             if workspace_only {
                 build_workspace(&root_path).await.map(|_| ())?
             } else {
@@ -640,7 +640,7 @@ async fn async_main() -> Result<()> {
             } else {
                 // Default to install if no arguments
                 let cwd = std::env::current_dir()?;
-                let root_path = update_cwd_to_root(&cwd).await?;
+                let root_path = init_project_root(&cwd).await?;
                 install(cli.ignore_scripts, &root_path).await?;
                 log_time_end("All packages installed");
             }

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -10,7 +10,7 @@ use crate::helper::lock::{
     Package, UpdatePackageJsonOptions, extract_package_name, group_by_depth,
     prepare_global_package_json, update_package_json,
 };
-use crate::helper::workspace::update_cwd_to_root;
+use crate::helper::workspace::init_project_root;
 use crate::model::package::PackageInfo;
 use crate::service::rebuild::RebuildService;
 use crate::util::json::load_package_lock_json_from_path;
@@ -190,7 +190,7 @@ impl InstallService {
         let cwd = std::env::current_dir().context("Failed to get current directory")?;
 
         // Update working directory to project root (if in workspace)
-        let root_path = update_cwd_to_root(&cwd).await?;
+        let root_path = init_project_root(&cwd).await?;
 
         // Update package.json and package-lock.json for all packages in batch
         update_package_json(&UpdatePackageJsonOptions {

--- a/crates/pm/src/util/config_file.rs
+++ b/crates/pm/src/util/config_file.rs
@@ -8,11 +8,21 @@ use std::sync::OnceLock;
 
 pub type ConfigResult<T> = Result<T>;
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+/// Cached merged config (global + local). Set on first `Config::load(false)`.
+static MERGED_CONFIG: OnceLock<Config> = OnceLock::new();
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
+    #[serde(default)]
     values: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     arrays: HashMap<String, Vec<String>>,
+    /// Default catalog: `[catalog]` section.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    catalog: HashMap<String, String>,
+    /// Named catalogs: `[catalogs.<name>]` sections.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    catalogs: HashMap<String, HashMap<String, String>>,
 }
 
 // global config path is ~/.utoo/config.toml
@@ -23,13 +33,30 @@ impl Config {
             return Self::load_from_path(&Self::global_config_path()?).await;
         }
 
-        let mut config = Self::load_from_path(&Self::global_config_path()?).await?;
-        let local_path = Self::local_config_path()?;
-        if crate::fs::try_exists(&local_path).await? {
-            let local_config = Self::load_from_path(&local_path).await?;
-            config.values.extend(local_config.values);
-            config.arrays.extend(local_config.arrays);
+        // Return cached merged config if available
+        if let Some(config) = MERGED_CONFIG.get() {
+            return Ok(config.clone());
         }
+
+        let mut config = Self::load_from_path(&Self::global_config_path()?).await?;
+
+        let local_config = {
+            let local_path = Self::local_config_path()?;
+            if crate::fs::try_exists(&local_path).await? {
+                Some(Self::load_from_path(&local_path).await?)
+            } else {
+                None
+            }
+        };
+        if let Some(local) = local_config {
+            config.values.extend(local.values);
+            config.arrays.extend(local.arrays);
+            // Catalogs are project-local only; take them from the local config
+            config.catalog = local.catalog;
+            config.catalogs = local.catalogs;
+        }
+
+        let _ = MERGED_CONFIG.set(config.clone());
         Ok(config)
     }
 
@@ -56,14 +83,22 @@ impl Config {
         self.save(global)
     }
 
-    pub(crate) async fn load_from_path(path: &Path) -> ConfigResult<Self> {
-        if !crate::fs::try_exists(path).await? {
-            return Ok(Config::default());
+    /// Build a `Catalogs` map from the parsed `[catalog]` and `[catalogs.*]` sections.
+    #[allow(dead_code)] // used by catalog protocol (upcoming)
+    pub fn catalogs(&self) -> HashMap<String, HashMap<String, String>> {
+        let mut result = self.catalogs.clone();
+        if !self.catalog.is_empty() {
+            result.insert(String::new(), self.catalog.clone());
         }
+        result
+    }
 
-        let content = fs::read_to_string(path)?;
-        let config = toml::from_str(&content)?;
-        Ok(config)
+    pub(crate) async fn load_from_path(path: &Path) -> ConfigResult<Self> {
+        match crate::fs::read_to_string(path).await {
+            Ok(content) => Ok(toml::from_str(&content)?),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Config::default()),
+            Err(e) => Err(e.into()),
+        }
     }
 
     pub fn save(&self, global: bool) -> ConfigResult<()> {
@@ -147,15 +182,18 @@ impl<T: Clone + Debug + 'static> ConfigValue<T> {
             return value.clone();
         }
 
-        // load from config
-        let config_result = Config::load(false).await;
-        if let Ok(config) = config_result {
-            let value_result = config.get(self.key);
-            if let Ok(Some(value)) = value_result {
-                let parsed_value = self.parse_config_value(&value);
-                let _ = self.value.set(parsed_value.clone());
-                return parsed_value;
-            }
+        // Ensure merged config is loaded and cached
+        if MERGED_CONFIG.get().is_none() {
+            let _ = Config::load(false).await; // populates MERGED_CONFIG
+        }
+
+        // Read from cached merged config (no clone of Config itself)
+        if let Some(config) = MERGED_CONFIG.get()
+            && let Ok(Some(value)) = config.get(self.key)
+        {
+            let parsed_value = self.parse_config_value(&value);
+            let _ = self.value.set(parsed_value.clone());
+            return parsed_value;
         }
 
         self.default.clone()
@@ -253,5 +291,58 @@ mod tests {
                 assert_eq!(config.get("keep").unwrap(), Some("yes".into()));
             });
         });
+    }
+
+    #[test]
+    fn test_catalogs_default_and_named() {
+        let config: Config = toml::from_str(
+            r#"
+[catalog]
+lodash = "^4.17.21"
+react = "^18.0.0"
+
+[catalogs.legacy]
+path-to-regexp = "^1.9.0"
+"#,
+        )
+        .unwrap();
+
+        let catalogs = config.catalogs();
+        let default = catalogs.get("").unwrap();
+        assert_eq!(default.get("lodash"), Some(&"^4.17.21".to_string()));
+        assert_eq!(default.get("react"), Some(&"^18.0.0".to_string()));
+
+        let legacy = catalogs.get("legacy").unwrap();
+        assert_eq!(legacy.get("path-to-regexp"), Some(&"^1.9.0".to_string()));
+    }
+
+    #[test]
+    fn test_catalogs_empty() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.catalogs().is_empty());
+    }
+
+    #[test]
+    fn test_catalogs_coexists_with_config_values() {
+        let config: Config = toml::from_str(
+            r#"
+[values]
+registry = "https://registry.npmmirror.com"
+
+[catalog]
+lodash = "^4.17.21"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.get("registry").unwrap(),
+            Some("https://registry.npmmirror.com".to_string())
+        );
+        let catalogs = config.catalogs();
+        assert_eq!(
+            catalogs.get("").unwrap().get("lodash"),
+            Some(&"^4.17.21".to_string())
+        );
     }
 }

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -64,6 +64,15 @@ pub fn get_registry() -> String {
     REGISTRY.get_sync()
 }
 
+#[allow(dead_code)] // used by catalog protocol (upcoming)
+pub async fn get_catalogs()
+-> std::collections::HashMap<String, std::collections::HashMap<String, String>> {
+    Config::load(false)
+        .await
+        .map(|c| c.catalogs())
+        .unwrap_or_default()
+}
+
 pub fn set_legacy_peer_deps(value: Option<bool>) {
     LEGACY_PEER_DEPS.set(value);
 }


### PR DESCRIPTION
## Summary

- Add `[catalog]` and `[catalogs.*]` TOML sections to `Config` struct via serde deserialization
- Add `Config::catalogs()` method and `get_catalogs()` accessor in `user_config`
- Rename `update_cwd_to_root` → `init_project_root` for clarity
- Unit tests for catalog parsing (default, named, empty, coexistence with config values)

Prerequisite for the catalog protocol feature (`feat/pm-catalog-protocol`).

## Test plan

- [x] `cargo test -p utoo-pm -- util::config_file` — 5 tests pass
- [x] `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)