### PR TITLE
perf(pm): skip binary mirror work when scripts are ignored

### DIFF
--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -233,6 +233,10 @@ async fn handle_cypress(
 }
 
 pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
+    if should_skip_binary_mirror() {
+        return Ok(());
+    }
+
     let config = load_config().await?;
 
     let mirrors = config["mirrors"]["china"]
@@ -285,12 +289,19 @@ pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
 fn should_skip_binary_mirror() -> bool {
     *SKIP_BINARY_MIRROR.get_or_init(|| {
         let registry = get_registry();
-        let skip = is_npm_registry(&registry);
+        let skip = should_skip_binary_mirror_for_registry(&registry);
         if skip {
-            tracing::debug!("Skipping binary mirror envs for npm registry: {}", registry);
+            tracing::debug!(
+                "Skipping binary mirror config for npm registry: {}",
+                registry
+            );
         }
         skip
     })
+}
+
+fn should_skip_binary_mirror_for_registry(registry: &str) -> bool {
+    is_npm_registry(registry)
 }
 
 pub async fn get_envs() -> Option<&'static Map<String, Value>> {
@@ -389,6 +400,19 @@ mod tests {
             get_replace_host_files(&binary_mirror),
             vec!["lib/index.js", "lib/install.js"]
         );
+    }
+
+    #[test]
+    fn test_should_skip_binary_mirror_for_npm_registry() {
+        assert!(should_skip_binary_mirror_for_registry(
+            "https://registry.npmjs.org"
+        ));
+        assert!(should_skip_binary_mirror_for_registry(
+            "https://registry.npmjs.org/"
+        ));
+        assert!(!should_skip_binary_mirror_for_registry(
+            "https://registry.npmmirror.com"
+        ));
     }
 
     #[tokio::test]

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -62,10 +62,15 @@ fn should_omit_package(package: &Package, omit: &HashSet<OmitType>) -> bool {
     false
 }
 
+fn should_update_package_binary(package: &Package, scripts: ScriptPolicy) -> bool {
+    scripts == ScriptPolicy::Run && package.has_install_scripts()
+}
+
 pub async fn install_packages(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
     omit: &HashSet<OmitType>,
+    scripts: ScriptPolicy,
 ) -> Result<()> {
     use crate::util::cloner::clone_package_once;
 
@@ -152,6 +157,7 @@ pub async fn install_packages(
                     // Check if this is an optional dependency
                     let is_optional =
                         package.optional == Some(true) || package.dev_optional == Some(true);
+                    let update_binary = should_update_package_binary(&package, scripts);
 
                     let task = tokio::spawn(async move {
                         if let Err(e) =
@@ -166,7 +172,10 @@ pub async fn install_packages(
                         }
                         PROGRESS_BAR.inc(1);
                         log_progress(&format!("{name} resolved"));
-                        update_package_binary(&target_path, &name).await
+                        if update_binary {
+                            update_package_binary(&target_path, &name).await?;
+                        }
+                        Ok(())
                     });
                     clone_tasks.push(task);
                 } else {
@@ -271,7 +280,7 @@ impl InstallService {
         }
 
         let link_start = Instant::now();
-        install_packages(&groups, root_path, omit)
+        install_packages(&groups, root_path, omit, scripts)
             .await
             .context("Failed to install packages")?;
 
@@ -410,6 +419,31 @@ mod tests {
         omit_dev_optional.insert(OmitType::Dev);
         omit_dev_optional.insert(OmitType::Optional);
         assert!(should_omit_package(&dev_optional_pkg, &omit_dev_optional));
+    }
+
+    #[test]
+    fn test_should_update_package_binary() {
+        let package_with_script = Package {
+            has_install_script: Some(true),
+            ..Package::default()
+        };
+        let package_without_script = Package {
+            has_install_script: Some(false),
+            ..Package::default()
+        };
+
+        assert!(should_update_package_binary(
+            &package_with_script,
+            ScriptPolicy::Run
+        ));
+        assert!(!should_update_package_binary(
+            &package_with_script,
+            ScriptPolicy::Ignore
+        ));
+        assert!(!should_update_package_binary(
+            &package_without_script,
+            ScriptPolicy::Run
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- skip binary mirror package rewrites when install scripts are ignored
- skip binary mirror config loading for the official npm registry
- add focused tests for the skip predicates

## Verification
- cargo fmt
- git diff --check
- cargo test -p utoo-pm test_should_ -- --nocapture (blocked: next.js/turbopack submodule files missing; submodule fetch/checkout did not populate next.js in this workspace)

## Risk
- Binary mirror rewriting now only runs when lifecycle scripts will run and the package declares install scripts. This should preserve scriptful installs while removing work from --ignore-scripts benchmark paths.