### PR TITLE
perf(pm): chunked parallel writes within tarball extraction

### DIFF
--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -65,17 +65,23 @@ async fn extract_tarball(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
     rx.await.with_context(|| "Extract task panicked")?
 }
 
-/// Synchronous extraction: decompress + parse + sequential write, all on rayon.
+/// Synchronous extraction: decompress + parse + chunked parallel write, all on rayon.
 ///
-/// Writes are sequential within a package: tar entries are naturally streamed in order,
-/// and files are typically small (< 64KB). Intra-package parallelism via `par_iter`
-/// creates many short tasks that trigger rayon work-stealing (futex park/unpark) and
-/// dominate context switches on large dep graphs. Cross-package parallelism is preserved
-/// by the outer `rayon::spawn` in `extract_tarball`.
+/// Writes are batched into fixed-size chunks: each rayon task writes a contiguous
+/// run of `WRITE_CHUNK_SIZE` files sequentially. This keeps multi-core parallelism
+/// for IO-overlap while cutting the rayon task count (and its work-stealing
+/// futex park/unpark pressure) by the chunk factor. Cross-package parallelism is
+/// preserved by the outer `rayon::spawn` in `extract_tarball`.
 fn extract_tarball_sync(gzip_bytes: Bytes, estimated_size: usize, dest: &Path) -> Result<()> {
+    use rayon::prelude::*;
     use std::collections::HashSet;
     use std::fs;
     use std::io::{Cursor, Read, Write};
+
+    /// Files per rayon task when writing extracted tar entries. Sized to amortize
+    /// work-stealing overhead while leaving enough tasks to keep cores busy on
+    /// large packages (e.g. 500-file packages → ~16 tasks with WRITE_CHUNK_SIZE=32).
+    const WRITE_CHUNK_SIZE: usize = 32;
 
     // Decompress gzip using libdeflate
     let mut output = vec![0u8; estimated_size];
@@ -157,22 +163,27 @@ fn extract_tarball_sync(gzip_bytes: Bytes, estimated_size: usize, dest: &Path) -
         fs::create_dir(dir).ok();
     }
 
-    // Write files sequentially. Cross-package parallelism is handled by the outer
-    // rayon::spawn; splitting individual files into rayon tasks caused excessive
-    // work-stealing ctx switches on large dep trees.
-    for entry in &entries {
-        let mut file = fs::File::create(&entry.path)
-            .with_context(|| format!("Failed to create: {}", entry.path.display()))?;
-        file.write_all(&entry.content)
-            .with_context(|| format!("Failed to write: {}", entry.path.display()))?;
+    // Chunked parallel writes: N files per rayon task. Retains IO-overlap
+    // parallelism across cores while cutting the rayon task count (and the
+    // associated work-stealing futex traffic) relative to per-file par_iter.
+    entries
+        .par_chunks(WRITE_CHUNK_SIZE)
+        .try_for_each(|chunk| -> Result<()> {
+            for entry in chunk {
+                let mut file = fs::File::create(&entry.path)
+                    .with_context(|| format!("Failed to create: {}", entry.path.display()))?;
+                file.write_all(&entry.content)
+                    .with_context(|| format!("Failed to write: {}", entry.path.display()))?;
 
-        // Skip chmod for 0o644 (most files) — File::create() already produces
-        // this via umask (0o666 & ~0o022 = 0o644).
-        #[cfg(unix)]
-        if entry.mode != 0o644 {
-            fs::set_permissions(&entry.path, fs::Permissions::from_mode(entry.mode)).ok();
-        }
-    }
+                // Skip chmod for 0o644 (most files) — File::create() already
+                // produces this via umask (0o666 & ~0o022 = 0o644).
+                #[cfg(unix)]
+                if entry.mode != 0o644 {
+                    fs::set_permissions(&entry.path, fs::Permissions::from_mode(entry.mode)).ok();
+                }
+            }
+            Ok(())
+        })?;
 
     // Set directory permissions
     #[cfg(unix)]

