### PR TITLE
chore(deps): bump opfs-project to 0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5410,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "opfs-project"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b76a7a429a2bc0ddca2f9a52c3eabf260664ca1f7e4305136dc80f309fb9d4"
+checksum = "d2c6f83474d2f7ca98f9f419568db611e171775fc59a524f1fd64574a868737f"
 dependencies = [
  "anyhow",
  "bytes",

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -16,7 +16,7 @@ flate2                   = "1.1.5"
 futures                  = { workspace = true }
 js-sys                   = "0.3.83"
 oneshot                  = "0.1.11"
-opfs-project             = "0.2.7"
+opfs-project             = "0.2.8"
 petgraph                 = "0.6"
 reqwest                  = { version = "0.12.22", default-features = false, features = ["json"] }
 rustc-hash               = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps \`opfs-project\` from 0.2.7 → 0.2.8.

Notable fix picked up: [utooland/opfs-project#43](https://github.com/utooland/opfs-project/pull/43) — on package upgrade (e.g. \`lodash 4.0.0\` → \`4.0.1\`), \`fuse.link\` under \`node_modules/<pkg>/\` is now rewritten to point at the new store directory instead of remaining stale. The in-memory link cache is also refreshed so readers never observe the old target after eviction.

## Test plan

- [ ] \`cargo check --workspace\` passes
- [ ] wasm build of \`utoo-wasm\` succeeds
- [ ] e2e: install a package at version X, then upgrade to version Y, verify resolved files come from the Y store path

🤖 Generated with [Claude Code](https://claude.com/claude-code)