### PR TITLE
test(pack): add test case for loader mulptile rename logic

### DIFF
--- a/crates/pack-tests/tests/snapshot/node_modules/frontmatter-loader/index.js
+++ b/crates/pack-tests/tests/snapshot/node_modules/frontmatter-loader/index.js
@@ -1,0 +1,3 @@
+module.exports = function frontmatterLoader() {
+    return "export default 'md-frontmatter'";
+}

--- a/crates/pack-tests/tests/snapshot/node_modules/title-loader/index.js
+++ b/crates/pack-tests/tests/snapshot/node_modules/title-loader/index.js
@@ -1,0 +1,3 @@
+module.exports = function titleLoader() {
+    return "export default 'js-frontmatter'";
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/config.json
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/config.json
@@ -1,0 +1,57 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "./input/index.tsx",
+        "name": "index"
+      }
+    ],
+    "module": {
+      "rules": {
+        "*.md": [
+          {
+            "condition": {
+              "query": {
+                "type": "constant",
+                "value": "?type=frontmatter"
+              }
+            },
+            "loaders": [
+              "frontmatter-loader"
+            ],
+            "as": "*.js"
+          }
+        ],
+        "*.js": [
+          {
+            "condition": {
+              "all": [
+                {
+                  "query": {
+                    "type": "constant",
+                    "value": "?type=frontmatter"
+                  }
+                },
+                {
+                  "not": {
+                    "path": {
+                      "type": "regex",
+                      "value": {
+                        "source": "\\.md\\.js$",
+                        "flags": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "loaders": [
+              "title-loader"
+            ],
+            "as": "*.js"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/input/index.tsx
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/input/index.tsx
@@ -1,0 +1,13 @@
+// @ts-ignore
+import markdownFrontmatter from './page.md?type=frontmatter';
+// @ts-ignore
+import jsFrontmatter from './page.js?type=frontmatter';
+
+export default function App() {
+    return (
+        <div>
+            <p id="markdown-frontmatter">{markdownFrontmatter}</p>
+            <p id="js-frontmatter">{jsFrontmatter}</p>
+        </div>
+    );
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/input/page.js
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/input/page.js
@@ -1,0 +1,1 @@
+module.exports = 'plain-js'

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/input/page.md
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/input/page.md
@@ -1,0 +1,5 @@
+---
+title: nav title
+---
+
+hello markdown

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/output/_project___78bb12b4.js
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/output/_project___78bb12b4.js
@@ -1,0 +1,73 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/node_modules/react/jsx-runtime.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+function jsx() {
+    return 'purposefully empty stub for react/jsx-runtime.js';
+}
+function jsxs() {
+    return 'purposefully empty stub for react/jsx-runtime.js';
+}
+__turbopack_context__.s([
+    "jsx",
+    0,
+    jsx,
+    "jsxs",
+    0,
+    jsxs
+]);
+}),
+"[project]/webpack-loaders/frontmatter-path-guard/input/page.md.js?type=frontmatter [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__default__export__ = 'md-frontmatter';
+__turbopack_context__.s([
+    "default",
+    0,
+    __TURBOPACK__default__export__
+]);
+}),
+"[project]/webpack-loaders/frontmatter-path-guard/input/page.js.js?type=frontmatter [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__default__export__ = 'js-frontmatter';
+__turbopack_context__.s([
+    "default",
+    0,
+    __TURBOPACK__default__export__
+]);
+}),
+"[project]/webpack-loaders/frontmatter-path-guard/input/index.tsx [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/node_modules/react/jsx-runtime.js [client] (ecmascript)");
+// @ts-ignore
+var __TURBOPACK__imported__module__$5b$project$5d2f$webpack$2d$loaders$2f$frontmatter$2d$path$2d$guard$2f$input$2f$page$2e$md$2e$js$3f$type$3d$frontmatter__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/webpack-loaders/frontmatter-path-guard/input/page.md.js?type=frontmatter [client] (ecmascript)");
+// @ts-ignore
+var __TURBOPACK__imported__module__$5b$project$5d2f$webpack$2d$loaders$2f$frontmatter$2d$path$2d$guard$2f$input$2f$page$2e$js$2e$js$3f$type$3d$frontmatter__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/webpack-loaders/frontmatter-path-guard/input/page.js.js?type=frontmatter [client] (ecmascript)");
+;
+;
+;
+function App() {
+    return /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["jsxs"])("div", {
+        children: [
+            /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["jsx"])("p", {
+                id: "markdown-frontmatter",
+                children: __TURBOPACK__imported__module__$5b$project$5d2f$webpack$2d$loaders$2f$frontmatter$2d$path$2d$guard$2f$input$2f$page$2e$md$2e$js$3f$type$3d$frontmatter__$5b$client$5d$__$28$ecmascript$29$__["default"]
+            }),
+            /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["jsx"])("p", {
+                id: "js-frontmatter",
+                children: __TURBOPACK__imported__module__$5b$project$5d2f$webpack$2d$loaders$2f$frontmatter$2d$path$2d$guard$2f$input$2f$page$2e$js$2e$js$3f$type$3d$frontmatter__$5b$client$5d$__$28$ecmascript$29$__["default"]
+            })
+        ]
+    });
+}
+__turbopack_context__.s([
+    "default",
+    0,
+    App
+]);
+}),
+]);
+
+//# sourceMappingURL=_project___78bb12b4.js.map

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/output/_project___78bb12b4.js.map
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/output/_project___78bb12b4.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/node_modules/react/jsx-runtime.js"],"sourcesContent":["export function jsx() {\n  return 'purposefully empty stub for react/jsx-runtime.js'\n}\nexport function jsxs() {\n  return 'purposefully empty stub for react/jsx-runtime.js'\n}\n"],"names":["jsx","jsxs"],"mappings":"AAAO,SAASA;IACd,OAAO;AACT;AACO,SAASC;IACd,OAAO;AACT","ignoreList":[0]}},
+    {"offset": {"line": 22, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/webpack-loaders/frontmatter-path-guard/input/page.md.js?type=frontmatter"],"sourcesContent":["export default 'md-frontmatter'"],"names":[],"mappings":"qCAAe"}},
+    {"offset": {"line": 32, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/webpack-loaders/frontmatter-path-guard/input/page.js.js?type=frontmatter"],"sourcesContent":["export default 'js-frontmatter'"],"names":[],"mappings":"qCAAe"}},
+    {"offset": {"line": 42, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/webpack-loaders/frontmatter-path-guard/input/index.tsx"],"sourcesContent":["// @ts-ignore\nimport markdownFrontmatter from './page.md?type=frontmatter';\n// @ts-ignore\nimport jsFrontmatter from './page.js?type=frontmatter';\n\nexport default function App() {\n    return (\n        <div>\n            <p id=\"markdown-frontmatter\">{markdownFrontmatter}</p>\n            <p id=\"js-frontmatter\">{jsFrontmatter}</p>\n        </div>\n    );\n}\n"],"names":["App","id"],"mappings":";AAAA,aAAa;AACb;AACA,aAAa;AACb;;;;AAEe,SAASA;IACpB,qBACI,iJAAC;;0BACG,gJAAC;gBAAEC,IAAG;0BAAwB,uMAAmB;;0BACjD,gJAAC;gBAAEA,IAAG;0BAAkB,uMAAa;;;;AAGjD"}}]
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/output/index.js
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/output/index.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["_project___78bb12b4.js"],"runtimeModuleIds":["[project]/webpack-loaders/frontmatter-path-guard/input/index.tsx [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/output/index.js.map
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/frontmatter-path-guard/output/index.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}


### PR DESCRIPTION


## Summary

A test case from dumi:

```ts
import a from './index.md?type=frontmatter'
```

we need a `md-loader` and a `query-loader` to deal the case, but the query-loader execute after `md-loader`, so the `query-loader` deal the suffix shoud be `.js` nor `.md`(which was renamed by `md-loader`).


## Test Plan

just add test.