--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -65,9 +65,14 @@ async fn extract_tarball(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
     rx.await.with_context(|| "Extract task panicked")?
 }
 
-/// Synchronous extraction: decompress + parse + parallel write, all on rayon.
+/// Synchronous extraction: decompress + parse + sequential write, all on rayon.
+///
+/// Writes are sequential within a package: tar entries are naturally streamed in order,
+/// and files are typically small (< 64KB). Intra-package parallelism via `par_iter`
+/// creates many short tasks that trigger rayon work-stealing (futex park/unpark) and
+/// dominate context switches on large dep graphs. Cross-package parallelism is preserved
+/// by the outer `rayon::spawn` in `extract_tarball`.
 fn extract_tarball_sync(gzip_bytes: Bytes, estimated_size: usize, dest: &Path) -> Result<()> {
-    use rayon::prelude::*;
     use std::collections::HashSet;
     use std::fs;
     use std::io::{Cursor, Read, Write};
@@ -152,8 +157,10 @@ fn extract_tarball_sync(gzip_bytes: Bytes, estimated_size: usize, dest: &Path) -
         fs::create_dir(dir).ok();
     }
 
-    // Write files in parallel using rayon
-    entries.par_iter().try_for_each(|entry| -> Result<()> {
+    // Write files sequentially. Cross-package parallelism is handled by the outer
+    // rayon::spawn; splitting individual files into rayon tasks caused excessive
+    // work-stealing ctx switches on large dep trees.
+    for entry in &entries {
         let mut file = fs::File::create(&entry.path)
             .with_context(|| format!("Failed to create: {}", entry.path.display()))?;
         file.write_all(&entry.content)
@@ -165,8 +172,7 @@ fn extract_tarball_sync(gzip_bytes: Bytes, estimated_size: usize, dest: &Path) -
         if entry.mode != 0o644 {
             fs::set_permissions(&entry.path, fs::Permissions::from_mode(entry.mode)).ok();
         }
-        Ok(())
-    })?;
+    }
 
     // Set directory permissions
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Second cherry-pick from #2818 (perf/extract-sequential-writes), targeting **install path / p3_cold_install**. Restructures intra-package tar entry writes in `crates/pm/src/util/extractor.rs` to reduce rayon work-stealing overhead while keeping multi-core IO overlap for large packages.

Two commits, applied as a sequence (not squashed) to preserve the empirical "why":

1. **`perf(pm): sequential writes within tarball extraction`** — Replace `par_iter` with sequential `for` loop. Each tar entry is small (microseconds to write) so per-entry rayon tasks were dominated by futex park/unpark. Worse than running the writes inline.

2. **`perf(pm): chunked parallel writes within tarball extraction`** — Replace the sequential loop with `par_chunks(WRITE_CHUNK_SIZE)`, where each rayon task writes a contiguous run of 32 files sequentially. Restores multi-core overlap for large packages while cutting task count by ~32×.

Together the two are the local optimum after the journey timeline tested both extremes:
- per-entry par_iter (too many tasks, work-stealing dominates)
- pure sequential (single-core IO bottleneck on large packages)
- `par_chunks(32)` (current — verified essential by reverting; sequential write regressed p3 by +3.67s with σ exploding 0.04 → 2.85)

### Files

`crates/pm/src/util/extractor.rs` only (49 lines changed). No new dependencies, no API changes, no Cargo.toml touched.

### Risk

Low. Confined to one file in a hot path that's covered by `cargo test -p utoo-pm` and `e2e/utoo-pm.sh`. The chunk size constant `WRITE_CHUNK_SIZE = 32` is documented inline; tuning it requires a follow-up.

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings --no-deps -p utoo-pm` clean
- [x] `cargo build --profile release-local -p utoo-pm` clean
- [x] `tombi format --check`, `npx biome ci`, `typos` — all clean
- [ ] CI `pm-bench-phases` (label: benchmark) — verify p3_cold_install impact on Linux x86_64 / macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)