### PR TITLE
ci(pm-release): fall back to kernel.org mirror when apt times out

### DIFF
--- a/.github/workflows/pm-release.yml
+++ b/.github/workflows/pm-release.yml
@@ -54,19 +54,38 @@ jobs:
     steps:
       - name: Install Linux Dependencies
         if: ${{ matrix.platform_os == 'linux' }}
+        timeout-minutes: 10
         env:
           DEBIAN_FRONTEND: noninteractive
+        # Short per-apt timeouts: on GHA runners that can't route to
+        # archive/security.ubuntu.com, apt otherwise sits in 90s × 8-IP SYN
+        # timeouts. Bail after 60s on the default mirror, swap to the
+        # Fastly-backed kernel.org mirror, and retry once.
+        #
+        # If the first attempt times out mid-unpack (e.g. libc6 upgrade),
+        # dpkg is left half-configured and the retry fails with
+        # "dpkg was interrupted". `dpkg --configure -a` finalises any
+        # pending unpack before we retry on the fallback mirror.
         run: |
-          apt-get update && apt-get install -y \
-            build-essential \
-            libc6-dev \
-            libglib2.0-0 \
-            curl \
-            tzdata \
-            pkg-config \
-            gnupg2 \
-            software-properties-common \
-            git
+          install_pkgs() {
+            timeout 60 apt-get update \
+              && timeout 180 apt-get install -y \
+                build-essential \
+                libc6-dev \
+                libglib2.0-0 \
+                curl \
+                tzdata \
+                pkg-config \
+                gnupg2 \
+                software-properties-common \
+                git
+          }
+          if ! install_pkgs; then
+            echo "apt default mirror failed/timed out, falling back to mirrors.edge.kernel.org"
+            dpkg --configure -a || true
+            sed -i 's|http://archive\.ubuntu\.com|http://mirrors.edge.kernel.org|g; s|http://security\.ubuntu\.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list
+            install_pkgs
+          fi
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
           chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null


### PR DESCRIPTION
## Summary

- The `utoopm-release` workflow's Linux build step failed in [run 24546249541](https://github.com/utooland/utoo/actions/runs/24546249541/job/71762421043) because the `ubuntu:20.04` container could not reach `archive.ubuntu.com` / `security.ubuntu.com` — `apt-get update` returned stale indexes and every package lookup then failed with `E: Unable to locate package build-essential`.
- Apply the same mirror-fallback pattern already used in `pm-e2e.yml`: wrap the initial apt install with a 60s update / 180s install timeout, and on failure rewrite `/etc/apt/sources.list` to `mirrors.edge.kernel.org` and retry once. `dpkg --configure -a` runs before the retry so a mid-unpack timeout (e.g. libc6 upgrade) doesn't block the fallback.

## Test plan

- [ ] Re-run the release workflow (via `workflow_dispatch`) on a commit including this change; confirm the Install Linux Dependencies step succeeds on both `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` containers.
- [ ] Verify that when the default mirror is reachable, the step still completes without falling back (log should not contain "falling back to mirrors.edge.kernel.org").

🤖 Generated with [Claude Code](https://claude.com/claude-code)