### PR TITLE
chore(pack): lock `get-port` to 5.1.1

### DIFF
--- a/packages/pack/package.json
+++ b/packages/pack/package.json
@@ -44,7 +44,7 @@
     "@utoo/pack-shared": "*",
     "domparser-rs": "^0.0.7",
     "find-up": "4.1.0",
-    "get-port": "^7.1.0",
+    "get-port": "5.1.1",
     "hono": "^4.12.5",
     "nanoid": "^3.3.11",
     "picocolors": "^1.1.1",


### PR DESCRIPTION


## Summary

fix: https://github.com/ant-design/ant-design-pro/issues/11653#issue-4221881042


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
