### PR TITLE
fix(pack): enable content_handing when client production build

### DIFF
--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -1095,7 +1095,6 @@ impl Project {
         let dist_root = self.dist_root().owned().await?;
         Ok(get_server_chunking_context(ServerChunkingContextOptions {
             mode,
-            config,
             root_path: dist_root.clone(),
             node_root: dist_root,
             node_root_to_root_path: rcstr!("/ROOT"),

--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -10,7 +10,7 @@ use turbopack::module_options::{
     CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleOptionsContext,
     ModuleRule, TypescriptTransformOptions, side_effect_free_packages_glob,
 };
-use turbopack_browser::{BrowserChunkingContext, CurrentChunkMethod};
+use turbopack_browser::{BrowserChunkingContext, ContentHashing, CurrentChunkMethod};
 use turbopack_core::{
     chunk::{
         ChunkingConfig, ChunkingContext, MangleType, MinifyType, SourceMapSourceType,
@@ -606,6 +606,7 @@ pub async fn get_client_chunking_context(
                 Vc::<CssChunkType>::default().to_resolved().await?,
                 css_chunking_config,
             )
+            .use_content_hashing(ContentHashing::Direct { length: 16 })
             .module_merging(*scope_hoisting.await?);
     }
 

--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -349,7 +349,6 @@ pub async fn get_server_resolve_options_context(
 #[derive(Clone, Debug, PartialEq, Eq, Hash, TaskInput, TraceRawVcs, Encode, Decode)]
 pub struct ServerChunkingContextOptions {
     pub mode: Vc<Mode>,
-    pub config: Vc<Config>,
     pub root_path: FileSystemPath,
     pub node_root: FileSystemPath,
     pub node_root_to_root_path: RcStr,
@@ -373,7 +372,6 @@ pub async fn get_server_chunking_context(
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let ServerChunkingContextOptions {
         mode,
-        config,
         root_path,
         node_root,
         node_root_to_root_path,


### PR DESCRIPTION
This pull request introduces improvements to the client chunking context and simplifies the server chunking context configuration. The main highlights are the addition of content hashing for generated filenames in both JavaScript and CSS outputs, and the removal of an unused `config` parameter from the server chunking context options and related code.

Enhancements to chunking and output configuration:

* Added `ContentHashing::Direct` (16 characters) to the client chunking context, ensuring that output files have content-based hashes for better cache management. (`crates/pack-core/src/client/context.rs`, [crates/pack-core/src/client/context.rsR609](diffhunk://#diff-d461bd97db3ff236dfca8f11983fe5834bf8e2e1a18d40961bfd911cc7d2a983R609))
* Updated the example configuration to use content hashes in output filenames for both JavaScript and CSS files, improving cache busting and asset management. (`examples/utooweb-demo/src/utoopackConfig.ts`, [examples/utooweb-demo/src/utoopackConfig.tsR8-R9](diffhunk://#diff-10b2646196efccc1168ad912cebfd11c76a57384175a36a66ebb660e2dd62b68R8-R9))

Codebase simplification:

* Removed the unused `config` field from `ServerChunkingContextOptions` and related function parameters, streamlining the server chunking context API. (`crates/pack-api/src/project.rs`, [[1]](diffhunk://#diff-843890350f51199fc9392b2c1c52bccdee68046d4a939bd282a008f6b0febfbcL1098); `crates/pack-core/src/server/contexts.rs`, [[2]](diffhunk://#diff-c835ea80e9bb29e3d52f2a4a6cede8b10bd6636576ca70455ac39df383661321L352) [[3]](diffhunk://#diff-c835ea80e9bb29e3d52f2a4a6cede8b10bd6636576ca70455ac39df383661321L376)
* Updated imports to include the new `ContentHashing` type for client chunking. (`crates/pack-core/src/client/context.rs`, [crates/pack-core/src/client/context.rsL13-R13](diffhunk://#diff-d461bd97db3ff236dfca8f11983fe5834bf8e2e1a18d40961bfd911cc7d2a983L13-R13))