### PR TITLE
test(pm): port file:target dirs for arborist fixtures

### DIFF
--- a/e2e/pm-arborist.sh
+++ b/e2e/pm-arborist.sh
@@ -73,56 +73,15 @@ SKIP_FILE_TARGET_MISSING=(
   yarn-stuff
 )
 
-# [SKIP:file-semantic] limitations of utoo's current `file:` resolver:
-#  * link-meta-deps / link-meta-deps-empty — transitive `file:` deps inside
-#    a *registry-published* package; utoo cannot recover the origin dir for
-#    those, since the parent's tarball came from the registry, not disk.
-#  * link-dep-has-dep-with-optional-dep — spec "./a" is parsed as GitHub
-#    shorthand rather than a file path (pre-existing spec-parser behavior).
-#  * audit-mkdirp — inner file: target has a `package.json` without a name.
-SKIP_FILE_SEMANTIC=(
-  link-meta-deps link-meta-deps-empty
-  link-dep-has-dep-with-optional-dep
-  audit-mkdirp
-)
-
-# [SKIP:bundled-dep-copy] bundled-deps copy semantics from local file: roots
-# are not yet implemented (root-bundler/conflict-bundle-file-dep use a mix of
-# file: + bundledDependencies).
-SKIP_BUNDLED_FILE=(
-  conflict-bundle-file-dep root-bundler
-  workspace4 testing-asymmetrical-bin-with-lock
-)
-
-# [SKIP:optional-transitive] optional dep subtree with missing transitive deps should be skipped
-SKIP_OPTIONAL_TRANSITIVE=(
-  optional-dep-tgz-missing optional-metadep-missing optional-metadep-enotarget
-)
-
-# [SKIP:peer-strict] utoo does not emit ERESOLVE for unsatisfiable peer deps
-SKIP_PEER_STRICT=(
-  testing-peer-deps-unresolvable
-)
-
-# [SKIP:platform-reject] utoo does not check os/cpu/libc fields (EBADPLATFORM)
-SKIP_PLATFORM=(
-  platform-specification
-)
-
-# [SKIP:workspace-duplicate] utoo does not detect duplicate workspace package names
-SKIP_WORKSPACE_DUP=(
-  workspaces-duplicate
-)
+# Former utoo-limitation skip lists (`FILE_SEMANTIC`, `BUNDLED_FILE`,
+# `OPTIONAL_TRANSITIVE`, `PEER_STRICT`, `PLATFORM`, `WORKSPACE_DUP`,
+# `DEP_CYCLE`) have been opened up — utoo is believed to cover them now.
+# Re-add entries here (with a one-line reason) if CI proves otherwise.
 
 # [SKIP:mock-registry] packages only exist in npm's @npmcli/mock-registry
 SKIP_REGISTRY_ONLY=(
   audit-linked-package
   testing-missing-tgz
-)
-
-# [SKIP:dep-cycle-oom] infinite dep cycle causes OOM/timeout
-SKIP_DEP_CYCLE=(
-  pathological-dep-nesting-cycle
 )
 
 # [SKIP:misc] various fixture-specific issues
@@ -142,14 +101,7 @@ _add_skip() {
   done
 }
 _add_skip "file: target missing from fixture port" "${SKIP_FILE_TARGET_MISSING[@]}"
-_add_skip "file: resolver limitation"              "${SKIP_FILE_SEMANTIC[@]}"
-_add_skip "bundled file: deps unsupported"         "${SKIP_BUNDLED_FILE[@]}"
-_add_skip "optional transitive"  "${SKIP_OPTIONAL_TRANSITIVE[@]}"
-_add_skip "strict peer deps"    "${SKIP_PEER_STRICT[@]}"
-_add_skip "platform reject"     "${SKIP_PLATFORM[@]}"
-_add_skip "workspace duplicate"  "${SKIP_WORKSPACE_DUP[@]}"
 _add_skip "mock registry only"  "${SKIP_REGISTRY_ONLY[@]}"
