### PR TITLE
perf(pm): reduce install hot path overhead

### DIFF
--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -233,6 +233,10 @@ async fn handle_cypress(
 }
 
 pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
+    if should_skip_binary_mirror() {
+        return Ok(());
+    }
+
     let config = load_config().await?;
 
     let mirrors = config["mirrors"]["china"]

--- a/crates/pm/src/service/clean.rs
+++ b/crates/pm/src/service/clean.rs
@@ -148,7 +148,10 @@ pub async fn clean_deps(groups: &HashMap<usize, Vec<(String, Package)>>, cwd: &P
         .flat_map(|pkgs| pkgs.iter().map(|(path, _)| path.clone()))
         .collect();
 
-    tracing::debug!("Valid packages: {valid_packages:?}");
+    tracing::debug!(
+        count = valid_packages.len(),
+        "Collected valid package paths"
+    );
 
     let mut nm_dirs = vec![cwd.join("node_modules")];
     for (_, ws_path, _) in workspace::find_workspaces(cwd).await? {

--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -158,7 +158,7 @@ impl PackageService {
 
             // Binary linking queue - always process if package has bin files
             if !package.bin_files.is_empty() {
-                tracing::debug!("Adding {} to bin linking queue", package.path.display());
+                tracing::trace!("Adding {} to bin linking queue", package.path.display());
                 queues.bin_linking.push((Rc::clone(&package), is_optional));
             }
         }
@@ -281,9 +281,12 @@ impl PackageService {
     /// Queue contains (PackageInfo, is_optional) tuples - is_optional is not used here
     /// as binary linking happens only for successfully installed packages
     async fn execute_binary_linking(queue: &[(Rc<PackageInfo>, bool)]) -> Result<()> {
+        let mut linked_packages = 0usize;
+        let mut linked_bins = 0usize;
         for (package, _is_optional) in queue {
             if !package.bin_files.is_empty() {
-                tracing::debug!("Linking binary files for {}", package.name);
+                tracing::trace!("Linking binary files for {}", package.name);
+                linked_packages += 1;
                 for (bin_name, relative_path) in &package.bin_files {
                     let target_path = package.path.join(relative_path);
                     if !crate::fs::try_exists(&target_path).await? {
@@ -319,10 +322,16 @@ impl PackageService {
                                 link_path.display()
                             )
                         })?;
+                    linked_bins += 1;
                 }
-                tracing::debug!("Linking binary files for {} successfully", package.name);
+                tracing::trace!("Linking binary files for {} successfully", package.name);
             }
         }
+        tracing::debug!(
+            packages = linked_packages,
+            bins = linked_bins,
+            "Binary linking completed"
+        );
         Ok(())
     }
 }

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -93,7 +93,7 @@ pub async fn clone_package_once(
 
             if fresh {
                 CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
-                tracing::debug!("Cloned: {}@{} to {}", name, version, target_path.display());
+                tracing::trace!("Cloned: {}@{} to {}", name, version, target_path.display());
             }
             Some(())
         })
@@ -406,7 +406,7 @@ async fn clone(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
         Retry::spawn(create_retry_strategy(), || async {
             match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
                 0 => {
-                    tracing::debug!("clone {} to {} success", real_src.display(), dst.display());
+                    tracing::trace!("clone {} to {} success", real_src.display(), dst.display());
                     Ok(())
                 }
                 _ => {
@@ -431,7 +431,7 @@ async fn clone(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
     {
         Retry::spawn(create_retry_strategy(), || async {
             hardlink_clone::clone_dir(&real_src, dst).await?;
-            tracing::debug!("clone {} to {} success", real_src.display(), dst.display());
+            tracing::trace!("clone {} to {} success", real_src.display(), dst.display());
             Ok::<(), anyhow::Error>(())
         })
         .await?;

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -81,7 +81,7 @@ pub async fn git_cache_lookup(name: &str, version: &str, tarball_url: &str) -> O
         .await
         .unwrap_or(false)
     {
-        tracing::debug!("Git package cache hit: {}@{}", name, version);
+        tracing::trace!("Git package cache hit: {}@{}", name, version);
         return Some(cache_path);
     }
     tracing::warn!(
@@ -118,7 +118,7 @@ pub async fn file_cache_lookup(name: &str, tarball_url: &str) -> Option<PathBuf>
     let abs_path = tarball_url.strip_prefix("file:")?;
     let hit = slot_cache_lookup(name, file_cache_slot(std::path::Path::new(abs_path))).await;
     if hit.is_some() {
-        tracing::debug!("file: dep cache hit: {} ({})", name, tarball_url);
+        tracing::trace!("file: dep cache hit: {} ({})", name, tarball_url);
     }
     hit
 }
@@ -127,7 +127,7 @@ pub async fn file_cache_lookup(name: &str, tarball_url: &str) -> Option<PathBuf>
 pub async fn http_tarball_cache_lookup(name: &str, tarball_url: &str) -> Option<PathBuf> {
     let hit = slot_cache_lookup(name, http_cache_slot(tarball_url)).await;
     if hit.is_some() {
-        tracing::debug!("HTTP tarball cache hit: {} ({})", name, tarball_url);
+        tracing::trace!("HTTP tarball cache hit: {} ({})", name, tarball_url);
     }
     hit
 }
@@ -173,7 +173,7 @@ pub async fn download_to_cache(name: &str, version: &str, tarball_url: &str) -> 
                 .unwrap_or(false)
             {
                 REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
-                tracing::debug!("Cache hit: {}@{}", name, version);
+                tracing::trace!("Cache hit: {}@{}", name, version);
                 return Some(cache_path);
             }
 
@@ -193,7 +193,7 @@ pub async fn download_to_cache(name: &str, version: &str, tarball_url: &str) -> 
                 .ok()?;
 
             DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
-            tracing::debug!("Downloaded: {}@{}", name, version);
+            tracing::trace!("Downloaded: {}@{}", name, version);
             Some(cache_path)
         })
         .await


### PR DESCRIPTION
## Summary
- avoid no-op binary mirror processing for official npm registry installs
- reduce hot-path debug log volume during pm installs by moving per-package cache/clone/bin messages to trace
- keep aggregate debug summaries for valid package paths and binary linking

## Verification
- cargo fmt
- cargo build -p utoo-pm --profile release-local
- cargo test -p utoo-pm
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps
- BENCH_RUNS=1 PM_LIST=utoo bash bench/pm-bench-phases.sh

Note: full workspace cargo clippy --all-targets -- -D warnings --no-deps is blocked in this environment by missing pkg-config/OpenSSL for unrelated pack dependencies (openssl-sys).