### PR TITLE
feat(web): prioritize importMaps over FS resolve in CJS loader

### DIFF
--- a/packages/utoo-web/src/webpackLoaders/cjs.ts
+++ b/packages/utoo-web/src/webpackLoaders/cjs.ts
@@ -61,7 +61,11 @@ const executeModule = (
   moduleRequire.resolve = (request: string) => request;
 
   const module = { exports: finalExports, require: moduleRequire };
-  if (moduleId.includes("node_modules")) {
+  if (
+    moduleId.includes("node_modules") ||
+    id in importMaps ||
+    moduleId in importMaps
+  ) {
     installedModules[moduleId] = module;
   }
 
@@ -129,6 +133,17 @@ const loadModule = (
   if (resolutionCache[cacheKey]) {
     const cachedId = resolutionCache[cacheKey];
     if (installedModules[cachedId]) return installedModules[cachedId].exports;
+
+    const sysCached =
+      System.get(cachedId) || (id !== cachedId && System.get(id));
+    if (sysCached) return sysCached.default;
+
+    // importMaps takes priority over cached FS path
+    const importMapCode = importMaps[cachedId] || importMaps[id];
+    if (importMapCode) {
+      const mid = importMaps[cachedId] ? cachedId : id;
+      return executeModule(importMapCode, mid, id, importMaps, entrypoint);
+    }
 
     const code = tryReadFile(cachedId);
     if (code !== null) {


### PR DESCRIPTION
## What

Optimize the CJS module loader to prioritize `importMaps` over file system reads for better performance and reliability.

## Changes

- **SystemJS cache check**: Added before importMaps in the resolution cache block (fastest path for already-loaded modules)
- **importMaps check before FS**: In the resolution cache block, check importMaps before falling back to `tryReadFile` — avoids unnecessary FS I/O for pre-bundled loader modules
- **Cache importMaps modules**: Extended `installedModules` caching to include modules resolved from importMaps, ensuring faster subsequent `require()` calls

## Why

`loadersImportMap` provides pre-bundled, CommonJS-compatible loader modules as URL/content strings. These should always be resolved before attempting file system reads, as they are guaranteed available and avoid OPFS I/O overhead.