### PR TITLE
docs(web): deduplicate Quick Start and API Reference in API docs

### DIFF
--- a/packages/utoo-web/API.md
+++ b/packages/utoo-web/API.md
@@ -69,95 +69,41 @@ await project.installServiceWorker();
 
 ### 3. Resolve and Install Dependencies
 
-`@utoo/web` provides two approaches for dependency management:
-
-#### Option A: Generate lock file from package.json (Recommended)
-
-Use the `deps()` method to resolve dependencies directly from your `package.json`. This generates a `package-lock.json` compatible lock file without needing one beforehand.
+Resolve dependencies from `package.json` and install them. Alternatively, pass an existing `package-lock.json` string directly to `install()`. See [`project.deps()`](#projectdepsoptions) and [`project.install()`](#projectinstallpackagelockjsonstring-maxconcurrentdownloads) for full options.
 
 ```typescript
-// Resolve dependencies from package.json
-const packageLock = await project.deps({
-    registry: "https://registry.npmmirror.com", // Optional: custom registry
-    concurrency: 20, // Optional: concurrent requests (default: 20)
-});
-
-// Install the resolved dependencies
+const packageLock = await project.deps();
 await project.install(packageLock);
-```
-
-#### Option B: Use existing package-lock.json
-
-If you already have a `package-lock.json`, you can use it directly:
-
-The dependency packages in the project's `node_modules` are actually logical links pointing to a global shared storage. This means that different projects under the same browser domain can share dependencies with the same name and version without repeated downloads. This mechanism is similar to `pnpm`'s storage strategy.
-
-This design has the following advantages:
-1. **Save Storage Space**: Identical versions of dependency packages are stored only once in OPFS, avoiding redundant usage.
-2. **Accelerate Project Initialization**: When creating a new project or switching projects, if the dependency packages already exist in the global storage, they can be reused directly, achieving second-level installation.
-3. **Reduce Network Traffic**: Frequently used dependency packages only need to be downloaded once, and subsequent projects can use them directly, significantly reducing network overhead.
-4. **Cross-Tab Reuse**: Even if a new browser tab is opened, as long as it is under the same domain, dependencies can be directly reused.
-
-```typescript
-// Import your package-lock.json as a JSON object.
-import { packageLock } from "../packageLock";
-
-await project.install(JSON.stringify(packageLock));
 ```
 
 ### 4. Write Project Files
 
-With the environment set up, you can now write your source files to the real file system.
+Write your source files to the file system. See [File System Methods](#file-system-methods) for the full API.
 
 ```typescript
-// An object containing file paths and their content.
 import { demoFiles } from "../demoFiles";
 
 await project.mkdir("src");
-
 for (const filePath in demoFiles) {
-    const content = demoFiles[filePath];
-    await project.writeFile(filePath, content);
+    await project.writeFile(filePath, demoFiles[filePath]);
 }
 ```
 
-### 5. Create Build Configuration
+### 5. Build
 
-You can provide the build configuration in two ways:
-
-#### Option A: Pass config directly (Recommended)
-
-Pass a `ConfigComplete` object directly to `build()` or `dev()`. This skips reading any config file from disk.
+Pass a config object directly, or write a `utoopack.json` to the project root. See [`project.build()`](#projectbuildoptions) and [`project.dev()`](#projectdevoptions) for full options.
 
 ```typescript
-const config = {
-  entry: [
-    {
-      import: "./src/index.tsx",
-      name: "main",
-    },
-  ],
-  output: {
-    path: "dist",
+await project.build({
+  config: {
+    entry: [{ import: "./src/index.tsx", name: "main" }],
+    output: { path: "dist" },
+    stats: true,
   },
-  stats: true,
-};
-
-await project.build({ config });
-// or for dev mode:
-project.dev({ config, onUpdate: (result) => console.log(result) });
+});
 ```
 
-#### Option B: Write a `utoopack.json` file
-
-Alternatively, write a `utoopack.json` to the project root. When no `config` is passed, the bundler reads this file automatically.
-
-```typescript
-await project.writeFile('utoopack.json', JSON.stringify(config, null, 2));
-await project.build();
-```
-
-To use loaders, you must add them to the `devDependencies` in your `package.json` and install them, just as you would in a standard Webpack project. Additionally, you must install `loader-runner`, as `@utoo/web` relies on the `loader-runner` mechanism and context to execute loaders.
+To use loaders, add them to `devDependencies` in your `package.json` along with `loader-runner`, then install them. See [`loadersImportMap`](#new-utooprojectoptions) for an alternative that avoids file system I/O overhead.
 
 After these steps, your project is fully initialized and ready for interaction.
 
@@ -226,6 +172,14 @@ Removes a directory.
 * `path` (string): The path to the directory to be removed.
 
 ### Dependency Management
+
+Installed packages are stored as logical links pointing to a global shared storage in OPFS. This means different projects under the same browser domain share dependencies with the same name and version without repeated downloads — similar to `pnpm`'s storage strategy.
+
+This design provides:
+1. **Save Storage Space**: Identical versions are stored only once in OPFS.
+2. **Accelerate Project Initialization**: Existing packages are reused directly, achieving second-level installation.
+3. **Reduce Network Traffic**: Frequently used packages only need to be downloaded once.
+4. **Cross-Tab Reuse**: Dependencies are shared across browser tabs on the same domain.
 
 #### `project.deps(options?)`
 

--- a/packages/utoo-web/API_zh-CN.md
+++ b/packages/utoo-web/API_zh-CN.md
@@ -69,95 +69,41 @@ await project.installServiceWorker();
 
 ### 3. 解析和安装依赖
 
-`@utoo/web` 提供两种依赖管理方式：
-
-#### 方式 A：从 package.json 生成 lock 文件（推荐）
-
-使用 `deps()` 方法直接从 `package.json` 解析依赖。这会生成一个与 `package-lock.json` 兼容的 lock 文件，无需预先准备 lock 文件。
+从 `package.json` 解析依赖并安装。也可以将已有的 `package-lock.json` 字符串直接传递给 `install()`。详见 [`project.deps()`](#projectdepsoptions) 和 [`project.install()`](#projectinstallpackagelockjsonstring-maxconcurrentdownloads)。
 
 ```typescript
-// 从 package.json 解析依赖
-const packageLock = await project.deps({
-    registry: "https://registry.npmmirror.com", // 可选：自定义 registry
-    concurrency: 20, // 可选：并发请求数（默认：20）
-});
-
-// 安装解析后的依赖
+const packageLock = await project.deps();
 await project.install(packageLock);
-```
-
-#### 方式 B：使用已有的 package-lock.json
-
-如果你已经有 `package-lock.json`，可以直接使用：
-
-项目 `node_modules` 中的依赖包实际上是指向全局共享存储的逻辑链接。这意味着在同一浏览器域名下的不同 project 之间，可以共享同名且同版本的依赖，无需重复下载。这种机制类似于 `pnpm` 的存储策略。
-
-这种设计具有以下优势：
-1. **节省存储空间**：相同版本的依赖包在 OPFS 中仅存储一份，避免了冗余占用。
-2. **加速项目初始化**：创建新项目或切换项目时，若依赖包已存在于全局存储中，可直接复用，实现秒级安装。
-3. **减少网络流量**：常用依赖包只需下载一次，后续项目即可直接使用，大幅降低网络开销。
-4. **跨标签页复用**：即使开启新的浏览器标签页，只要处于同一域名下，依赖均可以直接复用。
-
-```typescript
-// 将您的 package-lock.json 作为 JSON 对象导入。
-import { packageLock } from "../packageLock";
-
-await project.install(JSON.stringify(packageLock));
 ```
 
 ### 4. 写入项目文件
 
-环境设置好后，您现在可以将源文件写入真实文件系统。
+将源文件写入文件系统。详见[文件系统方法](#文件系统方法)。
 
 ```typescript
-// 一个包含文件路径及其内容的对象。
 import { demoFiles } from "../demoFiles";
 
 await project.mkdir("src");
-
 for (const filePath in demoFiles) {
-    const content = demoFiles[filePath];
-    await project.writeFile(filePath, content);
+    await project.writeFile(filePath, demoFiles[filePath]);
 }
 ```
 
-### 5. 创建构建配置
+### 5. 构建
 
-您可以通过两种方式提供构建配置：
-
-#### 方式 A：直接传递配置（推荐）
-
-将 `ConfigComplete` 对象直接传递给 `build()` 或 `dev()`。这会跳过从磁盘读取配置文件。
+直接传递配置对象，或将 `utoopack.json` 写入项目根目录。详见 [`project.build()`](#projectbuildoptions) 和 [`project.dev()`](#projectdevoptions)。
 
 ```typescript
-const config = {
-  entry: [
-    {
-      import: "./src/index.tsx",
-      name: "main",
-    },
-  ],
-  output: {
-    path: "dist",
+await project.build({
+  config: {
+    entry: [{ import: "./src/index.tsx", name: "main" }],
+    output: { path: "dist" },
+    stats: true,
   },
-  stats: true,
-};
-
-await project.build({ config });
-// 或者用于开发模式：
-project.dev({ config, onUpdate: (result) => console.log(result) });
+});
 ```
 
-#### 方式 B：写入 `utoopack.json` 文件
-
-或者，将 `utoopack.json` 写入项目根目录。当未传递 `config` 时，打包器会自动读取此文件。
-
-```typescript
-await project.writeFile('utoopack.json', JSON.stringify(config, null, 2));
-await project.build();
-```
-
-若要使用 loader，请将其添加至 `package.json` 的 `devDependencies` 中并安装，这与标准 webpack 项目的依赖管理方式一致。此外，由于 `@utoo/web` 遵循 `loader-runner` 的机制与上下文来执行 loader，您还需要同时安装 `loader-runner`。
+若要使用 loader，请将其与 `loader-runner` 一起添加至 `package.json` 的 `devDependencies` 中并安装。另可通过 [`loadersImportMap`](#new-utooprojectoptions) 配置预构建的 loader 以避免文件系统 I/O 开销。
 
 完成这些步骤后，您的项目就完全初始化并准备好进行交互了。
 
@@ -226,6 +172,14 @@ await project.build();
 * `path` (string): 要删除的目录的路径。
 
 ### 依赖管理
+
+已安装的依赖包以逻辑链接的形式指向 OPFS 中的全局共享存储。这意味着同一浏览器域名下的不同项目可以共享同名且同版本的依赖，无需重复下载——机制类似于 `pnpm` 的存储策略。
+
+这种设计具有以下优势：
+1. **节省存储空间**：相同版本的依赖包在 OPFS 中仅存储一份。
+2. **加速项目初始化**：已存在的依赖包可直接复用，实现秒级安装。
+3. **减少网络流量**：常用依赖包只需下载一次。
+4. **跨标签页复用**：同一域名下的浏览器标签页可直接共享依赖。
 
 #### `project.deps(options?)`
 


### PR DESCRIPTION
The Quick Start and API Reference sections had significant content overlap for dependency management, build config, and dev mode.

## Changes
- Condense Quick Start steps 3-5 to concise examples with cross-references to the API Reference
- Move global shared storage explanation to the API Reference's Dependency Management section
- Apply same changes to both EN and zh-CN versions

**Net result:** -134 lines removed, +42 lines added (92 fewer lines, zero information lost)