### PR TITLE
perf(pm): probe — WP + OnceMap (no aws-lc-rs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "ambient-authority"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,72 +727,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-fs-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
-dependencies = [
- "ambient-authority",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "ipnet",
- "maybe-owned",
- "rustix 1.1.2",
- "rustix-linux-procfs",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "cap-std"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
-dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
- "rustix 1.1.2",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix 1.1.2",
- "winx",
-]
-
-[[package]]
 name = "capacity_builder"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,39 +1248,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-assembler-x64"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c088d3406f0c0252efa7445adfd2d05736bfb5218838f64eaf79d567077aed14"
-dependencies = [
- "cranelift-assembler-x64-meta",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c03f887a763abb9c1dc08f722aa82b69067fda623b6f0273050f45f8b1a6776"
-dependencies = [
- "cranelift-srcgen",
-]
-
-[[package]]
 name = "cranelift-bforest"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "305d51c180ebdc46ef61bc60c54ae6512db3bc9a05842a1f1e762e45977019ab"
 dependencies = [
- "cranelift-entity 0.110.2",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206887a11a43f507fee320a218dc365980bfc42ec2696792079a9f8c9369e90"
-dependencies = [
- "cranelift-entity 0.125.4",
+ "cranelift-entity",
 ]
 
 [[package]]
@@ -1362,63 +1263,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "690d8ae6c73748e5ce3d8fe59034dceadb8823e6c8994ba324141c5eae909b0e"
 
 [[package]]
-name = "cranelift-bitset"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0790c83cfdab95709c5d0105fd888221e3af9049a7d7ec376ec901ab4e4dba"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "cranelift-codegen"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7ca95e831c18d1356da783765c344207cbdffea91e13e47fa9327dbb2e0719"
 dependencies = [
  "bumpalo",
- "cranelift-bforest 0.110.2",
- "cranelift-bitset 0.110.3",
- "cranelift-codegen-meta 0.110.3",
- "cranelift-codegen-shared 0.110.3",
- "cranelift-control 0.110.3",
- "cranelift-entity 0.110.2",
- "cranelift-isle 0.110.2",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
  "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
- "regalloc2 0.9.3",
+ "regalloc2",
  "rustc-hash 1.1.0",
  "smallvec",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a98aed2d262eda69310e84bae8e053ee4f17dbdd3347b8d9156aa618ba2de0a"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest 0.125.4",
- "cranelift-bitset 0.125.4",
- "cranelift-codegen-meta 0.125.4",
- "cranelift-codegen-shared 0.125.4",
- "cranelift-control 0.125.4",
- "cranelift-entity 0.125.4",
- "cranelift-isle 0.125.4",
- "gimli 0.32.3",
- "hashbrown 0.15.5",
- "log",
- "pulley-interpreter",
- "regalloc2 0.13.5",
- "rustc-hash 2.1.1",
- "serde",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasmtime-internal-math",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1427,20 +1291,7 @@ version = "0.110.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a2d2ab65e6cbf91f81781d8da65ec2005510f18300eff21a99526ed6785863"
 dependencies = [
- "cranelift-codegen-shared 0.110.3",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6906852826988563e9b0a9232ad951f53a47aa41ffd02f8ac852d3f41aae836a"
-dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared 0.125.4",
- "cranelift-srcgen",
- "heck 0.5.0",
- "pulley-interpreter",
+ "cranelift-codegen-shared",
 ]
 
 [[package]]
@@ -1448,12 +1299,6 @@ name = "cranelift-codegen-shared"
 version = "0.110.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efcff860573cf3db9ae98fbd949240d78b319df686cc306872e7fab60e9c84d7"
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a50105aab667b5cc845f2be37c78475d7cc127cd8ec0a31f7b2b71d526099a7"
 
 [[package]]
 name = "cranelift-control"
@@ -1465,32 +1310,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-control"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6adcc7aa7c0bc1727176a6f2d99c28a9e79a541ccd5ca911a0cb352da8befa36"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
 name = "cranelift-entity"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a48cb0a194c9ba82fec35a1e492055388d89b2e3c03dee9dcf2488892be8004d"
 dependencies = [
- "cranelift-bitset 0.110.3",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981b56af777f9a34ea6dcce93255125776d391410c2a68b75bed5941b714fa15"
-dependencies = [
- "cranelift-bitset 0.125.4",
- "serde",
- "serde_derive",
+ "cranelift-bitset",
 ]
 
 [[package]]
@@ -1499,22 +1324,10 @@ version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8327afc6c1c05f4be62fefce5b439fa83521c65363a322e86ea32c85e7ceaf64"
 dependencies = [
- "cranelift-codegen 0.110.2",
+ "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea982589684dfb71afecb9fc09555c3a266300a1162a60d7fa39d41a5705b1c"
-dependencies = [
- "cranelift-codegen 0.125.4",
- "log",
- "smallvec",
- "target-lexicon 0.13.5",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1522,29 +1335,6 @@ name = "cranelift-isle"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56b08621c00321efcfa3eee6a3179adc009e21ea8d24ca7adc3c326184bc3f48"
-
-[[package]]
-name = "cranelift-isle"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0422686b22ed6a1f33cc40e3c43eb84b67155788568d1a5cac8439d3dca1783"
-
-[[package]]
-name = "cranelift-native"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f697bbbe135c655ea1deb7af0bae4a5c4fae2c88fdfc0fa57b34ae58c91040"
-dependencies = [
- "cranelift-codegen 0.125.4",
- "libc",
- "target-lexicon 0.13.5",
-]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718efe674f3df645462677e22a3128e890d88ba55821bb091083d257707be76c"
 
 [[package]]
 name = "crc32fast"
@@ -2406,17 +2196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.1.2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,12 +2273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foldhash-portable"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631c01cdb9b602a84f0ef5e813d3691936aade6d390dba117f28aa03eb4d0e09"
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,17 +2304,6 @@ checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
 dependencies = [
  "swc_macros_common",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "fs-set-times"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
-dependencies = [
- "io-lifetimes",
- "rustix 1.1.2",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2753,11 +2515,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-dependencies = [
- "fallible-iterator",
- "indexmap 2.13.0",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "gix"
@@ -4318,22 +4075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-extras"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
-dependencies = [
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,12 +4446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libmimalloc-sys"
 version = "0.1.44"
 source = "git+https://github.com/utooland/mimalloc_rust.git#43eea63be488f068f0f1a31c07553fe262d34255"
@@ -4942,12 +4677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4972,15 +4701,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memfd"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
-dependencies = [
- "rustix 1.1.2",
-]
 
 [[package]]
 name = "memmap2"
@@ -5601,9 +5321,6 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
  "memchr",
 ]
 
@@ -5926,7 +5643,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "testing",
+ "testing 22.0.0",
  "tokio",
  "tracing-subscriber",
  "turbo-rcstr",
@@ -6279,6 +5996,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pot"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf741fa415952eb20f27fbc210dc85f31cc7cdc80aa3ce81d5e27d28a6f45dc2"
+dependencies = [
+ "byteorder",
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6519,29 +6247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beafc309a2d35e16cc390644d88d14dfa45e45e15075ec6a9e37f6dfb43e926f"
-dependencies = [
- "cranelift-bitset 0.125.4",
- "log",
- "pulley-macros",
- "wasmtime-internal-math",
-]
-
-[[package]]
-name = "pulley-macros"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885fbb6c07454cfc8725a18a1da3cfc328ee8c53fb8d0671ea313edc8567947"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6552,13 +6257,13 @@ dependencies = [
 
 [[package]]
 name = "qfilter"
-version = "0.3.0-alpha.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd9c903cd64233eb97cf95d96d58645c2b1c0154d30ff835f3bb4be417158b1"
+checksum = "746341cd2357c9a4df2d951522b4a8dd1ef553e543119899ad7bf87e938c8fbe"
 dependencies = [
- "foldhash-portable",
  "serde",
  "serde_bytes",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -6869,20 +6574,6 @@ dependencies = [
  "log",
  "rustc-hash 1.1.0",
  "slice-group-by",
- "smallvec",
-]
-
-[[package]]
-name = "regalloc2"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.15.5",
- "log",
- "rustc-hash 2.1.1",
  "smallvec",
 ]
 
@@ -7224,16 +6915,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustix-linux-procfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
-dependencies = [
- "once_cell",
- "rustix 1.1.2",
 ]
 
 [[package]]
@@ -7606,14 +7287,13 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "1.1.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2316d01592c3382277c5062105510e35e0a6bfb2851e30028485f7af8cf1240"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
 dependencies = [
- "itoa",
  "percent-encoding",
- "ryu",
  "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8070,9 +7750,9 @@ dependencies = [
 
 [[package]]
 name = "styled_components"
-version = "3.0.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99aeadac58111060ad883c7e7a01917bcecc6572243c06d41315f200cbaa9240"
+checksum = "a6db058537dae7321d7b35705641848f0e4433904325c9ecc99e099d645ed978"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -8080,18 +7760,18 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
- "swc_ecma_ast 23.0.0",
- "swc_ecma_utils 29.1.0",
- "swc_ecma_visit 23.0.0",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "3.0.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3917b257122e7cf3f46f95557af3178edaa9a3fd89fc1469768e05f01901e98"
+checksum = "1f296b6ef106e930a8138f6356bea12a53deccd7f5e0c686b67bcf2d49661d2a"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -8101,7 +7781,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
+ "swc_common 18.0.1",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_compat",
@@ -8109,12 +7789,12 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast 23.0.0",
- "swc_ecma_minifier",
- "swc_ecma_parser 38.0.2",
- "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_utils 29.1.0",
- "swc_ecma_visit 23.0.0",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_minifier 45.0.1",
+ "swc_ecma_parser 34.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -8124,6 +7804,58 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "swc"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fcdf3eb0f7f3aced6002421a1cde696d1bafd5070acf44c4b27164603f608"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes-str",
+ "dashmap 5.5.3",
+ "either",
+ "indexmap 2.13.0",
+ "jsonc-parser",
+ "once_cell",
+ "par-core",
+ "par-iter",
+ "parking_lot",
+ "regex",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_compiler_base 48.0.0",
+ "swc_config 3.1.2",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_codegen 23.0.0",
+ "swc_ecma_ext_transforms 26.0.0",
+ "swc_ecma_loader 18.0.0",
+ "swc_ecma_minifier 45.0.1",
+ "swc_ecma_parser 34.0.0",
+ "swc_ecma_preset_env 48.0.0",
+ "swc_ecma_transforms 47.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_transforms_compat 43.0.0",
+ "swc_ecma_transforms_optimization 39.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "swc_error_reporters 20.0.1",
+ "swc_node_comments 18.0.0",
+ "swc_plugin_backend_wasmer 7.0.0",
+ "swc_plugin_proxy 20.0.0",
+ "swc_plugin_runner 24.0.0",
+ "swc_sourcemap 9.3.4",
+ "swc_timer",
+ "swc_transform_common 12.0.0",
+ "swc_visit",
+ "tokio",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "swc"
@@ -8148,29 +7880,29 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_compiler_base",
- "swc_config",
+ "swc_compiler_base 54.0.0",
+ "swc_config 4.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen 26.0.1",
- "swc_ecma_ext_transforms",
- "swc_ecma_loader",
- "swc_ecma_minifier",
+ "swc_ecma_ext_transforms 29.0.0",
+ "swc_ecma_loader 21.0.0",
+ "swc_ecma_minifier 51.1.0",
  "swc_ecma_parser 38.0.2",
- "swc_ecma_preset_env",
- "swc_ecma_transforms",
+ "swc_ecma_preset_env 52.0.0",
+ "swc_ecma_transforms 51.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_compat",
- "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_compat 47.0.0",
+ "swc_ecma_transforms_optimization 43.0.0",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
- "swc_error_reporters",
- "swc_node_comments",
- "swc_plugin_backend_wasmer",
- "swc_plugin_proxy",
- "swc_plugin_runner",
- "swc_sourcemap",
+ "swc_error_reporters 23.0.0",
+ "swc_node_comments 21.0.0",
+ "swc_plugin_backend_wasmer 10.0.0",
+ "swc_plugin_proxy 23.0.0",
+ "swc_plugin_runner 27.0.0",
+ "swc_sourcemap 10.0.2",
  "swc_timer",
- "swc_transform_common",
+ "swc_transform_common 15.0.0",
  "swc_visit",
  "tokio",
  "tracing",
@@ -8228,17 +7960,25 @@ dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
+ "bytecheck 0.8.2",
  "bytes-str",
+ "cbor4ii",
  "either",
  "from_variant",
  "num-bigint",
  "once_cell",
+ "parking_lot",
+ "rancor",
+ "rkyv 0.8.12",
  "rustc-hash 2.1.1",
  "serde",
+ "shrink-to-fit",
  "siphasher 0.3.11",
  "swc_atoms",
  "swc_eq_ignore_macros",
+ "swc_sourcemap 9.3.4",
  "swc_visit",
+ "termcolor",
  "tracing",
  "unicode-width 0.2.2",
  "url",
@@ -8265,16 +8005,41 @@ dependencies = [
  "rkyv 0.8.12",
  "rustc-hash 2.1.1",
  "serde",
- "shrink-to-fit",
  "siphasher 0.3.11",
  "swc_atoms",
  "swc_eq_ignore_macros",
- "swc_sourcemap",
+ "swc_sourcemap 10.0.2",
  "swc_visit",
  "termcolor",
  "tracing",
  "unicode-width 0.2.2",
  "url",
+]
+
+[[package]]
+name = "swc_compiler_base"
+version = "48.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd68ff549974c02a5b3932a2b58938c168e01d7ac4663590afa96968fdcb4fc8"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes-str",
+ "once_cell",
+ "pathdiff",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_config 3.1.2",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_codegen 23.0.0",
+ "swc_ecma_minifier 45.0.1",
+ "swc_ecma_parser 34.0.0",
+ "swc_ecma_visit 20.0.0",
+ "swc_sourcemap 9.3.4",
+ "swc_timer",
 ]
 
 [[package]]
@@ -8293,14 +8058,35 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_config",
+ "swc_config 4.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen 26.0.1",
- "swc_ecma_minifier",
+ "swc_ecma_minifier 51.1.0",
  "swc_ecma_parser 38.0.2",
  "swc_ecma_visit 23.0.0",
- "swc_sourcemap",
+ "swc_sourcemap 10.0.2",
  "swc_timer",
+]
+
+[[package]]
+name = "swc_config"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e90b52ee734ded867104612218101722ad87ff4cf74fe30383bd244a533f97"
+dependencies = [
+ "anyhow",
+ "bytes-str",
+ "dashmap 5.5.3",
+ "globset",
+ "indexmap 2.13.0",
+ "once_cell",
+ "regex",
+ "regress",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "swc_config_macro",
+ "swc_sourcemap 9.3.4",
 ]
 
 [[package]]
@@ -8321,7 +8107,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_config_macro",
- "swc_sourcemap",
+ "swc_sourcemap 10.0.2",
 ]
 
 [[package]]
@@ -8355,60 +8141,88 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
+version = "57.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb84a28511166b70a7e651b730d99bd4d3e2914ede7009d77c65afbcdbae0ce"
+dependencies = [
+ "par-core",
+ "swc 55.0.0",
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_codegen 23.0.0",
+ "swc_ecma_lints",
+ "swc_ecma_loader 18.0.0",
+ "swc_ecma_minifier 45.0.1",
+ "swc_ecma_parser 34.0.0",
+ "swc_ecma_preset_env 48.0.0",
+ "swc_ecma_quote_macros",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_transforms_optimization 39.0.0",
+ "swc_ecma_transforms_proposal 37.0.0",
+ "swc_ecma_transforms_react 41.0.1",
+ "swc_ecma_transforms_typescript 41.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "swc_plugin_proxy 20.0.0",
+ "swc_plugin_runner 24.0.0",
+ "testing 19.0.0",
+ "vergen",
+]
+
+[[package]]
+name = "swc_core"
 version = "63.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb9470306b0d532da617be037de878f64ec0f04cb364d920e8cee05d658d66de"
 dependencies = [
  "par-core",
- "swc",
+ "swc 61.0.0",
  "swc_allocator",
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen 26.0.1",
- "swc_ecma_lints",
- "swc_ecma_loader",
- "swc_ecma_minifier",
+ "swc_ecma_loader 21.0.0",
+ "swc_ecma_minifier 51.1.0",
  "swc_ecma_parser 38.0.2",
- "swc_ecma_preset_env",
- "swc_ecma_quote_macros",
+ "swc_ecma_preset_env 52.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_optimization",
- "swc_ecma_transforms_proposal",
- "swc_ecma_transforms_react",
- "swc_ecma_transforms_typescript",
+ "swc_ecma_transforms_optimization 43.0.0",
+ "swc_ecma_transforms_react 45.0.0",
+ "swc_ecma_transforms_typescript 45.0.2",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
- "swc_plugin_proxy",
- "swc_plugin_runner",
- "testing",
+ "swc_plugin_proxy 23.0.0",
+ "swc_plugin_runner 27.0.0",
  "vergen",
 ]
 
 [[package]]
 name = "swc_css_ast"
-version = "21.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff309da4fdd0f4714dd0713f33279fac51c8f93e07750061d9c34fbe37a6860"
+checksum = "b88e8591e125ef6675325e58a2cf290a19f24083bdfdb125bcb134b1a3ac0c8b"
 dependencies = [
  "is-macro",
  "string_enum",
  "swc_atoms",
- "swc_common 21.0.1",
+ "swc_common 18.0.1",
 ]
 
 [[package]]
 name = "swc_css_codegen"
-version = "21.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aadad5a5d4dd5f08a3e772e325974dc9df2498dbc262093ba80fcb8304c004c"
+checksum = "7287baacc8ea51cffb8ef7233eac665eda0f72b04b07ec8d8c60070f2243dfb6"
 dependencies = [
  "auto_impl",
  "bitflags 2.9.4",
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
+ "swc_common 18.0.1",
  "swc_css_ast",
  "swc_css_codegen_macros",
  "swc_css_utils",
@@ -8426,14 +8240,14 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "21.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea25a7967900779f91066a3afe13f598e81bbcc3cff667a0dbe4e7c48f6e9ba"
+checksum = "774a552c784bf3f4b4109fa68800e02ae7908234d64f29f4fc7ed00a03e01a40"
 dependencies = [
  "bitflags 2.9.4",
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
+ "swc_common 18.0.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -8441,14 +8255,14 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "21.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c025e12b2b2c1e6e5e5c510e5273b7d5bf1cf49c3bbcaaca7b3ad513d25d43"
+checksum = "ecefd72f5a5c251f4e140674da3151380273dc784c66b481a3f7f7c6ea949519"
 dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
+ "swc_common 18.0.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -8456,22 +8270,22 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "21.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f512fc138752963c667d42e525784a14ad3be9d94caf31f96c628e6241b7f6d4"
+checksum = "8c8e9de84010575a6ecaff74a750fe55e579cf4b2ff4876f7ad23b8e8951c626"
 dependencies = [
  "lexical",
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
+ "swc_common 18.0.1",
  "swc_css_ast",
 ]
 
 [[package]]
 name = "swc_css_prefixer"
-version = "25.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a896bd66b62de8710cb66aa83db19871c51ce309c19a344b74198621275515"
+checksum = "b3bfe41b2281df544babf42a88399af3753212b8dbb0cedbf7cac9980f0e4e6a"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -8479,7 +8293,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 21.0.1",
+ "swc_common 18.0.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -8487,9 +8301,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "21.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3813f5bb082bcf15d825c60ea5304394f40d161b8949c5f67e66b92dd545484"
+checksum = "673ff16d1f6f29ca8ef038b08385b8c173703c98e47543b05f7beeac3bf14b32"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.1",
@@ -8502,13 +8316,13 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "21.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16cd73f86ec2fe7df85499a63abb4b4f956b24bf1e3540dacb598406e2e14c6"
+checksum = "bf9564e30ba8af784ac9bd8355a35ec51a3e4aa3ee86495e8cb4b182c6c53a51"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
+ "swc_common 18.0.1",
  "swc_css_ast",
  "swc_visit",
 ]
@@ -8520,11 +8334,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252124d0d786aa2338860701a067c93488747dfadbfedb16ac78f386e16a0ac4"
 dependencies = [
  "bitflags 2.9.4",
+ "cbor4ii",
  "is-macro",
  "num-bigint",
  "once_cell",
  "phf",
  "rustc-hash 2.1.1",
+ "serde",
+ "shrink-to-fit",
  "string_enum",
  "swc_atoms",
  "swc_common 18.0.1",
@@ -8546,7 +8363,6 @@ dependencies = [
  "phf",
  "rustc-hash 2.1.1",
  "serde",
- "shrink-to-fit",
  "string_enum",
  "swc_atoms",
  "swc_common 21.0.1",
@@ -8613,6 +8429,24 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c427e6db46fc66b2e5d53f191e798b8d991c22cf47fa495c6c968332cfccb548"
+dependencies = [
+ "rustc-hash 2.1.1",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_compat_es2015 42.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_bugfixes"
 version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22d4da77f7014b5efd416bb5208ab6e3d005ad5d532df8ced2904e50ca233d44"
@@ -8621,12 +8455,24 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_es2015",
+ "swc_ecma_compat_es2015 45.0.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
  "swc_trace_macro",
  "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_common"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a11705dc2b2a534e86317056bf85f6dfbc3d188cfd44dd07eb6b986800386"
+dependencies = [
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_utils 26.0.1",
 ]
 
 [[package]]
@@ -8637,8 +8483,36 @@ checksum = "d72d7d499e4bd4059ccfe432c1a52111a28fdd2b49b3882f18108fddfa3f6b4f"
 dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_utils 29.1.0",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2015"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0dccce1836d0c15e9e7114eef1dc39973efd45a8eb266251e551fac12a6cb7"
+dependencies = [
+ "arrayvec",
+ "indexmap 2.13.0",
+ "is-macro",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_config 3.1.2",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_compat_common 33.0.0",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_transforms_classes 37.0.0",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "swc_trace_macro",
+ "tracing",
 ]
 
 [[package]]
@@ -8656,16 +8530,29 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_config",
+ "swc_config 4.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_common",
- "swc_ecma_transformer",
+ "swc_ecma_compat_common 37.0.0",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_classes",
+ "swc_ecma_transforms_classes 41.0.1",
  "swc_ecma_transforms_macros",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
  "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2016"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce774431cd21cbb724e29c20e84ed98cbcb5e2b362cc3fa34a35c78b459af66f"
+dependencies = [
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8676,9 +8563,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1358f912b0b5bdb6509f64dada8dc9ac8dc9233175b1d033c571cd34ad0bbec"
 dependencies = [
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2017"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9201214d7b7337c9bd33b0a29e7993b93b6392f73dabf1290bbd9fe28be78eae"
+dependencies = [
+ "serde",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8691,9 +8593,23 @@ dependencies = [
  "serde",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2018"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518959bc86ab0e9717cf1877db13858ff3f5312dad877521b90a782dd2d3c242"
+dependencies = [
+ "serde",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8705,9 +8621,23 @@ checksum = "27ffcf499581d598250e4d93d45ef64fe81b16f83c3bcb8c21d27af2004e6f54"
 dependencies = [
  "serde",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2019"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e292d39a97e708841e6fb5c135e23d9df9f8194945eecef8cc63e9f999a700"
+dependencies = [
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8719,9 +8649,26 @@ checksum = "5125766d7ca9c4789eefdb68fd9d1bc9eba1119df21ad3d1fd7b0ac2808893d0"
 dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2020"
+version = "40.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9110bdfd1614351237e67727511b60c0fd070ccec0c8dc7a2b1d7e67ebb4b70"
+dependencies = [
+ "serde",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_compat_es2022 40.0.0",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
  "tracing",
 ]
 
@@ -8734,11 +8681,24 @@ dependencies = [
  "serde",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_es2022",
- "swc_ecma_transformer",
+ "swc_ecma_compat_es2022 44.0.0",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2021"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bdf4e0547ba148491e8d00fff315f40d54c928d4dda75f7325106bad5a05002"
+dependencies = [
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8749,9 +8709,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64ee2ff23cdc2bb9749f3fb730bd4a95cc26cdea84b384b85574a1ab43f78af"
 dependencies = [
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_compat_es2022"
+version = "40.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4251437fce71eb2c4cb24fcc332a74b47682cc8153c1f9dcf8c4add09a20e24c"
+dependencies = [
+ "rustc-hash 2.1.1",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_transforms_classes 37.0.0",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "swc_trace_macro",
  "tracing",
 ]
 
@@ -8765,9 +8745,9 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer",
+ "swc_ecma_transformer 13.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_classes",
+ "swc_ecma_transforms_classes 41.0.1",
  "swc_ecma_transforms_macros",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
@@ -8777,13 +8757,37 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_regexp"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c267d92e58db3f3c00cf3f7e93ee72391f5cc2d9a5877db63ca95d7495a535"
+dependencies = [
+ "icu_properties",
+ "swc_ecma_regexp_ast 0.7.0",
+ "swc_ecma_regexp_visit 0.7.0",
+]
+
+[[package]]
+name = "swc_ecma_compat_regexp"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf01bca3c32928c9cbc436f05efce56b5007ace2b3ac870eb710211b0fffa570"
 dependencies = [
  "icu_properties",
- "swc_ecma_regexp_ast",
- "swc_ecma_regexp_visit",
+ "swc_ecma_regexp_ast 0.10.0",
+ "swc_ecma_regexp_visit 0.10.0",
+]
+
+[[package]]
+name = "swc_ecma_ext_transforms"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a6aed670f87cde675f40dcd0ff5196f3cec9b2bc7e6fed12adf5b808f18eb69"
+dependencies = [
+ "phf",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
 ]
 
 [[package]]
@@ -8801,6 +8805,18 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_hooks"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9adff1f01550ef653e262ad709a2914d3dd6cfd559aea2e28eeeab8f895981"
+dependencies = [
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_visit 20.0.0",
+]
+
+[[package]]
+name = "swc_ecma_hooks"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee7662517362f6726b0e107a3caec2b4cc7d629f9bf702958948e9350722e52f"
@@ -8813,9 +8829,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "30.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003fdf93059f1c505ed81463ccf49230db69bb5003ff09606a6732f34ef81506"
+checksum = "b21488b346ed189e52c641259307eb6d5e322f3c832696358a661660ce8e8932"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -8825,11 +8841,33 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
- "swc_config",
- "swc_ecma_ast 23.0.0",
- "swc_ecma_utils 29.1.0",
- "swc_ecma_visit 23.0.0",
+ "swc_common 18.0.1",
+ "swc_config 3.1.2",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+]
+
+[[package]]
+name = "swc_ecma_loader"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b36b38399698e77c3d63838c2e32e40df0d5e55e489bef529a77a349a722c7a"
+dependencies = [
+ "anyhow",
+ "dashmap 5.5.3",
+ "lru",
+ "normpath",
+ "once_cell",
+ "parking_lot",
+ "path-clean 0.1.0",
+ "pathdiff",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "tracing",
 ]
 
 [[package]]
@@ -8856,6 +8894,43 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34b819aa304facc7d87912842adeb413730816055f693d5190a9207f5b0aa01"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.9.4",
+ "indexmap 2.13.0",
+ "num-bigint",
+ "num_cpus",
+ "once_cell",
+ "par-core",
+ "par-iter",
+ "parking_lot",
+ "phf",
+ "radix_fmt",
+ "rustc-hash 2.1.1",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_config 3.1.2",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_codegen 23.0.0",
+ "swc_ecma_hooks 0.4.0",
+ "swc_ecma_parser 34.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_transforms_optimization 39.0.0",
+ "swc_ecma_usage_analyzer",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "swc_timer",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_minifier"
 version = "51.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c25a685c2efe2f88ba359dde0a17382b28a206ea21b23bda612f97b2c423b2f2"
@@ -8877,13 +8952,13 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_config",
+ "swc_config 4.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen 26.0.1",
- "swc_ecma_hooks",
+ "swc_ecma_hooks 0.7.0",
  "swc_ecma_parser 38.0.2",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_optimization 43.0.0",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
  "swc_timer",
@@ -8912,6 +8987,27 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18271343933dfa820caba5fabb36118b1cfbf0010702a2947c8bf81b9154e36c"
+dependencies = [
+ "bitflags 2.9.4",
+ "either",
+ "num-bigint",
+ "phf",
+ "rustc-hash 2.1.1",
+ "seq-macro",
+ "serde",
+ "smartstring",
+ "stacker",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_parser"
 version = "38.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c251d44e048647b5335861d1585b3e95fa8bc74f6e7a40570b0ea95d27ba66"
@@ -8924,11 +9020,35 @@ dependencies = [
  "seq-macro",
  "serde",
  "smartstring",
- "stacker",
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "tracing",
+]
+
+[[package]]
+name = "swc_ecma_preset_env"
+version = "48.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3903fcc6dc4f51e898c643ece06bab6591237d466e0e69226810677b48bcbeb"
+dependencies = [
+ "anyhow",
+ "foldhash 0.1.5",
+ "indexmap 2.13.0",
+ "once_cell",
+ "precomputed-map",
+ "preset_env_base",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "string_enum",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transformer 9.0.0",
+ "swc_ecma_transforms 47.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
 ]
 
 [[package]]
@@ -8950,28 +9070,44 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer",
- "swc_ecma_transforms",
+ "swc_ecma_transformer 13.0.0",
+ "swc_ecma_transforms 51.0.0",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "38.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16896c184ff6915c85ee4bffd08db32e010b1c1a9628e6c4ee49a233653c20a7"
+checksum = "3adaa86c70b29508cc8ed9a4ff9690e5e47fffc12ac36a12ee4abe4acec16edd"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common 21.0.1",
- "swc_ecma_ast 23.0.0",
- "swc_ecma_parser 38.0.2",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_parser 34.0.0",
  "swc_macros_common",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "swc_ecma_regexp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb1c912d1f73009546bc8271feb40a2371f148fcde6a4b6f4973a1ce167bc07"
+dependencies = [
+ "phf",
+ "rustc-hash 2.1.1",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_regexp_ast 0.7.0",
+ "swc_ecma_regexp_common",
+ "swc_ecma_regexp_visit 0.7.0",
+ "unicode-id-start",
 ]
 
 [[package]]
@@ -8984,10 +9120,23 @@ dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_ecma_regexp_ast",
+ "swc_ecma_regexp_ast 0.10.0",
  "swc_ecma_regexp_common",
- "swc_ecma_regexp_visit",
+ "swc_ecma_regexp_visit 0.10.0",
  "unicode-id-start",
+]
+
+[[package]]
+name = "swc_ecma_regexp_ast"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568b408134ad2e201cd48db4d1ed7bed40abbec6e242fb8492a066834f674b11"
+dependencies = [
+ "bitflags 2.9.4",
+ "is-macro",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_regexp_common",
 ]
 
 [[package]]
@@ -9011,6 +9160,19 @@ checksum = "0a0a09a9e4dc09c97f07273695bd4b58e46b99dbb0cb788ce0dad2a181eb1e94"
 
 [[package]]
 name = "swc_ecma_regexp_visit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258ea946dddb367af135b8255c6ddd0b86a066f3d3c7d4bca2e624b77cd1b51f"
+dependencies = [
+ "serde",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_regexp_ast 0.7.0",
+ "swc_visit",
+]
+
+[[package]]
+name = "swc_ecma_regexp_visit"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73317054bba9a6fed553ce2c830702b8602fc5f5c08d9328bd3ab9d8489ce827"
@@ -9018,8 +9180,27 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_ecma_regexp_ast",
+ "swc_ecma_regexp_ast 0.10.0",
  "swc_visit",
+]
+
+[[package]]
+name = "swc_ecma_transformer"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133f705294aa6319310a98eed2e140ab34116f71b17174e2a994bb159d51fe9b"
+dependencies = [
+ "rustc-hash 2.1.1",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_compat_regexp 1.0.0",
+ "swc_ecma_hooks 0.4.0",
+ "swc_ecma_regexp 0.7.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "tracing",
 ]
 
 [[package]]
@@ -9032,13 +9213,31 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_regexp",
- "swc_ecma_hooks",
- "swc_ecma_regexp",
+ "swc_ecma_compat_regexp 4.0.0",
+ "swc_ecma_hooks 0.7.0",
+ "swc_ecma_regexp 0.10.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
  "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms"
+version = "47.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbe202e4a5b51a9f29275eac42fb785e907ac359edc61984788ff046b4fb20f"
+dependencies = [
+ "par-core",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_transforms_compat 43.0.0",
+ "swc_ecma_transforms_optimization 39.0.0",
+ "swc_ecma_transforms_proposal 37.0.0",
+ "swc_ecma_transforms_react 41.0.1",
+ "swc_ecma_transforms_typescript 41.0.0",
+ "swc_ecma_utils 26.0.1",
 ]
 
 [[package]]
@@ -9051,11 +9250,11 @@ dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_compat",
- "swc_ecma_transforms_optimization",
- "swc_ecma_transforms_proposal",
- "swc_ecma_transforms_react",
- "swc_ecma_transforms_typescript",
+ "swc_ecma_transforms_compat 47.0.0",
+ "swc_ecma_transforms_optimization 43.0.0",
+ "swc_ecma_transforms_proposal 41.0.3",
+ "swc_ecma_transforms_react 45.0.0",
+ "swc_ecma_transforms_typescript 45.0.2",
  "swc_ecma_utils 29.1.0",
 ]
 
@@ -9076,6 +9275,28 @@ dependencies = [
  "swc_common 18.0.1",
  "swc_ecma_ast 20.0.1",
  "swc_ecma_parser 33.0.1",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcea2b456609d624513ebd884c7152d5b1a04ad5dd8fcb957e00e8993387ed00"
+dependencies = [
+ "better_scoped_tls",
+ "indexmap 2.13.0",
+ "once_cell",
+ "par-core",
+ "phf",
+ "rustc-hash 2.1.1",
+ "serde",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_parser 34.0.0",
  "swc_ecma_utils 26.0.1",
  "swc_ecma_visit 20.0.0",
  "tracing",
@@ -9105,6 +9326,19 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd626c92e18463806ec5822d5cd6841e6903f92b7e6bd7348dba2179274932b"
+dependencies = [
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+]
+
+[[package]]
+name = "swc_ecma_transforms_classes"
 version = "41.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ffae23e996fa1a7b20b77ff599aa0e4997a6eb21369e2e5e906c91b89fdffaa"
@@ -9114,6 +9348,34 @@ dependencies = [
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
+]
+
+[[package]]
+name = "swc_ecma_transforms_compat"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed73c7ec4346508a9d63b98e2759b5da04e61667e5df1fd4d8ccfe629a75c45d"
+dependencies = [
+ "indexmap 2.13.0",
+ "par-core",
+ "serde",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_compat_bugfixes 42.0.0",
+ "swc_ecma_compat_common 33.0.0",
+ "swc_ecma_compat_es2015 42.0.0",
+ "swc_ecma_compat_es2016 38.0.0",
+ "swc_ecma_compat_es2017 38.0.0",
+ "swc_ecma_compat_es2018 39.0.0",
+ "swc_ecma_compat_es2019 38.0.0",
+ "swc_ecma_compat_es2020 40.0.0",
+ "swc_ecma_compat_es2021 38.0.0",
+ "swc_ecma_compat_es2022 40.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "tracing",
 ]
 
 [[package]]
@@ -9128,16 +9390,16 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_bugfixes",
- "swc_ecma_compat_common",
- "swc_ecma_compat_es2015",
- "swc_ecma_compat_es2016",
- "swc_ecma_compat_es2017",
- "swc_ecma_compat_es2018",
- "swc_ecma_compat_es2019",
- "swc_ecma_compat_es2020",
- "swc_ecma_compat_es2021",
- "swc_ecma_compat_es2022",
+ "swc_ecma_compat_bugfixes 46.0.0",
+ "swc_ecma_compat_common 37.0.0",
+ "swc_ecma_compat_es2015 45.0.0",
+ "swc_ecma_compat_es2016 42.0.0",
+ "swc_ecma_compat_es2017 42.0.0",
+ "swc_ecma_compat_es2018 43.0.0",
+ "swc_ecma_compat_es2019 42.0.0",
+ "swc_ecma_compat_es2020 44.0.0",
+ "swc_ecma_compat_es2021 42.0.0",
+ "swc_ecma_compat_es2022 44.0.0",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
@@ -9154,6 +9416,30 @@ dependencies = [
  "quote",
  "swc_macros_common",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "swc_ecma_transforms_optimization"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4701cee4bde4d90fba49381dd4de25c18ff60cefcfc4f45f4f1f1045c1cc83b2"
+dependencies = [
+ "bytes-str",
+ "dashmap 5.5.3",
+ "indexmap 2.13.0",
+ "once_cell",
+ "par-core",
+ "petgraph 0.7.1",
+ "rustc-hash 2.1.1",
+ "serde_json",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_parser 34.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "tracing",
 ]
 
 [[package]]
@@ -9182,6 +9468,24 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b05992a81ecd5d1bda71ae1f7300d28d466dde6fbd0e5dc1084f4325e6a097"
+dependencies = [
+ "either",
+ "rustc-hash 2.1.1",
+ "serde",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_transforms_classes 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+]
+
+[[package]]
+name = "swc_ecma_transforms_proposal"
 version = "41.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c49fd90ad7ef87cfacb9e15eb939bfecac83fe6638fdd4f94a31eff56b8276"
@@ -9193,9 +9497,34 @@ dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_classes",
+ "swc_ecma_transforms_classes 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
+]
+
+[[package]]
+name = "swc_ecma_transforms_react"
+version = "41.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e071551d429c184f40080696ee0bcbd54ccf75bf11569302b6dc5de106a6984"
+dependencies = [
+ "base64 0.22.1",
+ "bytes-str",
+ "indexmap 2.13.0",
+ "once_cell",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sha1",
+ "string_enum",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_config 3.1.2",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_hooks 0.4.0",
+ "swc_ecma_parser 34.0.0",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
 ]
 
 [[package]]
@@ -9214,13 +9543,31 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_config",
+ "swc_config 4.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_hooks",
+ "swc_ecma_hooks 0.7.0",
  "swc_ecma_parser 38.0.2",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
+]
+
+[[package]]
+name = "swc_ecma_transforms_typescript"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59c1d87f4c36161833462cbf16d769fce63158da04a42dbb83c8fac7ee8e04e"
+dependencies = [
+ "bytes-str",
+ "rustc-hash 2.1.1",
+ "serde",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_transforms_base 37.0.0",
+ "swc_ecma_transforms_react 41.0.1",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
 ]
 
 [[package]]
@@ -9236,9 +9583,27 @@ dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_react",
+ "swc_ecma_transforms_react 45.0.0",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
+]
+
+[[package]]
+name = "swc_ecma_usage_analyzer"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7aec80849cab609d92af5dd2670f18fc760f7029beb11beebcef3fed9ba3466"
+dependencies = [
+ "bitflags 2.9.4",
+ "indexmap 2.13.0",
+ "rustc-hash 2.1.1",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "swc_timer",
+ "tracing",
 ]
 
 [[package]]
@@ -9287,6 +9652,7 @@ checksum = "e971a258717db3dc8939c38410d8b8cb8126f1b05b9758672daa7cae3e0248c2"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
+ "serde",
  "swc_atoms",
  "swc_common 18.0.1",
  "swc_ecma_ast 20.0.1",
@@ -9302,7 +9668,6 @@ checksum = "ad65d392ed427dc9e94f16a3d802b02e27722c21227639c8d5f45f19757b447b"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
- "serde",
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
@@ -9312,9 +9677,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "3.0.0"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8058e754b05eb672671b71974c4f79673b32bc2a2763706ba6970f8d2c86f"
+checksum = "2bab802f4dfb3e9e21c5d7350776270fa436a164a83ff05991f1ddb1c849d25d"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -9325,13 +9690,13 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 21.0.1",
- "swc_ecma_ast 23.0.0",
- "swc_ecma_codegen 26.0.1",
- "swc_ecma_transforms",
- "swc_ecma_utils 29.1.0",
- "swc_ecma_visit 23.0.0",
- "swc_sourcemap",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_codegen 23.0.0",
+ "swc_ecma_transforms 47.0.0",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
+ "swc_sourcemap 9.3.4",
  "swc_trace_macro",
  "tracing",
 ]
@@ -9345,6 +9710,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "swc_error_reporters"
+version = "20.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3615d499e30e5bc4d53978d1fc4c1975c8be9acc79f42b5956bbca7fc7c6dc58"
+dependencies = [
+ "anyhow",
+ "miette",
+ "once_cell",
+ "serde",
+ "swc_common 18.0.1",
 ]
 
 [[package]]
@@ -9373,6 +9751,18 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e110f3d5684e9c087450ee522d4b8ba68fd91964992984032cc00194a212cde4"
+dependencies = [
+ "dashmap 5.5.3",
+ "rustc-hash 2.1.1",
+ "swc_atoms",
+ "swc_common 18.0.1",
+]
+
+[[package]]
+name = "swc_node_comments"
 version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acde6aa6ba214763f3bfc1f34686eed44266b9e602717e579f662ee2a3537f1"
@@ -9385,6 +9775,22 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_backend_wasmer"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a6a8648be03aaeaac5251823651d9b9c86a57db5e43064764c6b7fa5437d99"
+dependencies = [
+ "anyhow",
+ "enumset",
+ "parking_lot",
+ "swc_common 18.0.1",
+ "swc_plugin_runner 24.0.0",
+ "wasmer",
+ "wasmer-compiler-cranelift",
+ "wasmer-wasix",
+]
+
+[[package]]
+name = "swc_plugin_backend_wasmer"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78073d9b7e0c9fba6a21531fc1bb73d812ee8fc1d08616cf45b2fe0ade8da8ec"
@@ -9393,23 +9799,10 @@ dependencies = [
  "enumset",
  "parking_lot",
  "swc_common 21.0.1",
- "swc_plugin_runner",
+ "swc_plugin_runner 27.0.0",
  "wasmer",
  "wasmer-compiler-cranelift",
  "wasmer-wasix",
-]
-
-[[package]]
-name = "swc_plugin_backend_wasmtime"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80db3340ec910c54bb4c418cd838e51bd3574982d81debc8ffb1c28640931d10"
-dependencies = [
- "anyhow",
- "swc_common 21.0.1",
- "swc_plugin_runner",
- "wasi-common",
- "wasmtime",
 ]
 
 [[package]]
@@ -9421,6 +9814,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "swc_plugin_proxy"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78e1a9d26be495289cb07b9d73222f92f60b74d47904169d3ce4977600ec11e"
+dependencies = [
+ "better_scoped_tls",
+ "cbor4ii",
+ "rustc-hash 2.1.1",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_trace_macro",
+ "tracing",
 ]
 
 [[package]]
@@ -9440,6 +9848,27 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a48f119fba50bb6bbf54366fc37a7e0c4d94a641936a082330cc6ab8e3f947d"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "parking_lot",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_plugin_proxy 20.0.0",
+ "swc_transform_common 12.0.0",
+ "tracing",
+ "vergen",
+]
+
+[[package]]
+name = "swc_plugin_runner"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff8883348391cfcf1911454282a8c664cf4727b79f6c0d81457f7add873e64fb"
@@ -9453,28 +9882,47 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_plugin_proxy",
- "swc_transform_common",
+ "swc_plugin_proxy 23.0.0",
+ "swc_transform_common 15.0.0",
  "tracing",
  "vergen",
 ]
 
 [[package]]
 name = "swc_relay"
-version = "3.0.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a0e98d0497d914f2a0736be9be050af6c3c0fbb2a9d911dae40379fffcc7c8"
+checksum = "0afe4c35ddca5ad570916267c11e019ac91c85b5864ff6e66c6bb06ddabc239b"
 dependencies = [
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 21.0.1",
- "swc_ecma_ast 23.0.0",
- "swc_ecma_utils 29.1.0",
- "swc_ecma_visit 23.0.0",
+ "swc_common 18.0.1",
+ "swc_ecma_ast 20.0.1",
+ "swc_ecma_utils 26.0.1",
+ "swc_ecma_visit 20.0.0",
  "tracing",
+]
+
+[[package]]
+name = "swc_sourcemap"
+version = "9.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de08ef00f816acdd1a58ee8a81c0e1a59eefef2093aefe5611f256fa6b64c4d7"
+dependencies = [
+ "base64-simd 0.8.0",
+ "bitvec",
+ "bytes-str",
+ "data-encoding",
+ "debugid",
+ "if_chain",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "unicode-id-start",
+ "url",
 ]
 
 [[package]]
@@ -9513,6 +9961,18 @@ checksum = "dfd2b4b0adb82e36f2ac688d00a6a67132c7f4170c772617516793a701be89e8"
 dependencies = [
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "swc_transform_common"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc4a0e2aa9fac44d383127e01327710416dda5b637b0d134b7b8cf2ba6bde8e"
+dependencies = [
+ "better_scoped_tls",
+ "rustc-hash 2.1.1",
+ "serde",
+ "swc_common 18.0.1",
 ]
 
 [[package]]
@@ -9601,22 +10061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags 2.9.4",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.44",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9644,12 +10088,6 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -9704,6 +10142,27 @@ dependencies = [
 
 [[package]]
 name = "testing"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1506c602222ebab5d96100180f8d3c015b2394eceb00a46d20c25b8b1e5100"
+dependencies = [
+ "cargo_metadata 0.18.1",
+ "difference",
+ "once_cell",
+ "pretty_assertions",
+ "regex",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "swc_common 18.0.1",
+ "swc_error_reporters 20.0.1",
+ "testing_macros",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "testing"
 version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd50c53833442165fa5bf385497986c6ca501e8cf2df442919f5475aded14134"
@@ -9717,7 +10176,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common 21.0.1",
- "swc_error_reporters",
+ "swc_error_reporters 23.0.0",
  "testing_macros",
  "tracing",
  "tracing-subscriber",
@@ -10367,6 +10826,7 @@ name = "turbo-persistence"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "bitfield",
  "byteorder",
  "crc32fast",
@@ -10377,15 +10837,15 @@ dependencies = [
  "memmap2 0.9.8",
  "nohash-hasher",
  "parking_lot",
- "postcard",
+ "pot",
  "qfilter",
  "quick_cache",
  "rustc-hash 2.1.1",
  "smallvec",
  "thread_local",
  "tracing",
- "xxhash-rust",
- "zerocopy",
+ "turbo-bincode",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -10398,17 +10858,13 @@ version = "0.1.0"
 dependencies = [
  "bincode 2.0.1",
  "bytes-str",
- "inventory",
  "napi",
  "new_debug_unreachable",
  "rustc-hash 2.1.1",
  "serde",
  "shrink-to-fit",
- "smallvec",
  "triomphe 0.1.12",
- "turbo-bincode",
  "turbo-tasks-hash",
- "unty",
 ]
 
 [[package]]
@@ -10427,6 +10883,7 @@ dependencies = [
  "futures",
  "indexmap 2.13.0",
  "inventory",
+ "once_cell",
  "parking_lot",
  "pin-project-lite",
  "rayon",
@@ -10455,14 +10912,16 @@ name = "turbo-tasks-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "auto-hash-map",
  "bincode 2.0.1",
  "bitfield",
- "crossbeam-utils",
+ "byteorder",
  "dashmap 6.1.0",
  "either",
  "hashbrown 0.14.5",
  "indexmap 2.13.0",
+ "once_cell",
  "parking_lot",
  "rand 0.10.0",
  "ringmap",
@@ -10510,7 +10969,6 @@ name = "turbo-tasks-fetch"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "quick_cache",
  "reqwest 0.13.2",
  "rustls",
@@ -10569,9 +11027,8 @@ dependencies = [
  "data-encoding",
  "getrandom 0.3.3",
  "sha2",
- "smallvec",
  "turbo-tasks-macros",
- "xxhash-rust",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -10592,7 +11049,6 @@ dependencies = [
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 dependencies = [
- "libmimalloc-sys",
  "mimalloc",
 ]
 
@@ -10622,7 +11078,6 @@ dependencies = [
  "turbopack-core",
  "turbopack-css",
  "turbopack-ecmascript",
- "turbopack-ecmascript-runtime",
  "turbopack-env",
  "turbopack-mdx",
  "turbopack-node",
@@ -10636,7 +11091,6 @@ name = "turbopack-browser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "bincode 2.0.1",
  "either",
  "indoc",
@@ -10651,7 +11105,6 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
- "turbopack",
  "turbopack-core",
  "turbopack-css",
  "turbopack-ecmascript",
@@ -10692,7 +11145,6 @@ dependencies = [
  "data-encoding",
  "either",
  "indexmap 2.13.0",
- "num-bigint",
  "once_cell",
  "patricia_tree",
  "petgraph 0.8.3",
@@ -10703,8 +11155,8 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "swc_core 63.1.3",
- "swc_sourcemap",
+ "swc_core 57.0.1",
+ "swc_sourcemap 9.3.4",
  "tracing",
  "turbo-bincode",
  "turbo-esregex",
@@ -10726,7 +11178,6 @@ name = "turbopack-css"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "bincode 2.0.1",
  "indoc",
  "lightningcss",
@@ -10735,7 +11186,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
- "swc_core 63.1.3",
+ "swc_core 57.0.1",
  "tokio",
  "tracing",
  "turbo-bincode",
@@ -10752,7 +11203,6 @@ name = "turbopack-dev-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "auto-hash-map",
  "bincode 2.0.1",
  "flate2",
@@ -10812,13 +11262,12 @@ dependencies = [
  "serde_json",
  "smallvec",
  "strsim 0.11.1",
- "swc_core 63.1.3",
- "swc_sourcemap",
+ "swc_core 57.0.1",
+ "swc_sourcemap 9.3.4",
  "tokio",
  "tracing",
  "turbo-bincode",
  "turbo-esregex",
- "turbo-frozenmap",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
@@ -10854,9 +11303,9 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 63.1.3",
+ "swc_core 57.0.1",
  "swc_emotion",
- "swc_plugin_backend_wasmtime",
+ "swc_plugin_backend_wasmer 7.0.0",
  "swc_relay",
  "tracing",
  "turbo-rcstr",
@@ -10876,6 +11325,7 @@ dependencies = [
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
+ "turbopack",
  "turbopack-core",
  "turbopack-ecmascript",
 ]
@@ -10885,7 +11335,6 @@ name = "turbopack-env"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-env",
@@ -10899,7 +11348,6 @@ name = "turbopack-image"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.21.7",
  "bincode 2.0.1",
  "image",
@@ -10920,7 +11368,6 @@ name = "turbopack-mdx"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "markdown",
  "mdxjs",
  "serde",
@@ -10966,7 +11413,6 @@ dependencies = [
  "turbo-tasks-bytes",
  "turbo-tasks-env",
  "turbo-tasks-fs",
- "turbo-tasks-hash",
  "turbopack-cli-utils",
  "turbopack-core",
  "turbopack-ecmascript",
@@ -10991,7 +11437,6 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
- "turbopack",
  "turbopack-core",
  "turbopack-ecmascript",
  "turbopack-ecmascript-runtime",
@@ -11003,7 +11448,6 @@ name = "turbopack-resolve"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "bincode 2.0.1",
  "next-taskless",
  "regex",
@@ -11036,7 +11480,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "parking_lot",
- "swc_core 63.1.3",
+ "swc_core 57.0.1",
  "turbo-rcstr",
  "turbo-tasks",
  "turbopack-core",
@@ -11078,8 +11522,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tungstenite 0.21.0",
- "turbo-rcstr",
- "turbo-tasks-malloc",
  "turbopack-trace-utils",
  "zstd",
 ]
@@ -11136,6 +11578,9 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "typeid"
@@ -11346,6 +11791,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "crossbeam-queue",
+ "dashmap 6.1.0",
  "deno_semver",
  "dirs 5.0.1",
  "futures",
@@ -11368,6 +11815,7 @@ dependencies = [
  "tokio-fs-ext",
  "tokio-retry",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -11687,31 +12135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi-common"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7178030744403adba447b07cd5c1d683e4b01c5521dd96e14d082f3ed2c1f29c"
-dependencies = [
- "anyhow",
- "bitflags 2.9.4",
- "cap-fs-ext",
- "cap-rand",
- "cap-std",
- "cap-time-ext",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "log",
- "rustix 1.1.2",
- "system-interface",
- "thiserror 2.0.17",
- "tracing",
- "wasmtime",
- "wiggle",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11801,16 +12224,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.239.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
@@ -11885,7 +12298,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "shared-buffer",
  "tar",
- "target-lexicon 0.12.16",
+ "target-lexicon",
  "thiserror 1.0.69",
  "tracing",
  "wasm-bindgen",
@@ -11919,7 +12332,7 @@ dependencies = [
  "self_cell",
  "shared-buffer",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon",
  "thiserror 1.0.69",
  "wasmer-types",
  "wasmer-vm",
@@ -11934,15 +12347,15 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780f9c2050941b4e3f6bb82d32bd796a6c1750d2f97cbd892f07b384bb6af6f8"
 dependencies = [
- "cranelift-codegen 0.110.2",
- "cranelift-entity 0.110.2",
- "cranelift-frontend 0.110.2",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
  "gimli 0.28.1",
  "itertools 0.12.1",
  "more-asserts",
  "rayon",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon",
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
@@ -12055,7 +12468,7 @@ dependencies = [
  "rkyv 0.8.12",
  "serde",
  "sha2",
- "target-lexicon 0.12.16",
+ "target-lexicon",
  "thiserror 1.0.69",
  "wasmparser 0.224.1",
  "xxhash-rust",
@@ -12207,19 +12620,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
-dependencies = [
- "bitflags 2.9.4",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
@@ -12242,204 +12642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3981f3d51f39f24f5fc90f93049a90f08dbbca8deba602cd46bb8ca67a94718"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.239.0",
-]
-
-[[package]]
-name = "wasmtime"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81eafc07c867be94c47e0dc66355d9785e09107a18901f76a20701ba0663ad7"
-dependencies = [
- "addr2line",
- "anyhow",
- "async-trait",
- "bitflags 2.9.4",
- "bumpalo",
- "cc",
- "cfg-if",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "libc",
- "log",
- "mach2",
- "memfd",
- "object 0.37.3",
- "once_cell",
- "postcard",
- "pulley-interpreter",
- "rustix 1.1.2",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasmparser 0.239.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78587abe085a44a13c90fa16fea6db014e9883e627a7044d7f0cb397ad08d1da"
-dependencies = [
- "anyhow",
- "cranelift-bitset 0.125.4",
- "cranelift-entity 0.125.4",
- "gimli 0.32.3",
- "indexmap 2.13.0",
- "log",
- "object 0.37.3",
- "postcard",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
- "wasmprinter",
-]
-
-[[package]]
-name = "wasmtime-internal-cranelift"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb50f1c50365c32e557266ca85acdf77696c44a3f98797ba6af58cebc6d6d1e"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen 0.125.4",
- "cranelift-control 0.125.4",
- "cranelift-entity 0.125.4",
- "cranelift-frontend 0.125.4",
- "cranelift-native",
- "gimli 0.32.3",
- "itertools 0.14.0",
- "log",
- "object 0.37.3",
- "pulley-interpreter",
- "smallvec",
- "target-lexicon 0.13.5",
- "thiserror 2.0.17",
- "wasmparser 0.239.0",
- "wasmtime-environ",
- "wasmtime-internal-math",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-fiber"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9308cdb17f8d51e3164185616d809e28c29a6515c03b9dd95c89436b71f6d154"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "libc",
- "rustix 1.1.2",
- "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-debug"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9b63a22bf2a8b6a149a41c6768bc17a8b2e3288a249cb8216987fbd7128e81"
-dependencies = [
- "cc",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-icache-coherence"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8e042b6e3de2f3d708279f89f50b4b9aa1b9bab177300cdffb0ffcd2816df5"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "wasmtime-internal-math"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1f0674f38cd7d014eb1a49ea1d1766cca1a64459e8856ee118a10005302e16"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb24b7535306713e7a250f8b71e35f05b6a5031bf9c3ed7330c308e899cbe7d3"
-
-[[package]]
-name = "wasmtime-internal-unwinder"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d5a80e2623a49cb8e8c419542337b8fe0260b162c40dcc201080a84cbe9b7c"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen 0.125.4",
- "log",
- "object 0.37.3",
-]
-
-[[package]]
-name = "wasmtime-internal-versioned-export-macros"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e277f734b9256359b21517c3b0c26a2a9de6c53a51b670ae55cdcde548bf4e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4dc9333737142f6ece4369c8bcdda03a11edbd43d8fbd3e15004c194b9b743"
-dependencies = [
- "anyhow",
- "cranelift-codegen 0.125.4",
- "gimli 0.32.3",
- "log",
- "object 0.37.3",
- "target-lexicon 0.13.5",
- "wasmparser 0.239.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtimer"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12451,15 +12653,6 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wast"
-version = "35.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -12481,7 +12674,7 @@ version = "1.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec9b6eab7ecd4d639d78515e9ea491c9bacf494aa5eda10823bd35992cf8c1e"
 dependencies = [
- "wast 240.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -12563,47 +12756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
-name = "wiggle"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ee0c6dd73bdf0aff4404059bdc24ca61ad92056d20f4e59b8b0780789cafb4"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags 2.9.4",
- "thiserror 2.0.17",
- "tracing",
- "wasmtime",
- "wiggle-macro",
-]
-
-[[package]]
-name = "wiggle-generate"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e415549583fd492ccab881076fa5c41590362d3b5e99df793f619d67333c97b"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "witx",
-]
-
-[[package]]
-name = "wiggle-macro"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a533b4fdc593bf9c4bf52ae0b3a126f15babfb25fce03bfe0bcc84e1172222"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wiggle-generate",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12633,26 +12785,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0bb17ae9bf89ebc74512150e6ee0a27b1eac5ff3b54d8cec264f4b4255022d"
-dependencies = [
- "anyhow",
- "cranelift-assembler-x64",
- "cranelift-codegen 0.125.4",
- "gimli 0.32.3",
- "regalloc2 0.13.5",
- "smallvec",
- "target-lexicon 0.13.5",
- "thiserror 2.0.17",
- "wasmparser 0.239.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
-]
 
 [[package]]
 name = "windows-core"
@@ -13065,16 +13197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winx"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
-dependencies = [
- "bitflags 2.9.4",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13166,18 +13288,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "witx"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
-dependencies = [
- "anyhow",
- "log",
- "thiserror 1.0.69",
- "wast 35.0.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6924,6 +6924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -11804,6 +11805,8 @@ dependencies = [
  "pathdiff",
  "petgraph 0.6.5",
  "reqwest 0.12.24",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +733,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.2",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
+dependencies = [
+ "ambient-authority",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix 1.1.2",
+ "winx",
+]
+
+[[package]]
 name = "capacity_builder"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,12 +1320,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c088d3406f0c0252efa7445adfd2d05736bfb5218838f64eaf79d567077aed14"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c03f887a763abb9c1dc08f722aa82b69067fda623b6f0273050f45f8b1a6776"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
 name = "cranelift-bforest"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "305d51c180ebdc46ef61bc60c54ae6512db3bc9a05842a1f1e762e45977019ab"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.110.2",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206887a11a43f507fee320a218dc365980bfc42ec2696792079a9f8c9369e90"
+dependencies = [
+ "cranelift-entity 0.125.4",
 ]
 
 [[package]]
@@ -1263,26 +1362,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "690d8ae6c73748e5ce3d8fe59034dceadb8823e6c8994ba324141c5eae909b0e"
 
 [[package]]
+name = "cranelift-bitset"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0790c83cfdab95709c5d0105fd888221e3af9049a7d7ec376ec901ab4e4dba"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "cranelift-codegen"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7ca95e831c18d1356da783765c344207cbdffea91e13e47fa9327dbb2e0719"
 dependencies = [
  "bumpalo",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
+ "cranelift-bforest 0.110.2",
+ "cranelift-bitset 0.110.3",
+ "cranelift-codegen-meta 0.110.3",
+ "cranelift-codegen-shared 0.110.3",
+ "cranelift-control 0.110.3",
+ "cranelift-entity 0.110.2",
+ "cranelift-isle 0.110.2",
  "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
- "regalloc2",
+ "regalloc2 0.9.3",
  "rustc-hash 1.1.0",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a98aed2d262eda69310e84bae8e053ee4f17dbdd3347b8d9156aa618ba2de0a"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest 0.125.4",
+ "cranelift-bitset 0.125.4",
+ "cranelift-codegen-meta 0.125.4",
+ "cranelift-codegen-shared 0.125.4",
+ "cranelift-control 0.125.4",
+ "cranelift-entity 0.125.4",
+ "cranelift-isle 0.125.4",
+ "gimli 0.32.3",
+ "hashbrown 0.15.5",
+ "log",
+ "pulley-interpreter",
+ "regalloc2 0.13.5",
+ "rustc-hash 2.1.1",
+ "serde",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -1291,7 +1427,20 @@ version = "0.110.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a2d2ab65e6cbf91f81781d8da65ec2005510f18300eff21a99526ed6785863"
 dependencies = [
- "cranelift-codegen-shared",
+ "cranelift-codegen-shared 0.110.3",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6906852826988563e9b0a9232ad951f53a47aa41ffd02f8ac852d3f41aae836a"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared 0.125.4",
+ "cranelift-srcgen",
+ "heck 0.5.0",
+ "pulley-interpreter",
 ]
 
 [[package]]
@@ -1299,6 +1448,12 @@ name = "cranelift-codegen-shared"
 version = "0.110.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efcff860573cf3db9ae98fbd949240d78b319df686cc306872e7fab60e9c84d7"
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a50105aab667b5cc845f2be37c78475d7cc127cd8ec0a31f7b2b71d526099a7"
 
 [[package]]
 name = "cranelift-control"
@@ -1310,12 +1465,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-control"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6adcc7aa7c0bc1727176a6f2d99c28a9e79a541ccd5ca911a0cb352da8befa36"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "cranelift-entity"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a48cb0a194c9ba82fec35a1e492055388d89b2e3c03dee9dcf2488892be8004d"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.110.3",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "981b56af777f9a34ea6dcce93255125776d391410c2a68b75bed5941b714fa15"
+dependencies = [
+ "cranelift-bitset 0.125.4",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1324,10 +1499,22 @@ version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8327afc6c1c05f4be62fefce5b439fa83521c65363a322e86ea32c85e7ceaf64"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.110.2",
  "log",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea982589684dfb71afecb9fc09555c3a266300a1162a60d7fa39d41a5705b1c"
+dependencies = [
+ "cranelift-codegen 0.125.4",
+ "log",
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -1335,6 +1522,29 @@ name = "cranelift-isle"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56b08621c00321efcfa3eee6a3179adc009e21ea8d24ca7adc3c326184bc3f48"
+
+[[package]]
+name = "cranelift-isle"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0422686b22ed6a1f33cc40e3c43eb84b67155788568d1a5cac8439d3dca1783"
+
+[[package]]
+name = "cranelift-native"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f697bbbe135c655ea1deb7af0bae4a5c4fae2c88fdfc0fa57b34ae58c91040"
+dependencies = [
+ "cranelift-codegen 0.125.4",
+ "libc",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718efe674f3df645462677e22a3128e890d88ba55821bb091083d257707be76c"
 
 [[package]]
 name = "crc32fast"
@@ -2196,6 +2406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foldhash-portable"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631c01cdb9b602a84f0ef5e813d3691936aade6d390dba117f28aa03eb4d0e09"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2531,17 @@ checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
 dependencies = [
  "swc_macros_common",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2515,6 +2753,11 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.13.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "gix"
@@ -4075,6 +4318,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,6 +4705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.44"
 source = "git+https://github.com/utooland/mimalloc_rust.git#43eea63be488f068f0f1a31c07553fe262d34255"
@@ -4677,6 +4942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,6 +4972,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.2",
+]
 
 [[package]]
 name = "memmap2"
@@ -5321,6 +5601,9 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
  "memchr",
 ]
 
@@ -5643,7 +5926,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "testing 22.0.0",
+ "testing",
  "tokio",
  "tracing-subscriber",
  "turbo-rcstr",
@@ -5996,17 +6279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pot"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf741fa415952eb20f27fbc210dc85f31cc7cdc80aa3ce81d5e27d28a6f45dc2"
-dependencies = [
- "byteorder",
- "half",
- "serde",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6247,6 +6519,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulley-interpreter"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beafc309a2d35e16cc390644d88d14dfa45e45e15075ec6a9e37f6dfb43e926f"
+dependencies = [
+ "cranelift-bitset 0.125.4",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885fbb6c07454cfc8725a18a1da3cfc328ee8c53fb8d0671ea313edc8567947"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6257,13 +6552,13 @@ dependencies = [
 
 [[package]]
 name = "qfilter"
-version = "0.2.5"
+version = "0.3.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746341cd2357c9a4df2d951522b4a8dd1ef553e543119899ad7bf87e938c8fbe"
+checksum = "edd9c903cd64233eb97cf95d96d58645c2b1c0154d30ff835f3bb4be417158b1"
 dependencies = [
+ "foldhash-portable",
  "serde",
  "serde_bytes",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -6574,6 +6869,20 @@ dependencies = [
  "log",
  "rustc-hash 1.1.0",
  "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash 2.1.1",
  "smallvec",
 ]
 
@@ -6918,13 +7227,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -7288,13 +7606,14 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.13.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+checksum = "c2316d01592c3382277c5062105510e35e0a6bfb2851e30028485f7af8cf1240"
 dependencies = [
+ "itoa",
  "percent-encoding",
+ "ryu",
  "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7751,9 +8070,9 @@ dependencies = [
 
 [[package]]
 name = "styled_components"
-version = "0.139.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6db058537dae7321d7b35705641848f0e4433904325c9ecc99e099d645ed978"
+checksum = "99aeadac58111060ad883c7e7a01917bcecc6572243c06d41315f200cbaa9240"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -7761,18 +8080,18 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
+ "swc_common 21.0.1",
+ "swc_ecma_ast 23.0.0",
+ "swc_ecma_utils 29.1.0",
+ "swc_ecma_visit 23.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.114.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f296b6ef106e930a8138f6356bea12a53deccd7f5e0c686b67bcf2d49661d2a"
+checksum = "c3917b257122e7cf3f46f95557af3178edaa9a3fd89fc1469768e05f01901e98"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -7782,7 +8101,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common 21.0.1",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_compat",
@@ -7790,12 +8109,12 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_minifier 45.0.1",
- "swc_ecma_parser 34.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
+ "swc_ecma_ast 23.0.0",
+ "swc_ecma_minifier",
+ "swc_ecma_parser 38.0.2",
+ "swc_ecma_transforms_base 41.0.1",
+ "swc_ecma_utils 29.1.0",
+ "swc_ecma_visit 23.0.0",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -7805,58 +8124,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "swc"
-version = "55.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fcdf3eb0f7f3aced6002421a1cde696d1bafd5070acf44c4b27164603f608"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bytes-str",
- "dashmap 5.5.3",
- "either",
- "indexmap 2.13.0",
- "jsonc-parser",
- "once_cell",
- "par-core",
- "par-iter",
- "parking_lot",
- "regex",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_compiler_base 48.0.0",
- "swc_config 3.1.2",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_codegen 23.0.0",
- "swc_ecma_ext_transforms 26.0.0",
- "swc_ecma_loader 18.0.0",
- "swc_ecma_minifier 45.0.1",
- "swc_ecma_parser 34.0.0",
- "swc_ecma_preset_env 48.0.0",
- "swc_ecma_transforms 47.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_transforms_compat 43.0.0",
- "swc_ecma_transforms_optimization 39.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "swc_error_reporters 20.0.1",
- "swc_node_comments 18.0.0",
- "swc_plugin_backend_wasmer 7.0.0",
- "swc_plugin_proxy 20.0.0",
- "swc_plugin_runner 24.0.0",
- "swc_sourcemap 9.3.4",
- "swc_timer",
- "swc_transform_common 12.0.0",
- "swc_visit",
- "tokio",
- "tracing",
- "url",
-]
 
 [[package]]
 name = "swc"
@@ -7881,29 +8148,29 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_compiler_base 54.0.0",
- "swc_config 4.0.1",
+ "swc_compiler_base",
+ "swc_config",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen 26.0.1",
- "swc_ecma_ext_transforms 29.0.0",
- "swc_ecma_loader 21.0.0",
- "swc_ecma_minifier 51.1.0",
+ "swc_ecma_ext_transforms",
+ "swc_ecma_loader",
+ "swc_ecma_minifier",
  "swc_ecma_parser 38.0.2",
- "swc_ecma_preset_env 52.0.0",
- "swc_ecma_transforms 51.0.0",
+ "swc_ecma_preset_env",
+ "swc_ecma_transforms",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_compat 47.0.0",
- "swc_ecma_transforms_optimization 43.0.0",
+ "swc_ecma_transforms_compat",
+ "swc_ecma_transforms_optimization",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
- "swc_error_reporters 23.0.0",
- "swc_node_comments 21.0.0",
- "swc_plugin_backend_wasmer 10.0.0",
- "swc_plugin_proxy 23.0.0",
- "swc_plugin_runner 27.0.0",
- "swc_sourcemap 10.0.2",
+ "swc_error_reporters",
+ "swc_node_comments",
+ "swc_plugin_backend_wasmer",
+ "swc_plugin_proxy",
+ "swc_plugin_runner",
+ "swc_sourcemap",
  "swc_timer",
- "swc_transform_common 15.0.0",
+ "swc_transform_common",
  "swc_visit",
  "tokio",
  "tracing",
@@ -7961,25 +8228,17 @@ dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
- "bytecheck 0.8.2",
  "bytes-str",
- "cbor4ii",
  "either",
  "from_variant",
  "num-bigint",
  "once_cell",
- "parking_lot",
- "rancor",
- "rkyv 0.8.12",
  "rustc-hash 2.1.1",
  "serde",
- "shrink-to-fit",
  "siphasher 0.3.11",
  "swc_atoms",
  "swc_eq_ignore_macros",
- "swc_sourcemap 9.3.4",
  "swc_visit",
- "termcolor",
  "tracing",
  "unicode-width 0.2.2",
  "url",
@@ -8006,41 +8265,16 @@ dependencies = [
  "rkyv 0.8.12",
  "rustc-hash 2.1.1",
  "serde",
+ "shrink-to-fit",
  "siphasher 0.3.11",
  "swc_atoms",
  "swc_eq_ignore_macros",
- "swc_sourcemap 10.0.2",
+ "swc_sourcemap",
  "swc_visit",
  "termcolor",
  "tracing",
  "unicode-width 0.2.2",
  "url",
-]
-
-[[package]]
-name = "swc_compiler_base"
-version = "48.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd68ff549974c02a5b3932a2b58938c168e01d7ac4663590afa96968fdcb4fc8"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bytes-str",
- "once_cell",
- "pathdiff",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_config 3.1.2",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_codegen 23.0.0",
- "swc_ecma_minifier 45.0.1",
- "swc_ecma_parser 34.0.0",
- "swc_ecma_visit 20.0.0",
- "swc_sourcemap 9.3.4",
- "swc_timer",
 ]
 
 [[package]]
@@ -8059,35 +8293,14 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_config 4.0.1",
+ "swc_config",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen 26.0.1",
- "swc_ecma_minifier 51.1.0",
+ "swc_ecma_minifier",
  "swc_ecma_parser 38.0.2",
  "swc_ecma_visit 23.0.0",
- "swc_sourcemap 10.0.2",
+ "swc_sourcemap",
  "swc_timer",
-]
-
-[[package]]
-name = "swc_config"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e90b52ee734ded867104612218101722ad87ff4cf74fe30383bd244a533f97"
-dependencies = [
- "anyhow",
- "bytes-str",
- "dashmap 5.5.3",
- "globset",
- "indexmap 2.13.0",
- "once_cell",
- "regex",
- "regress",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "swc_config_macro",
- "swc_sourcemap 9.3.4",
 ]
 
 [[package]]
@@ -8108,7 +8321,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_config_macro",
- "swc_sourcemap 10.0.2",
+ "swc_sourcemap",
 ]
 
 [[package]]
@@ -8142,88 +8355,60 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "57.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84a28511166b70a7e651b730d99bd4d3e2914ede7009d77c65afbcdbae0ce"
-dependencies = [
- "par-core",
- "swc 55.0.0",
- "swc_allocator",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_codegen 23.0.0",
- "swc_ecma_lints",
- "swc_ecma_loader 18.0.0",
- "swc_ecma_minifier 45.0.1",
- "swc_ecma_parser 34.0.0",
- "swc_ecma_preset_env 48.0.0",
- "swc_ecma_quote_macros",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_transforms_optimization 39.0.0",
- "swc_ecma_transforms_proposal 37.0.0",
- "swc_ecma_transforms_react 41.0.1",
- "swc_ecma_transforms_typescript 41.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "swc_plugin_proxy 20.0.0",
- "swc_plugin_runner 24.0.0",
- "testing 19.0.0",
- "vergen",
-]
-
-[[package]]
-name = "swc_core"
 version = "63.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb9470306b0d532da617be037de878f64ec0f04cb364d920e8cee05d658d66de"
 dependencies = [
  "par-core",
- "swc 61.0.0",
+ "swc",
  "swc_allocator",
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen 26.0.1",
- "swc_ecma_loader 21.0.0",
- "swc_ecma_minifier 51.1.0",
+ "swc_ecma_lints",
+ "swc_ecma_loader",
+ "swc_ecma_minifier",
  "swc_ecma_parser 38.0.2",
- "swc_ecma_preset_env 52.0.0",
+ "swc_ecma_preset_env",
+ "swc_ecma_quote_macros",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_optimization 43.0.0",
- "swc_ecma_transforms_react 45.0.0",
- "swc_ecma_transforms_typescript 45.0.2",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_proposal",
+ "swc_ecma_transforms_react",
+ "swc_ecma_transforms_typescript",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
- "swc_plugin_proxy 23.0.0",
- "swc_plugin_runner 27.0.0",
+ "swc_plugin_proxy",
+ "swc_plugin_runner",
+ "testing",
  "vergen",
 ]
 
 [[package]]
 name = "swc_css_ast"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88e8591e125ef6675325e58a2cf290a19f24083bdfdb125bcb134b1a3ac0c8b"
+checksum = "2ff309da4fdd0f4714dd0713f33279fac51c8f93e07750061d9c34fbe37a6860"
 dependencies = [
  "is-macro",
  "string_enum",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common 21.0.1",
 ]
 
 [[package]]
 name = "swc_css_codegen"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7287baacc8ea51cffb8ef7233eac665eda0f72b04b07ec8d8c60070f2243dfb6"
+checksum = "1aadad5a5d4dd5f08a3e772e325974dc9df2498dbc262093ba80fcb8304c004c"
 dependencies = [
  "auto_impl",
  "bitflags 2.9.4",
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common 21.0.1",
  "swc_css_ast",
  "swc_css_codegen_macros",
  "swc_css_utils",
@@ -8241,14 +8426,14 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774a552c784bf3f4b4109fa68800e02ae7908234d64f29f4fc7ed00a03e01a40"
+checksum = "aea25a7967900779f91066a3afe13f598e81bbcc3cff667a0dbe4e7c48f6e9ba"
 dependencies = [
  "bitflags 2.9.4",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common 21.0.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -8256,14 +8441,14 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecefd72f5a5c251f4e140674da3151380273dc784c66b481a3f7f7c6ea949519"
+checksum = "36c025e12b2b2c1e6e5e5c510e5273b7d5bf1cf49c3bbcaaca7b3ad513d25d43"
 dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common 21.0.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -8271,22 +8456,22 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8e9de84010575a6ecaff74a750fe55e579cf4b2ff4876f7ad23b8e8951c626"
+checksum = "f512fc138752963c667d42e525784a14ad3be9d94caf31f96c628e6241b7f6d4"
 dependencies = [
  "lexical",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common 21.0.1",
  "swc_css_ast",
 ]
 
 [[package]]
 name = "swc_css_prefixer"
-version = "22.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bfe41b2281df544babf42a88399af3753212b8dbb0cedbf7cac9980f0e4e6a"
+checksum = "e3a896bd66b62de8710cb66aa83db19871c51ce309c19a344b74198621275515"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -8294,7 +8479,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common 21.0.1",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -8302,9 +8487,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673ff16d1f6f29ca8ef038b08385b8c173703c98e47543b05f7beeac3bf14b32"
+checksum = "b3813f5bb082bcf15d825c60ea5304394f40d161b8949c5f67e66b92dd545484"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.1",
@@ -8317,13 +8502,13 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9564e30ba8af784ac9bd8355a35ec51a3e4aa3ee86495e8cb4b182c6c53a51"
+checksum = "e16cd73f86ec2fe7df85499a63abb4b4f956b24bf1e3540dacb598406e2e14c6"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
+ "swc_common 21.0.1",
  "swc_css_ast",
  "swc_visit",
 ]
@@ -8335,14 +8520,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252124d0d786aa2338860701a067c93488747dfadbfedb16ac78f386e16a0ac4"
 dependencies = [
  "bitflags 2.9.4",
- "cbor4ii",
  "is-macro",
  "num-bigint",
  "once_cell",
  "phf",
  "rustc-hash 2.1.1",
- "serde",
- "shrink-to-fit",
  "string_enum",
  "swc_atoms",
  "swc_common 18.0.1",
@@ -8364,6 +8546,7 @@ dependencies = [
  "phf",
  "rustc-hash 2.1.1",
  "serde",
+ "shrink-to-fit",
  "string_enum",
  "swc_atoms",
  "swc_common 21.0.1",
@@ -8430,24 +8613,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c427e6db46fc66b2e5d53f191e798b8d991c22cf47fa495c6c968332cfccb548"
-dependencies = [
- "rustc-hash 2.1.1",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_compat_es2015 42.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "swc_trace_macro",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_bugfixes"
 version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22d4da77f7014b5efd416bb5208ab6e3d005ad5d532df8ced2904e50ca233d44"
@@ -8456,24 +8621,12 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_es2015 45.0.0",
+ "swc_ecma_compat_es2015",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
  "swc_trace_macro",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_common"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a11705dc2b2a534e86317056bf85f6dfbc3d188cfd44dd07eb6b986800386"
-dependencies = [
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_utils 26.0.1",
 ]
 
 [[package]]
@@ -8484,36 +8637,8 @@ checksum = "d72d7d499e4bd4059ccfe432c1a52111a28fdd2b49b3882f18108fddfa3f6b4f"
 dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_transformer",
  "swc_ecma_utils 29.1.0",
-]
-
-[[package]]
-name = "swc_ecma_compat_es2015"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0dccce1836d0c15e9e7114eef1dc39973efd45a8eb266251e551fac12a6cb7"
-dependencies = [
- "arrayvec",
- "indexmap 2.13.0",
- "is-macro",
- "rustc-hash 2.1.1",
- "serde",
- "serde_derive",
- "smallvec",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_config 3.1.2",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_compat_common 33.0.0",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_transforms_classes 37.0.0",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "swc_trace_macro",
- "tracing",
 ]
 
 [[package]]
@@ -8531,29 +8656,16 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_config 4.0.1",
+ "swc_config",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_common 37.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_compat_common",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_classes 41.0.1",
+ "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
  "swc_trace_macro",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_es2016"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce774431cd21cbb724e29c20e84ed98cbcb5e2b362cc3fa34a35c78b459af66f"
-dependencies = [
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8564,24 +8676,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1358f912b0b5bdb6509f64dada8dc9ac8dc9233175b1d033c571cd34ad0bbec"
 dependencies = [
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_es2017"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9201214d7b7337c9bd33b0a29e7993b93b6392f73dabf1290bbd9fe28be78eae"
-dependencies = [
- "serde",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8594,23 +8691,9 @@ dependencies = [
  "serde",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_es2018"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518959bc86ab0e9717cf1877db13858ff3f5312dad877521b90a782dd2d3c242"
-dependencies = [
- "serde",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8622,23 +8705,9 @@ checksum = "27ffcf499581d598250e4d93d45ef64fe81b16f83c3bcb8c21d27af2004e6f54"
 dependencies = [
  "serde",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_es2019"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e292d39a97e708841e6fb5c135e23d9df9f8194945eecef8cc63e9f999a700"
-dependencies = [
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8650,26 +8719,9 @@ checksum = "5125766d7ca9c4789eefdb68fd9d1bc9eba1119df21ad3d1fd7b0ac2808893d0"
 dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_es2020"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9110bdfd1614351237e67727511b60c0fd070ccec0c8dc7a2b1d7e67ebb4b70"
-dependencies = [
- "serde",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_compat_es2022 40.0.0",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
  "tracing",
 ]
 
@@ -8682,24 +8734,11 @@ dependencies = [
  "serde",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_es2022 44.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_compat_es2022",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_es2021"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bdf4e0547ba148491e8d00fff315f40d54c928d4dda75f7325106bad5a05002"
-dependencies = [
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
  "tracing",
 ]
 
@@ -8710,29 +8749,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64ee2ff23cdc2bb9749f3fb730bd4a95cc26cdea84b384b85574a1ab43f78af"
 dependencies = [
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compat_es2022"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4251437fce71eb2c4cb24fcc332a74b47682cc8153c1f9dcf8c4add09a20e24c"
-dependencies = [
- "rustc-hash 2.1.1",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_transforms_classes 37.0.0",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "swc_trace_macro",
  "tracing",
 ]
 
@@ -8746,9 +8765,9 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer 13.0.0",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_classes 41.0.1",
+ "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
@@ -8758,37 +8777,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_regexp"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c267d92e58db3f3c00cf3f7e93ee72391f5cc2d9a5877db63ca95d7495a535"
-dependencies = [
- "icu_properties",
- "swc_ecma_regexp_ast 0.7.0",
- "swc_ecma_regexp_visit 0.7.0",
-]
-
-[[package]]
-name = "swc_ecma_compat_regexp"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf01bca3c32928c9cbc436f05efce56b5007ace2b3ac870eb710211b0fffa570"
 dependencies = [
  "icu_properties",
- "swc_ecma_regexp_ast 0.10.0",
- "swc_ecma_regexp_visit 0.10.0",
-]
-
-[[package]]
-name = "swc_ecma_ext_transforms"
-version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6aed670f87cde675f40dcd0ff5196f3cec9b2bc7e6fed12adf5b808f18eb69"
-dependencies = [
- "phf",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
+ "swc_ecma_regexp_ast",
+ "swc_ecma_regexp_visit",
 ]
 
 [[package]]
@@ -8806,18 +8801,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_hooks"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9adff1f01550ef653e262ad709a2914d3dd6cfd559aea2e28eeeab8f895981"
-dependencies = [
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_visit 20.0.0",
-]
-
-[[package]]
-name = "swc_ecma_hooks"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee7662517362f6726b0e107a3caec2b4cc7d629f9bf702958948e9350722e52f"
@@ -8830,9 +8813,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "27.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b21488b346ed189e52c641259307eb6d5e322f3c832696358a661660ce8e8932"
+checksum = "003fdf93059f1c505ed81463ccf49230db69bb5003ff09606a6732f34ef81506"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -8842,33 +8825,11 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
- "swc_config 3.1.2",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
-]
-
-[[package]]
-name = "swc_ecma_loader"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b36b38399698e77c3d63838c2e32e40df0d5e55e489bef529a77a349a722c7a"
-dependencies = [
- "anyhow",
- "dashmap 5.5.3",
- "lru",
- "normpath",
- "once_cell",
- "parking_lot",
- "path-clean 0.1.0",
- "pathdiff",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_common 18.0.1",
- "tracing",
+ "swc_common 21.0.1",
+ "swc_config",
+ "swc_ecma_ast 23.0.0",
+ "swc_ecma_utils 29.1.0",
+ "swc_ecma_visit 23.0.0",
 ]
 
 [[package]]
@@ -8895,43 +8856,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "45.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34b819aa304facc7d87912842adeb413730816055f693d5190a9207f5b0aa01"
-dependencies = [
- "arrayvec",
- "bitflags 2.9.4",
- "indexmap 2.13.0",
- "num-bigint",
- "num_cpus",
- "once_cell",
- "par-core",
- "par-iter",
- "parking_lot",
- "phf",
- "radix_fmt",
- "rustc-hash 2.1.1",
- "ryu-js",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_config 3.1.2",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_codegen 23.0.0",
- "swc_ecma_hooks 0.4.0",
- "swc_ecma_parser 34.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_transforms_optimization 39.0.0",
- "swc_ecma_usage_analyzer",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "swc_timer",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_minifier"
 version = "51.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c25a685c2efe2f88ba359dde0a17382b28a206ea21b23bda612f97b2c423b2f2"
@@ -8953,13 +8877,13 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_config 4.0.1",
+ "swc_config",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen 26.0.1",
- "swc_ecma_hooks 0.7.0",
+ "swc_ecma_hooks",
  "swc_ecma_parser 38.0.2",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_optimization 43.0.0",
+ "swc_ecma_transforms_optimization",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
  "swc_timer",
@@ -8988,27 +8912,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18271343933dfa820caba5fabb36118b1cfbf0010702a2947c8bf81b9154e36c"
-dependencies = [
- "bitflags 2.9.4",
- "either",
- "num-bigint",
- "phf",
- "rustc-hash 2.1.1",
- "seq-macro",
- "serde",
- "smartstring",
- "stacker",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_parser"
 version = "38.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c251d44e048647b5335861d1585b3e95fa8bc74f6e7a40570b0ea95d27ba66"
@@ -9021,35 +8924,11 @@ dependencies = [
  "seq-macro",
  "serde",
  "smartstring",
+ "stacker",
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_preset_env"
-version = "48.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3903fcc6dc4f51e898c643ece06bab6591237d466e0e69226810677b48bcbeb"
-dependencies = [
- "anyhow",
- "foldhash 0.1.5",
- "indexmap 2.13.0",
- "once_cell",
- "precomputed-map",
- "preset_env_base",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "string_enum",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transformer 9.0.0",
- "swc_ecma_transforms 47.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
 ]
 
 [[package]]
@@ -9071,44 +8950,28 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_transformer 13.0.0",
- "swc_ecma_transforms 51.0.0",
+ "swc_ecma_transformer",
+ "swc_ecma_transforms",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "34.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adaa86c70b29508cc8ed9a4ff9690e5e47fffc12ac36a12ee4abe4acec16edd"
+checksum = "16896c184ff6915c85ee4bffd08db32e010b1c1a9628e6c4ee49a233653c20a7"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_parser 34.0.0",
+ "swc_common 21.0.1",
+ "swc_ecma_ast 23.0.0",
+ "swc_ecma_parser 38.0.2",
  "swc_macros_common",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "swc_ecma_regexp"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb1c912d1f73009546bc8271feb40a2371f148fcde6a4b6f4973a1ce167bc07"
-dependencies = [
- "phf",
- "rustc-hash 2.1.1",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_regexp_ast 0.7.0",
- "swc_ecma_regexp_common",
- "swc_ecma_regexp_visit 0.7.0",
- "unicode-id-start",
 ]
 
 [[package]]
@@ -9121,23 +8984,10 @@ dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_ecma_regexp_ast 0.10.0",
+ "swc_ecma_regexp_ast",
  "swc_ecma_regexp_common",
- "swc_ecma_regexp_visit 0.10.0",
+ "swc_ecma_regexp_visit",
  "unicode-id-start",
-]
-
-[[package]]
-name = "swc_ecma_regexp_ast"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568b408134ad2e201cd48db4d1ed7bed40abbec6e242fb8492a066834f674b11"
-dependencies = [
- "bitflags 2.9.4",
- "is-macro",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_regexp_common",
 ]
 
 [[package]]
@@ -9161,19 +9011,6 @@ checksum = "0a0a09a9e4dc09c97f07273695bd4b58e46b99dbb0cb788ce0dad2a181eb1e94"
 
 [[package]]
 name = "swc_ecma_regexp_visit"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258ea946dddb367af135b8255c6ddd0b86a066f3d3c7d4bca2e624b77cd1b51f"
-dependencies = [
- "serde",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_regexp_ast 0.7.0",
- "swc_visit",
-]
-
-[[package]]
-name = "swc_ecma_regexp_visit"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73317054bba9a6fed553ce2c830702b8602fc5f5c08d9328bd3ab9d8489ce827"
@@ -9181,27 +9018,8 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_ecma_regexp_ast 0.10.0",
+ "swc_ecma_regexp_ast",
  "swc_visit",
-]
-
-[[package]]
-name = "swc_ecma_transformer"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133f705294aa6319310a98eed2e140ab34116f71b17174e2a994bb159d51fe9b"
-dependencies = [
- "rustc-hash 2.1.1",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_compat_regexp 1.0.0",
- "swc_ecma_hooks 0.4.0",
- "swc_ecma_regexp 0.7.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "tracing",
 ]
 
 [[package]]
@@ -9214,31 +9032,13 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_regexp 4.0.0",
- "swc_ecma_hooks 0.7.0",
- "swc_ecma_regexp 0.10.0",
+ "swc_ecma_compat_regexp",
+ "swc_ecma_hooks",
+ "swc_ecma_regexp",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms"
-version = "47.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbe202e4a5b51a9f29275eac42fb785e907ac359edc61984788ff046b4fb20f"
-dependencies = [
- "par-core",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_transforms_compat 43.0.0",
- "swc_ecma_transforms_optimization 39.0.0",
- "swc_ecma_transforms_proposal 37.0.0",
- "swc_ecma_transforms_react 41.0.1",
- "swc_ecma_transforms_typescript 41.0.0",
- "swc_ecma_utils 26.0.1",
 ]
 
 [[package]]
@@ -9251,11 +9051,11 @@ dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_compat 47.0.0",
- "swc_ecma_transforms_optimization 43.0.0",
- "swc_ecma_transforms_proposal 41.0.3",
- "swc_ecma_transforms_react 45.0.0",
- "swc_ecma_transforms_typescript 45.0.2",
+ "swc_ecma_transforms_compat",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_proposal",
+ "swc_ecma_transforms_react",
+ "swc_ecma_transforms_typescript",
  "swc_ecma_utils 29.1.0",
 ]
 
@@ -9276,28 +9076,6 @@ dependencies = [
  "swc_common 18.0.1",
  "swc_ecma_ast 20.0.1",
  "swc_ecma_parser 33.0.1",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms_base"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea2b456609d624513ebd884c7152d5b1a04ad5dd8fcb957e00e8993387ed00"
-dependencies = [
- "better_scoped_tls",
- "indexmap 2.13.0",
- "once_cell",
- "par-core",
- "phf",
- "rustc-hash 2.1.1",
- "serde",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_parser 34.0.0",
  "swc_ecma_utils 26.0.1",
  "swc_ecma_visit 20.0.0",
  "tracing",
@@ -9327,19 +9105,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd626c92e18463806ec5822d5cd6841e6903f92b7e6bd7348dba2179274932b"
-dependencies = [
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_classes"
 version = "41.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ffae23e996fa1a7b20b77ff599aa0e4997a6eb21369e2e5e906c91b89fdffaa"
@@ -9349,34 +9114,6 @@ dependencies = [
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_compat"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed73c7ec4346508a9d63b98e2759b5da04e61667e5df1fd4d8ccfe629a75c45d"
-dependencies = [
- "indexmap 2.13.0",
- "par-core",
- "serde",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_compat_bugfixes 42.0.0",
- "swc_ecma_compat_common 33.0.0",
- "swc_ecma_compat_es2015 42.0.0",
- "swc_ecma_compat_es2016 38.0.0",
- "swc_ecma_compat_es2017 38.0.0",
- "swc_ecma_compat_es2018 39.0.0",
- "swc_ecma_compat_es2019 38.0.0",
- "swc_ecma_compat_es2020 40.0.0",
- "swc_ecma_compat_es2021 38.0.0",
- "swc_ecma_compat_es2022 40.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "tracing",
 ]
 
 [[package]]
@@ -9391,16 +9128,16 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_compat_bugfixes 46.0.0",
- "swc_ecma_compat_common 37.0.0",
- "swc_ecma_compat_es2015 45.0.0",
- "swc_ecma_compat_es2016 42.0.0",
- "swc_ecma_compat_es2017 42.0.0",
- "swc_ecma_compat_es2018 43.0.0",
- "swc_ecma_compat_es2019 42.0.0",
- "swc_ecma_compat_es2020 44.0.0",
- "swc_ecma_compat_es2021 42.0.0",
- "swc_ecma_compat_es2022 44.0.0",
+ "swc_ecma_compat_bugfixes",
+ "swc_ecma_compat_common",
+ "swc_ecma_compat_es2015",
+ "swc_ecma_compat_es2016",
+ "swc_ecma_compat_es2017",
+ "swc_ecma_compat_es2018",
+ "swc_ecma_compat_es2019",
+ "swc_ecma_compat_es2020",
+ "swc_ecma_compat_es2021",
+ "swc_ecma_compat_es2022",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
@@ -9417,30 +9154,6 @@ dependencies = [
  "quote",
  "swc_macros_common",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "swc_ecma_transforms_optimization"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4701cee4bde4d90fba49381dd4de25c18ff60cefcfc4f45f4f1f1045c1cc83b2"
-dependencies = [
- "bytes-str",
- "dashmap 5.5.3",
- "indexmap 2.13.0",
- "once_cell",
- "par-core",
- "petgraph 0.7.1",
- "rustc-hash 2.1.1",
- "serde_json",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_parser 34.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "tracing",
 ]
 
 [[package]]
@@ -9469,24 +9182,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b05992a81ecd5d1bda71ae1f7300d28d466dde6fbd0e5dc1084f4325e6a097"
-dependencies = [
- "either",
- "rustc-hash 2.1.1",
- "serde",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_transforms_classes 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_proposal"
 version = "41.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c49fd90ad7ef87cfacb9e15eb939bfecac83fe6638fdd4f94a31eff56b8276"
@@ -9498,34 +9193,9 @@ dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_classes 41.0.1",
+ "swc_ecma_transforms_classes",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_react"
-version = "41.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e071551d429c184f40080696ee0bcbd54ccf75bf11569302b6dc5de106a6984"
-dependencies = [
- "base64 0.22.1",
- "bytes-str",
- "indexmap 2.13.0",
- "once_cell",
- "rustc-hash 2.1.1",
- "serde",
- "sha1",
- "string_enum",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_config 3.1.2",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_hooks 0.4.0",
- "swc_ecma_parser 34.0.0",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
 ]
 
 [[package]]
@@ -9544,31 +9214,13 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common 21.0.1",
- "swc_config 4.0.1",
+ "swc_config",
  "swc_ecma_ast 23.0.0",
- "swc_ecma_hooks 0.7.0",
+ "swc_ecma_hooks",
  "swc_ecma_parser 38.0.2",
  "swc_ecma_transforms_base 41.0.1",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_typescript"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59c1d87f4c36161833462cbf16d769fce63158da04a42dbb83c8fac7ee8e04e"
-dependencies = [
- "bytes-str",
- "rustc-hash 2.1.1",
- "serde",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_transforms_base 37.0.0",
- "swc_ecma_transforms_react 41.0.1",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
 ]
 
 [[package]]
@@ -9584,27 +9236,9 @@ dependencies = [
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base 41.0.1",
- "swc_ecma_transforms_react 45.0.0",
+ "swc_ecma_transforms_react",
  "swc_ecma_utils 29.1.0",
  "swc_ecma_visit 23.0.0",
-]
-
-[[package]]
-name = "swc_ecma_usage_analyzer"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7aec80849cab609d92af5dd2670f18fc760f7029beb11beebcef3fed9ba3466"
-dependencies = [
- "bitflags 2.9.4",
- "indexmap 2.13.0",
- "rustc-hash 2.1.1",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "swc_timer",
- "tracing",
 ]
 
 [[package]]
@@ -9653,7 +9287,6 @@ checksum = "e971a258717db3dc8939c38410d8b8cb8126f1b05b9758672daa7cae3e0248c2"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
- "serde",
  "swc_atoms",
  "swc_common 18.0.1",
  "swc_ecma_ast 20.0.1",
@@ -9669,6 +9302,7 @@ checksum = "ad65d392ed427dc9e94f16a3d802b02e27722c21227639c8d5f45f19757b447b"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
+ "serde",
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
@@ -9678,9 +9312,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.115.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab802f4dfb3e9e21c5d7350776270fa436a164a83ff05991f1ddb1c849d25d"
+checksum = "11d8058e754b05eb672671b71974c4f79673b32bc2a2763706ba6970f8d2c86f"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -9691,13 +9325,13 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_codegen 23.0.0",
- "swc_ecma_transforms 47.0.0",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
- "swc_sourcemap 9.3.4",
+ "swc_common 21.0.1",
+ "swc_ecma_ast 23.0.0",
+ "swc_ecma_codegen 26.0.1",
+ "swc_ecma_transforms",
+ "swc_ecma_utils 29.1.0",
+ "swc_ecma_visit 23.0.0",
+ "swc_sourcemap",
  "swc_trace_macro",
  "tracing",
 ]
@@ -9711,19 +9345,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "swc_error_reporters"
-version = "20.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3615d499e30e5bc4d53978d1fc4c1975c8be9acc79f42b5956bbca7fc7c6dc58"
-dependencies = [
- "anyhow",
- "miette",
- "once_cell",
- "serde",
- "swc_common 18.0.1",
 ]
 
 [[package]]
@@ -9752,18 +9373,6 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e110f3d5684e9c087450ee522d4b8ba68fd91964992984032cc00194a212cde4"
-dependencies = [
- "dashmap 5.5.3",
- "rustc-hash 2.1.1",
- "swc_atoms",
- "swc_common 18.0.1",
-]
-
-[[package]]
-name = "swc_node_comments"
 version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acde6aa6ba214763f3bfc1f34686eed44266b9e602717e579f662ee2a3537f1"
@@ -9776,22 +9385,6 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_backend_wasmer"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a6a8648be03aaeaac5251823651d9b9c86a57db5e43064764c6b7fa5437d99"
-dependencies = [
- "anyhow",
- "enumset",
- "parking_lot",
- "swc_common 18.0.1",
- "swc_plugin_runner 24.0.0",
- "wasmer",
- "wasmer-compiler-cranelift",
- "wasmer-wasix",
-]
-
-[[package]]
-name = "swc_plugin_backend_wasmer"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78073d9b7e0c9fba6a21531fc1bb73d812ee8fc1d08616cf45b2fe0ade8da8ec"
@@ -9800,10 +9393,23 @@ dependencies = [
  "enumset",
  "parking_lot",
  "swc_common 21.0.1",
- "swc_plugin_runner 27.0.0",
+ "swc_plugin_runner",
  "wasmer",
  "wasmer-compiler-cranelift",
  "wasmer-wasix",
+]
+
+[[package]]
+name = "swc_plugin_backend_wasmtime"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80db3340ec910c54bb4c418cd838e51bd3574982d81debc8ffb1c28640931d10"
+dependencies = [
+ "anyhow",
+ "swc_common 21.0.1",
+ "swc_plugin_runner",
+ "wasi-common",
+ "wasmtime",
 ]
 
 [[package]]
@@ -9815,21 +9421,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "swc_plugin_proxy"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78e1a9d26be495289cb07b9d73222f92f60b74d47904169d3ce4977600ec11e"
-dependencies = [
- "better_scoped_tls",
- "cbor4ii",
- "rustc-hash 2.1.1",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_trace_macro",
- "tracing",
 ]
 
 [[package]]
@@ -9849,27 +9440,6 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a48f119fba50bb6bbf54366fc37a7e0c4d94a641936a082330cc6ab8e3f947d"
-dependencies = [
- "anyhow",
- "blake3",
- "parking_lot",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_plugin_proxy 20.0.0",
- "swc_transform_common 12.0.0",
- "tracing",
- "vergen",
-]
-
-[[package]]
-name = "swc_plugin_runner"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff8883348391cfcf1911454282a8c664cf4727b79f6c0d81457f7add873e64fb"
@@ -9883,47 +9453,28 @@ dependencies = [
  "swc_atoms",
  "swc_common 21.0.1",
  "swc_ecma_ast 23.0.0",
- "swc_plugin_proxy 23.0.0",
- "swc_transform_common 15.0.0",
+ "swc_plugin_proxy",
+ "swc_transform_common",
  "tracing",
  "vergen",
 ]
 
 [[package]]
 name = "swc_relay"
-version = "0.85.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afe4c35ddca5ad570916267c11e019ac91c85b5864ff6e66c6bb06ddabc239b"
+checksum = "d1a0e98d0497d914f2a0736be9be050af6c3c0fbb2a9d911dae40379fffcc7c8"
 dependencies = [
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 18.0.1",
- "swc_ecma_ast 20.0.1",
- "swc_ecma_utils 26.0.1",
- "swc_ecma_visit 20.0.0",
+ "swc_common 21.0.1",
+ "swc_ecma_ast 23.0.0",
+ "swc_ecma_utils 29.1.0",
+ "swc_ecma_visit 23.0.0",
  "tracing",
-]
-
-[[package]]
-name = "swc_sourcemap"
-version = "9.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de08ef00f816acdd1a58ee8a81c0e1a59eefef2093aefe5611f256fa6b64c4d7"
-dependencies = [
- "base64-simd 0.8.0",
- "bitvec",
- "bytes-str",
- "data-encoding",
- "debugid",
- "if_chain",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "unicode-id-start",
- "url",
 ]
 
 [[package]]
@@ -9962,18 +9513,6 @@ checksum = "dfd2b4b0adb82e36f2ac688d00a6a67132c7f4170c772617516793a701be89e8"
 dependencies = [
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "swc_transform_common"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc4a0e2aa9fac44d383127e01327710416dda5b637b0d134b7b8cf2ba6bde8e"
-dependencies = [
- "better_scoped_tls",
- "rustc-hash 2.1.1",
- "serde",
- "swc_common 18.0.1",
 ]
 
 [[package]]
@@ -10062,6 +9601,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-interface"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
+dependencies = [
+ "bitflags 2.9.4",
+ "cap-fs-ext",
+ "cap-std",
+ "fd-lock",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10089,6 +9644,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -10143,27 +9704,6 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1506c602222ebab5d96100180f8d3c015b2394eceb00a46d20c25b8b1e5100"
-dependencies = [
- "cargo_metadata 0.18.1",
- "difference",
- "once_cell",
- "pretty_assertions",
- "regex",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "swc_common 18.0.1",
- "swc_error_reporters 20.0.1",
- "testing_macros",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "testing"
 version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd50c53833442165fa5bf385497986c6ca501e8cf2df442919f5475aded14134"
@@ -10177,7 +9717,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common 21.0.1",
- "swc_error_reporters 23.0.0",
+ "swc_error_reporters",
  "testing_macros",
  "tracing",
  "tracing-subscriber",
@@ -10827,7 +10367,6 @@ name = "turbo-persistence"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bincode 2.0.1",
  "bitfield",
  "byteorder",
  "crc32fast",
@@ -10838,15 +10377,15 @@ dependencies = [
  "memmap2 0.9.8",
  "nohash-hasher",
  "parking_lot",
- "pot",
+ "postcard",
  "qfilter",
  "quick_cache",
  "rustc-hash 2.1.1",
  "smallvec",
  "thread_local",
  "tracing",
- "turbo-bincode",
- "twox-hash 2.1.2",
+ "xxhash-rust",
+ "zerocopy",
 ]
 
 [[package]]
@@ -10859,13 +10398,17 @@ version = "0.1.0"
 dependencies = [
  "bincode 2.0.1",
  "bytes-str",
+ "inventory",
  "napi",
  "new_debug_unreachable",
  "rustc-hash 2.1.1",
  "serde",
  "shrink-to-fit",
+ "smallvec",
  "triomphe 0.1.12",
+ "turbo-bincode",
  "turbo-tasks-hash",
+ "unty",
 ]
 
 [[package]]
@@ -10884,7 +10427,6 @@ dependencies = [
  "futures",
  "indexmap 2.13.0",
  "inventory",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "rayon",
@@ -10913,16 +10455,14 @@ name = "turbo-tasks-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arc-swap",
  "auto-hash-map",
  "bincode 2.0.1",
  "bitfield",
- "byteorder",
+ "crossbeam-utils",
  "dashmap 6.1.0",
  "either",
  "hashbrown 0.14.5",
  "indexmap 2.13.0",
- "once_cell",
  "parking_lot",
  "rand 0.10.0",
  "ringmap",
@@ -10970,6 +10510,7 @@ name = "turbo-tasks-fetch"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "quick_cache",
  "reqwest 0.13.2",
  "rustls",
@@ -11028,8 +10569,9 @@ dependencies = [
  "data-encoding",
  "getrandom 0.3.3",
  "sha2",
+ "smallvec",
  "turbo-tasks-macros",
- "twox-hash 2.1.2",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -11050,6 +10592,7 @@ dependencies = [
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 dependencies = [
+ "libmimalloc-sys",
  "mimalloc",
 ]
 
@@ -11079,6 +10622,7 @@ dependencies = [
  "turbopack-core",
  "turbopack-css",
  "turbopack-ecmascript",
+ "turbopack-ecmascript-runtime",
  "turbopack-env",
  "turbopack-mdx",
  "turbopack-node",
@@ -11092,6 +10636,7 @@ name = "turbopack-browser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode 2.0.1",
  "either",
  "indoc",
@@ -11106,6 +10651,7 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
+ "turbopack",
  "turbopack-core",
  "turbopack-css",
  "turbopack-ecmascript",
@@ -11146,6 +10692,7 @@ dependencies = [
  "data-encoding",
  "either",
  "indexmap 2.13.0",
+ "num-bigint",
  "once_cell",
  "patricia_tree",
  "petgraph 0.8.3",
@@ -11156,8 +10703,8 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "swc_core 57.0.1",
- "swc_sourcemap 9.3.4",
+ "swc_core 63.1.3",
+ "swc_sourcemap",
  "tracing",
  "turbo-bincode",
  "turbo-esregex",
@@ -11179,6 +10726,7 @@ name = "turbopack-css"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode 2.0.1",
  "indoc",
  "lightningcss",
@@ -11187,7 +10735,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
- "swc_core 57.0.1",
+ "swc_core 63.1.3",
  "tokio",
  "tracing",
  "turbo-bincode",
@@ -11204,6 +10752,7 @@ name = "turbopack-dev-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "auto-hash-map",
  "bincode 2.0.1",
  "flate2",
@@ -11263,12 +10812,13 @@ dependencies = [
  "serde_json",
  "smallvec",
  "strsim 0.11.1",
- "swc_core 57.0.1",
- "swc_sourcemap 9.3.4",
+ "swc_core 63.1.3",
+ "swc_sourcemap",
  "tokio",
  "tracing",
  "turbo-bincode",
  "turbo-esregex",
+ "turbo-frozenmap",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
@@ -11304,9 +10854,9 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 57.0.1",
+ "swc_core 63.1.3",
  "swc_emotion",
- "swc_plugin_backend_wasmer 7.0.0",
+ "swc_plugin_backend_wasmtime",
  "swc_relay",
  "tracing",
  "turbo-rcstr",
@@ -11326,7 +10876,6 @@ dependencies = [
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
- "turbopack",
  "turbopack-core",
  "turbopack-ecmascript",
 ]
@@ -11336,6 +10885,7 @@ name = "turbopack-env"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-env",
@@ -11349,6 +10899,7 @@ name = "turbopack-image"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.21.7",
  "bincode 2.0.1",
  "image",
@@ -11369,6 +10920,7 @@ name = "turbopack-mdx"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "markdown",
  "mdxjs",
  "serde",
@@ -11414,6 +10966,7 @@ dependencies = [
  "turbo-tasks-bytes",
  "turbo-tasks-env",
  "turbo-tasks-fs",
+ "turbo-tasks-hash",
  "turbopack-cli-utils",
  "turbopack-core",
  "turbopack-ecmascript",
@@ -11438,6 +10991,7 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
+ "turbopack",
  "turbopack-core",
  "turbopack-ecmascript",
  "turbopack-ecmascript-runtime",
@@ -11449,6 +11003,7 @@ name = "turbopack-resolve"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode 2.0.1",
  "next-taskless",
  "regex",
@@ -11481,7 +11036,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "parking_lot",
- "swc_core 57.0.1",
+ "swc_core 63.1.3",
  "turbo-rcstr",
  "turbo-tasks",
  "turbopack-core",
@@ -11523,6 +11078,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tungstenite 0.21.0",
+ "turbo-rcstr",
+ "turbo-tasks-malloc",
  "turbopack-trace-utils",
  "zstd",
 ]
@@ -11579,9 +11136,6 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-dependencies = [
- "rand 0.9.2",
-]
 
 [[package]]
 name = "typeid"
@@ -11792,8 +11346,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "crossbeam-queue",
- "dashmap 6.1.0",
  "deno_semver",
  "dirs 5.0.1",
  "futures",
@@ -11805,8 +11357,6 @@ dependencies = [
  "pathdiff",
  "petgraph 0.6.5",
  "reqwest 0.12.24",
- "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",
@@ -11818,7 +11368,6 @@ dependencies = [
  "tokio-fs-ext",
  "tokio-retry",
  "tracing",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -12138,6 +11687,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi-common"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7178030744403adba447b07cd5c1d683e4b01c5521dd96e14d082f3ed2c1f29c"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.4",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "log",
+ "rustix 1.1.2",
+ "system-interface",
+ "thiserror 2.0.17",
+ "tracing",
+ "wasmtime",
+ "wiggle",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12227,6 +11801,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
@@ -12301,7 +11885,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "shared-buffer",
  "tar",
- "target-lexicon",
+ "target-lexicon 0.12.16",
  "thiserror 1.0.69",
  "tracing",
  "wasm-bindgen",
@@ -12335,7 +11919,7 @@ dependencies = [
  "self_cell",
  "shared-buffer",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
  "thiserror 1.0.69",
  "wasmer-types",
  "wasmer-vm",
@@ -12350,15 +11934,15 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780f9c2050941b4e3f6bb82d32bd796a6c1750d2f97cbd892f07b384bb6af6f8"
 dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
+ "cranelift-codegen 0.110.2",
+ "cranelift-entity 0.110.2",
+ "cranelift-frontend 0.110.2",
  "gimli 0.28.1",
  "itertools 0.12.1",
  "more-asserts",
  "rayon",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
@@ -12471,7 +12055,7 @@ dependencies = [
  "rkyv 0.8.12",
  "serde",
  "sha2",
- "target-lexicon",
+ "target-lexicon 0.12.16",
  "thiserror 1.0.69",
  "wasmparser 0.224.1",
  "xxhash-rust",
@@ -12623,6 +12207,19 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.9.4",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
@@ -12645,6 +12242,204 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmprinter"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3981f3d51f39f24f5fc90f93049a90f08dbbca8deba602cd46bb8ca67a94718"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81eafc07c867be94c47e0dc66355d9785e09107a18901f76a20701ba0663ad7"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "async-trait",
+ "bitflags 2.9.4",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.1.2",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmparser 0.239.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78587abe085a44a13c90fa16fea6db014e9883e627a7044d7f0cb397ad08d1da"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset 0.125.4",
+ "cranelift-entity 0.125.4",
+ "gimli 0.32.3",
+ "indexmap 2.13.0",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasm-encoder 0.239.0",
+ "wasmparser 0.239.0",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb50f1c50365c32e557266ca85acdf77696c44a3f98797ba6af58cebc6d6d1e"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen 0.125.4",
+ "cranelift-control 0.125.4",
+ "cranelift-entity 0.125.4",
+ "cranelift-frontend 0.125.4",
+ "cranelift-native",
+ "gimli 0.32.3",
+ "itertools 0.14.0",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.17",
+ "wasmparser 0.239.0",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9308cdb17f8d51e3164185616d809e28c29a6515c03b9dd95c89436b71f6d154"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.1.2",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9b63a22bf2a8b6a149a41c6768bc17a8b2e3288a249cb8216987fbd7128e81"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb8e042b6e3de2f3d708279f89f50b4b9aa1b9bab177300cdffb0ffcd2816df5"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1f0674f38cd7d014eb1a49ea1d1766cca1a64459e8856ee118a10005302e16"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-slab"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb24b7535306713e7a250f8b71e35f05b6a5031bf9c3ed7330c308e899cbe7d3"
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d5a80e2623a49cb8e8c419542337b8fe0260b162c40dcc201080a84cbe9b7c"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen 0.125.4",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e277f734b9256359b21517c3b0c26a2a9de6c53a51b670ae55cdcde548bf4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4dc9333737142f6ece4369c8bcdda03a11edbd43d8fbd3e15004c194b9b743"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen 0.125.4",
+ "gimli 0.32.3",
+ "log",
+ "object 0.37.3",
+ "target-lexicon 0.13.5",
+ "wasmparser 0.239.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
 name = "wasmtimer"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12656,6 +12451,15 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
 ]
 
 [[package]]
@@ -12677,7 +12481,7 @@ version = "1.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec9b6eab7ecd4d639d78515e9ea491c9bacf494aa5eda10823bd35992cf8c1e"
 dependencies = [
- "wast",
+ "wast 240.0.0",
 ]
 
 [[package]]
@@ -12759,6 +12563,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "wiggle"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ee0c6dd73bdf0aff4404059bdc24ca61ad92056d20f4e59b8b0780789cafb4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.9.4",
+ "thiserror 2.0.17",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e415549583fd492ccab881076fa5c41590362d3b5e99df793f619d67333c97b"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a533b4fdc593bf9c4bf52ae0b3a126f15babfb25fce03bfe0bcc84e1172222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wiggle-generate",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12788,6 +12633,26 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0bb17ae9bf89ebc74512150e6ee0a27b1eac5ff3b54d8cec264f4b4255022d"
+dependencies = [
+ "anyhow",
+ "cranelift-assembler-x64",
+ "cranelift-codegen 0.125.4",
+ "gimli 0.32.3",
+ "regalloc2 0.13.5",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.17",
+ "wasmparser 0.239.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-math",
+]
 
 [[package]]
 name = "windows-core"
@@ -13200,6 +13065,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.9.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13291,6 +13166,18 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
 ]
 
 [[package]]

--- a/bench/pm-bench-pcap.sh
+++ b/bench/pm-bench-pcap.sh
@@ -19,12 +19,11 @@ export BUN_INSTALL_CACHE_DIR="$BUN_CACHE"
 
 mkdir -p "$PCAP_DIR"
 
-# Project must already be cloned by pm-bench-phases.sh (this script is meant
-# to run after it, reusing the clone).
 PROJECT_DIR="$BENCH_DIR/$PROJECT"
+mkdir -p "$BENCH_DIR"
 if [ ! -d "$PROJECT_DIR" ]; then
-  echo "missing $PROJECT_DIR — run pm-bench-phases.sh first" >&2
-  exit 1
+  echo "cloning $PROJECT into $PROJECT_DIR"
+  git clone --depth=1 "https://github.com/ant-design/${PROJECT}.git" "$PROJECT_DIR"
 fi
 
 # Extract hostname (strip scheme + any path) for DNS lookup.

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -25,13 +25,29 @@ tokio-fs-ext    = { workspace = true }
 tokio-retry     = "0.3"
 tracing         = { workspace = true }
 # HTTP client - works on both native and WASM
+#
+# We use `rustls-tls-native-roots-no-provider` (instead of the default
+# `rustls-tls-native-roots`) so reqwest doesn't pin the crypto provider
+# to `ring`. We then build our own `rustls::ClientConfig` with
+# `aws-lc-rs` (BoringSSL's crypto primitives) in `service/http.rs` and
+# pass it via `Client::use_preconfigured_tls`. Measured on CI against
+# npmjs.org: `ring` took 78 ms p50 / 154 ms max from CCS → first
+# AppData per handshake (CPU-bound; 128 parallel handshakes serialise
+# across 4 cores). aws-lc-rs's per-handshake CPU is roughly 3× faster.
 reqwest      = { version = "0.12", default-features = false, features = [
   "http2",
   "json",
-  "rustls-tls",
-  "rustls-tls-native-roots",
+  "rustls-tls-native-roots-no-provider",
   "socks"
 ] }
+# Our own rustls + aws-lc-rs crypto provider.
+rustls             = { version = "0.23", default-features = false, features = [
+  "aws-lc-rs",
+  "logging",
+  "std",
+  "tls12"
+] }
+rustls-native-certs = "0.8"
 # Shared URL-hash + staging helpers for native-only resolvers (git / http)
 sha2         = { workspace = true, optional = true }
 tempfile     = { workspace = true, optional = true }

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -17,42 +17,34 @@ dirs            = { workspace = true }
 futures         = "0.3"
 parking_lot     = { workspace = true }
 petgraph        = "0.6"
-serde           = { version = "1.0", features = ["derive"] }
-serde_json      = { workspace = true }
-simd-json       = "0.17"
-thiserror       = { workspace = true }
-tokio-fs-ext    = { workspace = true }
-tokio-retry     = "0.3"
-tracing         = { workspace = true }
+serde        = { version = "1.0", features = ["derive"] }
+serde_json   = { workspace = true }
+simd-json    = "0.17"
+thiserror    = { workspace = true }
+tokio-fs-ext = { workspace = true }
+tokio-retry  = "0.3"
+tracing      = { workspace = true }
 # HTTP client - works on both native and WASM
-#
-# We use `rustls-tls-native-roots-no-provider` (instead of the default
-# `rustls-tls-native-roots`) so reqwest doesn't pin the crypto provider
-# to `ring`. We then build our own `rustls::ClientConfig` with
-# `aws-lc-rs` (BoringSSL's crypto primitives) in `service/http.rs` and
-# pass it via `Client::use_preconfigured_tls`. Measured on CI against
-# npmjs.org: `ring` took 78 ms p50 / 154 ms max from CCS → first
-# AppData per handshake (CPU-bound; 128 parallel handshakes serialise
-# across 4 cores). aws-lc-rs's per-handshake CPU is roughly 3× faster.
-reqwest         = { version = "0.12", default-features = false, features = [
+reqwest      = { version = "0.12", default-features = false, features = [
   "http2",
   "json",
-  "rustls-tls-native-roots-no-provider",
+  "rustls-tls",
+  "rustls-tls-native-roots",
   "socks"
 ] }
 # Shared URL-hash + staging helpers for native-only resolvers (git / http)
-sha2            = { workspace = true, optional = true }
-tempfile        = { workspace = true, optional = true }
+sha2         = { workspace = true, optional = true }
+tempfile     = { workspace = true, optional = true }
 # Git clone (gated on `native-git`)
-gix             = { workspace = true, features = [
+gix          = { workspace = true, features = [
   "blocking-http-transport-reqwest-rust-tls",
   "blocking-network-client",
 ], optional = true }
 # HTTP tarball extraction (gated on `http-tarball`)
 # Uses libdeflater to match pm's extractor and avoid pulling a second gzip
 # implementation (flate2) into the workspace.
-libdeflater     = { version = "1.25", optional = true }
-tar             = { version = "0.4", optional = true }
+libdeflater  = { version = "1.25", optional = true }
+tar          = { version = "0.4", optional = true }
 
 # Async runtime (works on both native and WASM with forked tokio)
 [dependencies.tokio]
@@ -63,11 +55,7 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 # Native-only dependencies (not compiled for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libc                = "0.2"
-# Custom rustls config with aws-lc-rs crypto provider — see service/http.rs.
-# wasm32 falls back to reqwest's default rustls + ring (transitive via reqwest).
-rustls              = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
-rustls-native-certs = "0.8"
+libc = "0.2"
 
 # WASM-only dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -40,9 +40,6 @@ reqwest             = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots-no-provider",
   "socks"
 ] }
-# Our own rustls + aws-lc-rs crypto provider.
-rustls              = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
-rustls-native-certs = "0.8"
 # Shared URL-hash + staging helpers for native-only resolvers (git / http)
 sha2                = { workspace = true, optional = true }
 tempfile            = { workspace = true, optional = true }
@@ -66,7 +63,11 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 # Native-only dependencies (not compiled for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libc = "0.2"
+libc                = "0.2"
+# Custom rustls config with aws-lc-rs crypto provider — see service/http.rs.
+# wasm32 falls back to reqwest's default rustls + ring (transitive via reqwest).
+rustls              = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
+rustls-native-certs = "0.8"
 
 # WASM-only dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -7,21 +7,23 @@ license     = "MIT"
 
 # tombi: format.rules.table-keys-order.disabled = true
 [dependencies]
-anyhow       = { workspace = true }
-bytes        = "1"
-pathdiff     = { workspace = true }
-deno_semver  = "0.7"
-dirs         = { workspace = true }
-futures      = "0.3"
-parking_lot  = { workspace = true }
-petgraph     = "0.6"
-serde        = { version = "1.0", features = ["derive"] }
-serde_json   = { workspace = true }
-simd-json    = "0.17"
-thiserror    = { workspace = true }
-tokio-fs-ext = { workspace = true }
-tokio-retry  = "0.3"
-tracing      = { workspace = true }
+anyhow          = { workspace = true }
+bytes           = "1"
+pathdiff        = { workspace = true }
+crossbeam-queue = "0.3"
+dashmap         = "6"
+deno_semver     = "0.7"
+dirs            = { workspace = true }
+futures         = "0.3"
+parking_lot     = { workspace = true }
+petgraph        = "0.6"
+serde           = { version = "1.0", features = ["derive"] }
+serde_json      = { workspace = true }
+simd-json       = "0.17"
+thiserror       = { workspace = true }
+tokio-fs-ext    = { workspace = true }
+tokio-retry     = "0.3"
+tracing         = { workspace = true }
 # HTTP client - works on both native and WASM
 reqwest      = { version = "0.12", default-features = false, features = [
   "http2",
@@ -49,7 +51,7 @@ tar          = { version = "0.4", optional = true }
 workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 # Native-only dependencies (not compiled for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -57,7 +59,8 @@ libc = "0.2"
 
 # WASM-only dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3"  # For time in WASM
+js-sys              = "0.3"  # For time in WASM
+wasm-bindgen-futures = "0.4"  # spawn_local replaces tokio::spawn on wasm
 
 [features]
 default      = []

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -7,23 +7,23 @@ license     = "MIT"
 
 # tombi: format.rules.table-keys-order.disabled = true
 [dependencies]
-anyhow              = { workspace = true }
-bytes               = "1"
-pathdiff            = { workspace = true }
-crossbeam-queue     = "0.3"
-dashmap             = "6"
-deno_semver         = "0.7"
-dirs                = { workspace = true }
-futures             = "0.3"
-parking_lot         = { workspace = true }
-petgraph            = "0.6"
-serde               = { version = "1.0", features = ["derive"] }
-serde_json          = { workspace = true }
-simd-json           = "0.17"
-thiserror           = { workspace = true }
-tokio-fs-ext        = { workspace = true }
-tokio-retry         = "0.3"
-tracing             = { workspace = true }
+anyhow          = { workspace = true }
+bytes           = "1"
+pathdiff        = { workspace = true }
+crossbeam-queue = "0.3"
+dashmap         = "6"
+deno_semver     = "0.7"
+dirs            = { workspace = true }
+futures         = "0.3"
+parking_lot     = { workspace = true }
+petgraph        = "0.6"
+serde           = { version = "1.0", features = ["derive"] }
+serde_json      = { workspace = true }
+simd-json       = "0.17"
+thiserror       = { workspace = true }
+tokio-fs-ext    = { workspace = true }
+tokio-retry     = "0.3"
+tracing         = { workspace = true }
 # HTTP client - works on both native and WASM
 #
 # We use `rustls-tls-native-roots-no-provider` (instead of the default
@@ -34,25 +34,25 @@ tracing             = { workspace = true }
 # npmjs.org: `ring` took 78 ms p50 / 154 ms max from CCS → first
 # AppData per handshake (CPU-bound; 128 parallel handshakes serialise
 # across 4 cores). aws-lc-rs's per-handshake CPU is roughly 3× faster.
-reqwest             = { version = "0.12", default-features = false, features = [
+reqwest         = { version = "0.12", default-features = false, features = [
   "http2",
   "json",
   "rustls-tls-native-roots-no-provider",
   "socks"
 ] }
 # Shared URL-hash + staging helpers for native-only resolvers (git / http)
-sha2                = { workspace = true, optional = true }
-tempfile            = { workspace = true, optional = true }
+sha2            = { workspace = true, optional = true }
+tempfile        = { workspace = true, optional = true }
 # Git clone (gated on `native-git`)
-gix                 = { workspace = true, features = [
+gix             = { workspace = true, features = [
   "blocking-http-transport-reqwest-rust-tls",
   "blocking-network-client",
 ], optional = true }
 # HTTP tarball extraction (gated on `http-tarball`)
 # Uses libdeflater to match pm's extractor and avoid pulling a second gzip
 # implementation (flate2) into the workspace.
-libdeflater         = { version = "1.25", optional = true }
-tar                 = { version = "0.4", optional = true }
+libdeflater     = { version = "1.25", optional = true }
+tar             = { version = "0.4", optional = true }
 
 # Async runtime (works on both native and WASM with forked tokio)
 [dependencies.tokio]

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -7,23 +7,23 @@ license     = "MIT"
 
 # tombi: format.rules.table-keys-order.disabled = true
 [dependencies]
-anyhow          = { workspace = true }
-bytes           = "1"
-pathdiff        = { workspace = true }
-crossbeam-queue = "0.3"
-dashmap         = "6"
-deno_semver     = "0.7"
-dirs            = { workspace = true }
-futures         = "0.3"
-parking_lot     = { workspace = true }
-petgraph        = "0.6"
-serde           = { version = "1.0", features = ["derive"] }
-serde_json      = { workspace = true }
-simd-json       = "0.17"
-thiserror       = { workspace = true }
-tokio-fs-ext    = { workspace = true }
-tokio-retry     = "0.3"
-tracing         = { workspace = true }
+anyhow              = { workspace = true }
+bytes               = "1"
+pathdiff            = { workspace = true }
+crossbeam-queue     = "0.3"
+dashmap             = "6"
+deno_semver         = "0.7"
+dirs                = { workspace = true }
+futures             = "0.3"
+parking_lot         = { workspace = true }
+petgraph            = "0.6"
+serde               = { version = "1.0", features = ["derive"] }
+serde_json          = { workspace = true }
+simd-json           = "0.17"
+thiserror           = { workspace = true }
+tokio-fs-ext        = { workspace = true }
+tokio-retry         = "0.3"
+tracing             = { workspace = true }
 # HTTP client - works on both native and WASM
 #
 # We use `rustls-tls-native-roots-no-provider` (instead of the default
@@ -34,33 +34,28 @@ tracing         = { workspace = true }
 # npmjs.org: `ring` took 78 ms p50 / 154 ms max from CCS → first
 # AppData per handshake (CPU-bound; 128 parallel handshakes serialise
 # across 4 cores). aws-lc-rs's per-handshake CPU is roughly 3× faster.
-reqwest      = { version = "0.12", default-features = false, features = [
+reqwest             = { version = "0.12", default-features = false, features = [
   "http2",
   "json",
   "rustls-tls-native-roots-no-provider",
   "socks"
 ] }
 # Our own rustls + aws-lc-rs crypto provider.
-rustls             = { version = "0.23", default-features = false, features = [
-  "aws-lc-rs",
-  "logging",
-  "std",
-  "tls12"
-] }
+rustls              = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
 rustls-native-certs = "0.8"
 # Shared URL-hash + staging helpers for native-only resolvers (git / http)
-sha2         = { workspace = true, optional = true }
-tempfile     = { workspace = true, optional = true }
+sha2                = { workspace = true, optional = true }
+tempfile            = { workspace = true, optional = true }
 # Git clone (gated on `native-git`)
-gix          = { workspace = true, features = [
+gix                 = { workspace = true, features = [
   "blocking-http-transport-reqwest-rust-tls",
   "blocking-network-client",
 ], optional = true }
 # HTTP tarball extraction (gated on `http-tarball`)
 # Uses libdeflater to match pm's extractor and avoid pulling a second gzip
 # implementation (flate2) into the workspace.
-libdeflater  = { version = "1.25", optional = true }
-tar          = { version = "0.4", optional = true }
+libdeflater         = { version = "1.25", optional = true }
+tar                 = { version = "0.4", optional = true }
 
 # Async runtime (works on both native and WASM with forked tokio)
 [dependencies.tokio]
@@ -75,7 +70,7 @@ libc = "0.2"
 
 # WASM-only dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys              = "0.3"  # For time in WASM
+js-sys               = "0.3"  # For time in WASM
 wasm-bindgen-futures = "0.4"  # spawn_local replaces tokio::spawn on wasm
 
 [features]

--- a/crates/ruborist/src/lib.rs
+++ b/crates/ruborist/src/lib.rs
@@ -27,6 +27,7 @@ pub mod resolver;
 pub mod service;
 pub mod spec;
 pub mod traits;
+pub mod util;
 
 // ============================================================================
 // Re-exports: only items actually used by consumers
@@ -100,7 +101,3 @@ pub mod http {
     pub use crate::resolver::http::{file_cache_slot, http_cache_slot};
 }
 
-/// Utility functions.
-pub mod util {
-    pub use crate::model::util::{PackageNameStr, parse_package_spec, read_package_json};
-}

--- a/crates/ruborist/src/lib.rs
+++ b/crates/ruborist/src/lib.rs
@@ -22,6 +22,7 @@
 //! }).await?;
 //! ```
 
+pub mod maybe_send;
 pub mod model;
 pub mod resolver;
 pub mod service;
@@ -100,4 +101,3 @@ pub mod http {
     #[cfg(feature = "http-tarball")]
     pub use crate::resolver::http::{file_cache_slot, http_cache_slot};
 }
-

--- a/crates/ruborist/src/maybe_send.rs
+++ b/crates/ruborist/src/maybe_send.rs
@@ -1,0 +1,27 @@
+//! `Send`/`Sync` shim that is `Send`/`Sync` on native targets and
+//! no-op on `wasm32`. Lets the resolver share a single trait surface
+//! across multi-thread tokio (where futures must be `Send` to be
+//! `tokio::spawn`-able) and wasm-bindgen (where `JsFuture` is `!Send`
+//! and tasks run via `wasm_bindgen_futures::spawn_local`).
+
+/// `Send` on native, no-op on wasm32.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSend: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send> MaybeSend for T {}
+
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSend {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSend for T {}
+
+/// `Sync` on native, no-op on wasm32.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSync: Sync {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Sync> MaybeSync for T {}
+
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSync {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSync for T {}

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -34,7 +34,7 @@ use crate::resolver::preload::{PreloadConfig, preload_manifests};
 use crate::resolver::registry::{ResolveError, resolve_registry_dep};
 use crate::spec::{Catalogs, PackageSpec, Protocol};
 use crate::traits::progress::{BuildEvent, EventReceiver, NoopReceiver};
-use crate::traits::registry::{RegistryClient, ResolvedPackage};
+use crate::traits::registry::{PreloadRegistry, RegistryClient, ResolvedPackage};
 
 /// Dispatch a git/github spec to the real `gix`-backed resolver when the
 /// `native-git` feature is enabled, otherwise error with a hint.
@@ -458,13 +458,16 @@ async fn process_file_dep<E>(
 ///
 /// # Returns
 /// The result of processing (reused, created, or skipped)
-pub async fn process_dependency<R: RegistryClient>(
+pub async fn process_dependency<R: RegistryClient + crate::maybe_send::MaybeSync>(
     graph: &mut DependencyGraph,
     registry: &R,
     node_index: NodeIndex,
     edge_info: &DependencyEdgeInfo,
     config: &BuildDepsConfig,
-) -> Result<ProcessResult, ResolveError<R::Error>> {
+) -> Result<ProcessResult, ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     tracing::debug!(
         "Processing dependency {}@{} from [{:?}]",
         edge_info.name,
@@ -707,11 +710,14 @@ pub async fn process_dependency<R: RegistryClient>(
 /// // Add initial dependency edges to root...
 /// build_deps(&mut graph, &registry, PeerDeps::Include).await?;
 /// ```
-pub async fn build_deps<R: RegistryClient>(
+pub async fn build_deps<R: PreloadRegistry>(
     graph: &mut DependencyGraph,
     registry: &R,
     peer_deps: PeerDeps,
-) -> Result<(), ResolveError<R::Error>> {
+) -> Result<(), ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     let config = BuildDepsConfig::default().with_peer_deps(peer_deps);
     build_deps_with_config(graph, registry, config, &NoopReceiver).await
 }
@@ -729,12 +735,15 @@ pub async fn build_deps<R: RegistryClient>(
 /// * `registry` - Registry client for fetching packages
 /// * `peer_deps` - How to handle peer dependencies
 /// * `receiver` - Event receiver for handling build events
-pub async fn build_deps_with_receiver<R: RegistryClient, E: EventReceiver>(
+pub async fn build_deps_with_receiver<R: PreloadRegistry, E: EventReceiver>(
     graph: &mut DependencyGraph,
     registry: &R,
     peer_deps: PeerDeps,
     receiver: &E,
-) -> Result<(), ResolveError<R::Error>> {
+) -> Result<(), ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     let config = BuildDepsConfig::default().with_peer_deps(peer_deps);
     build_deps_with_config(graph, registry, config, receiver).await
 }
@@ -759,12 +768,15 @@ pub async fn build_deps_with_receiver<R: RegistryClient, E: EventReceiver>(
 ///
 /// build_deps_with_config(&mut graph, &registry, config, &receiver).await?;
 /// ```
-pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
+pub async fn build_deps_with_config<R: PreloadRegistry, E: EventReceiver>(
     graph: &mut DependencyGraph,
     registry: &R,
     config: BuildDepsConfig,
     receiver: &E,
-) -> Result<(), ResolveError<R::Error>> {
+) -> Result<(), ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     tracing::debug!(
         "Starting dependency tree build, peer_deps: {:?}, concurrency: {}, skip_preload: {}",
         config.peer_deps,
@@ -786,12 +798,14 @@ pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
 }
 
 /// Run the preload phase to warm up the cache with manifests.
-async fn run_preload_phase<R: RegistryClient, E: EventReceiver>(
+async fn run_preload_phase<R: PreloadRegistry, E: EventReceiver>(
     graph: &DependencyGraph,
     registry: &R,
     config: &BuildDepsConfig,
     receiver: &E,
-) {
+) where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     if config.skip_preload {
         return;
     }
@@ -804,18 +818,22 @@ async fn run_preload_phase<R: RegistryClient, E: EventReceiver>(
     }
 
     tracing::debug!("Preload phase: {} initial dependencies", initial_deps.len());
-    receiver.on_event(BuildEvent::PreloadStart {
-        count: initial_deps.len(),
-    });
+    // PreloadStart / PreloadComplete are emitted inside `preload_manifests`.
 
     let preload_config = PreloadConfig {
         peer_deps: config.peer_deps,
         concurrency: config.concurrency,
     };
 
+    // Wrap registry in Arc for the worker pool. Each worker holds an
+    // Arc<R> so resolution runs as an independent `tokio::spawn` task on
+    // the multi-thread runtime. UnifiedRegistry's Clone is shallow
+    // (Arc-based), so this clone is cheap.
+    let registry_arc = std::sync::Arc::new(registry.clone());
+
     let stats = preload_manifests(
         initial_deps,
-        registry,
+        registry_arc,
         preload_config,
         receiver,
         |_name, _manifest| {
@@ -829,21 +847,20 @@ async fn run_preload_phase<R: RegistryClient, E: EventReceiver>(
         stats.success_count,
         stats.failed_count
     );
-    receiver.on_event(BuildEvent::PreloadComplete {
-        success: stats.success_count,
-        failed: stats.failed_count,
-    });
 
     tracing::debug!("Preload phase: {:?}", start.elapsed());
 }
 
 /// Run the BFS traversal phase to build the dependency tree.
-async fn run_bfs_phase<R: RegistryClient, E: EventReceiver>(
+async fn run_bfs_phase<R: RegistryClient + crate::maybe_send::MaybeSync, E: EventReceiver>(
     graph: &mut DependencyGraph,
     registry: &R,
     config: &BuildDepsConfig,
     receiver: &E,
-) -> Result<(), ResolveError<R::Error>> {
+) -> Result<(), ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     let start = tokio::time::Instant::now();
 
     let mut current_level = vec![graph.root_index];
@@ -961,10 +978,13 @@ use std::path::Path;
 /// let pkg: PackageJson = serde_json::from_str(&pkg_content)?;
 /// let lock = resolve(&pkg, &registry).await?;
 /// ```
-pub async fn resolve<R: RegistryClient>(
+pub async fn resolve<R: PreloadRegistry>(
     pkg: &PackageJson,
     registry: &R,
-) -> Result<PackageLock, ResolveError<R::Error>> {
+) -> Result<PackageLock, ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     resolve_with_options(pkg, registry, PeerDeps::Include, &NoopReceiver).await
 }
 
@@ -975,12 +995,15 @@ pub async fn resolve<R: RegistryClient>(
 /// * `registry` - Registry client for fetching packages
 /// * `peer_deps` - How to handle peer dependencies
 /// * `receiver` - Event receiver for progress tracking
-pub async fn resolve_with_options<R: RegistryClient, E: EventReceiver>(
+pub async fn resolve_with_options<R: PreloadRegistry, E: EventReceiver>(
     pkg: &PackageJson,
     registry: &R,
     peer_deps: PeerDeps,
     receiver: &E,
-) -> Result<PackageLock, ResolveError<R::Error>> {
+) -> Result<PackageLock, ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     // Create graph with root node
     let mut graph = DependencyGraph::from_package_json(PathBuf::from("."), pkg.clone());
 

--- a/crates/ruborist/src/resolver/preload.rs
+++ b/crates/ruborist/src/resolver/preload.rs
@@ -1,20 +1,39 @@
-//! Parallel manifest preloading for dependency resolution.
+//! Parallel manifest preloading via multi-thread worker pool.
 //!
-//! Uses FuturesUnordered for true streaming concurrency: when a package resolves,
-//! its transitive dependencies are immediately added to the queue.
+//! N long-lived `tokio::spawn` workers pull work items from a shared
+//! lock-free `SegQueue`. Each spawned task is independent on tokio's
+//! multi-thread runtime, so when one worker is parsing manifest JSON
+//! (CPU-bound, simd_json), other workers can still drive their network
+//! IO. Replaces the prior `FuturesUnordered` design where the main task
+//! owned all preload futures and polled them cooperatively — every
+//! per-future await continuation (cache check / OnceMap / RetryIf /
+//! reqwest send / bytes / parse / transitive dispatch) ran on the same
+//! single task, plus all parses serialised in that task's polling.
+//!
+//! Wasm32 fallback uses `wasm_bindgen_futures::spawn_local` since
+//! `JsFuture` is `!Send`. Workers still run independently on the JS
+//! event loop; the queue + Notify + mpsc termination story is identical.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use futures::stream::{FuturesUnordered, StreamExt};
+use crossbeam_queue::SegQueue;
+use dashmap::DashSet;
+use tokio::sync::{Notify, mpsc};
 
+use crate::maybe_send::{MaybeSend, MaybeSync};
 use crate::model::manifest::CoreVersionManifest;
 use crate::model::node::PeerDeps;
+use crate::resolver::registry::ResolveError;
 use crate::resolver::registry::resolve_package;
 use crate::traits::progress::{BuildEvent, EventReceiver};
-use crate::traits::registry::RegistryClient;
+use crate::traits::registry::{RegistryClient, ResolvedPackage};
 
-/// Default concurrency limit for manifest fetching
+/// Default concurrency limit for manifest fetching.
+///
+/// Number of long-lived `tokio::spawn` workers. Each processes one
+/// `resolve_package` at a time on tokio's multi-thread runtime.
 pub const DEFAULT_CONCURRENCY: usize = 64;
 
 /// A dependency spec: (name, version_spec)
@@ -71,79 +90,179 @@ fn extract_transitive_deps(manifest: &CoreVersionManifest, config: &PreloadConfi
     deps
 }
 
-/// Preload all package manifests in parallel with streaming concurrency.
+/// Result message sent from worker to main task: name, resolve result,
+/// per-request elapsed ms, count of new transitives queued by this worker.
+type Completion<E> = (String, Result<ResolvedPackage, ResolveError<E>>, u64, usize);
+
+/// Preload all package manifests in parallel via a multi-thread worker pool.
+///
+/// `registry` is moved in and shared across workers via `Arc`. Each
+/// worker is a long-lived spawned task that pulls work items from a
+/// shared lock-free `SegQueue` until both the queue and the in-flight
+/// counter reach zero, signalling end-of-phase. Each spawned task is
+/// independent on tokio's multi-thread runtime — IO and CPU work
+/// (simd_json parse) parallelise across cores.
+///
+/// `receiver` and `on_manifest` run on the main task only — they do
+/// not need to be `Send`/`Sync`.
 pub async fn preload_manifests<R, E, F>(
     initial_deps: Vec<Dep>,
-    registry: &R,
+    registry: Arc<R>,
     config: PreloadConfig,
     receiver: &E,
     mut on_manifest: F,
 ) -> PreloadStats
 where
-    R: RegistryClient,
+    R: RegistryClient + MaybeSend + MaybeSync + 'static,
+    R::Error: MaybeSend,
     E: EventReceiver,
     F: FnMut(&str, Arc<CoreVersionManifest>),
 {
     let mut stats = PreloadStats::default();
-    let mut processed: HashSet<String> = HashSet::new();
-    let mut pending: VecDeque<Dep> = initial_deps.into();
-    let concurrency = config.concurrency;
+
+    // Shared work queue and dedup set (lock-free, multi-thread safe).
+    let pending: Arc<SegQueue<Dep>> = Arc::new(SegQueue::new());
+    let processed: Arc<DashSet<String>> = Arc::new(DashSet::new());
+
+    // Counters for global termination — when `dispatched == completed`
+    // and the queue is empty, the phase is done.
+    let dispatched: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    let completed: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    let shutdown: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+
+    // Wake-up signal for workers parked on an empty queue.
+    let notify: Arc<Notify> = Arc::new(Notify::new());
+
+    // Result channel — workers send completions, main task drains.
+    let (result_tx, mut result_rx) = mpsc::unbounded_channel::<Completion<R::Error>>();
+
+    // Seed the queue with initial deps (deduped via DashSet).
+    for dep in initial_deps {
+        let key = format!("{}@{}", dep.0, dep.1);
+        if processed.insert(key) {
+            pending.push(dep);
+            dispatched.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+    let initial_count = dispatched.load(Ordering::Relaxed);
+    let concurrency = config.concurrency.max(1);
 
     tracing::debug!(
-        "Preload: {} initial deps, concurrency={}",
-        pending.len(),
+        "Preload: {} initial deps, concurrency={}, mode=mt-worker-pool",
+        initial_count,
         concurrency
     );
 
-    let mut futures = FuturesUnordered::new();
-    let mut in_flight = 0usize;
-    let mut started = false;
+    // Short-circuit if nothing was seeded.
+    if initial_count == 0 {
+        receiver.on_event(BuildEvent::PreloadStart { count: 0 });
+        receiver.on_event(BuildEvent::PreloadComplete {
+            success: 0,
+            failed: 0,
+        });
+        return stats;
+    }
 
-    loop {
-        // Fill up to concurrency limit
-        while in_flight < concurrency {
-            let item = loop {
-                let Some((name, spec)) = pending.pop_front() else {
-                    break None;
-                };
-                let key = format!("{}@{}", name, spec);
-                if !processed.contains(&key) {
-                    processed.insert(key);
-                    break Some((name, spec));
+    for _ in 0..concurrency {
+        let pending = Arc::clone(&pending);
+        let processed = Arc::clone(&processed);
+        let dispatched = Arc::clone(&dispatched);
+        let completed = Arc::clone(&completed);
+        let shutdown = Arc::clone(&shutdown);
+        let notify = Arc::clone(&notify);
+        let result_tx = result_tx.clone();
+        let config_for_worker = config.clone();
+        let registry = Arc::clone(&registry);
+
+        let worker = async move {
+            loop {
+                // Try fetching work first — fast path when queue is hot.
+                if let Some((name, spec)) = pending.pop() {
+                    let start = tokio::time::Instant::now();
+                    let result = resolve_package(&*registry, &name, &spec).await;
+                    let elapsed_ms = start.elapsed().as_millis() as u64;
+
+                    let new_added = if let Ok(resolved) = &result {
+                        let mut count = 0usize;
+                        for tdep in extract_transitive_deps(&resolved.manifest, &config_for_worker)
+                        {
+                            let key = format!("{}@{}", tdep.0, tdep.1);
+                            if processed.insert(key) {
+                                pending.push(tdep);
+                                count += 1;
+                            }
+                        }
+                        if count > 0 {
+                            dispatched.fetch_add(count, Ordering::Release);
+                            // Wake parked workers so they pick up the new
+                            // work before checking the termination condition.
+                            notify.notify_waiters();
+                        }
+                        count
+                    } else {
+                        0
+                    };
+
+                    if result_tx
+                        .send((name, result, elapsed_ms, new_added))
+                        .is_err()
+                    {
+                        // Main task dropped the receiver — done.
+                        break;
+                    }
+                    let done = completed.fetch_add(1, Ordering::AcqRel) + 1;
+
+                    // After completion, check global done condition. The
+                    // `Acquire` on dispatched pairs with the `Release` in
+                    // the producer add above, so we won't miss late
+                    // transitives queued by a sibling worker.
+                    if done == dispatched.load(Ordering::Acquire) && pending.is_empty() {
+                        shutdown.store(true, Ordering::Release);
+                        notify.notify_waiters();
+                        break;
+                    }
+                    continue;
                 }
-            };
 
-            let Some((name, spec)) = item else {
-                break;
-            };
-
-            if !started {
-                receiver.on_event(BuildEvent::PreloadStart { count: 1 });
-                started = true;
-            } else {
-                receiver.on_event(BuildEvent::PreloadQueued { count: 1 });
+                // Queue empty — register interest before re-checking, then
+                // park. The Notify+enable() pattern guarantees we won't
+                // miss a `notify_waiters()` racing with our park.
+                if shutdown.load(Ordering::Acquire) {
+                    break;
+                }
+                let notified = notify.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if !pending.is_empty() {
+                    continue;
+                }
+                if shutdown.load(Ordering::Acquire) {
+                    break;
+                }
+                if completed.load(Ordering::Acquire) == dispatched.load(Ordering::Acquire) {
+                    shutdown.store(true, Ordering::Release);
+                    notify.notify_waiters();
+                    break;
+                }
+                notified.await;
             }
-
-            receiver.on_event(BuildEvent::PreloadFetching { name: &name });
-
-            futures.push(async move {
-                let start = tokio::time::Instant::now();
-                let result = resolve_package(registry, &name, &spec).await;
-                let elapsed_ms = start.elapsed().as_millis() as u64;
-                (name, result, elapsed_ms)
-            });
-            in_flight += 1;
-        }
-
-        if in_flight == 0 {
-            break;
-        }
-
-        let Some((name, result, elapsed_ms)) = futures.next().await else {
-            break;
         };
-        in_flight -= 1;
+        #[cfg(not(target_arch = "wasm32"))]
+        tokio::spawn(worker);
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(worker);
+    }
+    // Drop the original sender so when all worker clones drop on exit, the
+    // result channel closes and the main loop terminates.
+    drop(result_tx);
 
+    receiver.on_event(BuildEvent::PreloadStart {
+        count: initial_count,
+    });
+
+    // Main task: drain completions, run user callbacks. Receiver/callback
+    // run on this task only — they don't need to be Send/Sync.
+    while let Some((name, result, elapsed_ms, new_added)) = result_rx.recv().await {
         if stats.success_count == 0 && stats.failed_count == 0 {
             stats.min_request_ms = elapsed_ms;
             stats.max_request_ms = elapsed_ms;
@@ -152,6 +271,10 @@ where
             stats.max_request_ms = stats.max_request_ms.max(elapsed_ms);
         }
         stats.total_request_ms += elapsed_ms;
+
+        if new_added > 0 {
+            receiver.on_event(BuildEvent::PreloadQueued { count: new_added });
+        }
 
         match result {
             Ok(resolved) => {
@@ -163,11 +286,8 @@ where
                     version: &resolved.version,
                     current: stats.success_count,
                 });
-
-                // Send PackageResolved event for pipeline downloading
                 receiver.on_event(BuildEvent::PackageResolved((&*resolved.manifest).into()));
 
-                pending.extend(extract_transitive_deps(&resolved.manifest, &config));
                 on_manifest(&name, resolved.manifest);
             }
             Err(e) => {
@@ -177,7 +297,14 @@ where
         }
     }
 
-    stats.total_processed = processed.len();
+    // Snapshot the dedup set's size for the historical observable.
+    stats.total_processed = {
+        let mut set: HashSet<String> = HashSet::with_capacity(processed.len());
+        for entry in processed.iter() {
+            set.insert(entry.key().clone());
+        }
+        set.len()
+    };
 
     receiver.on_event(BuildEvent::PreloadComplete {
         success: stats.success_count,
@@ -208,9 +335,8 @@ mod tests {
     use crate::model::manifest::CoreVersionManifest;
     use crate::traits::progress::NoopReceiver;
     use crate::traits::registry::mock::MockRegistryClient;
-    use std::cell::RefCell;
     use std::collections::HashMap;
-    use std::rc::Rc;
+    use std::sync::Mutex;
 
     fn manifest(name: &str, version: &str) -> CoreVersionManifest {
         CoreVersionManifest {
@@ -237,30 +363,30 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_preload_single() {
         let mut registry = MockRegistryClient::new();
         registry.add_package("lodash", "4.17.21", manifest("lodash", "4.17.21"));
 
-        let cache: Rc<RefCell<HashMap<String, Arc<CoreVersionManifest>>>> = Default::default();
-        let cache_clone = Rc::clone(&cache);
+        let cache: Arc<Mutex<HashMap<String, Arc<CoreVersionManifest>>>> = Default::default();
+        let cache_clone = Arc::clone(&cache);
 
         let stats = preload_manifests(
             vec![("lodash".into(), "^4.17.0".into())],
-            &registry,
+            Arc::new(registry),
             PreloadConfig::default(),
             &NoopReceiver,
-            |name, m| {
-                cache_clone.borrow_mut().insert(name.into(), m);
+            move |name, m| {
+                cache_clone.lock().unwrap().insert(name.into(), m);
             },
         )
         .await;
 
         assert_eq!(stats.success_count, 1);
-        assert!(cache.borrow().contains_key("lodash"));
+        assert!(cache.lock().unwrap().contains_key("lodash"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_preload_transitive() {
         let mut registry = MockRegistryClient::new();
         registry.add_package(
@@ -270,44 +396,44 @@ mod tests {
         );
         registry.add_package("b", "1.0.0", manifest("b", "1.0.0"));
 
-        let cache: Rc<RefCell<HashMap<String, Arc<CoreVersionManifest>>>> = Default::default();
-        let cache_clone = Rc::clone(&cache);
+        let cache: Arc<Mutex<HashMap<String, Arc<CoreVersionManifest>>>> = Default::default();
+        let cache_clone = Arc::clone(&cache);
 
         let stats = preload_manifests(
             vec![("a".into(), "^1.0.0".into())],
-            &registry,
+            Arc::new(registry),
             PreloadConfig::default(),
             &NoopReceiver,
-            |name, m| {
-                cache_clone.borrow_mut().insert(name.into(), m);
+            move |name, m| {
+                cache_clone.lock().unwrap().insert(name.into(), m);
             },
         )
         .await;
 
         assert_eq!(stats.success_count, 2);
-        assert!(cache.borrow().contains_key("a"));
-        assert!(cache.borrow().contains_key("b"));
+        assert!(cache.lock().unwrap().contains_key("a"));
+        assert!(cache.lock().unwrap().contains_key("b"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_preload_missing() {
         let registry = MockRegistryClient::new();
-        let cache: Rc<RefCell<HashMap<String, Arc<CoreVersionManifest>>>> = Default::default();
-        let cache_clone = Rc::clone(&cache);
+        let cache: Arc<Mutex<HashMap<String, Arc<CoreVersionManifest>>>> = Default::default();
+        let cache_clone = Arc::clone(&cache);
 
         let stats = preload_manifests(
             vec![("nonexistent".into(), "^1.0.0".into())],
-            &registry,
+            Arc::new(registry),
             PreloadConfig::default(),
             &NoopReceiver,
-            |name, m| {
-                cache_clone.borrow_mut().insert(name.into(), m);
+            move |name, m| {
+                cache_clone.lock().unwrap().insert(name.into(), m);
             },
         )
         .await;
 
         assert_eq!(stats.failed_count, 1);
-        assert!(cache.borrow().is_empty());
+        assert!(cache.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/ruborist/src/resolver/registry.rs
+++ b/crates/ruborist/src/resolver/registry.rs
@@ -114,11 +114,14 @@ impl<E: std::error::Error + 'static> std::error::Error for ResolveError<E> {
 /// let resolved = resolve_package(&registry, "lodash", "^4.0.0").await?;
 /// println!("Resolved to {}@{}", resolved.name, resolved.version);
 /// ```
-pub async fn resolve_package<R: RegistryClient>(
+pub async fn resolve_package<R: RegistryClient + crate::maybe_send::MaybeSync>(
     registry: &R,
     name: &str,
     spec: &str,
-) -> Result<ResolvedPackage, ResolveError<R::Error>> {
+) -> Result<ResolvedPackage, ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     // Normalize spec first to handle npm: alias and workspace: prefix
     // This ensures correct behavior even if RegistryClient::resolve_package is overridden
     // e.g., "wrap-ansi-cjs" + "npm:wrap-ansi@^7.0.0" -> fetch "wrap-ansi" @ "^7.0.0"
@@ -167,12 +170,15 @@ pub fn resolve_from_manifest<E: std::error::Error + 'static>(
 ///
 /// For optional dependencies, returns `Ok(None)` on resolution failure
 /// instead of propagating the error.
-pub async fn resolve_registry_dep<R: RegistryClient>(
+pub async fn resolve_registry_dep<R: RegistryClient + crate::maybe_send::MaybeSync>(
     registry: &R,
     name: &str,
     spec: &str,
     edge_type: &EdgeType,
-) -> Result<Option<ResolvedPackage>, ResolveError<R::Error>> {
+) -> Result<Option<ResolvedPackage>, ResolveError<R::Error>>
+where
+    R::Error: crate::maybe_send::MaybeSend,
+{
     match resolve_package(registry, name, spec).await {
         Ok(resolved) => Ok(Some(resolved)),
         Err(e) => {

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -93,6 +93,49 @@ pub(crate) fn get_client() -> Result<&'static reqwest::Client> {
     HTTP_CLIENT.as_ref().map_err(|e| anyhow!("{e}"))
 }
 
+/// Build a `rustls::ClientConfig` using the `aws-lc-rs` crypto provider
+/// instead of reqwest's default `ring`. Measured on CI (4-core runner)
+/// against npmjs.org, ring's per-TLS-handshake client-side CPU cost
+/// (ECDHE key derivation + cert verification + Finished MAC) serialised
+/// across 128 parallel handshakes into a 154 ms "CCS → first AppData"
+/// span — the HTTP requests couldn't fire until all TLS crypto drained
+/// through 4 async workers. aws-lc-rs uses BoringSSL's assembly-optimised
+/// primitives and is roughly 3× faster at handshake work.
+#[cfg(not(target_arch = "wasm32"))]
+fn build_rustls_config() -> Result<rustls::ClientConfig> {
+    // Install aws-lc-rs as the default for any other rustls consumer in
+    // the process. Idempotent — only the first call per process wins.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    // Load OS root certs. On Linux this hits /etc/ssl/certs/,
+    // on macOS it queries the Security framework keychain. Called once
+    // per process via `HTTP_CLIENT`'s `LazyLock`.
+    let roots = rustls_native_certs::load_native_certs();
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in roots.certs {
+        // Best-effort: skip any cert rustls refuses (same tolerance
+        // native-tls shows). A hard fail here would brick every
+        // request on a box with one bad root in its trust store.
+        let _ = root_store.add(cert);
+    }
+    if !roots.errors.is_empty() {
+        tracing::debug!(
+            "rustls-native-certs reported {} non-fatal load issues",
+            roots.errors.len()
+        );
+    }
+
+    let config = rustls::ClientConfig::builder_with_provider(std::sync::Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| anyhow!("rustls safe_default_protocol_versions: {e}"))?
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
+
+    Ok(config)
+}
+
 /// Create a [`reqwest::ClientBuilder`] with TLS, DNS caching, and proxy
 /// from environment variables.
 ///
@@ -112,8 +155,9 @@ pub fn client_builder() -> Result<reqwest::ClientBuilder> {
     let builder = {
         use crate::service::dns::shared_resolver;
 
+        let tls_config = build_rustls_config()?;
         let mut builder = builder
-            .use_rustls_tls()
+            .use_preconfigured_tls(tls_config)
             .no_proxy()
             .dns_resolver(shared_resolver());
 

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -93,49 +93,6 @@ pub(crate) fn get_client() -> Result<&'static reqwest::Client> {
     HTTP_CLIENT.as_ref().map_err(|e| anyhow!("{e}"))
 }
 
-/// Build a `rustls::ClientConfig` using the `aws-lc-rs` crypto provider
-/// instead of reqwest's default `ring`. Measured on CI (4-core runner)
-/// against npmjs.org, ring's per-TLS-handshake client-side CPU cost
-/// (ECDHE key derivation + cert verification + Finished MAC) serialised
-/// across 128 parallel handshakes into a 154 ms "CCS → first AppData"
-/// span — the HTTP requests couldn't fire until all TLS crypto drained
-/// through 4 async workers. aws-lc-rs uses BoringSSL's assembly-optimised
-/// primitives and is roughly 3× faster at handshake work.
-#[cfg(not(target_arch = "wasm32"))]
-fn build_rustls_config() -> Result<rustls::ClientConfig> {
-    // Install aws-lc-rs as the default for any other rustls consumer in
-    // the process. Idempotent — only the first call per process wins.
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
-    // Load OS root certs. On Linux this hits /etc/ssl/certs/,
-    // on macOS it queries the Security framework keychain. Called once
-    // per process via `HTTP_CLIENT`'s `LazyLock`.
-    let roots = rustls_native_certs::load_native_certs();
-    let mut root_store = rustls::RootCertStore::empty();
-    for cert in roots.certs {
-        // Best-effort: skip any cert rustls refuses (same tolerance
-        // native-tls shows). A hard fail here would brick every
-        // request on a box with one bad root in its trust store.
-        let _ = root_store.add(cert);
-    }
-    if !roots.errors.is_empty() {
-        tracing::debug!(
-            "rustls-native-certs reported {} non-fatal load issues",
-            roots.errors.len()
-        );
-    }
-
-    let config = rustls::ClientConfig::builder_with_provider(std::sync::Arc::new(
-        rustls::crypto::aws_lc_rs::default_provider(),
-    ))
-    .with_safe_default_protocol_versions()
-    .map_err(|e| anyhow!("rustls safe_default_protocol_versions: {e}"))?
-    .with_root_certificates(root_store)
-    .with_no_client_auth();
-
-    Ok(config)
-}
-
 /// Create a [`reqwest::ClientBuilder`] with TLS, DNS caching, and proxy
 /// from environment variables.
 ///
@@ -155,9 +112,8 @@ pub fn client_builder() -> Result<reqwest::ClientBuilder> {
     let builder = {
         use crate::service::dns::shared_resolver;
 
-        let tls_config = build_rustls_config()?;
         let mut builder = builder
-            .use_preconfigured_tls(tls_config)
+            .use_rustls_tls()
             .no_proxy()
             .dns_resolver(shared_resolver());
 

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -68,6 +68,13 @@ pub struct UnifiedRegistry {
     registry_url: String,
     cache: Arc<PackageCache>,
     supports_semver: bool,
+    /// Dedupes concurrent `resolve_full_manifest` fetches for the same
+    /// package name. First caller hits the network and stores the result;
+    /// other callers wait on `Notify` and read the shared `Arc`. Built on
+    /// `DashMap` + `tokio::sync::Notify` so the fast path (cache hit) is
+    /// lock-free.
+    #[cfg(not(target_arch = "wasm32"))]
+    inflight: Arc<crate::util::oncemap::OnceMap<String, FullManifestResult>>,
 }
 
 /// Builder for `UnifiedRegistry`.
@@ -137,6 +144,8 @@ impl UnifiedRegistryBuilder {
             registry_url,
             cache,
             supports_semver,
+            #[cfg(not(target_arch = "wasm32"))]
+            inflight: Arc::new(crate::util::oncemap::OnceMap::new()),
         }
     }
 }
@@ -153,6 +162,8 @@ impl Clone for UnifiedRegistry {
             registry_url: self.registry_url.clone(),
             cache: Arc::clone(&self.cache),
             supports_semver: self.supports_semver,
+            #[cfg(not(target_arch = "wasm32"))]
+            inflight: Arc::clone(&self.inflight),
         }
     }
 }
@@ -161,8 +172,13 @@ impl Clone for UnifiedRegistry {
 ///
 /// Separates the 200 (full data) and 304 (use cache) cases at the type level,
 /// so callers can pattern-match instead of string-matching error messages.
-/// Transient return value, immediately destructured — Box not needed.
+///
+/// `Clone` is required so multiple `resolve_full_manifest` callers that
+/// coalesce through `OnceMap` can each take an owned copy of the shared
+/// `Arc<FullManifestResult>`. `FullManifest` clones cheaply via
+/// `Arc<[u8]>` for its raw bytes, and the other fields are small.
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 enum FullManifestResult {
     /// Fresh manifest fetched from the network (HTTP 200).
     Full(FullManifest),
@@ -202,13 +218,50 @@ impl UnifiedRegistry {
     /// 4. On 304: use disk cache data
     /// 5. On 200: update memory + disk cache
     async fn resolve_full_manifest(&self, name: &str) -> Result<FullManifestResult, RegistryError> {
-        // 1. Check memory cache first
+        // 1. Fast path: memory cache hit (lock-free read).
         if let Some(manifest) = self.cache.get_full_manifest(name) {
             tracing::debug!("Memory cache hit for full manifest: {}", name);
             return Ok(FullManifestResult::Full(manifest));
         }
 
-        // 2. Load etag from disk cache (if available)
+        // 2. Coalesce concurrent callers for the same name via OnceMap.
+        // First caller runs the fetch closure; others await the shared
+        // result on the OnceMap's `Notify` and clone the cached value.
+        // This avoids 50 packages all triggering 50 simultaneous fetches
+        // of `react` when only 1 is needed.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let shared = self
+                .inflight
+                .get_or_init(name.to_string(), || async {
+                    self.fetch_full_manifest_network(name).await.ok()
+                })
+                .await;
+
+            match shared {
+                Some(arc) => Ok((*arc).clone()),
+                None => {
+                    // OnceMap clears the key on None, so the next caller
+                    // retries the fetch. Retry once here with a fresh error
+                    // so we surface a useful message to this caller.
+                    self.fetch_full_manifest_network(name).await
+                }
+            }
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.fetch_full_manifest_network(name).await
+        }
+    }
+
+    /// Perform the actual network fetch + cache update. Separated from
+    /// `resolve_full_manifest` so the OnceMap closure can invoke it
+    /// without re-entering the dedup layer.
+    async fn fetch_full_manifest_network(
+        &self,
+        name: &str,
+    ) -> Result<FullManifestResult, RegistryError> {
+        // 1. Load etag from disk cache (if available)
         let disk_versions = self.cache.get_versions_from_disk(name).await;
         let etag = disk_versions.as_ref().and_then(|v| v.etag.clone());
 

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -140,7 +140,7 @@ pub trait RegistryClient {
     fn fetch_full_manifest(
         &self,
         name: &str,
-    ) -> impl Future<Output = Result<FullManifest, Self::Error>>;
+    ) -> impl Future<Output = Result<FullManifest, Self::Error>> + crate::maybe_send::MaybeSend;
 
     /// Fetch specific version manifest from registry.
     ///
@@ -153,7 +153,11 @@ pub trait RegistryClient {
         &self,
         name: &str,
         spec: &str,
-    ) -> impl Future<Output = Result<Arc<CoreVersionManifest>, Self::Error>> {
+    ) -> impl Future<Output = Result<Arc<CoreVersionManifest>, Self::Error>> + crate::maybe_send::MaybeSend
+    where
+        Self: crate::maybe_send::MaybeSync,
+        Self::Error: crate::maybe_send::MaybeSend,
+    {
         async move {
             let manifest = self.fetch_full_manifest(name).await?;
             let version_list: Vec<String> = manifest.versions.clone();
@@ -193,7 +197,11 @@ pub trait RegistryClient {
         &self,
         name: &str,
         spec: &str,
-    ) -> impl Future<Output = Result<ResolvedPackage, Self::Error>> {
+    ) -> impl Future<Output = Result<ResolvedPackage, Self::Error>> + crate::maybe_send::MaybeSend
+    where
+        Self: crate::maybe_send::MaybeSync,
+        Self::Error: crate::maybe_send::MaybeSend,
+    {
         async move {
             // Normalize spec (handles npm: alias and workspace: prefix)
             let (fetch_name, fetch_spec) = normalize_spec(name, spec);
@@ -267,7 +275,11 @@ pub trait RegistryClient {
     fn fetch_versions_info(
         &self,
         name: &str,
-    ) -> impl Future<Output = Result<VersionsInfo, Self::Error>> {
+    ) -> impl Future<Output = Result<VersionsInfo, Self::Error>> + crate::maybe_send::MaybeSend
+    where
+        Self: crate::maybe_send::MaybeSync,
+        Self::Error: crate::maybe_send::MaybeSend,
+    {
         async move {
             let manifest = self.fetch_full_manifest(name).await?;
             Ok(VersionsInfo {
@@ -314,12 +326,41 @@ pub trait RegistryClient {
     }
 }
 
+/// Convenience bound for registries usable by the parallel preload worker pool.
+///
+/// `Clone + 'static` lets callers share one owned handle across N spawned
+/// workers (`Arc<R>` on native, `Rc<R>` on wasm). `MaybeSend + MaybeSync`
+/// expand to `Send + Sync` on native (so the spawned worker future can be
+/// scheduled across tokio's multi-thread runtime) and to no-op shims on
+/// wasm (where `wasm_bindgen_futures::spawn_local` runs everything on the
+/// JS event loop and `JsFuture` is `!Send`). Both `UnifiedRegistry` (real
+/// client; `Clone` is shallow Arc-based) and `MockRegistryClient` (test
+/// client) satisfy this trivially.
+pub trait PreloadRegistry:
+    RegistryClient + Clone + crate::maybe_send::MaybeSend + crate::maybe_send::MaybeSync + 'static
+where
+    Self::Error: crate::maybe_send::MaybeSend,
+{
+}
+
+impl<T> PreloadRegistry for T
+where
+    T: RegistryClient
+        + Clone
+        + crate::maybe_send::MaybeSend
+        + crate::maybe_send::MaybeSync
+        + 'static,
+    T::Error: crate::maybe_send::MaybeSend,
+{
+}
+
 /// A simple in-memory registry client for testing.
 #[cfg(test)]
 pub mod mock {
     use super::*;
 
     /// Internal package data for mock registry.
+    #[derive(Clone)]
     struct MockPackage {
         name: String,
         dist_tags: HashMap<String, String>,
@@ -327,6 +368,7 @@ pub mod mock {
     }
 
     /// Mock registry client that returns predefined packages.
+    #[derive(Clone)]
     pub struct MockRegistryClient {
         packages: HashMap<String, MockPackage>,
     }

--- a/crates/ruborist/src/util/mod.rs
+++ b/crates/ruborist/src/util/mod.rs
@@ -1,0 +1,5 @@
+//! Utility modules and re-exports.
+
+pub use crate::model::util::{PackageNameStr, parse_package_spec, read_package_json};
+
+pub mod oncemap;

--- a/crates/ruborist/src/util/oncemap.rs
+++ b/crates/ruborist/src/util/oncemap.rs
@@ -1,0 +1,465 @@
+#![allow(dead_code)]
+//! OnceMap: A concurrent map that ensures each key's work is done exactly once.
+//!
+//! Based on the pattern from uv package manager:
+//! <https://codepointer.substack.com/p/uv-oncemap-rust-pattern-for-running>
+//!
+//! When multiple tasks request the same resource concurrently:
+//! - First caller executes the work
+//! - Other callers wait and receive the shared result
+//! - No duplicate work is performed
+//!
+//! # Typical Use Case in Package Manager
+//!
+//! ```text
+//!                    Dependency Graph
+//!
+//!           ┌─────────┐
+//!           │  app    │
+//!           └────┬────┘
+//!         ┌──────┼──────┐
+//!         ▼      ▼      ▼
+//!     ┌───────┐ ┌───┐ ┌───────┐
+//!     │ lib-a │ │...│ │ lib-z │
+//!     └───┬───┘ └───┘ └───┬───┘
+//!         │               │
+//!         └───────┬───────┘
+//!                 ▼
+//!            ┌─────────┐
+//!            │  react  │  ◄── requested by multiple deps
+//!            └─────────┘
+//!
+//!     Without OnceMap:
+//!       lib-a fetches react ──► network request
+//!       lib-z fetches react ──► network request (duplicate!)
+//!
+//!     With OnceMap:
+//!       lib-a fetches react ──► network request
+//!       lib-z waits on lib-a ──► shares result (no duplicate!)
+//! ```
+
+use dashmap::{DashMap, mapref::entry::Entry};
+use std::future::Future;
+use std::hash::Hash;
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+/// The state of a value in the OnceMap.
+enum Value<V> {
+    /// Work is in progress, waiters can subscribe to the notify.
+    Waiting(Arc<Notify>),
+    /// Work is complete, result is available.
+    Done(Arc<V>),
+}
+
+/// A concurrent map that ensures each key's work is done exactly once.
+///
+/// # Example
+/// ```ignore
+/// let map: OnceMap<String, Vec<u8>> = OnceMap::new();
+///
+/// // Multiple tasks can call get_or_init concurrently
+/// // Only one will actually fetch, others will wait
+/// let result = map.get_or_init("react", || async {
+///     fetch_package("react").await
+/// }).await;
+/// ```
+pub struct OnceMap<K, V> {
+    map: DashMap<K, Value<V>>,
+    /// Waiters for keys that don't exist yet.
+    /// When get_or_init/complete finishes a key, it notifies and removes the entry.
+    waiters: DashMap<K, Arc<Notify>>,
+}
+
+impl<K, V> Default for OnceMap<K, V>
+where
+    K: Eq + Hash + Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> OnceMap<K, V>
+where
+    K: Eq + Hash + Clone,
+{
+    /// Create a new empty OnceMap.
+    pub fn new() -> Self {
+        Self {
+            map: DashMap::new(),
+            waiters: DashMap::new(),
+        }
+    }
+
+    /// Register a key as pending (Waiting state) without starting work.
+    /// Returns the Notify handle if newly registered, None if already exists.
+    pub fn register(&self, key: K) -> Option<Arc<Notify>> {
+        use dashmap::mapref::entry::Entry;
+        match self.map.entry(key) {
+            Entry::Occupied(_) => None,
+            Entry::Vacant(vacant) => {
+                let notify = Arc::new(Notify::new());
+                vacant.insert(Value::Waiting(Arc::clone(&notify)));
+                Some(notify)
+            }
+        }
+    }
+
+    /// Wait for a key to complete.
+    ///
+    /// - If the key exists and is Done, returns immediately.
+    /// - If the key exists and is Waiting, waits for it to complete.
+    /// - If the key doesn't exist yet, waits for it to be created and completed.
+    ///
+    /// This enables parent-ordering in the clone pipeline: a child package
+    /// can wait for its parent's clone to finish even if the parent's
+    /// `get_or_init` hasn't been called yet.
+    pub async fn wait_if_pending(&self, key: &K) {
+        // Fast path: key already exists
+        if let Some(entry) = self.map.get(key) {
+            match entry.value() {
+                Value::Done(_) => return,
+                Value::Waiting(notify) => {
+                    let notify = Arc::clone(notify);
+                    let notified = notify.notified();
+                    drop(entry);
+
+                    if let Some(entry) = self.map.get(key)
+                        && matches!(entry.value(), Value::Done(_))
+                    {
+                        return;
+                    }
+
+                    notified.await;
+                    return;
+                }
+            }
+        }
+
+        // Key doesn't exist yet — register a creation waiter.
+        // get_or_init/complete will notify this when the key reaches Done (or fails).
+        let creation_notify = self
+            .waiters
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(Notify::new()))
+            .clone();
+
+        // Register notified BEFORE double-checking to prevent missed notifications.
+        let notified = creation_notify.notified();
+
+        // Double-check: key might have been created and completed between
+        // the initial map.get and registering here.
+        if let Some(entry) = self.map.get(key)
+            && matches!(entry.value(), Value::Done(_))
+        {
+            return;
+        }
+
+        // Wait for the key to be created and completed
+        notified.await;
+    }
+
+    /// Complete a pre-registered key with a value.
+    ///
+    /// This is used in conjunction with `register()` for the pre-registration pattern:
+    /// 1. Call `register(key)` synchronously to claim the key
+    /// 2. Do async work
+    /// 3. Call `complete(key, value, notify)` to store result and notify waiters
+    ///
+    /// The notify handle must be the one returned from `register()`.
+    pub fn complete(&self, key: K, value: Option<V>, notify: Arc<Notify>) {
+        match value {
+            Some(v) => {
+                self.map.insert(key.clone(), Value::Done(Arc::new(v)));
+            }
+            None => {
+                self.map.remove(&key);
+            }
+        }
+        self.notify_all(&key, &notify);
+    }
+
+    /// Notify both the work-notify and any creation waiters for a key.
+    fn notify_all(&self, key: &K, notify: &Notify) {
+        notify.notify_waiters();
+        if let Some((_, cn)) = self.waiters.remove(key) {
+            cn.notify_waiters();
+        }
+    }
+
+    /// Get or initialize a value for the given key.
+    ///
+    /// If the key doesn't exist, the provided async closure will be called to compute the value.
+    /// If another task is already computing the value, this will wait for it to complete.
+    ///
+    /// Returns `Some(Arc<V>)` if the computation succeeded, `None` if it failed.
+    pub async fn get_or_init<F, Fut>(&self, key: K, init: F) -> Option<Arc<V>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Option<V>>,
+    {
+        // Fast path: check if already done
+        if let Some(entry) = self.map.get(&key)
+            && let Value::Done(result) = entry.value()
+        {
+            return Some(Arc::clone(result));
+        }
+
+        // Try to register as the worker
+        let notify = Arc::new(Notify::new());
+        let entry = self.map.entry(key.clone());
+
+        match entry {
+            Entry::Occupied(occupied) => {
+                // Someone else is working on it or it's done
+                match occupied.get() {
+                    Value::Done(result) => {
+                        return Some(Arc::clone(result));
+                    }
+                    Value::Waiting(existing_notify) => {
+                        let existing_notify = Arc::clone(existing_notify);
+
+                        // Register the waiter BEFORE releasing the lock.
+                        // This prevents a race condition where the worker completes
+                        // and calls notify_waiters() between dropping the lock and
+                        // registering the waiter - which would cause us to miss the
+                        // notification and wait forever.
+                        let notified = existing_notify.notified();
+
+                        // Now safe to release the lock
+                        drop(occupied);
+
+                        // Double-check: the value might have been inserted between
+                        // releasing the lock and here. If so, return it directly.
+                        if let Some(entry) = self.map.get(&key)
+                            && let Value::Done(result) = entry.value()
+                        {
+                            return Some(Arc::clone(result));
+                        }
+
+                        // Wait for the worker to complete
+                        notified.await;
+
+                        // Check the result
+                        if let Some(entry) = self.map.get(&key)
+                            && let Value::Done(result) = entry.value()
+                        {
+                            return Some(Arc::clone(result));
+                        }
+                        return None;
+                    }
+                }
+            }
+            Entry::Vacant(vacant) => {
+                // We are the worker
+                vacant.insert(Value::Waiting(Arc::clone(&notify)));
+            }
+        }
+
+        // Execute the work
+        let result = init().await;
+
+        // Update the map with the result
+        let arc_value = result.map(|v| {
+            let arc = Arc::new(v);
+            self.map.insert(key.clone(), Value::Done(Arc::clone(&arc)));
+            arc
+        });
+        if arc_value.is_none() {
+            self.map.remove(&key);
+        }
+        self.notify_all(&key, &notify);
+        arc_value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_single_execution() {
+        let map: OnceMap<String, i32> = OnceMap::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let call_count_clone = Arc::clone(&call_count);
+        let result = map
+            .get_or_init("key".to_string(), || async move {
+                call_count_clone.fetch_add(1, Ordering::SeqCst);
+                Some(42)
+            })
+            .await;
+
+        assert_eq!(*result.unwrap(), 42);
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+
+        // Second call should return cached result
+        let call_count_clone = Arc::clone(&call_count);
+        let result = map
+            .get_or_init("key".to_string(), || async move {
+                call_count_clone.fetch_add(1, Ordering::SeqCst);
+                Some(100)
+            })
+            .await;
+
+        assert_eq!(*result.unwrap(), 42); // Still 42, not 100
+        assert_eq!(call_count.load(Ordering::SeqCst), 1); // Still 1, not called again
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_requests() {
+        let map = Arc::new(OnceMap::<String, i32>::new());
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = vec![];
+
+        // Spawn 10 concurrent tasks requesting the same key
+        for _ in 0..10 {
+            let map = Arc::clone(&map);
+            let call_count = Arc::clone(&call_count);
+
+            handles.push(tokio::spawn(async move {
+                map.get_or_init("shared_key".to_string(), || async move {
+                    // Simulate slow work
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    call_count.fetch_add(1, Ordering::SeqCst);
+                    Some(42)
+                })
+                .await
+            }));
+        }
+
+        // Wait for all tasks
+        let results: Vec<_> = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|r| r.unwrap())
+            .collect();
+
+        // All should get the same result
+        for result in results {
+            assert_eq!(*result.unwrap(), 42);
+        }
+
+        // Work should only be done once
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_failed_work_allows_retry() {
+        let map: OnceMap<String, i32> = OnceMap::new();
+        let attempt = Arc::new(AtomicUsize::new(0));
+
+        // First attempt fails
+        let attempt_clone = Arc::clone(&attempt);
+        let result = map
+            .get_or_init("key".to_string(), || async move {
+                attempt_clone.fetch_add(1, Ordering::SeqCst);
+                None // Fail
+            })
+            .await;
+        assert!(result.is_none());
+
+        // Second attempt should be allowed and succeed
+        let attempt_clone = Arc::clone(&attempt);
+        let result = map
+            .get_or_init("key".to_string(), || async move {
+                attempt_clone.fetch_add(1, Ordering::SeqCst);
+                Some(42)
+            })
+            .await;
+        assert_eq!(*result.unwrap(), 42);
+        assert_eq!(attempt.load(Ordering::SeqCst), 2);
+    }
+
+    /// Test that waiters don't miss notifications due to race conditions.
+    ///
+    /// This test verifies the fix for a race condition where a waiter could
+    /// miss the notification if the worker completed between the waiter
+    /// releasing the lock and registering for notifications.
+    ///
+    /// Timeline of the race condition (before fix):
+    /// ```text
+    /// Worker                          Waiter
+    /// ──────                          ──────
+    /// 1. register key
+    ///    insert Waiting(notify)
+    ///    start work...
+    ///                                 2. sees Waiting state
+    ///                                    clone notify
+    ///                                    drop(lock) ← release lock
+    ///
+    ///                                    ┌─────────────────┐
+    ///                                    │  DANGER WINDOW  │
+    ///                                    │  (not listening │
+    ///                                    │   for notify)   │
+    ///                                    └─────────────────┘
+    ///
+    /// 3. work done!
+    ///    insert Done(value)
+    ///    notify_waiters() ← sent!
+    ///    (but no one listening)
+    ///
+    ///                                 4. notified = notify.notified()
+    ///                                    ← too late! already notified
+    ///
+    ///                                 5. notified.await
+    ///                                    ← waits forever, deadlock!
+    /// ```
+    ///
+    /// The fix: register `notified()` BEFORE releasing the lock, then
+    /// double-check if the value was inserted.
+    #[tokio::test]
+    async fn test_no_missed_notifications() {
+        use tokio::sync::Barrier;
+
+        let map = Arc::new(OnceMap::<String, i32>::new());
+        let barrier = Arc::new(Barrier::new(2));
+
+        // Spawn the worker task
+        let map_clone = Arc::clone(&map);
+        let barrier_clone = Arc::clone(&barrier);
+        let worker = tokio::spawn(async move {
+            map_clone
+                .get_or_init("key".to_string(), || async move {
+                    // Wait for waiter to be ready
+                    barrier_clone.wait().await;
+                    // Small delay to let waiter release lock
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    Some(42)
+                })
+                .await
+        });
+
+        // Spawn waiter task
+        let map_clone = Arc::clone(&map);
+        let barrier_clone = Arc::clone(&barrier);
+        let waiter = tokio::spawn(async move {
+            // Small delay to ensure worker registers first
+            tokio::time::sleep(Duration::from_millis(1)).await;
+
+            // Signal worker to proceed
+            barrier_clone.wait().await;
+
+            // This should not hang - if it does, the race condition exists
+            map_clone
+                .get_or_init("key".to_string(), || async move {
+                    panic!("Waiter should not execute work");
+                })
+                .await
+        });
+
+        // Use timeout to detect deadlock
+        let timeout = Duration::from_secs(2);
+        let results = tokio::time::timeout(timeout, futures::future::join(worker, waiter))
+            .await
+            .expect("Test timed out - possible deadlock due to missed notification");
+
+        // Both should get the same result
+        assert_eq!(*results.0.unwrap().unwrap(), 42);
+        assert_eq!(*results.1.unwrap().unwrap(), 42);
+    }
+}


### PR DESCRIPTION
Strip aws-lc-rs from #2838's bundle to isolate which of the 3 drivers contribute. Linear stack: baseline → +WP → +WP+OnceMap → +aws-lc-rs.