### PR TITLE
fix(pm): normalize extracted file permissions to 0o644/0o755

### DIFF
--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -121,7 +121,11 @@ fn extract_tarball_sync(gzip_bytes: Bytes, estimated_size: usize, dest: &Path) -
                 .read_to_end(&mut content)
                 .with_context(|| format!("Failed to read tar entry: {}", path.display()))?;
 
-            let mode = entry.header().mode().unwrap_or(0o644);
+            // Normalize to npm/pnpm convention: 0o755 if any exec bit is set,
+            // else 0o644. Preserving raw tar modes (e.g. 0o640 in google-protobuf)
+            // breaks world-readability in containers and multi-user setups.
+            let raw_mode = entry.header().mode().unwrap_or(0o644);
+            let mode = if raw_mode & 0o111 != 0 { 0o755 } else { 0o644 };
             entries.push(ExtractedEntry {
                 path: full_path,
                 content,

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -825,4 +825,51 @@ fi
 echo -e "${GREEN}PASS: legacyPeerDeps=false — peer deps auto-installed${NC}"
 cd ../../..
 
+# Case: tarball permission normalization
+# google-protobuf@4.0.2 ships files at 0o640 in its tarball (package.json,
+# google-protobuf.js, README.md, LICENSE*). Preserving raw tar modes leaves
+# them unreadable by "other" and breaks container/cross-user reads — npm and
+# pnpm both normalize to 0o644. This is a regression guard for that behavior.
+echo -e "${YELLOW}Case: tarball permission normalization (google-protobuf)${NC}"
+PERM_DIR=$(mktemp -d)
+pushd "$PERM_DIR"
+cat > package.json <<'PKGJSON'
+{
+  "name": "perm-normalize-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "google-protobuf": "4.0.2"
+  }
+}
+PKGJSON
+
+# Force a cold extract so the normalization path actually runs
+rm -rf ~/.cache/nm/google-protobuf
+
+utoo install --ignore-scripts --registry=https://registry.npmjs.org \
+  || { echo -e "${RED}FAIL: utoo install failed for perm-normalize-test${NC}"; popd; rm -rf "$PERM_DIR"; exit 1; }
+
+# Every file under the package must be world-readable.
+# Without the fix, the 0o640 files above are listed here and the case fails.
+NON_READABLE=$(find node_modules/google-protobuf -type f ! -perm -0004 -print)
+if [ -n "$NON_READABLE" ]; then
+    echo -e "${RED}FAIL: files missing other-read bit after install:${NC}"
+    echo "$NON_READABLE"
+    ls -la node_modules/google-protobuf/
+    popd; rm -rf "$PERM_DIR"; exit 1
+fi
+
+# Spot-check one of the known-0o640 files landed at exactly 0o644 (not 0o640,
+# not 0o755 — we should not grant exec unless the tar entry had it).
+# `stat -c` (GNU) / `stat -f` (BSD) differ; use Node for portability.
+MODE=$(node -e "console.log((require('fs').statSync('node_modules/google-protobuf/package.json').mode & 0o777).toString(8))")
+if [ "$MODE" != "644" ]; then
+    echo -e "${RED}FAIL: package.json mode is 0o$MODE, expected 0o644${NC}"
+    popd; rm -rf "$PERM_DIR"; exit 1
+fi
+echo -e "${GREEN}PASS: tarball permissions normalized to 0o644${NC}"
+
+popd
+rm -rf "$PERM_DIR"
+
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"


### PR DESCRIPTION
## Summary

- Tar entries from some npm packages ship with restrictive modes (e.g. `google-protobuf@4.0.2`'s `package.json`, `google-protobuf.js`, `README.md`, and `LICENSE*` are all `0o640`). Preserving the raw tar mode leaves those files unreadable by "other", which breaks container runtimes and multi-user setups.
- Normalize extraction to match npm/pnpm: `0o755` if any exec bit is set in the header, `0o644` otherwise. The existing skip-chmod-for-`0o644` fast path still applies to typical files.
- Added a regression case to `e2e/utoo-pm.sh` that installs `google-protobuf@4.0.2` into a temp dir (cold cache forced) and asserts every file is world-readable and `package.json` is exactly `0o644`.

## Repro (before)

```
$ tar -tvf google-protobuf-4.0.2.tgz | grep '^-rw-r-----'
-rw-r-----  package/google-protobuf.js
-rw-r-----  package/package.json
-rw-r-----  package/README.md
-rw-r-----  package/LICENSE.md
-rw-r-----  package/LICENSE-asserts.md

$ utoo install  # files land on disk at 0o640 (unreadable by "other")
```

After this change they land at `0o644`, matching `npm install` / `pnpm install`.

## Test plan

- [ ] `cargo test -p utoo-pm`
- [ ] `./e2e/utoo-pm.sh` — new "tarball permission normalization" case passes
- [ ] Manually confirmed: `node_modules/google-protobuf/*.js,*.md,package.json` all `0o644` after cold install

🤖 Generated with [Claude Code](https://claude.com/claude-code)