### PR TITLE
fix(pm): bound install pipeline task concurrency

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::Instant;
+use tokio::task::JoinSet;
 
 use crate::cmd::deps::build_deps;
 use crate::fs;
@@ -23,6 +24,7 @@ use crate::util::linker::link;
 use crate::util::logger::{
     PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
 };
+use crate::util::sysconf::parallel_io_limit;
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
 
 use super::binary::update_package_binary;
@@ -62,6 +64,13 @@ fn should_omit_package(package: &Package, omit: &HashSet<OmitType>) -> bool {
     false
 }
 
+async fn join_next_clone_task(clone_tasks: &mut JoinSet<Result<()>>) -> Result<()> {
+    if let Some(result) = clone_tasks.join_next().await {
+        result.context("clone task panicked")??;
+    }
+    Ok(())
+}
+
 pub async fn install_packages(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
@@ -83,7 +92,8 @@ pub async fn install_packages(
     depths.sort_unstable();
 
     for depth in depths.iter() {
-        let mut clone_tasks: Vec<tokio::task::JoinHandle<Result<()>>> = Vec::new();
+        let mut clone_tasks = JoinSet::new();
+        let clone_limit = parallel_io_limit();
 
         if let Some(packages) = groups.get(depth) {
             for (path, package) in packages.iter() {
@@ -153,7 +163,11 @@ pub async fn install_packages(
                     let is_optional =
                         package.optional == Some(true) || package.dev_optional == Some(true);
 
-                    let task = tokio::spawn(async move {
+                    while clone_tasks.len() >= clone_limit {
+                        join_next_clone_task(&mut clone_tasks).await?;
+                    }
+
+                    clone_tasks.spawn(async move {
                         if let Err(e) =
                             clone_package_once(&name, &version, &resolved, &target_path).await
                         {
@@ -168,7 +182,6 @@ pub async fn install_packages(
                         log_progress(&format!("{name} resolved"));
                         update_package_binary(&target_path, &name).await
                     });
-                    clone_tasks.push(task);
                 } else {
                     PROGRESS_BAR.inc(1);
                     tracing::debug!("{path} no resolved info skipped");
@@ -176,8 +189,8 @@ pub async fn install_packages(
             }
         }
 
-        for task in clone_tasks {
-            task.await??;
+        while !clone_tasks.is_empty() {
+            join_next_clone_task(&mut clone_tasks).await?;
         }
     }
 

--- a/crates/pm/src/service/pipeline/worker.rs
+++ b/crates/pm/src/service/pipeline/worker.rs
@@ -3,6 +3,11 @@ use std::path::PathBuf;
 use super::receiver::PipelineChannels;
 use crate::util::cloner::{clone_package_once, wait_clone_if_pending};
 use crate::util::downloader::{download_to_cache, is_git_url};
+use crate::util::sysconf::parallel_io_limit;
+
+async fn join_one(tasks: &mut tokio::task::JoinSet<()>) {
+    let _ = tasks.join_next().await;
+}
 
 /// Pipeline worker handles for awaiting completion.
 pub struct PipelineHandles {
@@ -22,6 +27,8 @@ impl PipelineHandles {
 pub fn start_workers(channels: PipelineChannels, cwd: PathBuf) -> PipelineHandles {
     let download_handle = tokio::spawn(async move {
         let mut rx = channels.download_rx;
+        let mut tasks = tokio::task::JoinSet::new();
+        let limit = parallel_io_limit();
         while let Some(info) = rx.recv().await {
             let Some(tarball_url) = info.tarball_url else {
                 continue;
@@ -39,14 +46,22 @@ pub fn start_workers(channels: PipelineChannels, cwd: PathBuf) -> PipelineHandle
             }
             let name = info.name;
             let version = info.version;
-            tokio::spawn(async move {
+            while tasks.len() >= limit {
+                join_one(&mut tasks).await;
+            }
+            tasks.spawn(async move {
                 download_to_cache(&name, &version, &tarball_url).await;
             });
+        }
+        while !tasks.is_empty() {
+            join_one(&mut tasks).await;
         }
     });
 
     let clone_handle = tokio::spawn(async move {
         let mut rx = channels.clone_rx;
+        let mut tasks = tokio::task::JoinSet::new();
+        let limit = parallel_io_limit();
         while let Some(msg) = rx.recv().await {
             let Some(tarball_url) = msg.info.tarball_url else {
                 continue;
@@ -55,7 +70,10 @@ pub fn start_workers(channels: PipelineChannels, cwd: PathBuf) -> PipelineHandle
             let version = msg.info.version;
             let target = cwd.join(&msg.path);
             let parent_path = msg.parent_path.map(|p| cwd.join(&p));
-            tokio::spawn(async move {
+            while tasks.len() >= limit {
+                join_one(&mut tasks).await;
+            }
+            tasks.spawn(async move {
                 if let Some(ref parent) = parent_path {
                     wait_clone_if_pending(&parent.to_string_lossy()).await;
                 }
@@ -63,6 +81,9 @@ pub fn start_workers(channels: PipelineChannels, cwd: PathBuf) -> PipelineHandle
                     tracing::debug!("Pipeline pre-clone failed for {name}@{version}: {e:#}");
                 }
             });
+        }
+        while !tasks.is_empty() {
+            join_one(&mut tasks).await;
         }
     });
 

--- a/crates/pm/src/util/sysconf.rs
+++ b/crates/pm/src/util/sysconf.rs
@@ -15,6 +15,18 @@ pub fn init() {
         .ok();
 }
 
+/// Conservative upper bound for filesystem-heavy parallel work.
+///
+/// Package linking is mostly blocking I/O. Letting one task per package enter
+/// the blocking pool at once creates scheduler churn on large dependency
+/// graphs, while a limit based on CPU parallelism still keeps disk queues full.
+pub fn parallel_io_limit() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().saturating_mul(4))
+        .unwrap_or(32)
+        .clamp(16, 128)
+}
+
 /// Restore default SIGPIPE handling so broken pipes cause a clean exit
 /// instead of a panic. Same approach as ripgrep and fd.
 #[cfg(unix)]
@@ -53,5 +65,11 @@ mod tests {
             let prev = libc::signal(libc::SIGPIPE, libc::SIG_DFL);
             assert_eq!(prev, libc::SIG_DFL);
         }
+    }
+
+    #[test]
+    fn test_parallel_io_limit_is_bounded() {
+        let limit = parallel_io_limit();
+        assert!((16..=128).contains(&limit));
     }
 }


### PR DESCRIPTION
## Summary
- Bound filesystem-heavy package clone/link work with a CPU-based parallel I/O limit.
- Track and drain install/pipeline subtasks with JoinSet so pipeline completion reflects actual spawned work.
- Added a small bound check for the new concurrency helper.

## Validation
- cargo build --profile release-local -p utoo-pm
- cargo test -p utoo-pm
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps
- Warm-link validation on ant-design temp checkout with populated cache: 4643 added, 3281 reused, 0 downloaded, wall 0.99s

## Notes
- Full bench/pm-bench-phases.sh with ant-design Phase 0 was started with BENCH_RUNS=1 PM_LIST=utoo, but the cold install did not complete in a reasonable window in this runner and was interrupted after it had already materialized thousands of node_modules/cache entries.
- Full-workspace cargo clippy --all-targets -- -D warnings --no-deps is blocked in this environment by unrelated openssl-sys requiring pkg-config/OpenSSL for workspace crates outside utoo-pm.