### PR TITLE
fix(pm): use relative symlinks for bin and workspace links

### DIFF
--- a/agents/rust-code-guard.md
+++ b/agents/rust-code-guard.md
@@ -366,3 +366,4 @@ Scan through this list during every review for high-frequency Rust anti-patterns
 | A15 | String Gymnastics | Multi-layer `starts_with` / `split` chains | Parse once into structured typed `enum` |
 | A16 | Broad Re-export Leak | `pub use module::*` leaking internal helpers | Export precise types explicitly |
 | A17 | Large Enum Variant Size | A single large variant inflating the enum footprint | Heap-allocate the large variant via `Box<T>` |
+| A18 | Trivial Wrapper Function | One-line fn that just forwards to another fn with identical signature | Call the underlying function directly |

--- a/crates/pm/src/util/linker.rs
+++ b/crates/pm/src/util/linker.rs
@@ -2,11 +2,22 @@ use crate::fs;
 use anyhow::{Context, Result};
 use std::path::{self, Path, PathBuf};
 
+/// Convert a path to absolute. Treats empty paths as `"."` because lockfiles
+/// use `resolved: ""` for the root workspace linking itself.
+fn to_absolute(p: &Path) -> Result<PathBuf> {
+    let p = if p.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        p
+    };
+    path::absolute(p).context("Failed to resolve absolute path")
+}
+
 /// Resolve src/dst to absolute paths, ensure parent dir exists, clean up stale destination.
 /// Returns `None` if the link is already up-to-date, `Some((src, dst))` if work is needed.
 async fn prepare_link(src: &Path, dst: &Path) -> Result<Option<(PathBuf, PathBuf)>> {
-    let abs_src = path::absolute(src).context("Failed to resolve absolute path")?;
-    let abs_dst = path::absolute(dst).context("Failed to resolve absolute path")?;
+    let abs_src = to_absolute(src)?;
+    let abs_dst = to_absolute(dst)?;
 
     if !fs::try_exists(&abs_src).await? {
         anyhow::bail!("Source file does not exist: {}", abs_src.display());

--- a/crates/pm/src/util/linker.rs
+++ b/crates/pm/src/util/linker.rs
@@ -54,13 +54,18 @@ async fn prepare_link(src: &Path, dst: &Path) -> Result<Option<(PathBuf, PathBuf
     Ok(Some((abs_src, abs_dst)))
 }
 
+/// Create a relative symlink: compute the path to `src` relative to `dst`'s
+/// parent directory, then create the symlink.
+async fn relative_symlink(src: &Path, dst: &Path) -> Result<()> {
+    let parent = dst.parent().context("link destination has no parent")?;
+    let rel = pathdiff::diff_paths(src, parent).context("Failed to compute relative path")?;
+    symlink(&rel, dst).await
+}
+
 /// Create a relative symlink. Used for workspace links, `utoo link`, etc.
 pub async fn link(src: &Path, dst: &Path) -> Result<()> {
     if let Some((abs_src, abs_dst)) = prepare_link(src, dst).await? {
-        let parent = abs_dst.parent().context("link destination has no parent")?;
-        let rel_src =
-            pathdiff::diff_paths(&abs_src, parent).context("Failed to compute relative path")?;
-        symlink(&rel_src, &abs_dst).await?;
+        relative_symlink(&abs_src, &abs_dst).await?;
     }
     Ok(())
 }
@@ -77,12 +82,7 @@ pub async fn link_bin(src: &Path, dst: &Path) -> Result<()> {
     };
 
     #[cfg(unix)]
-    {
-        let bin_dir = abs_dst.parent().context("bin link has no parent dir")?;
-        let rel_src = pathdiff::diff_paths(&abs_src, bin_dir)
-            .context("Failed to compute relative path for bin link")?;
-        symlink(&rel_src, &abs_dst).await?;
-    }
+    relative_symlink(&abs_src, &abs_dst).await?;
 
     #[cfg(windows)]
     win_bin_shims(&abs_src, &abs_dst).await?;

--- a/crates/pm/src/util/linker.rs
+++ b/crates/pm/src/util/linker.rs
@@ -30,10 +30,12 @@ async fn prepare_link(src: &Path, dst: &Path) -> Result<Option<(PathBuf, PathBuf
     }
 
     if let Ok(metadata) = fs::symlink_metadata(&abs_dst).await {
-        // Already a symlink pointing to the correct source — nothing to do
+        // Already a symlink pointing to the correct source — nothing to do.
+        // Compare relative-to-relative to avoid `..` mismatch between lexicographic forms.
         if metadata.is_symlink()
             && let Ok(target) = fs::read_link(&abs_dst).await
-            && target == abs_src
+            && let Some(parent) = abs_dst.parent()
+            && pathdiff::diff_paths(&abs_src, parent).as_deref() == Some(&*target)
         {
             return Ok(None);
         }
@@ -52,17 +54,21 @@ async fn prepare_link(src: &Path, dst: &Path) -> Result<Option<(PathBuf, PathBuf
     Ok(Some((abs_src, abs_dst)))
 }
 
-/// Create a symlink. Used for workspace links, `utoo link`, etc.
+/// Create a relative symlink. Used for workspace links, `utoo link`, etc.
 pub async fn link(src: &Path, dst: &Path) -> Result<()> {
     if let Some((abs_src, abs_dst)) = prepare_link(src, dst).await? {
-        symlink(&abs_src, &abs_dst).await?;
+        let parent = abs_dst.parent().context("link destination has no parent")?;
+        let rel_src =
+            pathdiff::diff_paths(&abs_src, parent).context("Failed to compute relative path")?;
+        symlink(&rel_src, &abs_dst).await?;
     }
     Ok(())
 }
 
 /// Link a binary into node_modules/.bin.
 ///
-/// - Unix: symlink (same as `link`)
+/// - Unix: relative symlink so the link stays valid when the tree is mounted
+///   at a different prefix (e.g. inside a Docker container).
 /// - Windows: hardlink/copy + .cmd shim, following npm's cmd-shim convention.
 ///   Symlinks are avoided because they require admin privileges on Windows.
 pub async fn link_bin(src: &Path, dst: &Path) -> Result<()> {
@@ -71,7 +77,12 @@ pub async fn link_bin(src: &Path, dst: &Path) -> Result<()> {
     };
 
     #[cfg(unix)]
-    symlink(&abs_src, &abs_dst).await?;
+    {
+        let bin_dir = abs_dst.parent().context("bin link has no parent dir")?;
+        let rel_src = pathdiff::diff_paths(&abs_src, bin_dir)
+            .context("Failed to compute relative path for bin link")?;
+        symlink(&rel_src, &abs_dst).await?;
+    }
 
     #[cfg(windows)]
     win_bin_shims(&abs_src, &abs_dst).await?;
@@ -262,6 +273,39 @@ mod tests {
         let result = link(&src2_path, &dst_path);
         assert!(result.await.is_ok());
         assert_eq!(fs::read_to_string(&dst_path).unwrap(), "test2");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_link_bin_creates_relative_symlink() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Simulate node_modules/@napi-rs/cli/scripts/index.js
+        let pkg_dir = temp_path.join("node_modules/@napi-rs/cli/scripts");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        let src_path = pkg_dir.join("index.js");
+        fs::write(&src_path, "#!/usr/bin/env node").unwrap();
+
+        let dst_path = temp_path.join("node_modules/.bin/napi");
+
+        link_bin(&src_path, &dst_path).await.unwrap();
+
+        assert!(dst_path.is_symlink());
+        // Symlink target must be relative, not absolute
+        let raw_target = fs::read_link(&dst_path).unwrap();
+        assert!(
+            raw_target.is_relative(),
+            "expected relative symlink, got: {}",
+            raw_target.display()
+        );
+        assert_eq!(
+            fs::read_to_string(&dst_path).unwrap(),
+            "#!/usr/bin/env node"
+        );
+
+        // Calling link_bin again should be a no-op (idempotent)
+        link_bin(&src_path, &dst_path).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/pm/src/util/linker.rs
+++ b/crates/pm/src/util/linker.rs
@@ -1,22 +1,12 @@
 use crate::fs;
 use anyhow::{Context, Result};
-use std::path::{Path, PathBuf};
-
-/// Convert a path to absolute path
-fn to_absolute(path: &Path) -> Result<PathBuf> {
-    if path.is_absolute() {
-        Ok(path.to_path_buf())
-    } else {
-        let cwd = std::env::current_dir().context("Failed to get current working directory")?;
-        Ok(cwd.join(path))
-    }
-}
+use std::path::{self, Path, PathBuf};
 
 /// Resolve src/dst to absolute paths, ensure parent dir exists, clean up stale destination.
 /// Returns `None` if the link is already up-to-date, `Some((src, dst))` if work is needed.
 async fn prepare_link(src: &Path, dst: &Path) -> Result<Option<(PathBuf, PathBuf)>> {
-    let abs_src = to_absolute(src)?;
-    let abs_dst = to_absolute(dst)?;
+    let abs_src = path::absolute(src).context("Failed to resolve absolute path")?;
+    let abs_dst = path::absolute(dst).context("Failed to resolve absolute path")?;
 
     if !fs::try_exists(&abs_src).await? {
         anyhow::bail!("Source file does not exist: {}", abs_src.display());
@@ -103,7 +93,16 @@ async fn symlink(src: &Path, dst: &Path) -> Result<()> {
 
 #[cfg(windows)]
 async fn symlink(src: &Path, dst: &Path) -> Result<()> {
-    if fs::metadata(src).await?.is_dir() {
+    // `src` may be relative (e.g. `../foo`). Resolve against `dst`'s parent
+    // so we can query metadata on the actual target.
+    let resolved = if src.is_relative() {
+        dst.parent()
+            .map(|p| p.join(src))
+            .unwrap_or(src.to_path_buf())
+    } else {
+        src.to_path_buf()
+    };
+    if fs::metadata(&resolved).await?.is_dir() {
         fs::symlink_dir(src, dst).await
     } else {
         fs::symlink_file(src, dst).await


### PR DESCRIPTION
## Summary

- Switch `link()` and `link_bin()` to create relative symlinks via `pathdiff::diff_paths`, matching npm's native behavior
- Fix CI Docker builds where absolute symlinks break because the project is mounted at a different path (e.g. `/build` vs `/home/runner/work/...`)
- Update `prepare_link` idempotency check to compare relative-to-relative, avoiding false mismatches with `..` components

Fixes `utoopack-release-x86_64-unknown-linux-musl` CI failure: `sh: napi: not found`

## Test plan

- [x] `cargo test -p utoo-pm -- linker` — 6 tests pass (including new `test_link_bin_creates_relative_symlink`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] Local `utoo install` — all symlinks are relative, zero absolute symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)