### PR TITLE
fix(pm): skip binary mirror lookup for npm registry

### DIFF
--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -233,6 +233,10 @@ async fn handle_cypress(
 }
 
 pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
+    if should_skip_binary_mirror() {
+        return Ok(());
+    }
+
     let config = load_config().await?;
 
     let mirrors = config["mirrors"]["china"]
@@ -283,14 +287,15 @@ pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
 }
 
 fn should_skip_binary_mirror() -> bool {
-    *SKIP_BINARY_MIRROR.get_or_init(|| {
-        let registry = get_registry();
-        let skip = is_npm_registry(&registry);
-        if skip {
-            tracing::debug!("Skipping binary mirror envs for npm registry: {}", registry);
-        }
-        skip
-    })
+    *SKIP_BINARY_MIRROR.get_or_init(|| should_skip_binary_mirror_for_registry(&get_registry()))
+}
+
+fn should_skip_binary_mirror_for_registry(registry: &str) -> bool {
+    let skip = is_npm_registry(registry);
+    if skip {
+        tracing::debug!("Skipping binary mirror envs for npm registry: {}", registry);
+    }
+    skip
 }
 
 pub async fn get_envs() -> Option<&'static Map<String, Value>> {
@@ -342,6 +347,19 @@ mod tests {
                 .unwrap()
                 .contains_key("replaceHostFiles")
         );
+    }
+
+    #[test]
+    fn test_should_skip_binary_mirror_for_npm_registry() {
+        assert!(should_skip_binary_mirror_for_registry(
+            "https://registry.npmjs.org"
+        ));
+        assert!(should_skip_binary_mirror_for_registry(
+            "https://registry.npmjs.com"
+        ));
+        assert!(!should_skip_binary_mirror_for_registry(
+            "https://registry.npmmirror.com"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Skip binary mirror config loading in update_package_binary when the active registry is official npm.
- Add a unit test for the npm-registry skip predicate.

## Verification
- cargo test -p utoo-pm service::binary::tests::test_should_skip_binary_mirror_for_npm_registry
- cargo fmt
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps
- cargo build --profile release-local -p utoo-pm

## Notes
- bench/pm-bench-phases.sh could not be run in this container because hyperfine and bun are not installed.