### PR TITLE
feat(pack): support `type` field in module rules

### DIFF
--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -575,13 +575,49 @@ impl TryFrom<ConfigConditionItem> for ConditionItem {
     }
 }
 
+#[turbo_tasks::value(operation)]
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TurbopackModuleType {
+    Asset,
+    Ecmascript,
+    Typescript,
+    Css,
+    CssModule,
+    Json,
+    Wasm,
+    Raw,
+    Node,
+    Bytes,
+}
+
+impl From<&TurbopackModuleType> for RcStr {
+    fn from(value: &TurbopackModuleType) -> Self {
+        match value {
+            TurbopackModuleType::Asset => rcstr!("asset"),
+            TurbopackModuleType::Ecmascript => rcstr!("ecmascript"),
+            TurbopackModuleType::Typescript => rcstr!("typescript"),
+            TurbopackModuleType::Css => rcstr!("css"),
+            TurbopackModuleType::CssModule => rcstr!("css-module"),
+            TurbopackModuleType::Json => rcstr!("json"),
+            TurbopackModuleType::Wasm => rcstr!("wasm"),
+            TurbopackModuleType::Raw => rcstr!("raw"),
+            TurbopackModuleType::Node => rcstr!("node"),
+            TurbopackModuleType::Bytes => rcstr!("bytes"),
+        }
+    }
+}
+
 #[turbo_tasks::value]
 #[derive(Clone, Debug, Deserialize, OperationValue)]
 #[serde(rename_all = "camelCase")]
 pub struct RuleConfigItem {
+    #[serde(default)]
     pub loaders: Vec<LoaderItem>,
     #[serde(default, alias = "as")]
     pub rename_as: Option<RcStr>,
+    #[serde(default, alias = "type")]
+    pub module_type: Option<TurbopackModuleType>,
     #[serde(default)]
     pub condition: Option<ConfigConditionItem>,
 }
@@ -1229,6 +1265,7 @@ impl Config {
                     RuleConfigCollectionItem::Full(RuleConfigItem {
                         loaders,
                         rename_as,
+                        module_type,
                         condition,
                     }) => {
                         // If the extension contains a wildcard, and the rename_as does not,
@@ -1270,7 +1307,9 @@ impl Config {
                                 loaders: transform_loaders(&mut loaders.iter()),
                                 rename_as: rename_as.clone(),
                                 condition,
-                                module_type: None,
+                                // `module_type` is optional and is configured in userland as a string.
+                                // Turbopack consumes it as `Option<RcStr>`.
+                                module_type: module_type.as_ref().map(RcStr::from),
                             },
                         ));
                     }

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -725,15 +725,42 @@ pub enum SchemaModuleRuleItem {
     Full(Box<SchemaRuleConfigItem>),
 }
 
+/// Module type for a module rule (`type` / `moduleType` field).
+///
+/// Values must match pack-core / Turbopack's `ConfiguredModuleType::parse()`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum SchemaTurbopackModuleType {
+    Asset,
+    Ecmascript,
+    Typescript,
+    Css,
+    CssModule,
+    Json,
+    Wasm,
+    Raw,
+    Node,
+    Bytes,
+}
+
 /// Full module rule configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaRuleConfigItem {
     /// Loaders to apply
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub loaders: Vec<SchemaLoaderItem>,
     /// Rename the module as another extension
     #[serde(default, alias = "as")]
     pub rename_as: Option<String>,
+    /// Optional configured module type (`type` / `moduleType`).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "type",
+        alias = "moduleType"
+    )]
+    pub module_type: Option<SchemaTurbopackModuleType>,
     /// Condition for applying the rule
     #[serde(default)]
     pub condition: Option<SchemaConfigConditionItem>,
