### PR TITLE
refactor(pack): remove Next.js-specific experimental config fields

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -290,7 +290,7 @@ pub async fn get_client_module_options_context(
         ecmascript: EcmascriptOptionsContext {
             enable_typeof_window_inlining: Some(TypeofWindow::Object),
             source_maps,
-            import_externals: *config.import_externals().await?,
+            import_externals: true,
             enable_typescript_transform: Some(
                 TypescriptTransformOptions::default().resolved_cell(),
             ),

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -1,10 +1,9 @@
 use std::sync::LazyLock;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
 use either::Either;
 use regex::Regex;
-use rustc_hash::FxHashSet;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_esregex::EsRegex;
@@ -36,22 +35,6 @@ use crate::{
 pub struct ModularizeImports(
     #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<String, ModularizeImportPackageConfig>,
 );
-
-#[turbo_tasks::value(transparent)]
-#[derive(Clone, Debug)]
-pub struct CacheKinds(FxHashSet<RcStr>);
-
-impl CacheKinds {
-    pub fn extend<I: IntoIterator<Item = RcStr>>(&mut self, iter: I) {
-        self.0.extend(iter);
-    }
-}
-
-impl Default for CacheKinds {
-    fn default() -> Self {
-        CacheKinds(["default", "remote"].iter().map(|&s| s.into()).collect())
-    }
-}
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionalJsonValue(
@@ -711,92 +694,8 @@ impl TryFrom<RegexComponents> for EsRegex {
 pub struct ExperimentalConfig {
     #[bincode(with = "turbo_bincode::serde_self_describing")]
     swc_plugins: Option<Vec<(RcStr, serde_json::Value)>>,
-    #[serde(rename = "dynamicIO")]
-    dynamic_io: Option<bool>,
-    use_cache: Option<bool>,
-    #[bincode(with = "turbo_bincode::serde_self_describing")]
-    cache_handlers: Option<FxIndexMap<RcStr, RcStr>>,
-    esm_externals: Option<EsmExternals>,
-    /// Using this feature will enable the `react@experimental` for the `app`
-    /// directory.
-    ppr: Option<ExperimentalPartialPrerendering>,
-    taint: Option<bool>,
     react_compiler: Option<ReactCompilerOptionsOrBoolean>,
-    view_transition: Option<bool>,
-    server_actions: Option<ServerActionsOrLegacyBool>,
 }
-
-#[turbo_tasks::value]
-#[derive(Clone, Debug, Deserialize, OperationValue)]
-#[serde(rename_all = "lowercase")]
-pub enum ExperimentalPartialPrerenderingIncrementalValue {
-    Incremental,
-}
-
-#[turbo_tasks::value]
-#[derive(Clone, Debug, Deserialize, OperationValue)]
-#[serde(untagged)]
-pub enum ExperimentalPartialPrerendering {
-    Boolean(bool),
-    Incremental(ExperimentalPartialPrerenderingIncrementalValue),
-}
-
-#[turbo_tasks::value]
-#[derive(Clone, Debug, Deserialize, OperationValue)]
-#[serde(untagged)]
-pub enum ServerActionsOrLegacyBool {
-    /// The current way to configure server actions sub behaviors.
-    ServerActionsConfig(ServerActions),
-
-    /// The legacy way to disable server actions. This is no longer used, server
-    /// actions is always enabled.
-    LegacyBool(bool),
-}
-
-#[turbo_tasks::value]
-#[derive(Clone, Debug, Deserialize, OperationValue)]
-#[serde(rename_all = "kebab-case")]
-pub enum EsmExternalsValue {
-    Loose,
-}
-
-#[turbo_tasks::value]
-#[derive(Clone, Debug, Deserialize, OperationValue)]
-#[serde(untagged)]
-pub enum EsmExternals {
-    Loose(EsmExternalsValue),
-    Bool(bool),
-}
-
-#[turbo_tasks::value]
-#[derive(Clone, Debug, Default, Deserialize, OperationValue)]
-#[serde(rename_all = "camelCase")]
-pub struct ServerActions {
-    /// Allows adjusting body parser size limit for server actions.
-    pub body_size_limit: Option<SizeLimit>,
-}
-
-#[turbo_tasks::value(eq = "manual")]
-#[derive(Clone, Debug, Deserialize, OperationValue)]
-#[serde(untagged)]
-pub enum SizeLimit {
-    Number(f64),
-    WithUnit(String),
-}
-
-// Manual implementation of PartialEq and Eq for SizeLimit because f64 doesn't
-// implement Eq.
-impl PartialEq for SizeLimit {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (SizeLimit::Number(a), SizeLimit::Number(b)) => a.to_bits() == b.to_bits(),
-            (SizeLimit::WithUnit(a), SizeLimit::WithUnit(b)) => a == b,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for SizeLimit {}
 
 #[turbo_tasks::value]
 #[derive(Clone, Debug, Deserialize, OperationValue)]
@@ -907,9 +806,6 @@ pub struct SwcPlugins(
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionalMdxTransformOptions(Option<ResolvedVc<MdxTransformOptions>>);
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionServerActions(Option<ServerActions>);
 
 #[turbo_tasks::value(transparent)]
 pub struct ExternalsConfig(
@@ -1360,15 +1256,6 @@ impl Config {
     }
 
     #[turbo_tasks::function]
-    pub async fn import_externals(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(match self.experimental.esm_externals {
-            Some(EsmExternals::Bool(b)) => b,
-            Some(EsmExternals::Loose(_)) => bail!("esmExternals = \"loose\" is not supported"),
-            None => true,
-        }))
-    }
-
-    #[turbo_tasks::function]
     pub fn image_config(&self) -> Vc<OptionImageConfig> {
         Vc::cell(self.images.clone())
     }
@@ -1386,17 +1273,6 @@ impl Config {
     #[turbo_tasks::function]
     pub fn experimental_swc_plugins(&self) -> Vc<SwcPlugins> {
         Vc::cell(self.experimental.swc_plugins.clone().unwrap_or_default())
-    }
-
-    #[turbo_tasks::function]
-    pub fn experimental_server_actions(&self) -> Vc<OptionServerActions> {
-        Vc::cell(match self.experimental.server_actions.as_ref() {
-            Some(ServerActionsOrLegacyBool::ServerActionsConfig(server_actions)) => {
-                Some(server_actions.clone())
-            }
-            Some(ServerActionsOrLegacyBool::LegacyBool(true)) => Some(ServerActions::default()),
-            _ => None,
-        })
     }
 
     #[turbo_tasks::function]
@@ -1455,60 +1331,6 @@ impl Config {
     #[turbo_tasks::function]
     pub fn inline_css(&self) -> Vc<OptionalJsonValue> {
         Vc::cell(self.styles.as_ref().and_then(|op| op.inline_css.clone()))
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_ppr(&self) -> Vc<bool> {
-        Vc::cell(
-            self.experimental
-                .ppr
-                .as_ref()
-                .map(|ppr| match ppr {
-                    ExperimentalPartialPrerendering::Incremental(
-                        ExperimentalPartialPrerenderingIncrementalValue::Incremental,
-                    ) => true,
-                    ExperimentalPartialPrerendering::Boolean(b) => *b,
-                })
-                .unwrap_or(false),
-        )
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_taint(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.taint.unwrap_or(false))
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_view_transition(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.view_transition.unwrap_or(false))
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_dynamic_io(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.dynamic_io.unwrap_or(false))
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_use_cache(&self) -> Vc<bool> {
-        Vc::cell(
-            self.experimental
-                .use_cache
-                // "use cache" was originally implicitly enabled with the
-                // dynamicIO flag, so we transfer the value for dynamicIO to the
-                // explicit useCache flag to ensure backwards compatibility.
-                .unwrap_or(self.experimental.dynamic_io.unwrap_or(false)),
-        )
-    }
-
-    #[turbo_tasks::function]
-    pub fn cache_kinds(&self) -> Vc<CacheKinds> {
-        let mut cache_kinds = CacheKinds::default();
-
-        if let Some(handlers) = self.experimental.cache_handlers.as_ref() {
-            cache_kinds.extend(handlers.keys().cloned());
-        }
-
-        cache_kinds.cell()
     }
 
     #[turbo_tasks::function]
@@ -1688,24 +1510,6 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_esm_externals_deserialization() {
-        let json = serde_json::json!({
-            "esmExternals": true
-        });
-        let config: ExperimentalConfig = serde_json::from_value(json).unwrap();
-        assert_eq!(config.esm_externals, Some(EsmExternals::Bool(true)));
-
-        let json = serde_json::json!({
-            "esmExternals": "loose"
-        });
-        let config: ExperimentalConfig = serde_json::from_value(json).unwrap();
-        assert_eq!(
-            config.esm_externals,
-            Some(EsmExternals::Loose(EsmExternalsValue::Loose))
-        );
-    }
 
     #[test]
     fn test_externals_deserialization() {

--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -199,7 +199,7 @@ pub async fn get_server_module_options_context(
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             source_maps,
-            import_externals: *config.import_externals().await?,
+            import_externals: true,
             enable_typescript_transform: Some(
                 TypescriptTransformOptions::default().resolved_cell(),
             ),

--- a/crates/pack-schema/README.md
+++ b/crates/pack-schema/README.md
@@ -1,42 +1,41 @@
 # Pack Schema
 
-一个用于 utoopack 配置文件的 JSON Schema 生成器，为 `utoopack.json` 配置文件提供类型提示和验证支持。
+A JSON Schema generator for utoopack configuration files, providing type hints and validation support for `utoopack.json`.
 
-## ✨ 功能特性
+## ✨ Features
 
-- 🔧 **完整的配置支持**: 支持所有 pack-core 配置选项，包括复杂的 externals 配置
-- 📝 **智能提示**: 为配置文件提供自动补全和验证
-- 🎯 **类型安全**: 基于 Rust 类型系统生成准确的 JSON Schema
-- 🔄 **架构同步**: 通过镜像类型与 pack-core 保持同步
-- ⚡ **易于集成**: 支持多种 IDE 和编辑器的自动配置
+- 🔧 **Complete configuration support**: Covers all pack-core configuration options, including complex externals configuration
+- 📝 **Smart hints**: Provides auto-completion and validation for configuration files
+- 🎯 **Type safety**: Generates accurate JSON Schema based on the Rust type system
+- 🔄 **Schema sync**: Stays in sync with pack-core via mirrored types
+- ⚡ **Easy integration**: Supports auto-configuration in various IDEs and editors
 
-## 🏗️ 架构设计
+## 🏗️ Architecture
 
-### 核心理念
+### Core Concept
 
-Pack Schema 采用了**镜像类型架构**，既解决了用户提出的"避免重复配置维护"问题，又保持了 JsonSchema 兼容性：
+Pack Schema adopts a **mirrored type architecture** that avoids duplicate configuration maintenance while preserving JsonSchema compatibility:
 
-1. **直接引用 pack-core**: 通过 `pub use pack_core::config::*` 重导出所有核心类型
-2. **Schema 兼容类型**: 创建与 pack-core 结构完全对应但使用标准类型的 Schema 结构
+1. **Direct re-export from pack-core**: Re-exports all core types via `pub use pack_core::config::*`
+2. **Schema-compatible types**: Creates Schema structs that mirror pack-core structures but use standard types
 
-### 类型映射策略
+### Type Mapping Strategy
 
-| pack-core 类型 | pack-schema 类型 | 说明 |
-|---------------|-----------------|------|
-| `RcStr` | `String` | JSON Schema 兼容的字符串类型 |
-| `FxIndexMap<K,V>` | `HashMap<K,V>` | 标准 HashMap 替代 |
-| `FxHashSet<T>` | `Vec<T>` | 数组表示集合 |
-| turbo-tasks 类型 | 对应标准类型 | 移除运行时特定注解 |
+| pack-core type | pack-schema type | Description |
+|---------------|-----------------|-------------|
+| `RcStr` | `String` | JSON Schema compatible string type |
+| `FxIndexMap<K,V>` | `HashMap<K,V>` | Standard HashMap replacement |
+| `FxHashSet<T>` | `Vec<T>` | Array representation for sets |
+| turbo-tasks types | Corresponding standard types | Runtime-specific annotations removed |
 
-## 🚀 使用方法
+## 🚀 Usage
 
-### 生成 Schema
+### Generating the Schema
 
 ```bash
-# 使用 just (推荐)
+# Using just (recommended)
 just schema
 
-# 或直接使用 cargo
+# Or directly via cargo
 cargo run -p pack-schema
-
 ```

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -859,50 +859,10 @@ pub struct SchemaExperimentalConfig {
     #[schemars(description = "SWC plugins as [path, options] tuples")]
     pub swc_plugins: Option<Vec<(String, serde_json::Value)>>,
 
-    /// Dynamic IO
-    #[serde(rename = "dynamicIO", skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Dynamic IO")]
-    pub dynamic_io: Option<bool>,
-
-    /// Use cache
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Use cache")]
-    pub use_cache: Option<bool>,
-
-    /// Cache handlers
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Cache handlers")]
-    pub cache_handlers: Option<HashMap<String, String>>,
-
-    /// ESM externals
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "ESM externals")]
-    pub esm_externals: Option<serde_json::Value>,
-
-    /// Partial prerendering
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Partial prerendering")]
-    pub ppr: Option<serde_json::Value>,
-
-    /// Taint
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Taint")]
-    pub taint: Option<bool>,
-
     /// React compiler
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "React compiler")]
     pub react_compiler: Option<serde_json::Value>,
-
-    /// View transition
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "View transition")]
-    pub view_transition: Option<bool>,
-
-    /// Server actions
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Server actions")]
-    pub server_actions: Option<serde_json::Value>,
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -20,15 +20,7 @@ export type RustifiedEnv = { name: string; value: string }[];
 
 export interface ExperimentalConfig {
   swcPlugins?: [string, any][];
-  dynamicIO?: boolean;
-  useCache?: boolean;
-  cacheHandlers?: Record<string, string>;
-  esmExternals?: boolean | "loose";
-  ppr?: boolean | "incremental";
-  taint?: boolean;
   reactCompiler?: boolean | any;
-  viewTransition?: boolean;
-  serverActions?: boolean | any;
 }
 
 export type JSONValue =

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -1,16 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ProjectOptions",
-  "description": "Top-level project options configuration This represents the root structure of utoopack.json",
+  "title": "CompleteConfig",
+  "description": "Top-level configuration for utoopack.json This represents the JSON config file structure, aligned with pack-core's `Config` struct.",
   "type": "object",
   "properties": {
-    "buildId": {
-      "description": "The build id.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "cacheHandler": {
       "description": "Cache handler configuration",
       "type": [
@@ -25,24 +18,6 @@
         "null"
       ],
       "additionalProperties": true
-    },
-    "defineEnv": {
-      "description": "A map of environment variables which should get injected at compile time.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SchemaDefineEnv"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "dev": {
-      "description": "Whether to run in development mode",
-      "type": [
-        "boolean",
-        "null"
-      ]
     },
     "devServer": {
       "description": "Development server configuration",
@@ -144,13 +119,6 @@
         }
       ]
     },
-    "packPath": {
-      "description": "Absolute path for @utoo/pack",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "persistentCaching": {
       "description": "Enable persistent caching",
       "type": [
@@ -158,21 +126,25 @@
         "null"
       ]
     },
-    "processEnv": {
-      "description": "A map of environment variables to use when compiling code.",
+    "provider": {
+      "description": "Provider (ProvidePlugin) configuration",
       "type": [
         "object",
         "null"
       ],
       "additionalProperties": {
-        "type": "string"
+        "$ref": "#/definitions/SchemaProviderConfigValue"
       }
     },
-    "projectPath": {
-      "description": "A path inside the root_path which contains the app directories.",
-      "type": [
-        "string",
-        "null"
+    "react": {
+      "description": "React configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaReactConfig"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "resolve": {
@@ -184,13 +156,6 @@
         {
           "type": "null"
         }
-      ]
-    },
-    "rootPath": {
-      "description": "A root path from which all files must be nested under.",
-      "type": [
-        "string",
-        "null"
       ]
     },
     "sourceMaps": {
@@ -224,36 +189,152 @@
         "string",
         "null"
       ]
-    },
-    "watch": {
-      "description": "Filesystem watcher options.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SchemaWatchOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
     }
   },
   "definitions": {
-    "SchemaConfigConditionItem": {
-      "description": "Configuration condition item",
-      "type": "object",
-      "required": [
-        "path"
-      ],
-      "properties": {
-        "path": {
-          "description": "Condition path configuration",
-          "allOf": [
-            {
-              "$ref": "#/definitions/SchemaConfigConditionPath"
+    "SchemaConfigConditionContentType": {
+      "description": "Configuration condition for content type",
+      "oneOf": [
+        {
+          "description": "Glob pattern for content type matching",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "glob"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          ]
+          }
+        },
+        {
+          "description": "Regex match for content type",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "regex"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/SchemaRegexComponents"
+            }
+          }
         }
-      }
+      ]
+    },
+    "SchemaConfigConditionItem": {
+      "description": "Configuration condition item — supports compound conditions (all/any/not) and base conditions with path, content, query, and contentType matchers.",
+      "anyOf": [
+        {
+          "description": "All conditions must match",
+          "type": "object",
+          "required": [
+            "all"
+          ],
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SchemaConfigConditionItem"
+              }
+            }
+          }
+        },
+        {
+          "description": "Any condition must match",
+          "type": "object",
+          "required": [
+            "any"
+          ],
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SchemaConfigConditionItem"
+              }
+            }
+          }
+        },
+        {
+          "description": "Negate a condition",
+          "type": "object",
+          "required": [
+            "not"
+          ],
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/SchemaConfigConditionItem"
+            }
+          }
+        },
+        {
+          "description": "Base condition with path/content/query/contentType matchers",
+          "type": "object",
+          "properties": {
+            "content": {
+              "description": "Content regex",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SchemaRegexComponents"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contentType": {
+              "description": "Content type condition",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SchemaConfigConditionContentType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "path": {
+              "description": "Path condition",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SchemaConfigConditionPath"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "query": {
+              "description": "Query condition",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SchemaConfigConditionQuery"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Built-in condition (e.g., \"server\", \"client\", \"edge\")",
+          "type": "string"
+        }
+      ]
     },
     "SchemaConfigConditionPath": {
       "description": "Configuration condition path",
@@ -279,6 +360,49 @@
         },
         {
           "description": "Regular expression for path matching",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "regex"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/SchemaRegexComponents"
+            }
+          }
+        }
+      ]
+    },
+    "SchemaConfigConditionQuery": {
+      "description": "Configuration condition for query strings",
+      "oneOf": [
+        {
+          "description": "Constant string match for query",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "constant"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Regex match for query",
           "type": "object",
           "required": [
             "type",
@@ -326,42 +450,6 @@
           }
         }
       ]
-    },
-    "SchemaDefineEnv": {
-      "description": "Environment variables for build-time injection",
-      "type": "object",
-      "properties": {
-        "client": {
-          "description": "Client-side environment variables",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/SchemaEnvVar"
-          }
-        },
-        "edge": {
-          "description": "Edge-side environment variables",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/SchemaEnvVar"
-          }
-        },
-        "nodejs": {
-          "description": "Node.js environment variables",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/SchemaEnvVar"
-          }
-        }
-      }
     },
     "SchemaDevServer": {
       "description": "Development server configuration",
@@ -418,88 +506,30 @@
         }
       }
     },
