### PR TITLE
fix(pack): normalized style config

### DIFF
--- a/packages/pack/src/core/project.ts
+++ b/packages/pack/src/core/project.ts
@@ -102,13 +102,13 @@ function normalizeStyles(
   };
 }
 
-async function serializeConfig(
+export async function serializeConfig(
   config: ConfigComplete,
   isDev: boolean,
 ): Promise<string> {
   const configSerializable = {
     ...config,
-    ...normalizeStyles(config.styles, isDev),
+    styles: normalizeStyles(config.styles, isDev),
   };
 
   if (configSerializable.entry) {


### PR DESCRIPTION

## Summary

if config `styles.emotion` as true will cause build panic:

<img width="1746" height="1460" alt="image" src="https://github.com/user-attachments/assets/358206b4-bbb5-4c77-bc74-914e45d1b246" />


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
