### PR TITLE
chore(web): upgrade opfs-project@0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5138,9 +5138,9 @@ dependencies = [
 
 [[package]]
 name = "opfs-project"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a381fc127e7673d1d63c8a1fb26a4eb91f6674a7bc5dc5fde3ac8f5ad7be885e"
+checksum = "f1c2ad2c13b8e6df6f3bb1ead42d7ee63e39a8d5d710d528b43fd060f10116a1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -16,7 +16,7 @@ flate2                   = "1.1.5"
 futures                  = { workspace = true }
 js-sys                   = "0.3.83"
 oneshot                  = "0.1.11"
-opfs-project             = "0.2.5"
+opfs-project             = "0.2.6"
 petgraph                 = "0.6"
 reqwest                  = { version = "0.12.22", default-features = false, features = ["json"] }
 rustc-hash               = { workspace = true }


### PR DESCRIPTION
This pull request updates the version of the `opfs-project` dependency in the `crates/utoo-wasm/Cargo.toml` file from `0.2.5` to `0.2.6`.

Dependency update:

* Bumped `opfs-project` dependency version to `0.2.6` in `Cargo.toml` to include the latest features or fixes.