### PR TITLE
perf(pm): skip npm binary mirror work

### DIFF
--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -233,6 +233,10 @@ async fn handle_cypress(
 }
 
 pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
+    if should_skip_binary_mirror() {
+        return Ok(());
+    }
+
     let config = load_config().await?;
 
     let mirrors = config["mirrors"]["china"]
@@ -282,7 +286,7 @@ pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
-fn should_skip_binary_mirror() -> bool {
+pub(crate) fn should_skip_binary_mirror() -> bool {
     *SKIP_BINARY_MIRROR.get_or_init(|| {
         let registry = get_registry();
         let skip = is_npm_registry(&registry);

--- a/crates/pm/src/service/clean.rs
+++ b/crates/pm/src/service/clean.rs
@@ -143,13 +143,6 @@ async fn remove_unused_packages(
 
 /// Clean unused dependencies across all workspace node_modules directories.
 pub async fn clean_deps(groups: &HashMap<usize, Vec<(String, Package)>>, cwd: &Path) -> Result<()> {
-    let valid_packages: HashSet<String> = groups
-        .values()
-        .flat_map(|pkgs| pkgs.iter().map(|(path, _)| path.clone()))
-        .collect();
-
-    tracing::debug!("Valid packages: {valid_packages:?}");
-
     let mut nm_dirs = vec![cwd.join("node_modules")];
     for (_, ws_path, _) in workspace::find_workspaces(cwd).await? {
         let ws_nm = ws_path.join("node_modules");
@@ -158,6 +151,18 @@ pub async fn clean_deps(groups: &HashMap<usize, Vec<(String, Package)>>, cwd: &P
             nm_dirs.push(ws_nm);
         }
     }
+
+    nm_dirs.retain(|nm_dir| nm_dir.exists());
+    if nm_dirs.is_empty() {
+        return Ok(());
+    }
+
+    let valid_packages: HashSet<String> = groups
+        .values()
+        .flat_map(|pkgs| pkgs.iter().map(|(path, _)| path.clone()))
+        .collect();
+
+    tracing::debug!("Valid packages: {valid_packages:?}");
 
     for nm_dir in &nm_dirs {
         remove_stale_entries(nm_dir).await?;

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -25,7 +25,7 @@ use crate::util::logger::{
 };
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
 
-use super::binary::update_package_binary;
+use super::binary::{should_skip_binary_mirror, update_package_binary};
 use super::clean::clean_deps;
 
 /// Check if a package should be omitted based on omit config
@@ -74,6 +74,8 @@ pub async fn install_packages(
     log_progress("validating node_modules");
     clean_deps(groups, cwd).await?;
     log_progress("linking packages");
+
+    let update_binaries = !should_skip_binary_mirror();
 
     // Always process level-by-level to ensure parent directories exist before
     // children. Within each level, tasks run concurrently. The pipeline's
@@ -166,7 +168,11 @@ pub async fn install_packages(
                         }
                         PROGRESS_BAR.inc(1);
                         log_progress(&format!("{name} resolved"));
-                        update_package_binary(&target_path, &name).await
+                        if update_binaries {
+                            update_package_binary(&target_path, &name).await
+                        } else {
+                            Ok(())
+                        }
                     });
                     clone_tasks.push(task);
                 } else {


### PR DESCRIPTION
## Summary
- Skip binary mirror config lookup and per-package mirror processing when installing from the official npm registry.
- Avoid building the valid-package cleanup set when no node_modules directories exist during fresh installs.

## pm-bench analysis
Command: PATH=target/release-local:$PATH BENCH_RUNS=1 PM_LIST=utoo RESULTS_DIR=/tmp/pm-bench-results-* bash bench/pm-bench-phases.sh

Baseline -> optimized, utoo only on ant-design:
- p0 full cold: 11.818s -> 11.269s (network-bound; optimized run used similar downloads)
- p1 resolve: 4.917s -> 5.066s (no install-path change; run noise)
- p3 cold install: 10.045s -> 10.338s (optimized run hit one registry retry)
- p4 warm link: 1.067s -> 1.039s; netRX 16KB -> 495B; RSS 105MB -> 100MB; sys CPU 11.416s -> 10.413s

## Verification
- cargo fmt
- cargo test -p utoo-pm
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps

Note: cargo clippy --all-targets -- -D warnings --no-deps is blocked in this environment before checking this change because pack-related targets require openssl-sys and pkg-config/OpenSSL is unavailable.