### PR TITLE
fix(pack): avoid resolving browser field when build with server

### DIFF
--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -313,7 +313,6 @@ pub async fn get_server_resolve_options_context(
         custom_conditions,
         import_map: Some(server_import_map),
         fallback_import_map: Some(server_fallback_import_map),
-        browser: true,
         module: true,
         before_resolve_plugins: vec![ResolvedVc::upcast(externals_plugin)],
         after_resolve_plugins: vec![ResolvedVc::upcast(externals_plugin)],

--- a/crates/pack-tests/tests/snapshot/style/css_modules/issues/Issue-while-running-loader-0ae341.txt
+++ b/crates/pack-tests/tests/snapshot/style/css_modules/issues/Issue-while-running-loader-0ae341.txt
@@ -1,0 +1,18 @@
+warning - [transform] /style/css_modules/input/normal_css_modules/style.module.scss  Issue while running loader
+  
+  SassWarning: Deprecation Warning on line 6, column 22 of file://WORKSPACE_ROOT/crates/pack-tests/tests/snapshot/style/css_modules/input/normal_css_modules/style.module.scss:6:22:
+  Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
+  Use color.adjust instead.
+  
+  More info and automated migrator: https://sass-lang.com/d/import
+  
+  6 |     background-color: darken($primary-color, 10%);
+  
+  
+  input/normal_css_modules/style.module.scss 7:23  root stylesheet
+  
+  
+  Import trace:
+    Browser:
+      ./style/css_modules/input/normal_css_modules/style.module.scss
+      ./style/css_modules/input/index.ts

--- a/crates/pack-tests/tests/snapshot/style/css_modules/issues/Issue-while-running-loader-3210e1.txt
+++ b/crates/pack-tests/tests/snapshot/style/css_modules/issues/Issue-while-running-loader-3210e1.txt
@@ -1,0 +1,20 @@
+warning - [transform] /style/css_modules/input/normal_css_modules/style.module.scss  Issue while running loader
+  
+  SassWarning: Deprecation Warning on line 6, column 22 of file://WORKSPACE_ROOT/crates/pack-tests/tests/snapshot/style/css_modules/input/normal_css_modules/style.module.scss:6:22:
+  darken() is deprecated. Suggestions:
+  
+  color.scale($color, $lightness: -24.6376811594%)
+  color.adjust($color, $lightness: -10%)
+  
+  More info: https://sass-lang.com/d/color-functions
+  
+  6 |     background-color: darken($primary-color, 10%);
+  
+  
+  input/normal_css_modules/style.module.scss 7:23  root stylesheet
+  
+  
+  Import trace:
+    Browser:
+      ./style/css_modules/input/normal_css_modules/style.module.scss
+      ./style/css_modules/input/index.ts

--- a/crates/pack-tests/tests/snapshot/style/css_modules/issues/Issue-while-running-loader-a70edc.txt
+++ b/crates/pack-tests/tests/snapshot/style/css_modules/issues/Issue-while-running-loader-a70edc.txt
@@ -1,0 +1,18 @@
+warning - [transform] /style/css_modules/input/auto_css_modules/style.scss  Issue while running loader
+  
+  SassWarning: Deprecation Warning on line 6, column 22 of file://WORKSPACE_ROOT/crates/pack-tests/tests/snapshot/style/css_modules/input/auto_css_modules/style.scss:6:22:
+  Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
+  Use color.adjust instead.
+  
+  More info and automated migrator: https://sass-lang.com/d/import
+  
+  6 |     background-color: darken($primary-color, 10%);
+  
+  
+  input/auto_css_modules/style.scss 7:23  root stylesheet
+  
+  
+  Import trace:
+    Browser:
+      ./style/css_modules/input/auto_css_modules/style.scss
+      ./style/css_modules/input/index.ts

--- a/crates/pack-tests/tests/snapshot/style/css_modules/issues/Issue-while-running-loader-b82c80.txt
+++ b/crates/pack-tests/tests/snapshot/style/css_modules/issues/Issue-while-running-loader-b82c80.txt
@@ -1,0 +1,20 @@
+warning - [transform] /style/css_modules/input/auto_css_modules/style.scss  Issue while running loader
+  
+  SassWarning: Deprecation Warning on line 6, column 22 of file://WORKSPACE_ROOT/crates/pack-tests/tests/snapshot/style/css_modules/input/auto_css_modules/style.scss:6:22:
+  darken() is deprecated. Suggestions:
+  
+  color.scale($color, $lightness: -24.6376811594%)
+  color.adjust($color, $lightness: -10%)
+  
+  More info: https://sass-lang.com/d/color-functions
+  
+  6 |     background-color: darken($primary-color, 10%);
+  
+  
+  input/auto_css_modules/style.scss 7:23  root stylesheet
+  
+  
+  Import trace:
+    Browser:
+      ./style/css_modules/input/auto_css_modules/style.scss
+      ./style/css_modules/input/index.ts


### PR DESCRIPTION
This pull request primarily adds new test snapshots for Sass deprecation warnings related to the use of deprecated global built-in functions and the `darken()` function in SCSS files. Additionally, there is a minor change to the server context configuration.

Test coverage for Sass deprecations:

* Added snapshot tests to capture warnings about deprecated global built-in Sass functions and the `darken()` function, including suggestions for migration to `color.adjust` and `color.scale` in both auto and normal CSS modules. [[1]](diffhunk://#diff-f823ac3c3e3c45113db37e3b800e7e5a682402b55d7ff399b9b18156c5ef7b42R1-R18) [[2]](diffhunk://#diff-efd84e9fda3b3b2fa70b74da210d840a99c8e0505cabda3f227fdb989a0fd7a1R1-R20) [[3]](diffhunk://#diff-c57e44867adf9d951eb566fdd5d1afeb3618b2d488a6a695d094fd0edbd5020cR1-R18) [[4]](diffhunk://#diff-e27867d7c83da1d18db73303d41493e4dd159e144ef36544fa8a8a7374e511bfR1-R20)

Server context configuration:

* Removed the `browser: true` option from the server resolve options context in `crates/pack-core/src/server/contexts.rs`, which may affect how modules are resolved on the server.