### PR TITLE
fix(pack): add createRequire as global API in loader worker and fix hmr

### DIFF
--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -1291,20 +1291,38 @@ impl Project {
     /// version in that session.
     #[turbo_tasks::function]
     pub async fn hmr_version_state(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         identifier: RcStr,
         session: TransientInstance<()>,
     ) -> Result<Vc<VersionState>> {
-        let version = self.hmr_version(identifier);
-
         // The session argument is important to avoid caching this function between
         // sessions.
         let _ = session;
 
+        #[turbo_tasks::function(operation)]
+        async fn hmr_version_operation(
+            this: ResolvedVc<Project>,
+            identifier: RcStr,
+        ) -> Result<Vc<Box<dyn Version>>> {
+            let content = this.hmr_content(identifier).await?;
+            if let Some(content) = &*content {
+                Ok(content.version())
+            } else {
+                Ok(Vc::upcast(NotFoundVersion::new()))
+            }
+        }
+        let version_op = hmr_version_operation(self, identifier);
+
         // INVALIDATION: This is intentionally untracked to avoid invalidating this
         // function completely. We want to initialize the VersionState with the
-        // first seen version of the session.
-        let state = VersionState::new(version.into_trait_ref().await?).await?;
+        // first seen version of the session, not re-create it on every change.
+        let state = VersionState::new(
+            version_op
+                .read_trait_strongly_consistent()
+                .untracked()
+                .await?,
+        )
+        .await?;
         Ok(state)
     }
 
@@ -1330,7 +1348,7 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn hmr_identifiers(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
         if let Some(map) = self.await?.versioned_content_map {
-            Ok(map.keys_in_path(self.dist_root().owned().await?))
+            Ok(map.keys_in_path(self.client_root().owned().await?))
         } else {
             bail!("must be in dev mode to hmr")
         }

--- a/packages/utoo-web/src/webpackLoaders/cjs.ts
+++ b/packages/utoo-web/src/webpackLoaders/cjs.ts
@@ -255,5 +255,14 @@ export async function cjs(
   // @ts-ignore
   self.__systemjs_require__.resolve = (request: string) => request;
 
+  // @ts-ignore
+  self.createRequire = (filename: string) => {
+    const context = path.dirname(filename);
+    const req: any = (id: string) =>
+      loadModule(id, context, importMaps, entrypoint);
+    req.resolve = (request: string) => request;
+    return req;
+  };
+
   loadModule(entrypoint, path.dirname(entrypoint), importMaps, entrypoint);
 }

--- a/packages/utoo-web/src/webpackLoaders/polyfills/nodePolyFills.ts
+++ b/packages/utoo-web/src/webpackLoaders/polyfills/nodePolyFills.ts
@@ -129,10 +129,14 @@ export default {
   },
 
   get module() {
-    return require("module");
+    return {
+      createRequire: (self as any).createRequire,
+    };
   },
   get "node:module"() {
-    return require("module");
+    return {
+      createRequire: (self as any).createRequire,
+    };
   },
 
   get net() {


### PR DESCRIPTION
## Changes

### `packages/utoo-web/src/webpackLoaders/cjs.ts`
- Expose `createRequire` on `self` (global) inside the `cjs()` function, so webpack loaders can use `createRequire(filename)` to get a `require` function that resolves modules relative to `path.dirname(filename)`

### `packages/utoo-web/src/webpackLoaders/polyfills/nodePolyFills.ts`
- Update `module` / `node:module` polyfill getters to return `{ createRequire }` from the global, so `require('module').createRequire` and `import { createRequire } from 'module'` both work

### `next.js` submodule
- Update submodule pointer to include wasm file write support and `available_parallelism` improvements (utooland/next.js#138)

### `crates/pack-api/src/project.rs` — Fix HMR updates always returning `Update::None`

Two bugs were fixed:

1. **`hmr_version_state` was re-creating VersionState on every change** — The old implementation used `version.into_trait_ref().await?` which is *tracked*, causing turbo-tasks to re-execute `hmr_version_state` whenever content changed. This created a new `VersionState` initialized with the *new* version, so `content.update(from)` always compared identical versions → `Update::None`. Fixed by using an inner `#[turbo_tasks::function(operation)]` with `.read_trait_strongly_consistent().untracked()`, matching the Next.js implementation.

2. **`hmr_identifiers` used `dist_root()` instead of `client_root()`** — Output chunk assets are stored on the virtual `client-fs` filesystem, but `keys_in_path(dist_root)` queries the `output-fs`, which only contained `stats.json`. Changed to `client_root()` to match how `hmr_content()` and `emit_all_output_assets()` use the same root.
