### PR TITLE
perf(pm): force HTTP/1.1 + 256-conn idle pool for manifest fetching

### DIFF
--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -159,7 +159,16 @@ pub fn client_builder() -> Result<reqwest::ClientBuilder> {
         let mut builder = builder
             .no_proxy()
             .dns_resolver(shared_resolver())
-            .connect_timeout(CONNECT_TIMEOUT);
+            .connect_timeout(CONNECT_TIMEOUT)
+            // Force HTTP/1.1 with a per-host connection pool. reqwest
+            // multiplexes all requests over a single HTTP/2 connection by
+            // default, so a slow response head-of-line-blocks the rest of
+            // the manifest fetch phase. An H1 pool lets concurrent
+            // manifest requests open independent TCP streams. Pool size
+            // matches preload's effective concurrency cap so every
+            // in-flight fetch can keep its conn warm without churn.
+            .http1_only()
+            .pool_max_idle_per_host(256);
 
         #[cfg(target_os = "macos")]
         {


### PR DESCRIPTION
## Summary

Forces reqwest to use HTTP/1.1 with a per-host connection pool (`pool_max_idle_per_host(256)`). reqwest's default H2 multiplexing serializes all requests through a single TCP connection — a single slow response head-of-line-blocks the entire manifest fetch phase. H1 + pool lets concurrent fetches open independent TCP streams.

## Local measurement (M-series macOS, ant-design / npmmirror, 8-run interleaved)

baseline = `next` HEAD (already includes #2856: aws-lc-rs macOS-only + connect_timeout 5 s)

| | min | max | mean | median | σ |
|---|---:|---:|---:|---:|---:|
| baseline | 4.00 | 11.18 | 5.59 | **4.46** | 2.43 |
| + h1pool | 3.86 | 6.94 | 4.83 | **4.28** | 1.09 |

Δ median **−0.20 s**, σ shrinks 2.43 → 1.09 (more consistent runs).

The signal is muted vs. plain `next` (where the same change measured **−3.25 s, −44 %**). Reason: #2856's `connect_timeout(5 s)` already kills hung sockets that previously caused H2 HOL stalls.

Pushed for CI bench-phases verification on Linux x86_64 / Mac CI — different network/CPU profile than local, may show a different signal.

## Why bother if local is muted

- σ tightens 2.43 → 1.09 — even if mean Δ is small, the **distribution is tighter** which matters for tail latency
- CI Linux ubuntu-latest's network conditions tend to expose H2 HOL more (slower CDN edge, higher RTT variance vs. local macOS to npmmirror)
- Future-proofs against H2 stack regressions (independent of TLS provider choice)

## Risk

Two-line builder chain change in `crates/ruborist/src/service/http.rs`. No new deps, no API change. Reverting is one-line.

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings --no-deps -p utoo-pm -p utoo-ruborist` clean
- [x] Local 8×2 interleaved bench
- [ ] CI `pm-bench-phases` (label: benchmark) — confirm Linux/Mac p1_resolve impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)