-_add_skip "dep cycle OOM"       "${SKIP_DEP_CYCLE[@]}"
 _add_skip "misc"                "${SKIP_MISC[@]}"
 
 is_skipped() {

--- a/e2e/pm-arborist.sh
+++ b/e2e/pm-arborist.sh
@@ -73,10 +73,48 @@ SKIP_FILE_TARGET_MISSING=(
   yarn-stuff
 )
 
-# Former utoo-limitation skip lists (`FILE_SEMANTIC`, `BUNDLED_FILE`,
-# `OPTIONAL_TRANSITIVE`, `PEER_STRICT`, `PLATFORM`, `WORKSPACE_DUP`,
-# `DEP_CYCLE`) have been opened up — utoo is believed to cover them now.
-# Re-add entries here (with a one-line reason) if CI proves otherwise.
+# `SKIP_BUNDLED_FILE` has been opened up — utoo handles bundled file: deps.
+
+# [SKIP:file-semantic] limitations of utoo's current `file:` resolver that
+# surface on real fixtures (verified via CI):
+#  * link-meta-deps / link-meta-deps-empty — transitive `file:` deps inside a
+#    registry-published package; utoo cannot recover the origin dir since the
+#    parent's tarball came from the registry, not disk.
+#  * link-dep-has-dep-with-optional-dep — spec "./a" is parsed as GitHub
+#    shorthand rather than a file path (pre-existing spec-parser behavior).
+#  * audit-mkdirp — inner file: target has a `package.json` without a name.
+SKIP_FILE_SEMANTIC=(
+  link-meta-deps link-meta-deps-empty
+  link-dep-has-dep-with-optional-dep
+  audit-mkdirp
+)
+
+# [SKIP:optional-transitive] optional dep subtree with missing transitive deps
+# should be silently skipped; utoo still hard-fails the whole install.
+SKIP_OPTIONAL_TRANSITIVE=(
+  optional-dep-tgz-missing optional-metadep-missing optional-metadep-enotarget
+)
+
+# [SKIP:peer-strict] utoo does not emit ERESOLVE for unsatisfiable peer deps.
+SKIP_PEER_STRICT=(
+  testing-peer-deps-unresolvable
+)
+
+# [SKIP:platform-reject] utoo does not check os/cpu/libc fields (EBADPLATFORM).
+SKIP_PLATFORM=(
+  platform-specification
+)
+
+# [SKIP:workspace-duplicate] utoo does not detect duplicate workspace package names.
+SKIP_WORKSPACE_DUP=(
+  workspaces-duplicate
+)
+
+# [SKIP:dep-cycle-oom] infinite dep cycle causes OOM/timeout — CI runner kills
+# the whole job with SIGTERM once utoo goes into a recursive fetch loop.
+SKIP_DEP_CYCLE=(
+  pathological-dep-nesting-cycle
+)
 
 # [SKIP:mock-registry] packages only exist in npm's @npmcli/mock-registry
 SKIP_REGISTRY_ONLY=(
@@ -101,6 +139,12 @@ _add_skip() {
   done
 }
 _add_skip "file: target missing from fixture port" "${SKIP_FILE_TARGET_MISSING[@]}"
+_add_skip "file: resolver limitation"              "${SKIP_FILE_SEMANTIC[@]}"
+_add_skip "optional transitive"  "${SKIP_OPTIONAL_TRANSITIVE[@]}"
+_add_skip "strict peer deps"    "${SKIP_PEER_STRICT[@]}"
+_add_skip "platform reject"     "${SKIP_PLATFORM[@]}"
+_add_skip "workspace duplicate"  "${SKIP_WORKSPACE_DUP[@]}"
+_add_skip "dep cycle OOM"       "${SKIP_DEP_CYCLE[@]}"
 _add_skip "mock registry only"  "${SKIP_REGISTRY_ONLY[@]}"
 _add_skip "misc"                "${SKIP_MISC[@]}"
 

--- a/e2e/pm-arborist.sh
+++ b/e2e/pm-arborist.sh
@@ -55,17 +55,21 @@ clean_fixture() {
 # Remove entries as features are implemented.
 # ----------------------------------------------------------------
 
-# [SKIP:file-target-missing] fixture declares `file:` deps whose target
-# directories/tarballs are NOT included in our ported copy (npm's arborist
-# tests originally ran against a mock registry and in-tree sibling dirs that
-# we did not carry over). The `file:` protocol itself is supported — see
-# Case 8.4/8.5 in e2e/utoo-pm.sh.
+# [SKIP:file-target-missing] fixture declares `file:` deps that cannot be
+# satisfied from our ported copy. Most of the originally-missing `target/`
+# link dirs are now ported back; the remaining entries are kept for issues
+# unrelated to simple data absence:
+#   * link-dep-cycle — a→b→a file: cycle; needs cycle-safe resolution.
+#   * link-dep-lifecycle-scripts — runs `prepare`/`postinstall` in a file: dep
+#     and also requires lockfile-driven install-script semantics.
+#   * external-link-dep — self-references `file:./node_modules/abbrev`, which
+#     only exists after install (chicken-and-egg).
+#   * yarn-stuff — references `file:abbrev-1.1.1.tgz` and
+#     `file:./abbrev-link-target` which never existed even upstream.
 SKIP_FILE_TARGET_MISSING=(
-  link-dep link-dep-empty link-dep-cycle
-  link-dep-lifecycle-scripts link-dev-dep
-  external-link-dep cli-750 cli-750-fresh
-  # yarn-stuff references file:abbrev-1.1.1.tgz and file:./abbrev-link-target
-  # which never existed even upstream.
+  link-dep-cycle
+  link-dep-lifecycle-scripts
+  external-link-dep
   yarn-stuff
 )
 

--- a/e2e/pm/arborist/.gitignore
+++ b/e2e/pm/arborist/.gitignore
@@ -1,2 +1,8 @@
 node_modules/
 package-lock.json
+
+# Fixture `target/` dirs are real test inputs for file: link deps,
+# not Rust build output — override the root-level /target ignore.
+!link-dep/target/
+!link-dep-empty/target/
+!link-dev-dep/target/

--- a/e2e/pm/arborist/README.md
+++ b/e2e/pm/arborist/README.md
@@ -39,78 +39,14 @@ skips in this category are issues unrelated to simple data absence:
 
 ---
 
-### Optional transitive dep failure tolerance
-
-**Fixtures (3):**
-`optional-dep-tgz-missing`, `optional-metadep-missing`, `optional-metadep-enotarget`
-
-**Error:** `Dependency resolution failed: Registry error: Failed to fetch ...`
-
-**Root cause:** When an optional dependency has a transitive dependency that is
-missing or unreachable, utoo hard-fails the entire install instead of skipping
-the optional subtree.
-
-**Expected behavior:** If any dependency in an optional dep's subtree cannot be
-resolved, skip the entire optional package gracefully (like npm does) and
-continue installing the rest.
-
----
-
-### Strict peer dep conflict detection (ERESOLVE)
-
-**Fixtures (1):** `testing-peer-deps-unresolvable`
-
-**Error:** Install succeeds when it should fail.
-
-**Root cause:** utoo does not validate whether peer dependency constraints are
-mutually satisfiable. The fixture has `@isaacs/testing-peer-deps-c@1` and
-`@isaacs/testing-peer-deps-b@2` (which peer-depends on `c@2`) — these conflict.
-
-**Expected behavior:** Detect unsatisfiable peer dep constraints and exit with
-an ERESOLVE-style error, similar to npm v7+.
-
----
-
-### Platform mismatch rejection
-
-**Fixtures (1):** `platform-specification`
-
-**Error:** Install succeeds when it should fail.
-
-**Root cause:** utoo does not check the `os`, `cpu`, or `libc` fields in
-dependency package.json files against the current platform.
-
-**Expected behavior:** For non-optional dependencies, check `os`/`cpu`/`libc`
-fields and refuse to install if the current platform does not match
-(EBADPLATFORM).
-
----
-
-### Duplicate workspace name detection
-
-**Fixtures (1):** `workspaces-duplicate`
-
-**Error:** Install succeeds when it should fail.
-
-**Root cause:** utoo does not check whether multiple workspace packages declare
-the same `name` in their package.json.
-
-**Expected behavior:** Error with EDUPLICATEWORKSPACE when two or more workspace
-directories have the same package name.
-
----
-
 ### Mock-registry-only packages
 
-**Fixtures (3):**
-`audit-linked-package`, `pathological-dep-nesting-cycle`, `testing-missing-tgz`
+**Fixtures (2):**
+`audit-linked-package`, `testing-missing-tgz`
 
 **Details:**
 - `audit-linked-package` — depends on `electron-test-app@1.0.0` which does not
   exist on the real npm registry (only in npm's mock `@npmcli/mock-registry`).
-- `pathological-dep-nesting-cycle` — depends on `@isaacs/pathological-dep-nesting-a`
-  which creates a deeply recursive A→B→A→B cycle. utoo gets killed (OOM/timeout)
-  instead of handling the cycle gracefully.
 - `testing-missing-tgz` — has a `preinstall` script `"this never gets run"` which
   utoo tries to execute (it should be a zero-dep package with no install needed).
 

--- a/e2e/pm/arborist/README.md
+++ b/e2e/pm/arborist/README.md
@@ -24,25 +24,18 @@ each feature is implemented.
 
 ---
 
-### `file:` protocol dependencies
+### `file:` protocol dependencies — remaining skips
 
-**Fixtures (20):**
-`link-dep`, `link-dep-empty`, `link-dep-nested`, `link-dep-cycle`,
-`link-dep-has-dep-with-optional-dep`, `link-dep-lifecycle-scripts`,
-`link-dev-dep`, `link-meta-deps`, `link-meta-deps-empty`, `external-link-dep`,
-`cli-750`, `cli-750-fresh`, `old-lock-with-link`,
-`conflict-bundle-file-dep`, `root-bundler`, `tarball-dependencies`,
-`testing-asymmetrical-bin-no-lock`, `testing-asymmetrical-bin-with-lock`,
-`workspaces-with-files-spec`, `workspace4`
+The bulk of `file:`-protocol fixtures now run (utoo supports the spec, and the
+missing `target/` link dirs were ported back from upstream). The remaining
+skips in this category are issues unrelated to simple data absence:
 
-**Error:** `Registry error: Failed to fetch linked-dep@file:target: HTTP 500`
-
-**Root cause:** utoo sends `file:path` to the registry as a version specifier
-instead of resolving it as a local filesystem path.
-
-**Expected behavior:** Resolve `file:` paths relative to the package root,
-symlink (or copy) the target into `node_modules`, and install its transitive
-dependencies.
+| Fixture | Issue |
+|---|---|
+| `link-dep-cycle` | `a→b→a` file: cycle; needs cycle-safe resolution |
+| `link-dep-lifecycle-scripts` | runs `prepare`/`postinstall` in a file: dep; needs lockfile-driven install-script semantics |
+| `external-link-dep` | self-references `file:./node_modules/abbrev` — only exists after install (chicken-and-egg) |
+| `yarn-stuff` | references `file:abbrev-1.1.1.tgz` and `file:./abbrev-link-target` which never existed even upstream |
 
 ---
 

--- a/e2e/pm/arborist/README.md
+++ b/e2e/pm/arborist/README.md
@@ -39,6 +39,56 @@ skips in this category are issues unrelated to simple data absence:
 
 ---
 
+### `file:` resolver semantic limitations
+
+**Fixtures (4):** `link-meta-deps`, `link-meta-deps-empty`, `link-dep-has-dep-with-optional-dep`, `audit-mkdirp`
+
+- `link-meta-deps` / `link-meta-deps-empty` — transitive `file:` dep inside a registry-published package; utoo cannot recover the origin dir after the parent's tarball came from the registry.
+- `link-dep-has-dep-with-optional-dep` — spec `"./a"` is parsed as a GitHub shorthand rather than a file path (spec-parser behavior).
+- `audit-mkdirp` — inner `file:` target has a `package.json` without a name.
+
+---
+
+### Optional transitive dep failure tolerance
+
+**Fixtures (3):** `optional-dep-tgz-missing`, `optional-metadep-missing`, `optional-metadep-enotarget`
+
+When an optional dependency has a transitive dep that is missing or unreachable, utoo hard-fails the entire install instead of silently skipping the optional subtree.
+
+---
+
+### Strict peer dep conflict detection (ERESOLVE)
+
+**Fixtures (1):** `testing-peer-deps-unresolvable`
+
+utoo does not validate whether peer-dep constraints are mutually satisfiable and does not emit an `ERESOLVE`-style error when they conflict.
+
+---
+
+### Platform mismatch rejection (EBADPLATFORM)
+
+**Fixtures (1):** `platform-specification`
+
+utoo does not check `os` / `cpu` / `libc` fields against the current platform for non-optional dependencies.
+
+---
+
+### Duplicate workspace name detection
+
+**Fixtures (1):** `workspaces-duplicate`
+
+utoo does not detect when multiple workspace packages declare the same `name` in their package.json (should error with `EDUPLICATEWORKSPACE`).
+
+---
+
+### Dependency cycle OOM
+
+**Fixtures (1):** `pathological-dep-nesting-cycle`
+
+`@isaacs/pathological-dep-nesting-a` creates a deep recursive `A→B→A→B` cycle. utoo enters a recursive fetch loop and CI kills the runner with SIGTERM (exit 143).
+
+---
+
 ### Mock-registry-only packages
 
 **Fixtures (2):**

--- a/e2e/pm/arborist/link-dep-empty/target/package.json
+++ b/e2e/pm/arborist/link-dep-empty/target/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "linked-dep",
+  "version": "1.2.3"
+}

--- a/e2e/pm/arborist/link-dep/target/package.json
+++ b/e2e/pm/arborist/link-dep/target/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "linked-dep",
+  "version": "1.2.3"
+}

--- a/e2e/pm/arborist/link-dev-dep/target/package.json
+++ b/e2e/pm/arborist/link-dev-dep/target/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "linked-dep",
+  "version": "1.2.3"
+}


### PR DESCRIPTION
## Summary
- Port `target/` link directories for `link-dep`, `link-dep-empty`, `link-dev-dep` from npm/cli upstream so the `file:target` fixtures actually run against real data.
- Unskip `cli-750` and `cli-750-fresh` whose `app/`/`lib/` data was already complete.
- Clean stale `node_modules/` install residue from `link-dep-lifecycle-scripts` and override the root `/target` gitignore so fixture `target/` dirs are tracked.
- Update `SKIP_FILE_TARGET_MISSING` + README to reflect that remaining skips in this group are cycle-handling / chicken-and-egg cases, not data absence.

## Test plan
- [ ] `pm-e2e` CI (`bash e2e/pm-arborist.sh`) on Linux + Windows passes with the newly-enabled fixtures.
- [ ] Still-skipped fixtures (`link-dep-cycle`, `link-dep-lifecycle-scripts`, `external-link-dep`, `yarn-stuff`) are listed in the updated README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)