### PR TITLE
fix(pm): skip npm binary mirror lookup

### DIFF
--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -233,6 +233,10 @@ async fn handle_cypress(
 }
 
 pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
+    if should_skip_binary_mirror() {
+        return Ok(());
+    }
+
     let config = load_config().await?;
 
     let mirrors = config["mirrors"]["china"]
@@ -282,12 +286,19 @@ pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
+fn should_skip_binary_mirror_for_registry(registry: &str) -> bool {
+    is_npm_registry(registry)
+}
+
 fn should_skip_binary_mirror() -> bool {
     *SKIP_BINARY_MIRROR.get_or_init(|| {
         let registry = get_registry();
-        let skip = is_npm_registry(&registry);
+        let skip = should_skip_binary_mirror_for_registry(&registry);
         if skip {
-            tracing::debug!("Skipping binary mirror envs for npm registry: {}", registry);
+            tracing::debug!(
+                "Skipping binary mirror config for npm registry: {}",
+                registry
+            );
         }
         skip
     })
@@ -342,6 +353,19 @@ mod tests {
                 .unwrap()
                 .contains_key("replaceHostFiles")
         );
+    }
+
+    #[test]
+    fn test_should_skip_binary_mirror_for_npm_registry() {
+        assert!(should_skip_binary_mirror_for_registry(
+            "https://registry.npmjs.org"
+        ));
+        assert!(should_skip_binary_mirror_for_registry(
+            "https://registry.npmjs.org/"
+        ));
+        assert!(!should_skip_binary_mirror_for_registry(
+            "https://registry.npmmirror.com"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Skip install-time binary mirror config loading when the selected registry is the official npm registry.
- Reuse the same npm-registry predicate already used for binary mirror envs.
- Add a focused test covering npm and npmmirror registry behavior.

## Validation
- `cargo fmt -p utoo-pm`
- `cargo test -p utoo-pm service::binary::tests::test_should_skip_binary_mirror_for_npm_registry`
- `cargo build -p utoo-pm --profile release-local`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
- `cargo test -p utoo-pm`
- `PATH=/home/killa/multica_workspaces/56c053c2-a029-45bb-a3f8-c83499005c8a/f45d2706/workdir/utoo/target/release-local:$PATH BENCH_RUNS=1 PM_LIST=utoo BENCH_DIR=/tmp/pm-bench-eggd RESULTS_DIR=/tmp/pm-bench-results-eggd UTOO_CACHE=/tmp/utoo-bench-cache-eggd bash bench/pm-bench-phases.sh`

Benchmark summary, `PM_LIST=utoo`, single run:
- p0_full_cold: 11.22s
- p1_resolve: 5.49s
- p3_cold_install: 9.87s
- p4_warm_link: 1.09s

Note: full workspace `cargo clippy --all-targets -- -D warnings --no-deps` is blocked in this runner by missing system `pkg-config`/OpenSSL for unrelated workspace dependencies; package-scoped PM clippy passed.