### PR TITLE
feat(web): prioritize importMaps in CJS module resolution

### DIFF
--- a/packages/utoo-web/src/webpackLoaders/cjs.ts
+++ b/packages/utoo-web/src/webpackLoaders/cjs.ts
@@ -139,18 +139,9 @@ const loadModule = (
   // 1. Resolve
   let resolvedId = id.startsWith(".") ? path.join(context, id) : id;
 
-  // 2. Check Cache (SystemJS)
-  const sysDef =
-    System.get(resolvedId) || (id !== resolvedId && System.get(id));
-  if (sysDef) return sysDef.default;
-
-  // 3. Check Node Polyfills
-  if (id in nodePolyFills) return (nodePolyFills as any)[id];
-  if (resolvedId in nodePolyFills) return (nodePolyFills as any)[resolvedId];
-
-  // 4. Check importMaps & FS
-  let moduleCode = importMaps[resolvedId] || importMaps[id];
-  let moduleId = importMaps[resolvedId] ? resolvedId : id;
+  // 2. Check importMaps (highest priority)
+  let moduleCode = importMaps[id];
+  let moduleId = id;
 
   if (!moduleCode) {
     let longestMatch: { key: string; sanitized: string } | null = null;
@@ -178,6 +169,20 @@ const loadModule = (
           : resolvedId;
     }
   }
+
+  if (moduleCode) {
+    resolutionCache[`${context}:${id}`] = moduleId;
+    return executeModule(moduleCode, moduleId, id, importMaps, entrypoint);
+  }
+
+  // 3. Check Cache (SystemJS)
+  const sysDef =
+    System.get(resolvedId) || (id !== resolvedId && System.get(id));
+  if (sysDef) return sysDef.default;
+
+  // 4. Check Node Polyfills
+  if (id in nodePolyFills) return (nodePolyFills as any)[id];
+  if (resolvedId in nodePolyFills) return (nodePolyFills as any)[resolvedId];
 
   // Fallback: Try resolving from node_modules
   if (!moduleCode && !id.startsWith(".") && !id.startsWith("/")) {


### PR DESCRIPTION
## Summary

Move importMaps check to highest priority in `loadModule` resolution order (in `cjs.ts`), before SystemJS cache and Node polyfills. When an importMaps match is found, return immediately without falling through to other resolution strategies.

## Resolution Order (after change)

1. Resolution cache
2. **importMaps** ← moved to highest priority, with early return
3. SystemJS cache
4. Node polyfills
5. `node_modules` fallback
6. Absolute/relative FS fallback

## Impact

- Modules in importMaps now always win over SystemJS cache and Node polyfills
- **No breaking changes** for non-importMaps resolving — when importMaps has no match, execution falls through to the remaining strategies in the exact same order as before