### PR TITLE
feat(pack): add tracing option to control default tracing output

### DIFF
--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -116,6 +116,9 @@ pub struct NapiProjectOptions {
     /// The build id.
     pub build_id: String,
 
+    /// Whether to enable default tracing logs.
+    pub tracing: bool,
+
     pub pack_path: String,
 }
 
@@ -333,7 +336,7 @@ pub fn project_new(
                 .with(chrome_layer)
                 .init();
         });
-    } else {
+    } else if options.tracing {
         TRACING_INIT.call_once(|| {
             let env_filter = EnvFilter::try_from_default_env();
             let env_filter_enabled = env_filter.is_ok();

--- a/packages/pack-cli/src/commands/build.ts
+++ b/packages/pack-cli/src/commands/build.ts
@@ -22,6 +22,10 @@ export default defineCommand({
       type: "boolean",
       description: "Enable webpack mode",
     },
+    tracing: {
+      type: "boolean",
+      description: "Enable default tracing logs (pass --no-tracing to disable)",
+    },
   },
   async run({ args }) {
     const { projectOptions, projectPath, rootPath } =

--- a/packages/pack-cli/src/commands/dev.ts
+++ b/packages/pack-cli/src/commands/dev.ts
@@ -22,6 +22,10 @@ export default defineCommand({
       type: "boolean",
       description: "Enable webpack mode",
     },
+    tracing: {
+      type: "boolean",
+      description: "Enable default tracing logs (pass --no-tracing to disable)",
+    },
   },
   async run({ args }) {
     const { projectOptions, projectPath, rootPath } =

--- a/packages/pack-cli/src/utils/common.ts
+++ b/packages/pack-cli/src/utils/common.ts
@@ -62,8 +62,9 @@ export async function resolveBuildOptions(flags: {
   project?: string;
   root?: string;
   webpack?: boolean;
+  tracing?: boolean;
 }): Promise<BuildOptions> {
-  const { project, root, webpack } = flags;
+  const { project, root, webpack, tracing: tracingFlag } = flags;
   const cwd = process.cwd();
   const configDir = path.resolve(cwd, project || "");
   let projectPath = project ? path.resolve(cwd, project) : undefined;
@@ -80,6 +81,7 @@ export async function resolveBuildOptions(flags: {
       watch,
       dev,
       buildId,
+      tracing: configTracing,
       packPath,
       rootPath: configRootPath,
       projectPath: configProjectPath,
@@ -98,6 +100,7 @@ export async function resolveBuildOptions(flags: {
       watch,
       dev,
       buildId,
+      tracing: tracingFlag ?? configTracing,
       packPath,
     } as unknown as utooPack.BundleOptions;
   }

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -383,6 +383,12 @@ export interface BundleOptions {
   buildId?: string;
 
   /**
+   * Whether to enable default utoopack tracing logs.
+   * Defaults to true.
+   */
+  tracing?: boolean;
+
+  /**
    * Absolute path for `@utoo/pack`.
    */
   packPath?: string;
@@ -395,7 +401,10 @@ export interface BundleOptions {
  */
 export type UserConfig = ConfigComplete &
   Partial<
-    Pick<BundleOptions, "processEnv" | "watch" | "dev" | "buildId" | "packPath">
+    Pick<
+      BundleOptions,
+      "processEnv" | "watch" | "dev" | "buildId" | "tracing" | "packPath"
+    >
   > & {
     rootPath?: string;
     projectPath?: string;

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -81,6 +81,8 @@ export interface NapiProjectOptions {
   dev: boolean
   /** The build id. */
   buildId: string
+  /** Whether to enable default tracing logs. */
+  tracing: boolean
   packPath: string
 }
 /** [NapiProjectOptions] with all fields optional. */

--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -55,6 +55,7 @@ async function buildInternal(
       },
       dev: bundleOptions.dev ?? false,
       buildId: bundleOptions.buildId || nanoid(),
+      tracing: bundleOptions.tracing ?? true,
       config: {
         ...bundleOptions.config,
         stats:

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -123,6 +123,7 @@ export async function createHotReloader(
       },
       dev: true,
       buildId: bundleOptions.buildId || nanoid(),
+      tracing: bundleOptions.tracing ?? true,
       config: {
         ...bundleOptions.config,
         mode: "development",


### PR DESCRIPTION


## Summary

Add option for control `@utoo/pack`'s tracing output.

issue: https://github.com/utooland/utoo/issues/2792

PR: https://github.com/umijs/umi/pull/13297


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