@@ -1197,7 +1224,8 @@ mod tests {
             "rules": {
               "*.txt": {
                 "loaders": ["./test-file-loader.js"],
-                "as": "*.js"
+                "as": "*.js",
+                "type": "css-module"
               },
               "*.svg": "svg-loader"
             }

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/config.json
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/config.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "./input/index.ts",
+        "name": "index"
+      }
+    ],
+    "module": {
+      "rules": {
+        "*.txt": {
+          "loaders": [
+            "test-file-loader"
+          ],
+          "type": "ecmascript"
+        },
+        "*.svg": {
+          "type": "asset"
+        }
+      }
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/input/data.txt
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/input/data.txt
@@ -1,0 +1,1 @@
+Hello from module_type

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/input/icon.svg
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/input/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2L2 22h20L12 2z"/></svg>

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/input/index.ts
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/input/index.ts
@@ -1,0 +1,6 @@
+// @ts-ignore
+import data from "./data.txt";
+// @ts-ignore
+import iconUrl from "./icon.svg";
+
+export default { data, iconUrl };

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/icon.28d0165b.svg
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/icon.28d0165b.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2L2 22h20L12 2z"/></svg>

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/index.js
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/index.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_aa3a7b06.js"],"runtimeModuleIds":["[project]/webpack-loaders/module-type/input/index.ts [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/index.js.map
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/index.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/input_aa3a7b06.js
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/input_aa3a7b06.js
@@ -1,0 +1,30 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/webpack-loaders/module-type/input/data.txt [client] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+module.exports = "Got a buffer of 23 bytes";
+}),
+"[project]/webpack-loaders/module-type/input/icon.svg (static in ecmascript)", ((__turbopack_context__) => {
+
+__turbopack_context__.q("/icon.28d0165b.svg");}),
+"[project]/webpack-loaders/module-type/input/index.ts [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+// @ts-ignore
+var __TURBOPACK__imported__module__$5b$project$5d2f$webpack$2d$loaders$2f$module$2d$type$2f$input$2f$data$2e$txt__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/webpack-loaders/module-type/input/data.txt [client] (ecmascript)");
+// @ts-ignore
+var __TURBOPACK__imported__module__$5b$project$5d2f$webpack$2d$loaders$2f$module$2d$type$2f$input$2f$icon$2e$svg__$28$static__in__ecmascript$29$__ = __turbopack_context__.i("[project]/webpack-loaders/module-type/input/icon.svg (static in ecmascript)");
+;
+;
+var __TURBOPACK__default__export__ = {
+    data: __TURBOPACK__imported__module__$5b$project$5d2f$webpack$2d$loaders$2f$module$2d$type$2f$input$2f$data$2e$txt__$5b$client$5d$__$28$ecmascript$29$__["default"],
+    iconUrl: __TURBOPACK__imported__module__$5b$project$5d2f$webpack$2d$loaders$2f$module$2d$type$2f$input$2f$icon$2e$svg__$28$static__in__ecmascript$29$__["default"]
+};
+__turbopack_context__.s([
+    "default",
+    0,
+    __TURBOPACK__default__export__
+]);
+}),
+]);
+
+//# sourceMappingURL=input_aa3a7b06.js.map

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/input_aa3a7b06.js.map
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/module-type/output/input_aa3a7b06.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 3, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/webpack-loaders/module-type/input/data.txt"],"sourcesContent":["module.exports = \"Got a buffer of 23 bytes\""],"names":["module","exports"],"mappings":"AAAAA,OAAOC,OAAO,GAAG"}},
+    {"offset": {"line": 11, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/webpack-loaders/module-type/input/index.ts"],"sourcesContent":["// @ts-ignore\nimport data from \"./data.txt\";\n// @ts-ignore\nimport iconUrl from \"./icon.svg\";\n\nexport default { data, iconUrl };\n"],"names":["data","iconUrl"],"mappings":"AAAA,aAAa;AACb;AACA,aAAa;AACb;;;qCAEe;IAAEA,MAAAA,6JAAI;IAAEC,SAAAA,yJAAO;AAAC"}}]
+}

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -68,7 +68,7 @@ export type TurbopackModuleType =
   | "bytes";
 
 export type TurbopackRuleConfigItem = {
-  loaders: TurbopackLoaderItem[];
+  loaders?: TurbopackLoaderItem[];
   as?: string;
   /**
    * Controls the configured module type for matching resources.

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -55,9 +55,26 @@ export type TurbopackRuleCondition =
       contentType?: string | RegExp;
     };
 
+export type TurbopackModuleType =
+  | "asset"
+  | "ecmascript"
+  | "typescript"
+  | "css"
+  | "css-module"
+  | "json"
+  | "wasm"
+  | "raw"
+  | "node"
+  | "bytes";
+
 export type TurbopackRuleConfigItem = {
   loaders: TurbopackLoaderItem[];
   as?: string;
+  /**
+   * Controls the configured module type for matching resources.
+   * Mapped to Turbopack's `ConfiguredModuleType`.
+   */
+  type?: TurbopackModuleType;
   condition?: TurbopackRuleCondition;
 };
 

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -1412,6 +1412,17 @@
             "string",
             "null"
           ]
+        },
+        "type": {
+          "description": "Optional configured module type (`type` / `moduleType`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaTurbopackModuleType"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -1505,6 +1516,22 @@
             "minItems": 2
           }
         }
+      ]
+    },
+    "SchemaTurbopackModuleType": {
+      "description": "Module type for a module rule (`type` / `moduleType` field).\n\nValues must match pack-core / Turbopack's `ConfiguredModuleType::parse()`.",
+      "type": "string",
+      "enum": [
+        "asset",
+        "ecmascript",
+        "typescript",
+        "css",
+        "css-module",
+        "json",
+        "wasm",
+        "raw",
+        "node",
+        "bytes"
       ]
     }
   }


### PR DESCRIPTION
Closes #2793

## Summary

- Add `TurbopackModuleType` enum and `module_type` / `type` field to `RuleConfigItem` in `pack-core`, enabling users to set the Turbopack module type directly in a rule without requiring a loader or `as` rename
- Make `loaders` optional (defaults to `[]`) so type-only rules like `{ "*.svg": { "type": "asset" } }` deserialize correctly
- Mirror `SchemaTurbopackModuleType` enum in `pack-schema` and regenerate `config_schema.json`
- Add `TurbopackModuleType` union type and `type` field to `pack-shared` TypeScript types

Supports the same API as [Next.js Turbopack module types](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#module-types):

```js
module.exports = {
  pack: {
    rules: {
      '*.svg': {
        type: 'asset',
      },
    },
  },
}
```

## Test plan

- [x] Snapshot test `webpack-loaders/module-type` covering `type: "ecmascript"` (loader + type) and `type: "asset"` (type-only, no loader)
- [x] `cargo clippy` and `cargo fmt` clean