-    "SchemaEnvVar": {
-      "description": "Environment variable pair",
-      "type": "object",
-      "required": [
-        "name",
-        "value"
-      ],
-      "properties": {
-        "name": {
-          "description": "Variable name",
-          "type": "string"
-        },
-        "value": {
-          "description": "Variable value",
-          "type": "string"
-        }
-      }
-    },
     "SchemaExperimentalConfig": {
       "description": "Experimental features configuration",
       "type": "object",
       "properties": {
-        "cacheHandlers": {
-          "description": "Cache handlers",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "dynamicIO": {
-          "description": "Dynamic IO",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "esmExternals": {
-          "description": "ESM externals"
-        },
-        "mdxRs": {
-          "description": "MDX-RS options"
-        },
-        "ppr": {
-          "description": "Partial prerendering"
-        },
         "reactCompiler": {
           "description": "React compiler"
         },
-        "serverActions": {
-          "description": "Server actions"
-        },
         "swcPlugins": {
-          "description": "SWC plugins",
+          "description": "SWC plugins as [path, options] tuples",
           "type": [
             "array",
             "null"
           ],
-          "items": true
-        },
-        "taint": {
-          "description": "Taint",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "useCache": {
-          "description": "Use cache",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "viewTransition": {
-          "description": "View transition",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "type": "string"
+              },
+              true
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
         }
       }
     },
@@ -549,7 +579,7 @@
       "description": "External dependency configuration",
       "anyOf": [
         {
-          "description": "Simple string external (e.g., \\\"react\\\" -> \\\"React\\\")",
+          "description": "Simple string external (e.g., \"react\" -> \"React\")",
           "type": "string"
         },
         {
@@ -815,16 +845,6 @@
       "description": "Module configuration",
       "type": "object",
       "properties": {
-        "conditions": {
-          "description": "Module conditions configuration",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/definitions/SchemaConfigConditionItem"
-          }
-        },
         "rules": {
           "description": "Module rules configuration",
           "type": [
@@ -961,14 +981,14 @@
           ]
         },
         "removeUnusedExports": {
-          "description": "Whether to remove unused exports",
+          "description": "Whether to remove unused exports. Defaults to false in development, true in production.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "removeUnusedImports": {
-          "description": "Whether to remove unused imports",
+          "description": "Whether to remove unused imports. Defaults to false in development, true in production.",
           "type": [
             "boolean",
             "null"
@@ -1002,7 +1022,7 @@
           ]
         },
         "wasmAsAsset": {
-          "description": "Whether to bunle wasm as asset. Defaults to false. When false, WASM files will be output as static assets.",
+          "description": "Whether to bundle WASM as asset. Defaults to false. When false, WASM files will be output as static assets.",
           "type": [
             "boolean",
             "null"
@@ -1014,8 +1034,15 @@
       "description": "Output configuration",
       "type": "object",
       "properties": {
+        "assetModuleFilename": {
+          "description": "Filename pattern for asset modules (images, fonts, etc.)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "chunkFilename": {
-          "description": "Filename pattern for chunk files",
+          "description": "Filename pattern for JS chunk files",
           "type": [
             "string",
             "null"
@@ -1045,6 +1072,20 @@
             "$ref": "#/definitions/SchemaCopyItem"
           }
         },
+        "cssChunkFilename": {
+          "description": "Filename pattern for CSS chunk files",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cssFilename": {
+          "description": "Filename pattern for main CSS files",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "entryRootExport": {
           "description": "Expose entry module exports to global scope with the specified name. When set, all named exports from the entry module will be available on window/globalThis under the specified name. If set to empty string, will use package.json name. Default: None (no exposure)",
           "type": [
@@ -1053,7 +1094,7 @@
           ]
         },
         "filename": {
-          "description": "Filename pattern for main files",
+          "description": "Filename pattern for main JS files",
           "type": [
             "string",
             "null"
@@ -1061,6 +1102,13 @@
         },
         "path": {
           "description": "Output directory path",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "publicPath": {
+          "description": "URL prefix prepended to all chunk and asset URLs. Use 'runtime' for runtime-resolved public path.",
           "type": [
             "string",
             "null"
@@ -1086,6 +1134,42 @@
         "standalone",
         "export"
       ]
+    },
+    "SchemaProviderConfigValue": {
+      "description": "Provider configuration value. Can be a simple module name string or a [module, export] tuple.",
+      "anyOf": [
+        {
+          "description": "Simple module import, e.g. \"jquery\"",
+          "type": "string"
+        },
+        {
+          "description": "Named export import, e.g. [\"buffer\", \"Buffer\"]",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "SchemaReactConfig": {
+      "description": "React configuration",
+      "type": "object",
+      "properties": {
+        "importSource": {
+          "description": "Custom JSX import source",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runtime": {
+          "description": "JSX runtime to use (automatic or classic)",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     },
     "SchemaRegexComponents": {
       "description": "Regular expression components",
@@ -1274,38 +1358,6 @@
           }
         }
       ]
-    },
-    "SchemaWatchOptions": {
-      "description": "Filesystem watcher options",
-      "type": "object",
-      "required": [
-        "enable"
-      ],
-      "properties": {
-        "enable": {
-          "description": "Whether to watch the filesystem for file changes.",
-          "type": "boolean"
-        },
-        "ignored": {
-          "description": "Paths to ignore when watching for file changes. By default, ignores: node_modules",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "pollInterval": {
-          "description": "Enable polling at a certain interval if the native file watching doesn't work (e.g. docker).",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Remove Next.js-specific fields from ExperimentalConfig that are not used by utoopack standalone.

**Removed fields:** dynamicIO, useCache, cacheHandlers, esmExternals, ppr, taint, viewTransition, serverActions

**Removed types:** CacheKinds, ExperimentalPartialPrerendering*, ServerActionsOrLegacyBool, EsmExternals*, ServerActions, SizeLimit, OptionServerActions

**Removed accessors:** enable_ppr, enable_taint, enable_view_transition, enable_dynamic_io, enable_use_cache, experimental_server_actions, cache_kinds, import_externals

**Other:**
- Hardcoded import_externals: true in client/server contexts (previous default)
- Regenerated config_schema.json
- Translated pack-schema README to English