### PR TITLE
ci(workflows): cancel in-progress runs on new PR pushes & improve README badges

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pack-integration.yml
+++ b/.github/workflows/pack-integration.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pack-perf.yml
+++ b/.github/workflows/pack-perf.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main, next ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pm-bench.yml
+++ b/.github/workflows/pm-bench.yml
@@ -44,6 +44,10 @@ on:
   pull_request:
     types: [labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     # Run on manual trigger or when PR is labeled with 'benchmark'

--- a/.github/workflows/pm-ci.yml
+++ b/.github/workflows/pm-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pm-e2e.yml
+++ b/.github/workflows/pm-e2e.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-title:
     name: Check PR Title for Scope

--- a/.github/workflows/tombi.yml
+++ b/.github/workflows/tombi.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/utooweb-ci.yml
+++ b/.github/workflows/utooweb-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,20 @@
 <h1>Utoo</h1>
 <p><strong>Unified Toolchain: Open & Optimized</strong></p>
 
-[![License](https://img.shields.io/github/license/utooland/utoo?style=flat-square)](./LICENSE)
+[![license](https://img.shields.io/github/license/utooland/utoo?style=flat-square)](./LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](./CONTRIBUTING.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/utooland/utoo)
-[![npm](https://img.shields.io/npm/v/utoo?style=flat-square)](https://www.npmjs.com/package/utoo)
-[![npm downloads](https://img.shields.io/npm/dm/utoo?style=flat-square)](https://www.npmjs.com/package/utoo)
-[![@utoo/pack downloads](https://img.shields.io/npm/dm/@utoo/pack?style=flat-square)](https://www.npmjs.com/package/@utoo/pack)
-[![@utoo/web downloads](https://img.shields.io/npm/dm/@utoo/web?style=flat-square)](https://www.npmjs.com/package/@utoo/web)
-[![PM CI](https://github.com/utooland/utoo/actions/workflows/pm-ci.yml/badge.svg)](https://github.com/utooland/utoo/actions/workflows/pm-ci.yml)
-[![Pack CI](https://github.com/utooland/utoo/actions/workflows/pack-ci.yml/badge.svg)](https://github.com/utooland/utoo/actions/workflows/pack-ci.yml)
+
+[![npm](https://img.shields.io/npm/v/utoo?style=flat-square&label=utoo)](https://www.npmjs.com/package/utoo)
+[![npm](https://img.shields.io/npm/v/@utoo/pack?style=flat-square&label=@utoo/pack)](https://www.npmjs.com/package/@utoo/pack)
+[![npm](https://img.shields.io/npm/v/@utoo/web?style=flat-square&label=@utoo/web)](https://www.npmjs.com/package/@utoo/web)
+
+[![downloads](https://img.shields.io/npm/dm/utoo?style=flat-square&label=utoo%20downloads)](https://www.npmjs.com/package/utoo)
+[![downloads](https://img.shields.io/npm/dm/@utoo/pack?style=flat-square&label=@utoo/pack%20downloads)](https://www.npmjs.com/package/@utoo/pack)
+[![downloads](https://img.shields.io/npm/dm/@utoo/web?style=flat-square&label=@utoo/web%20downloads)](https://www.npmjs.com/package/@utoo/web)
+
+[![PM CI](https://img.shields.io/github/actions/workflow/status/utooland/utoo/pm-ci.yml?style=flat-square&label=PM%20CI)](https://github.com/utooland/utoo/actions/workflows/pm-ci.yml)
+[![Pack CI](https://img.shields.io/github/actions/workflow/status/utooland/utoo/pack-ci.yml?style=flat-square&label=Pack%20CI)](https://github.com/utooland/utoo/actions/workflows/pack-ci.yml)
 
 </div>
 


### PR DESCRIPTION
## What

### 1. Cancel in-progress CI runs on new PR pushes

Added concurrency groups to all 13 PR-triggered workflows. When a PR receives a new push, any in-progress run for the same PR is automatically cancelled.

**Affected:** biome, clippy, format, pack-ci, pack-integration, pack-perf, pm-bench, pm-ci, pm-e2e, pr-title, tombi, typos, utooweb-ci.

### 2. Improve README badge layout

- Add explicit labels for scoped npm packages
- Switch CI badges to shields.io flat-square style for consistency
- Reorganize badges into two logical rows