### PR TITLE
fix(pack): compatWebpack treeshaking config

### DIFF
--- a/packages/pack-shared/src/webpackCompat.ts
+++ b/packages/pack-shared/src/webpackCompat.ts
@@ -697,7 +697,7 @@ function compatOptimization(
     noMangling: webpackOptimization.mangleExports === false,
     minify: minimize,
     concatenateModules,
-    treeShaking: enableTreeShaking,
+    treeShaking: false,
     removeUnusedExports: enableTreeShaking,
     removeUnusedImports: enableTreeShaking,
   };

--- a/packages/pack-shared/src/webpackCompat.ts
+++ b/packages/pack-shared/src/webpackCompat.ts
@@ -686,7 +686,7 @@ function compatOptimization(
   }
   const { moduleIds, minimize, concatenateModules, usedExports } =
     webpackOptimization;
-  const enableTreeShaking = usedExports !== false;
+  const enableWebpackUsedExports = usedExports !== false;
   return {
     moduleIds:
       moduleIds === "named"
@@ -698,8 +698,8 @@ function compatOptimization(
     minify: minimize,
     concatenateModules,
     treeShaking: false,
-    removeUnusedExports: enableTreeShaking,
-    removeUnusedImports: enableTreeShaking,
+    removeUnusedExports: enableWebpackUsedExports,
+    removeUnusedImports: enableWebpackUsedExports,
   };
 }
 

--- a/packages/pack-shared/src/webpackCompat.ts
+++ b/packages/pack-shared/src/webpackCompat.ts
@@ -686,6 +686,7 @@ function compatOptimization(
   }
   const { moduleIds, minimize, concatenateModules, usedExports } =
     webpackOptimization;
+  const enableTreeShaking = usedExports !== false;
   return {
     moduleIds:
       moduleIds === "named"
@@ -696,9 +697,9 @@ function compatOptimization(
     noMangling: webpackOptimization.mangleExports === false,
     minify: minimize,
     concatenateModules,
-    treeShaking: !!usedExports,
-    removeUnusedExports: !!usedExports,
-    removeUnusedImports: !!usedExports,
+    treeShaking: enableTreeShaking,
+    removeUnusedExports: enableTreeShaking,
+    removeUnusedImports: enableTreeShaking,
   };
 }
 


### PR DESCRIPTION

## Summary

Default value of webpack's unsedexports is true: https://webpack.js.org/configuration/optimization/#optimizationusedexports

It means even if it's undefined(user don't config), it will enable.

`!!undefined === false` in javascript, so in the default case utoopack will disable tree shaking(but webpack will enable).


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
