### PR TITLE
perf(pm): skip binary mirror lookup for npm registry

### DIFF
--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -233,6 +233,10 @@ async fn handle_cypress(
 }
 
 pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
+    if should_skip_binary_mirror() {
+        return Ok(());
+    }
+
     let config = load_config().await?;
 
     let mirrors = config["mirrors"]["china"]


### PR DESCRIPTION
Summary:
- Skip binary mirror config loading during package binary updates when the active registry is the official npm registry.
- Avoids an unnecessary registry request in npmjs pm-bench install/link phases.

Verification:
- cargo build -p utoo-pm --release
- cargo test -p utoo-pm service::binary -- --nocapture
- BENCH_RUNS=1 PM_LIST=utoo PROJECT=ant-design REGISTRY=https://registry.npmjs.org PATH=/home/killa/multica_workspaces/56c053c2-a029-45bb-a3f8-c83499005c8a/0e8f1ac6/workdir/utoo/target/release:/home/killa/.local/bin:/home/killa/multica_workspaces/56c053c2-a029-45bb-a3f8-c83499005c8a/0e8f1ac6/codex-home/tmp/arg0/codex-arg01UKLE1:/home/killa/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/killa/.local/bin:/home/killa/.local/bin:/home/killa/.npm-global/bin:/home/killa/.cargo/bin:/home/killa/.local/bin:/home/killa/.nvm/versions/node/v22.22.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/snap/bin:/home/killa/.local/share/JetBrains/Toolbox/scripts:/home/killa/.local/share/JetBrains/Toolbox/scripts bash bench/pm-bench-phases.sh

Benchmark slice:
- p0 full cold: 11.81s
- p1 resolve: 5.08s
- p3 cold install: 9.97s
- p4 warm link: 1.07s, netRX 19KB

Risk: mirror rewriting is unchanged for npmmirror and other non-npm registries.