### PR TITLE
fix(deps): update tar to 0.4.45 (CVE-2026-33056)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9275,9 +9275,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -23,7 +23,7 @@ rustc-hash               = { workspace = true }
 serde                    = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen       = "0.6.5"
 serde_json               = { workspace = true }
-tar                      = "0.4.44"
+tar                      = "0.4.45"
 tokio                    = { workspace = true, features = ["rt", "rt-multi-thread", "time"] }
 tokio-fs-ext             = { workspace = true, features = ["opfs_offload", "opfs_tracing", "opfs_watch"] }
 tracing                  = { workspace = true }


### PR DESCRIPTION
## Summary
- Update `tar` crate from 0.4.44 to 0.4.45 to fix [CVE-2026-33056](https://blog.rust-lang.org/2026/03/21/cve-2026-33056/) (arbitrary directory permission change during extraction)
- Affected crates: `utoo-pm`, `utoo-wasm`

## Test plan
- [x] `cargo fmt` passed
- [x] `cargo clippy --all-targets -- -D warnings --no-deps` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)