### PR TITLE
chore(pack): force enable workerThreads loader runtime in sass example

### DIFF
--- a/examples/with-sass/utoopack.json
+++ b/examples/with-sass/utoopack.json
@@ -12,5 +12,6 @@
     "filename": "[name].[contenthash:8]",
     "chunkFilename": "[name].[contenthash:8]",
     "clean": true
-  }
+  },
+  "pluginRuntimeStrategy": "workerThreads"
 }


### PR DESCRIPTION
This pull request introduces a configuration change to the `utoopack.json` file to improve build performance.

Build configuration:

* Added the `pluginRuntimeStrategy` property set to `"workerThreads"` in `utoopack.json` to enable plugins to run in worker threads, which can enhance build speed and resource utilization.