### PR TITLE
perf(pm): single-flight manifest fetches via OnceMap

### DIFF
--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -5,10 +5,10 @@ use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
+use utoo_ruborist::util::OnceMap;
 
 use super::downloader::{is_git_url, resolve_cache_path};
 use super::json::load_package_json;
-use super::oncemap::OnceMap;
 use super::retry::create_retry_strategy;
 use crate::fs;
 

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -10,10 +10,10 @@ use tokio::sync::Semaphore;
 use tokio_retry::RetryIf;
 use utoo_ruborist::http::{file_cache_slot, http_cache_slot};
 use utoo_ruborist::spec::Protocol;
+use utoo_ruborist::util::OnceMap;
 
 use super::cache::get_cache_dir;
 use super::extractor::extract_and_write;
-use super::oncemap::OnceMap;
 use super::retry::{RetryableError, build_dns_cached_client, create_retry_strategy};
 use super::user_config::get_manifests_concurrency_limit_sync;
 

--- a/crates/pm/src/util/mod.rs
+++ b/crates/pm/src/util/mod.rs
@@ -12,7 +12,6 @@ pub mod integrity;
 pub mod json;
 pub mod linker;
 pub mod logger;
-pub mod oncemap;
 pub mod platform_const;
 pub mod registry;
 pub mod retry;

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -9,6 +9,7 @@ license     = "MIT"
 [dependencies]
 anyhow       = { workspace = true }
 bytes        = "1"
+dashmap      = "6.1.0"
 pathdiff     = { workspace = true }
 deno_semver  = "0.7"
 dirs         = { workspace = true }

--- a/crates/ruborist/src/lib.rs
+++ b/crates/ruborist/src/lib.rs
@@ -27,6 +27,7 @@ pub mod resolver;
 pub mod service;
 pub mod spec;
 pub mod traits;
+pub mod util;
 
 // ============================================================================
 // Re-exports: only items actually used by consumers
@@ -98,9 +99,4 @@ pub mod git {
 pub mod http {
     #[cfg(feature = "http-tarball")]
     pub use crate::resolver::http::{file_cache_slot, http_cache_slot};
-}
-
-/// Utility functions.
-pub mod util {
-    pub use crate::model::util::{PackageNameStr, parse_package_spec, read_package_json};
 }

--- a/crates/ruborist/src/model/manifest.rs
+++ b/crates/ruborist/src/model/manifest.rs
@@ -40,9 +40,15 @@ pub struct FullManifest {
     #[serde(default, deserialize_with = "deserialize_version_keys")]
     pub versions: Vec<String>,
 
-    /// Raw HTTP response bytes. Injected post-parse; used for on-demand version extraction.
+    /// Pre-parsed `versions` subtree from the registry response.
+    ///
+    /// Populated once at fetch time by [`crate::service::manifest::fetch_full_manifest`]
+    /// (which parses the raw JSON to a `simd_json::OwnedValue` and takes the
+    /// `versions` field out). [`extract_version`](Self::extract_version) then
+    /// looks up a single version by key and deserializes only that subtree —
+    /// no full reparse of the manifest payload per call.
     #[serde(skip)]
-    pub raw: Arc<[u8]>,
+    pub versions_tree: Arc<simd_json::OwnedValue>,
 
     pub time: HashMap<String, String>,
 
@@ -76,17 +82,17 @@ pub struct FullManifest {
 }
 
 impl FullManifest {
-    /// Extract a single version from raw bytes on demand.
+    /// Extract a single version from the pre-parsed `versions` subtree.
     ///
-    /// Copies raw bytes, parses with `simd_json::to_borrowed_value`, navigates
-    /// to `versions[ver]`, then converts to the target type via `serde_json::Value`.
+    /// Looks the version up in [`Self::versions_tree`] (parsed once at fetch
+    /// time) and deserializes that subtree directly into `T` without cloning
+    /// the intermediate tree — `&OwnedValue` is itself a serde `Deserializer`,
+    /// so strings/arrays/maps are visited in place and only `T`'s own owned
+    /// fields are allocated.
     fn extract_version<T: for<'de> Deserialize<'de>>(&self, version: &str) -> Option<T> {
         use simd_json::prelude::ValueObjectAccess;
-        let mut buf = self.raw.to_vec();
-        let parsed = simd_json::to_borrowed_value(&mut buf).ok()?;
-        let version_obj = parsed.get("versions")?.get(version)?;
-        let value = serde_json::to_value(version_obj).ok()?;
-        serde_json::from_value(value).ok()
+        let val = self.versions_tree.get(version)?;
+        T::deserialize(val).ok()
     }
 
     /// Parse a single version on demand into CoreVersionManifest (hot path).

--- a/crates/ruborist/src/model/manifest.rs
+++ b/crates/ruborist/src/model/manifest.rs
@@ -40,15 +40,13 @@ pub struct FullManifest {
     #[serde(default, deserialize_with = "deserialize_version_keys")]
     pub versions: Vec<String>,
 
-    /// Pre-parsed `versions` subtree from the registry response.
-    ///
-    /// Populated once at fetch time by [`crate::service::manifest::fetch_full_manifest`]
-    /// (which parses the raw JSON to a `simd_json::OwnedValue` and takes the
-    /// `versions` field out). [`extract_version`](Self::extract_version) then
-    /// looks up a single version by key and deserializes only that subtree —
-    /// no full reparse of the manifest payload per call.
+    /// Raw HTTP response bytes. Injected post-parse; used for on-demand
+    /// version extraction via [`extract_version`](Self::extract_version).
+    /// Storing the raw bytes (rather than a parsed tree) keeps the cached
+    /// `FullManifest` compact — npm `versions` subtrees parsed to a typed
+    /// tree expand to ~1.5–2.5x the raw size on real-world packages.
     #[serde(skip)]
-    pub versions_tree: Arc<simd_json::OwnedValue>,
+    pub raw: Arc<[u8]>,
 
     pub time: HashMap<String, String>,
 
@@ -82,17 +80,24 @@ pub struct FullManifest {
 }
 
 impl FullManifest {
-    /// Extract a single version from the pre-parsed `versions` subtree.
+    /// Extract a single version from raw bytes on demand.
     ///
-    /// Looks the version up in [`Self::versions_tree`] (parsed once at fetch
-    /// time) and deserializes that subtree directly into `T` without cloning
-    /// the intermediate tree — `&OwnedValue` is itself a serde `Deserializer`,
-    /// so strings/arrays/maps are visited in place and only `T`'s own owned
-    /// fields are allocated.
+    /// Parses the full manifest into a `simd_json::BorrowedValue` tree
+    /// (transient, dropped at end of call), navigates to the matching
+    /// version, and deserializes that subtree directly into `T`.
+    /// `&BorrowedValue` is itself a serde `Deserializer`, so the matched
+    /// subtree is visited in place — no intermediate `serde_json::Value`
+    /// allocation.
+    ///
+    /// `OnceMap` single-flight in `UnifiedRegistry` reduces the per-key
+    /// invocation count to one, so the per-call full-tree parse cost is
+    /// bounded.
     fn extract_version<T: for<'de> Deserialize<'de>>(&self, version: &str) -> Option<T> {
         use simd_json::prelude::ValueObjectAccess;
-        let val = self.versions_tree.get(version)?;
-        T::deserialize(val).ok()
+        let mut buf = self.raw.to_vec();
+        let parsed = simd_json::to_borrowed_value(&mut buf).ok()?;
+        let version_obj = parsed.get("versions")?.get(version)?;
+        T::deserialize(version_obj).ok()
     }
 
     /// Parse a single version on demand into CoreVersionManifest (hot path).

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -126,8 +126,8 @@ impl Default for BuildDepsConfig {
             concurrency: crate::resolver::preload::DEFAULT_CONCURRENCY,
             skip_preload: false,
             cache_dir: dirs::home_dir().map(|d| d.join(".cache/nm")),
-            git_clone_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            http_fetch_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            git_clone_cache: Arc::new(GitCloneCache::new()),
+            http_fetch_cache: Arc::new(HttpFetchCache::new()),
             catalogs: HashMap::new(),
         }
     }

--- a/crates/ruborist/src/resolver/common.rs
+++ b/crates/ruborist/src/resolver/common.rs
@@ -1,6 +1,8 @@
 //! Shared helpers for native, non-registry resolvers (git, http tarball).
 //!
-//! - [`DedupCache<T>`] / [`dedup_init`] — session-scoped one-fetch-per-key
+//! - [`DedupCache<T>`] — session-scoped single-flight cache (alias for
+//!   [`OnceMap`](crate::util::OnceMap)) so concurrent fetches of the same key
+//!   share one underlying request.
 //! - [`validate_package_name`] — path-traversal guard for cache paths
 //! - [`finalize_non_registry_manifest`] — empty-version default, `dist`,
 //!   `has_install_script`
@@ -11,9 +13,7 @@
 //!   `super::git`   — caches at `<cache>/<name>/<commit_sha>/`
 //!   `super::http`  — caches at `<cache>/<name>/_http_<url_hash>/`
 
-use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 #[cfg(any(feature = "native-git", feature = "http-tarball"))]
 use std::path::Path;
@@ -23,12 +23,14 @@ use anyhow::Context;
 use anyhow::{Result, anyhow};
 
 use crate::model::manifest::{CoreVersionManifest, Dist};
+use crate::util::OnceMap;
 
 /// Session-scoped dedup cache keyed by canonical URL (+ optional ref).
 ///
-/// Concurrent requests for the same key share a single [`tokio::sync::OnceCell`],
-/// so only the first caller performs the fetch and the rest await.
-pub type DedupCache<T> = tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::OnceCell<Arc<T>>>>>;
+/// Concurrent requests for the same key share a single [`OnceMap`] entry,
+/// so only the first caller performs the fetch and the rest await its result.
+/// On error, the entry is removed so subsequent calls retry.
+pub type DedupCache<T> = OnceMap<String, T>;
 
 /// Reject package names that contain path-traversal components
 /// (`..`, absolute roots) before using them in `cache_dir.join(name)`.
@@ -135,23 +137,24 @@ where
     }
 }
 
-/// Look up (or create) the dedup cell for `key`, then run `init` under it.
+/// Look up (or create) the dedup entry for `key`, then run `init` under it.
 ///
-/// Wraps the `lock → entry(...).or_insert_with(OnceCell) → clone` ritual both
-/// resolvers need, and returns the cloned `Arc<T>` ready for use.
-pub async fn dedup_init<T, F, Fut>(cache: &DedupCache<T>, key: String, init: F) -> Result<Arc<T>>
+/// Single-flight wrapper over [`OnceMap::get_or_try_init`]: concurrent callers
+/// for the same key share one `init` invocation; on `Err` the entry is removed
+/// so subsequent calls retry.
+pub async fn dedup_init<T, F, Fut>(
+    cache: &DedupCache<T>,
+    key: String,
+    init: F,
+) -> Result<std::sync::Arc<T>>
 where
     T: Send + Sync + 'static,
     F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = Result<Arc<T>>>,
+    Fut: std::future::Future<Output = Result<T>>,
 {
-    let cell = {
-        let mut map = cache.lock().await;
-        map.entry(key)
-            .or_insert_with(|| Arc::new(tokio::sync::OnceCell::new()))
-            .clone()
-    };
-    cell.get_or_try_init(init).await.cloned()
+    cache
+        .get_or_try_init::<anyhow::Error, _, _>(key, init)
+        .await
 }
 
 #[cfg(test)]

--- a/crates/ruborist/src/resolver/git.rs
+++ b/crates/ruborist/src/resolver/git.rs
@@ -364,7 +364,6 @@ pub async fn ensure_repo_cached(
                 &resolved_url,
                 &name_owned,
             )
-            .map(Arc::new)
         })
         .await
         .context("git resolver task failed")?

--- a/crates/ruborist/src/resolver/http.rs
+++ b/crates/ruborist/src/resolver/http.rs
@@ -86,7 +86,6 @@
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
@@ -199,7 +198,7 @@ pub(crate) async fn resolve_http_dep(
     let manifest = dedup_init(fetch_cache, url_owned.clone(), move || async move {
         let bytes = download_tarball(&url_owned).await?;
         tokio::task::spawn_blocking(move || {
-            fetch_and_extract_blocking(&cache_dir_owned, &url_owned, bytes).map(Arc::new)
+            fetch_and_extract_blocking(&cache_dir_owned, &url_owned, bytes)
         })
         .await
         .context("http tarball extractor task failed")?

--- a/crates/ruborist/src/service/cache.rs
+++ b/crates/ruborist/src/service/cache.rs
@@ -24,15 +24,13 @@
 //!  MemoryCache ─ Clone ─► (cheap: Arc ref-count)
 //!  │
 //!  └──► Arc<MemoryCacheInner>              single allocation
-//!       ├── RwLock<HashMap<FullManifest>>   full package metadata
-//!       ├── RwLock<HashMap<VersionsInfo>>   version lists + dist-tags
-//!       └── RwLock<HashMap<Arc<CoreVersionManifest>>>
+//!       ├── DashMap<Arc<FullManifest>>      sharded, lock-free reads
+//!       ├── DashMap<Arc<VersionsInfo>>
+//!       └── DashMap<Arc<CoreVersionManifest>>
 //!                           │
 //!                           ▼
-//!                    Arc<CoreVersionManifest>   value-level sharing
-//!                    ├── get → Arc clone    O(1) ref-count
-//!                    ├── set → Arc clone    O(1) ref-count
-//!                    └── used by PackageNode, ResolvedPackage, preload
+//!                    All values Arc-wrapped → get/set is O(1) ref-count,
+//!                    no full clone of the (large) manifest payload.
 //!
 //!  Global singleton: GLOBAL_MEMORY_CACHE (LazyLock)
 //!  └── all UnifiedRegistry instances share the same cache
@@ -78,31 +76,33 @@ pub struct Versions {
 }
 
 // ============================================================================
-// Memory cache implementation (thread-safe with parking_lot::RwLock)
+// Memory cache implementation (lock-free reads via DashMap)
 // ============================================================================
 
 use std::sync::{Arc, LazyLock};
 
-use parking_lot::RwLock;
+use dashmap::DashMap;
 
-/// Thread-safe in-memory cache using a single `Arc` wrapper with
-/// per-collection `parking_lot::RwLock` for fine-grained concurrency.
+/// Thread-safe in-memory cache. Uses sharded `DashMap`s so concurrent reads
+/// are lock-free across shards and writes only contend within a single shard;
+/// values are stored as `Arc<…>` so reads return cheap ref-count clones
+/// instead of cloning the full (potentially large) manifest payload.
 #[derive(Clone)]
 pub struct MemoryCache(Arc<MemoryCacheInner>);
 
 struct MemoryCacheInner {
-    full_manifests: RwLock<HashMap<String, FullManifest>>,
-    versions_info: RwLock<HashMap<String, VersionsInfo>>,
-    version_manifests: RwLock<HashMap<String, Arc<CoreVersionManifest>>>,
+    full_manifests: DashMap<String, Arc<FullManifest>>,
+    versions_info: DashMap<String, Arc<VersionsInfo>>,
+    version_manifests: DashMap<String, Arc<CoreVersionManifest>>,
 }
 
 /// Global singleton for memory cache.
 /// This ensures all UnifiedRegistry instances share the same cache.
 static GLOBAL_MEMORY_CACHE: LazyLock<MemoryCache> = LazyLock::new(|| {
     MemoryCache(Arc::new(MemoryCacheInner {
-        full_manifests: RwLock::new(HashMap::new()),
-        versions_info: RwLock::new(HashMap::new()),
-        version_manifests: RwLock::new(HashMap::new()),
+        full_manifests: DashMap::new(),
+        versions_info: DashMap::new(),
+        version_manifests: DashMap::new(),
     }))
 });
 
@@ -119,21 +119,21 @@ impl MemoryCache {
     }
 
     // Full manifests
-    pub fn get_full_manifest(&self, name: &str) -> Option<FullManifest> {
-        self.0.full_manifests.read().get(name).cloned()
+    pub fn get_full_manifest(&self, name: &str) -> Option<Arc<FullManifest>> {
+        self.0.full_manifests.get(name).map(|v| v.clone())
     }
 
-    pub fn set_full_manifest(&self, name: String, manifest: FullManifest) {
-        self.0.full_manifests.write().insert(name, manifest);
+    pub fn set_full_manifest(&self, name: String, manifest: Arc<FullManifest>) {
+        self.0.full_manifests.insert(name, manifest);
     }
 
     // Versions info
-    pub fn get_versions(&self, name: &str) -> Option<VersionsInfo> {
-        self.0.versions_info.read().get(name).cloned()
+    pub fn get_versions(&self, name: &str) -> Option<Arc<VersionsInfo>> {
+        self.0.versions_info.get(name).map(|v| v.clone())
     }
 
-    pub fn set_versions(&self, name: String, info: VersionsInfo) {
-        self.0.versions_info.write().insert(name, info);
+    pub fn set_versions(&self, name: String, info: Arc<VersionsInfo>) {
+        self.0.versions_info.insert(name, info);
     }
 
     // Version manifests (Arc-wrapped for cheap cloning)
@@ -143,7 +143,7 @@ impl MemoryCache {
         version: &str,
     ) -> Option<Arc<CoreVersionManifest>> {
         let key = format!("{name}@{version}");
-        self.0.version_manifests.read().get(&key).cloned()
+        self.0.version_manifests.get(&key).map(|v| v.clone())
     }
 
     pub fn set_version_manifest(
@@ -153,29 +153,28 @@ impl MemoryCache {
         manifest: Arc<CoreVersionManifest>,
     ) {
         let key = format!("{name}@{version}");
-        self.0.version_manifests.write().insert(key, manifest);
+        self.0.version_manifests.insert(key, manifest);
     }
 
     // Stats
     pub fn full_manifest_count(&self) -> usize {
-        self.0.full_manifests.read().len()
+        self.0.full_manifests.len()
     }
 
     pub fn versions_count(&self) -> usize {
-        self.0.versions_info.read().len()
+        self.0.versions_info.len()
     }
 
     pub fn version_manifest_count(&self) -> usize {
-        self.0.version_manifests.read().len()
+        self.0.version_manifests.len()
     }
 
     /// Export all version manifests for persistence.
     pub fn export_version_manifests(&self) -> Vec<(String, Arc<CoreVersionManifest>)> {
         self.0
             .version_manifests
-            .read()
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|kv| (kv.key().clone(), kv.value().clone()))
             .collect()
     }
 }
@@ -241,7 +240,7 @@ impl PackageCache {
     // === Memory cache operations (sync) ===
 
     /// Get full manifest from memory cache.
-    pub fn get_full_manifest(&self, name: &str) -> Option<FullManifest> {
+    pub fn get_full_manifest(&self, name: &str) -> Option<Arc<FullManifest>> {
         let result = self.memory.get_full_manifest(name);
         if result.is_some() {
             tracing::debug!("Memory cache hit for full manifest: {name}");
@@ -250,13 +249,13 @@ impl PackageCache {
     }
 
     /// Set full manifest in memory cache.
-    pub fn set_full_manifest(&self, name: String, manifest: FullManifest) {
+    pub fn set_full_manifest(&self, name: String, manifest: Arc<FullManifest>) {
         tracing::debug!("Caching full manifest in memory: {name}");
         self.memory.set_full_manifest(name, manifest);
     }
 
     /// Get versions info from memory cache.
-    pub fn get_versions(&self, name: &str) -> Option<VersionsInfo> {
+    pub fn get_versions(&self, name: &str) -> Option<Arc<VersionsInfo>> {
         let result = self.memory.get_versions(name);
         if result.is_some() {
             tracing::debug!("Memory cache hit for versions: {name}");
@@ -265,7 +264,7 @@ impl PackageCache {
     }
 
     /// Set versions info in memory cache.
-    pub fn set_versions(&self, name: String, info: VersionsInfo) {
+    pub fn set_versions(&self, name: String, info: Arc<VersionsInfo>) {
         tracing::debug!("Caching versions in memory: {name}");
         self.memory.set_versions(name, info);
     }
@@ -297,7 +296,7 @@ impl PackageCache {
     // === Disk cache operations (async, uses tokio-fs-ext) ===
 
     /// Load versions info from disk cache.
-    pub async fn get_versions_from_disk(&self, name: &str) -> Option<VersionsInfo> {
+    pub async fn get_versions_from_disk(&self, name: &str) -> Option<Arc<VersionsInfo>> {
         let cache_dir = self.cache_dir.as_ref()?;
         let path = get_versions_cache_path(cache_dir, name);
 
@@ -308,6 +307,7 @@ impl PackageCache {
         match super::fs::read_json::<VersionsInfo>(&path).await {
             Ok(info) => {
                 tracing::debug!("Disk cache hit for versions: {name}");
+                let info = Arc::new(info);
                 // Also cache in memory
                 self.memory.set_versions(name.to_string(), info.clone());
                 Some(info)
@@ -468,12 +468,13 @@ pub struct ProjectPackageCache {
 
 /// Thread-safe project cache for dependency resolution state.
 ///
-/// This cache stores:
-/// - spec -> version mappings (which version was resolved for each spec)
-/// - version -> manifest mappings (resolved manifest data)
+/// Sharded per package name via `DashMap` so concurrent lookups across
+/// distinct packages don't contend. Within a single package the inner
+/// per-package state is small and protected by a short-held parking_lot
+/// mutex (writes are infrequent: once per resolved spec).
 #[derive(Clone, Default)]
 pub struct ProjectCache {
-    data: Arc<RwLock<ProjectCacheData>>,
+    cache: Arc<DashMap<String, Arc<parking_lot::Mutex<ProjectPackageCache>>>>,
 }
 
 impl ProjectCache {
@@ -482,21 +483,15 @@ impl ProjectCache {
     }
 
     pub fn get_resolved_version(&self, name: &str, spec: &str) -> Option<String> {
-        self.data
-            .read()
-            .cache
-            .get(name)
-            .and_then(|pkg| pkg.specs.get(spec))
-            .cloned()
+        let entry = self.cache.get(name)?;
+        let pkg = entry.lock();
+        pkg.specs.get(spec).cloned()
     }
 
     pub fn get_manifest(&self, name: &str, version: &str) -> Option<Arc<CoreVersionManifest>> {
-        self.data
-            .read()
-            .cache
-            .get(name)
-            .and_then(|pkg| pkg.manifests.get(version))
-            .map(|m| Arc::new(m.clone()))
+        let entry = self.cache.get(name)?;
+        let pkg = entry.lock();
+        pkg.manifests.get(version).cloned().map(Arc::new)
     }
 
     pub fn set_resolved(
@@ -506,22 +501,35 @@ impl ProjectCache {
         version: &str,
         manifest: &CoreVersionManifest,
     ) {
-        let mut data = self.data.write();
-        let pkg = data.cache.entry(name.to_string()).or_default();
+        let entry = self
+            .cache
+            .entry(name.to_string())
+            .or_insert_with(|| Arc::new(parking_lot::Mutex::new(ProjectPackageCache::default())))
+            .clone();
+        let mut pkg = entry.lock();
         pkg.specs.insert(spec.to_string(), version.to_string());
         pkg.manifests.insert(version.to_string(), manifest.clone());
     }
 
     pub fn export(&self) -> ProjectCacheData {
-        self.data.read().clone()
+        let cache = self
+            .cache
+            .iter()
+            .map(|kv| (kv.key().clone(), kv.value().lock().clone()))
+            .collect();
+        ProjectCacheData { cache }
     }
 
     pub fn import(&self, data: ProjectCacheData) {
-        *self.data.write() = data;
+        self.cache.clear();
+        for (name, pkg) in data.cache {
+            self.cache
+                .insert(name, Arc::new(parking_lot::Mutex::new(pkg)));
+        }
     }
 
     pub fn clear(&self) {
-        self.data.write().cache.clear();
+        self.cache.clear();
     }
 }
 
@@ -578,7 +586,7 @@ mod tests {
             ..Default::default()
         };
 
-        cache.set_full_manifest("test".to_string(), manifest.clone());
+        cache.set_full_manifest("test".to_string(), Arc::new(manifest));
 
         let retrieved = cache.get_full_manifest("test").unwrap();
         assert_eq!(retrieved.name, "test");
@@ -598,7 +606,7 @@ mod tests {
             last_updated: 12345,
         };
 
-        cache.set_versions("test".to_string(), info.clone());
+        cache.set_versions("test".to_string(), Arc::new(info));
 
         let retrieved = cache.get_versions("test").unwrap();
         assert_eq!(retrieved.versions.version_list, vec!["1.0.0"]);

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -91,12 +91,27 @@ pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<Fetch
                         .await
                         .map_err(|e| FetchError::Permanent(anyhow!("Response read error: {e}")))?
                         .to_vec();
-                    // Save raw bytes before simd_json mutates the parse buffer
-                    let mut parse_buf = raw_bytes.clone();
+                    // Two parses against independent buffers (simd_json mutates in-place):
+                    //   1. Skeleton (name / dist_tags / versions: Vec<String>) via the
+                    //      `IgnoredAny`-based serde path — fast, doesn't materialize
+                    //      version values.
+                    //   2. Full owned tree, from which we take the `versions` subtree
+                    //      and stash it on the manifest for `extract_version`.
+                    let mut skeleton_buf = raw_bytes.clone();
                     let mut manifest: FullManifest =
-                        simd_json::serde::from_slice(&mut parse_buf)
+                        simd_json::serde::from_slice(&mut skeleton_buf)
                             .map_err(|e| FetchError::Permanent(anyhow!("JSON parse error: {e}")))?;
-                    manifest.raw = std::sync::Arc::from(raw_bytes);
+                    let mut tree_buf = raw_bytes;
+                    let mut root = simd_json::to_owned_value(&mut tree_buf).map_err(|e| {
+                        FetchError::Permanent(anyhow!("JSON tree parse error: {e}"))
+                    })?;
+                    let versions_tree = match &mut root {
+                        simd_json::OwnedValue::Object(map) => {
+                            map.remove("versions").unwrap_or_default()
+                        }
+                        _ => simd_json::OwnedValue::default(),
+                    };
+                    manifest.versions_tree = std::sync::Arc::new(versions_tree);
 
                     Ok(FetchManifestResult::Ok(manifest, new_etag))
                 } else {

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -91,27 +91,12 @@ pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<Fetch
                         .await
                         .map_err(|e| FetchError::Permanent(anyhow!("Response read error: {e}")))?
                         .to_vec();
-                    // Two parses against independent buffers (simd_json mutates in-place):
-                    //   1. Skeleton (name / dist_tags / versions: Vec<String>) via the
-                    //      `IgnoredAny`-based serde path — fast, doesn't materialize
-                    //      version values.
-                    //   2. Full owned tree, from which we take the `versions` subtree
-                    //      and stash it on the manifest for `extract_version`.
-                    let mut skeleton_buf = raw_bytes.clone();
+                    // Save raw bytes before simd_json mutates the parse buffer.
+                    let mut parse_buf = raw_bytes.clone();
                     let mut manifest: FullManifest =
-                        simd_json::serde::from_slice(&mut skeleton_buf)
+                        simd_json::serde::from_slice(&mut parse_buf)
                             .map_err(|e| FetchError::Permanent(anyhow!("JSON parse error: {e}")))?;
-                    let mut tree_buf = raw_bytes;
-                    let mut root = simd_json::to_owned_value(&mut tree_buf).map_err(|e| {
-                        FetchError::Permanent(anyhow!("JSON tree parse error: {e}"))
-                    })?;
-                    let versions_tree = match &mut root {
-                        simd_json::OwnedValue::Object(map) => {
-                            map.remove("versions").unwrap_or_default()
-                        }
-                        _ => simd_json::OwnedValue::default(),
-                    };
-                    manifest.versions_tree = std::sync::Arc::new(versions_tree);
+                    manifest.raw = std::sync::Arc::from(raw_bytes);
 
                     Ok(FetchManifestResult::Ok(manifest, new_etag))
                 } else {

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -185,11 +185,9 @@ impl Clone for UnifiedRegistry {
 ///
 /// Separates the 200 (full data) and 304 (use cache) cases at the type level,
 /// so callers can pattern-match instead of string-matching error messages.
-/// Transient return value, immediately destructured — Box not needed.
-#[allow(clippy::large_enum_variant)]
 enum FullManifestResult {
     /// Fresh manifest fetched from the network (HTTP 200).
-    Full(FullManifest),
+    Full(Arc<FullManifest>),
     /// ETag matched, versions cache is valid (HTTP 304).
     /// Caller should resolve from the in-memory versions cache and
     /// fetch individual version manifests as needed.
@@ -257,16 +255,16 @@ impl UnifiedRegistry {
                 .map_err(RegistryError)?
                 {
                     manifest::FetchManifestResult::Ok(manifest, new_etag) => {
-                        self.cache
-                            .set_full_manifest(name.to_string(), manifest.clone());
-                        let versions_info = VersionsInfo {
+                        let versions_info = Arc::new(VersionsInfo {
                             versions: Versions {
                                 version_list: manifest.versions.clone(),
                                 dist_tags: manifest.dist_tags.clone(),
                             },
                             etag: new_etag,
                             last_updated: current_timestamp_secs(),
-                        };
+                        });
+                        self.cache
+                            .set_full_manifest(name.to_string(), Arc::new(manifest));
                         self.cache
                             .set_versions(name.to_string(), versions_info.clone());
                         self.cache.set_versions_to_disk(name, &versions_info).await;
@@ -287,16 +285,16 @@ impl UnifiedRegistry {
                             .await
                             .map_err(RegistryError)?;
 
-                            self.cache
-                                .set_full_manifest(name.to_string(), manifest.clone());
-                            let versions_info = VersionsInfo {
+                            let versions_info = Arc::new(VersionsInfo {
                                 versions: Versions {
                                     version_list: manifest.versions.clone(),
                                     dist_tags: manifest.dist_tags.clone(),
                                 },
                                 etag: new_etag,
                                 last_updated: current_timestamp_secs(),
-                            };
+                            });
+                            self.cache
+                                .set_full_manifest(name.to_string(), Arc::new(manifest));
                             self.cache
                                 .set_versions(name.to_string(), versions_info.clone());
                             self.cache.set_versions_to_disk(name, &versions_info).await;
@@ -409,25 +407,12 @@ impl RegistryClient for UnifiedRegistry {
         self.supports_semver
     }
 
-    fn get_cached_full_manifest(&self, name: &str) -> Option<FullManifest> {
-        self.cache.get_full_manifest(name)
-    }
-
-    fn get_cached_versions(&self, name: &str) -> Option<crate::traits::registry::VersionsInfo> {
-        self.cache
-            .get_versions(name)
-            .map(|v| crate::traits::registry::VersionsInfo {
-                version_list: v.versions.version_list,
-                dist_tags: v.versions.dist_tags,
-            })
-    }
-
     fn cache_version_manifest(&self, name: &str, spec: &str, manifest: Arc<CoreVersionManifest>) {
         self.cache
             .set_version_manifest(name.to_string(), spec.to_string(), manifest);
     }
 
-    async fn fetch_full_manifest(&self, name: &str) -> Result<FullManifest, Self::Error> {
+    async fn fetch_full_manifest(&self, name: &str) -> Result<Arc<FullManifest>, Self::Error> {
         match self.resolve_full_manifest(name).await? {
             FullManifestResult::Full(manifest) => Ok(manifest),
             FullManifestResult::NotModified => {

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -44,6 +44,18 @@ use crate::model::manifest::{CoreVersionManifest, FullManifest};
 use crate::resolver::semver::normalize_spec;
 use crate::resolver::version::resolve_target_version;
 use crate::traits::registry::{RegistryClient, RegistryError, ResolvedPackage, is_npm_registry};
+use crate::util::OnceMap;
+
+/// Inflight outcome for a full-manifest fetch — discriminates the cache
+/// state without re-cloning the manifest into the OnceMap.
+#[derive(Clone, Copy)]
+enum InflightFull {
+    /// 200: full manifest now in `PackageCache::set_full_manifest` — re-read it.
+    Full,
+    /// 304: only `VersionsInfo` was refreshed; caller must surface as
+    /// `FullManifestResult::NotModified`.
+    NotModified,
+}
 
 /// Unified registry client that works on both native and WASM.
 ///
@@ -68,6 +80,14 @@ pub struct UnifiedRegistry {
     registry_url: String,
     cache: Arc<PackageCache>,
     supports_semver: bool,
+    /// Single-flight gate for full-manifest fetches keyed by package name.
+    /// Concurrent resolves for the same name share the underlying network +
+    /// disk work; result is read back from `cache` (or surfaced as 304).
+    inflight_full: Arc<OnceMap<String, InflightFull>>,
+    /// Single-flight gate for version-manifest fetches keyed by `(name, spec)`.
+    /// `name@spec` is used because semver registries resolve spec server-side,
+    /// so two requests with the same name but different specs must not share.
+    inflight_version: Arc<OnceMap<(String, String), CoreVersionManifest>>,
 }
 
 /// Builder for `UnifiedRegistry`.
@@ -137,6 +157,8 @@ impl UnifiedRegistryBuilder {
             registry_url,
             cache,
             supports_semver,
+            inflight_full: Arc::new(OnceMap::new()),
+            inflight_version: Arc::new(OnceMap::new()),
         }
     }
 }
@@ -153,6 +175,8 @@ impl Clone for UnifiedRegistry {
             registry_url: self.registry_url.clone(),
             cache: Arc::clone(&self.cache),
             supports_semver: self.supports_semver,
+            inflight_full: Arc::clone(&self.inflight_full),
+            inflight_version: Arc::clone(&self.inflight_version),
         }
     }
 }
@@ -202,86 +226,101 @@ impl UnifiedRegistry {
     /// 4. On 304: use disk cache data
     /// 5. On 200: update memory + disk cache
     async fn resolve_full_manifest(&self, name: &str) -> Result<FullManifestResult, RegistryError> {
-        // 1. Check memory cache first
+        // 1. Check memory cache first (fast path before contending on the inflight map).
         if let Some(manifest) = self.cache.get_full_manifest(name) {
             tracing::debug!("Memory cache hit for full manifest: {}", name);
             return Ok(FullManifestResult::Full(manifest));
         }
 
-        // 2. Load etag from disk cache (if available)
-        let disk_versions = self.cache.get_versions_from_disk(name).await;
-        let etag = disk_versions.as_ref().and_then(|v| v.etag.clone());
-
-        // 3. Fetch from network with ETag for validation
-        match manifest::fetch_full_manifest(manifest::FetchManifestOptions {
-            registry_url: &self.registry_url,
-            name,
-            format: manifest::MetadataFormat::Abbreviated,
-            etag: etag.as_deref(),
-        })
-        .await
-        .map_err(RegistryError)?
-        {
-            manifest::FetchManifestResult::Ok(manifest, new_etag) => {
-                // 4. Cache full manifest in memory
-                self.cache
-                    .set_full_manifest(name.to_string(), manifest.clone());
-
-                // 5. Extract and cache versions info (lightweight)
-                let versions_info = VersionsInfo {
-                    versions: Versions {
-                        version_list: manifest.versions.clone(),
-                        dist_tags: manifest.dist_tags.clone(),
-                    },
-                    etag: new_etag.clone(),
-                    last_updated: current_timestamp_secs(),
-                };
-                self.cache
-                    .set_versions(name.to_string(), versions_info.clone());
-
-                // 6. Write versions to disk (non-blocking for native, blocking for WASM)
-                self.cache.set_versions_to_disk(name, &versions_info).await;
-
-                Ok(FullManifestResult::Full(manifest))
-            }
-            manifest::FetchManifestResult::NotModified => {
-                // 304 Not Modified - use disk cache versions info
-                tracing::debug!("ETag cache hit (304) for: {}", name);
-
-                if let Some(versions_info) = disk_versions {
-                    // Cache versions in memory for later use
-                    self.cache
-                        .set_versions(name.to_string(), versions_info.clone());
-
-                    Ok(FullManifestResult::NotModified)
-                } else {
-                    // Disk cache corrupted, fetch fresh (without etag)
-                    let (manifest, new_etag) = manifest::fetch_full_manifest_fresh(
-                        &self.registry_url,
-                        name,
-                        manifest::MetadataFormat::Abbreviated,
-                    )
-                    .await
-                    .map_err(RegistryError)?;
-
-                    self.cache
-                        .set_full_manifest(name.to_string(), manifest.clone());
-
-                    let versions_info = VersionsInfo {
-                        versions: Versions {
-                            version_list: manifest.versions.clone(),
-                            dist_tags: manifest.dist_tags.clone(),
-                        },
-                        etag: new_etag.clone(),
-                        last_updated: current_timestamp_secs(),
-                    };
-                    self.cache
-                        .set_versions(name.to_string(), versions_info.clone());
-                    self.cache.set_versions_to_disk(name, &versions_info).await;
-
-                    Ok(FullManifestResult::Full(manifest))
+        // 2. Single-flight: dedup concurrent disk + network work for the same
+        //    package name. Init populates `cache` as a side effect; both worker
+        //    and waiters then read the populated cache below.
+        let outcome = self
+            .inflight_full
+            .get_or_try_init::<RegistryError, _, _>(name.to_string(), || async {
+                // Re-check memory cache inside the worker — a previous flight may
+                // have populated it while we were queuing on dashmap's shard lock.
+                if self.cache.get_full_manifest(name).is_some() {
+                    return Ok(InflightFull::Full);
                 }
+
+                let disk_versions = self.cache.get_versions_from_disk(name).await;
+                let etag = disk_versions.as_ref().and_then(|v| v.etag.clone());
+
+                match manifest::fetch_full_manifest(manifest::FetchManifestOptions {
+                    registry_url: &self.registry_url,
+                    name,
+                    format: manifest::MetadataFormat::Abbreviated,
+                    etag: etag.as_deref(),
+                })
+                .await
+                .map_err(RegistryError)?
+                {
+                    manifest::FetchManifestResult::Ok(manifest, new_etag) => {
+                        self.cache
+                            .set_full_manifest(name.to_string(), manifest.clone());
+                        let versions_info = VersionsInfo {
+                            versions: Versions {
+                                version_list: manifest.versions.clone(),
+                                dist_tags: manifest.dist_tags.clone(),
+                            },
+                            etag: new_etag,
+                            last_updated: current_timestamp_secs(),
+                        };
+                        self.cache
+                            .set_versions(name.to_string(), versions_info.clone());
+                        self.cache.set_versions_to_disk(name, &versions_info).await;
+                        Ok(InflightFull::Full)
+                    }
+                    manifest::FetchManifestResult::NotModified => {
+                        tracing::debug!("ETag cache hit (304) for: {}", name);
+                        if let Some(versions_info) = disk_versions {
+                            self.cache.set_versions(name.to_string(), versions_info);
+                            Ok(InflightFull::NotModified)
+                        } else {
+                            // Disk cache corrupted, fetch fresh (without etag)
+                            let (manifest, new_etag) = manifest::fetch_full_manifest_fresh(
+                                &self.registry_url,
+                                name,
+                                manifest::MetadataFormat::Abbreviated,
+                            )
+                            .await
+                            .map_err(RegistryError)?;
+
+                            self.cache
+                                .set_full_manifest(name.to_string(), manifest.clone());
+                            let versions_info = VersionsInfo {
+                                versions: Versions {
+                                    version_list: manifest.versions.clone(),
+                                    dist_tags: manifest.dist_tags.clone(),
+                                },
+                                etag: new_etag,
+                                last_updated: current_timestamp_secs(),
+                            };
+                            self.cache
+                                .set_versions(name.to_string(), versions_info.clone());
+                            self.cache.set_versions_to_disk(name, &versions_info).await;
+                            Ok(InflightFull::Full)
+                        }
+                    }
+                }
+            })
+            .await?;
+
+        match *outcome {
+            InflightFull::Full => {
+                // Populated by the inflight worker; missing here would only mean
+                // a race with cache eviction — surface a clear error.
+                self.cache
+                    .get_full_manifest(name)
+                    .map(FullManifestResult::Full)
+                    .ok_or_else(|| {
+                        RegistryError(anyhow!(
+                            "full manifest for {name} vanished from cache after fetch"
+                        ))
+                    })
             }
+            InflightFull::NotModified => Ok(FullManifestResult::NotModified),
         }
     }
 
@@ -299,53 +338,67 @@ impl UnifiedRegistry {
         name: &str,
         spec: &str,
     ) -> Result<Arc<CoreVersionManifest>, RegistryError> {
-        // 1. Check memory cache using name@spec as key
+        // 1. Check memory cache using name@spec as key (fast path).
         if let Some(manifest) = self.cache.get_version_manifest(name, spec) {
             tracing::debug!("Memory cache hit for version manifest: {}@{}", name, spec);
             return Ok(manifest);
         }
 
-        // 2. Check disk cache (only for non-semver registries)
-        // Semver registries resolve specs server-side, so disk cache keys (name@spec)
-        // may not match the actual resolved version.
-        if !self.supports_semver
-            && let Some(manifest) = self.cache.get_version_manifest_from_disk(name, spec).await
-        {
-            tracing::debug!("Disk cache hit for version manifest: {}@{}", name, spec);
-            // Already cached in memory by get_version_manifest_from_disk
-            return Ok(manifest);
-        }
+        // 2. Single-flight: concurrent resolves for the same (name, spec) share
+        //    the disk-cache check + network fetch. The OnceMap-stored
+        //    `Arc<CoreVersionManifest>` is the canonical result; PackageCache
+        //    is populated as a side effect for cross-registry/cross-instance
+        //    sharing via the global memory cache singleton.
+        self.inflight_version
+            .get_or_try_init::<RegistryError, _, _>(
+                (name.to_string(), spec.to_string()),
+                || async {
+                    // Re-check memory cache inside the worker (covers the brief
+                    // window between fast-path miss and shard-lock acquire).
+                    if let Some(manifest) = self.cache.get_version_manifest(name, spec) {
+                        // OnceMap requires owning the V; clone the inner manifest
+                        // out of its Arc.
+                        return Ok((*manifest).clone());
+                    }
 
-        // 3. Fetch from network (http module handles pure HTTP)
-        // Use abbreviated format only for semver-supporting registries
-        tracing::debug!("Cache miss for {}@{}, fetching from network", name, spec);
-        let manifest = manifest::fetch_version_manifest(manifest::FetchVersionManifestOptions {
-            registry_url: &self.registry_url,
-            name,
-            spec,
-            format: if self.supports_semver {
-                manifest::MetadataFormat::Abbreviated
-            } else {
-                manifest::MetadataFormat::Complete
-            },
-        })
-        .await
-        .map_err(RegistryError)?;
+                    if !self.supports_semver
+                        && let Some(manifest) =
+                            self.cache.get_version_manifest_from_disk(name, spec).await
+                    {
+                        tracing::debug!("Disk cache hit for version manifest: {}@{}", name, spec);
+                        return Ok((*manifest).clone());
+                    }
 
-        let manifest = Arc::new(manifest);
+                    tracing::debug!("Cache miss for {}@{}, fetching from network", name, spec);
+                    let manifest =
+                        manifest::fetch_version_manifest(manifest::FetchVersionManifestOptions {
+                            registry_url: &self.registry_url,
+                            name,
+                            spec,
+                            format: if self.supports_semver {
+                                manifest::MetadataFormat::Abbreviated
+                            } else {
+                                manifest::MetadataFormat::Complete
+                            },
+                        })
+                        .await
+                        .map_err(RegistryError)?;
 
-        // 4. Cache in memory
-        self.cache
-            .set_version_manifest(name.to_string(), spec.to_string(), manifest.clone());
-
-        // 5. Write to disk cache (only for non-semver registries)
-        if !self.supports_semver {
-            self.cache
-                .set_version_manifest_to_disk(name, spec, &manifest)
-                .await;
-        }
-
-        Ok(manifest)
+                    let arc_manifest = Arc::new(manifest.clone());
+                    self.cache.set_version_manifest(
+                        name.to_string(),
+                        spec.to_string(),
+                        arc_manifest.clone(),
+                    );
+                    if !self.supports_semver {
+                        self.cache
+                            .set_version_manifest_to_disk(name, spec, &arc_manifest)
+                            .await;
+                    }
+                    Ok(manifest)
+                },
+            )
+            .await
     }
 }
 
@@ -393,53 +446,9 @@ impl RegistryClient for UnifiedRegistry {
         name: &str,
         spec: &str,
     ) -> Result<Arc<CoreVersionManifest>, Self::Error> {
-        // 1. Check memory cache first
-        if let Some(manifest) = self.cache.get_version_manifest(name, spec) {
-            tracing::debug!("Memory cache hit for version manifest: {}@{}", name, spec);
-            return Ok(manifest);
-        }
-
-        // 2. Check disk cache (only for non-semver registries where spec is exact version)
-        if !self.supports_semver
-            && let Some(manifest) = self.cache.get_version_manifest_from_disk(name, spec).await
-        {
-            tracing::debug!("Disk cache hit for version manifest: {}@{}", name, spec);
-            // Cache in memory for next time
-            self.cache
-                .set_version_manifest(name.to_string(), spec.to_string(), manifest.clone());
-            return Ok(manifest);
-        }
-
-        // 3. Fetch from network
-        // Both semver and non-semver registries support {registry}/{name}/{version}
-        // Use abbreviated format only for semver-supporting registries
-        let manifest = manifest::fetch_version_manifest(manifest::FetchVersionManifestOptions {
-            registry_url: &self.registry_url,
-            name,
-            spec,
-            format: if self.supports_semver {
-                manifest::MetadataFormat::Abbreviated
-            } else {
-                manifest::MetadataFormat::Complete
-            },
-        })
-        .await
-        .map_err(RegistryError)?;
-
-        let manifest = Arc::new(manifest);
-
-        // 4. Cache the result
-        self.cache
-            .set_version_manifest(name.to_string(), spec.to_string(), manifest.clone());
-
-        // 5. Write to disk cache (only for non-semver registries)
-        if !self.supports_semver {
-            self.cache
-                .set_version_manifest_to_disk(name, spec, &manifest)
-                .await;
-        }
-
-        Ok(manifest)
+        // Delegates to `resolve_version_manifest` so the inflight dedup +
+        // memory/disk cache logic lives in one place.
+        self.resolve_version_manifest(name, spec).await
     }
 
     async fn resolve_package(

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -46,17 +46,6 @@ use crate::resolver::version::resolve_target_version;
 use crate::traits::registry::{RegistryClient, RegistryError, ResolvedPackage, is_npm_registry};
 use crate::util::OnceMap;
 
-/// Inflight outcome for a full-manifest fetch — discriminates the cache
-/// state without re-cloning the manifest into the OnceMap.
-#[derive(Clone, Copy)]
-enum InflightFull {
-    /// 200: full manifest now in `PackageCache::set_full_manifest` — re-read it.
-    Full,
-    /// 304: only `VersionsInfo` was refreshed; caller must surface as
-    /// `FullManifestResult::NotModified`.
-    NotModified,
-}
-
 /// Unified registry client that works on both native and WASM.
 ///
 /// Uses three-tier caching:
@@ -81,13 +70,16 @@ pub struct UnifiedRegistry {
     cache: Arc<PackageCache>,
     supports_semver: bool,
     /// Single-flight gate for full-manifest fetches keyed by package name.
-    /// Concurrent resolves for the same name share the underlying network +
-    /// disk work; result is read back from `cache` (or surfaced as 304).
-    inflight_full: Arc<OnceMap<String, InflightFull>>,
-    /// Single-flight gate for version-manifest fetches keyed by `(name, spec)`.
-    /// `name@spec` is used because semver registries resolve spec server-side,
-    /// so two requests with the same name but different specs must not share.
-    inflight_version: Arc<OnceMap<(String, String), CoreVersionManifest>>,
+    /// **Gate-only**: the entry value is `()`; the canonical
+    /// `Arc<FullManifest>` lives in `PackageCache`. Concurrent resolves for
+    /// the same name share one network + disk + parse round-trip; the
+    /// 200/304 outcome is recovered by inspecting cache state after the
+    /// gate releases.
+    inflight_full: Arc<OnceMap<String, ()>>,
+    /// Single-flight gate for version-manifest fetches keyed by
+    /// `(name, spec)`. Same gate-only pattern: the canonical `Arc<…>`
+    /// lives in `PackageCache.version_manifests`; the gate stores `()`.
+    inflight_version: Arc<OnceMap<(String, String), ()>>,
 }
 
 /// Builder for `UnifiedRegistry`.
@@ -217,29 +209,26 @@ impl UnifiedRegistry {
 
     /// Resolve full manifest with three-tier caching and ETag validation.
     ///
-    /// Cache flow:
-    /// 1. Check memory cache -> return if hit
-    /// 2. Check disk cache for versions.json (etag + version list)
-    /// 3. Fetch from network with etag for 304 validation
-    /// 4. On 304: use disk cache data
-    /// 5. On 200: update memory + disk cache
+    /// Single-flight cache flow:
+    /// 1. Memory cache hit on `full_manifests` → return immediately (Arc bump).
+    /// 2. Otherwise, acquire the gate-only `inflight_full<name>`. The worker
+    ///    closure populates `PackageCache` as a side effect: writes
+    ///    `full_manifests` on 200, writes only `versions_info` on 304.
+    /// 3. After the gate releases, recover the outcome by inspecting cache
+    ///    state — `full_manifests` populated → 200, only `versions_info`
+    ///    populated → 304.
     async fn resolve_full_manifest(&self, name: &str) -> Result<FullManifestResult, RegistryError> {
-        // 1. Check memory cache first (fast path before contending on the inflight map).
         if let Some(manifest) = self.cache.get_full_manifest(name) {
             tracing::debug!("Memory cache hit for full manifest: {}", name);
             return Ok(FullManifestResult::Full(manifest));
         }
 
-        // 2. Single-flight: dedup concurrent disk + network work for the same
-        //    package name. Init populates `cache` as a side effect; both worker
-        //    and waiters then read the populated cache below.
-        let outcome = self
-            .inflight_full
+        self.inflight_full
             .get_or_try_init::<RegistryError, _, _>(name.to_string(), || async {
-                // Re-check memory cache inside the worker — a previous flight may
-                // have populated it while we were queuing on dashmap's shard lock.
+                // Re-check inside the worker — a previous winner may have
+                // populated the cache while we queued on the OnceMap shard.
                 if self.cache.get_full_manifest(name).is_some() {
-                    return Ok(InflightFull::Full);
+                    return Ok(());
                 }
 
                 let disk_versions = self.cache.get_versions_from_disk(name).await;
@@ -266,17 +255,18 @@ impl UnifiedRegistry {
                         self.cache
                             .set_full_manifest(name.to_string(), Arc::new(manifest));
                         self.cache
-                            .set_versions(name.to_string(), versions_info.clone());
+                            .set_versions(name.to_string(), Arc::clone(&versions_info));
                         self.cache.set_versions_to_disk(name, &versions_info).await;
-                        Ok(InflightFull::Full)
                     }
                     manifest::FetchManifestResult::NotModified => {
                         tracing::debug!("ETag cache hit (304) for: {}", name);
                         if let Some(versions_info) = disk_versions {
+                            // Only populate `versions_info`; absence of
+                            // `full_manifests` after the gate is the 304
+                            // signal.
                             self.cache.set_versions(name.to_string(), versions_info);
-                            Ok(InflightFull::NotModified)
                         } else {
-                            // Disk cache corrupted, fetch fresh (without etag)
+                            // Disk cache corrupted, fetch fresh (without etag).
                             let (manifest, new_etag) = manifest::fetch_full_manifest_fresh(
                                 &self.registry_url,
                                 name,
@@ -296,29 +286,25 @@ impl UnifiedRegistry {
                             self.cache
                                 .set_full_manifest(name.to_string(), Arc::new(manifest));
                             self.cache
-                                .set_versions(name.to_string(), versions_info.clone());
+                                .set_versions(name.to_string(), Arc::clone(&versions_info));
                             self.cache.set_versions_to_disk(name, &versions_info).await;
-                            Ok(InflightFull::Full)
                         }
                     }
                 }
+                Ok(())
             })
             .await?;
 
-        match *outcome {
-            InflightFull::Full => {
-                // Populated by the inflight worker; missing here would only mean
-                // a race with cache eviction — surface a clear error.
-                self.cache
-                    .get_full_manifest(name)
-                    .map(FullManifestResult::Full)
-                    .ok_or_else(|| {
-                        RegistryError(anyhow!(
-                            "full manifest for {name} vanished from cache after fetch"
-                        ))
-                    })
-            }
-            InflightFull::NotModified => Ok(FullManifestResult::NotModified),
+        // Cache state is the discriminator: `full_manifests` populated → 200;
+        // only `versions_info` populated → 304; neither → cache eviction race.
+        if let Some(manifest) = self.cache.get_full_manifest(name) {
+            Ok(FullManifestResult::Full(manifest))
+        } else if self.cache.get_versions(name).is_some() {
+            Ok(FullManifestResult::NotModified)
+        } else {
+            Err(RegistryError(anyhow!(
+                "manifest for {name} vanished from cache after fetch"
+            )))
         }
     }
 
@@ -342,32 +328,31 @@ impl UnifiedRegistry {
         name: &str,
         spec: &str,
     ) -> Result<Arc<CoreVersionManifest>, RegistryError> {
-        // 1. Check memory cache using name@spec as key (fast path).
         if let Some(manifest) = self.cache.get_version_manifest(name, spec) {
             tracing::debug!("Memory cache hit for version manifest: {}@{}", name, spec);
             return Ok(manifest);
         }
 
-        // 2. Single-flight: concurrent resolves for the same (name, spec) share
-        //    the disk-cache check + network fetch + full-manifest extraction.
-        //    PackageCache is populated as a side effect for fast-path hits on
-        //    subsequent calls.
         self.inflight_version
             .get_or_try_init::<RegistryError, _, _>(
                 (name.to_string(), spec.to_string()),
                 || async {
-                    // Re-check memory cache inside the worker (covers the brief
-                    // window between fast-path miss and shard-lock acquire).
-                    if let Some(manifest) = self.cache.get_version_manifest(name, spec) {
-                        return Ok((*manifest).clone());
+                    // Re-check inside the worker (covers the brief window
+                    // between fast-path miss and OnceMap shard-lock acquire).
+                    if self.cache.get_version_manifest(name, spec).is_some() {
+                        return Ok(());
                     }
 
                     if !self.supports_semver
-                        && let Some(manifest) =
-                            self.cache.get_version_manifest_from_disk(name, spec).await
+                        && self
+                            .cache
+                            .get_version_manifest_from_disk(name, spec)
+                            .await
+                            .is_some()
                     {
                         tracing::debug!("Disk cache hit for version manifest: {}@{}", name, spec);
-                        return Ok((*manifest).clone());
+                        // `get_version_manifest_from_disk` already populated memory.
+                        return Ok(());
                     }
 
                     if !self.supports_semver {
@@ -377,23 +362,23 @@ impl UnifiedRegistry {
                         // same name share one full-manifest fetch.
                         let (resolved_version, manifest) =
                             self.resolve_via_full_manifest(name, spec).await?;
-                        let arc = Arc::new(manifest.clone());
+                        let arc = Arc::new(manifest);
                         self.cache.set_version_manifest(
                             name.to_string(),
                             spec.to_string(),
-                            arc.clone(),
+                            Arc::clone(&arc),
                         );
                         if resolved_version != spec {
                             self.cache.set_version_manifest(
                                 name.to_string(),
                                 resolved_version.clone(),
-                                arc.clone(),
+                                Arc::clone(&arc),
                             );
                         }
                         self.cache
                             .set_version_manifest_to_disk(name, &resolved_version, &arc)
                             .await;
-                        return Ok(manifest);
+                        return Ok(());
                     }
 
                     tracing::debug!("Cache miss for {}@{}, fetching from network", name, spec);
@@ -410,12 +395,20 @@ impl UnifiedRegistry {
                     self.cache.set_version_manifest(
                         name.to_string(),
                         spec.to_string(),
-                        Arc::new(manifest.clone()),
+                        Arc::new(manifest),
                     );
-                    Ok(manifest)
+                    Ok(())
                 },
             )
-            .await
+            .await?;
+
+        // Gate released — populated either by us, a prior waiter, or a previous
+        // run that hit memory/disk cache. Missing only on cache eviction race.
+        self.cache.get_version_manifest(name, spec).ok_or_else(|| {
+            RegistryError(anyhow!(
+                "version manifest for {name}@{spec} vanished from cache after fetch"
+            ))
+        })
     }
 
     /// Resolve `(name, spec)` for non-semver registries by reading the full

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -331,6 +331,12 @@ impl UnifiedRegistry {
     /// 1. Memory cache -> fastest
     /// 2. Disk cache -> persistent
     /// 3. Network -> authoritative
+    ///
+    /// Non-semver registries resolve the spec by extracting the matching
+    /// version from the full manifest (the latter is itself single-flight
+    /// gated by `inflight_full`). Semver registries query the version
+    /// manifest directly. Either way the work for one `(name, spec)` runs
+    /// once; concurrent callers for the same key share the result.
     async fn resolve_version_manifest(
         &self,
         name: &str,
@@ -343,10 +349,9 @@ impl UnifiedRegistry {
         }
 
         // 2. Single-flight: concurrent resolves for the same (name, spec) share
-        //    the disk-cache check + network fetch. The OnceMap-stored
-        //    `Arc<CoreVersionManifest>` is the canonical result; PackageCache
-        //    is populated as a side effect for cross-registry/cross-instance
-        //    sharing via the global memory cache singleton.
+        //    the disk-cache check + network fetch + full-manifest extraction.
+        //    PackageCache is populated as a side effect for fast-path hits on
+        //    subsequent calls.
         self.inflight_version
             .get_or_try_init::<RegistryError, _, _>(
                 (name.to_string(), spec.to_string()),
@@ -354,8 +359,6 @@ impl UnifiedRegistry {
                     // Re-check memory cache inside the worker (covers the brief
                     // window between fast-path miss and shard-lock acquire).
                     if let Some(manifest) = self.cache.get_version_manifest(name, spec) {
-                        // OnceMap requires owning the V; clone the inner manifest
-                        // out of its Arc.
                         return Ok((*manifest).clone());
                     }
 
@@ -367,36 +370,111 @@ impl UnifiedRegistry {
                         return Ok((*manifest).clone());
                     }
 
+                    if !self.supports_semver {
+                        // Non-semver: resolve the spec by extracting the matching
+                        // version from the full manifest. `resolve_full_manifest`
+                        // is itself inflight-gated, so concurrent specs for the
+                        // same name share one full-manifest fetch.
+                        let (resolved_version, manifest) =
+                            self.resolve_via_full_manifest(name, spec).await?;
+                        let arc = Arc::new(manifest.clone());
+                        self.cache.set_version_manifest(
+                            name.to_string(),
+                            spec.to_string(),
+                            arc.clone(),
+                        );
+                        if resolved_version != spec {
+                            self.cache.set_version_manifest(
+                                name.to_string(),
+                                resolved_version.clone(),
+                                arc.clone(),
+                            );
+                        }
+                        self.cache
+                            .set_version_manifest_to_disk(name, &resolved_version, &arc)
+                            .await;
+                        return Ok(manifest);
+                    }
+
                     tracing::debug!("Cache miss for {}@{}, fetching from network", name, spec);
                     let manifest =
                         manifest::fetch_version_manifest(manifest::FetchVersionManifestOptions {
                             registry_url: &self.registry_url,
                             name,
                             spec,
-                            format: if self.supports_semver {
-                                manifest::MetadataFormat::Abbreviated
-                            } else {
-                                manifest::MetadataFormat::Complete
-                            },
+                            format: manifest::MetadataFormat::Abbreviated,
                         })
                         .await
                         .map_err(RegistryError)?;
 
-                    let arc_manifest = Arc::new(manifest.clone());
                     self.cache.set_version_manifest(
                         name.to_string(),
                         spec.to_string(),
-                        arc_manifest.clone(),
+                        Arc::new(manifest.clone()),
                     );
-                    if !self.supports_semver {
-                        self.cache
-                            .set_version_manifest_to_disk(name, spec, &arc_manifest)
-                            .await;
-                    }
                     Ok(manifest)
                 },
             )
             .await
+    }
+
+    /// Resolve `(name, spec)` for non-semver registries by reading the full
+    /// manifest and extracting the matching version.
+    ///
+    /// Handles the 304 (NotModified) case by falling back to the in-memory
+    /// versions cache for resolution and a single-version network fetch for
+    /// the manifest itself. The caller is responsible for caching the
+    /// extracted manifest; this helper does not touch `PackageCache`.
+    async fn resolve_via_full_manifest(
+        &self,
+        name: &str,
+        spec: &str,
+    ) -> Result<(String, CoreVersionManifest), RegistryError> {
+        match self.resolve_full_manifest(name).await? {
+            FullManifestResult::Full(full) => {
+                if full.versions.is_empty() {
+                    return Err(RegistryError(anyhow!("No versions available for {}", name)));
+                }
+                let resolved_version =
+                    resolve_target_version(&full.dist_tags, &full.versions, spec)
+                        .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
+                let core = full.get_core_version(&resolved_version).ok_or_else(|| {
+                    RegistryError(anyhow!(
+                        "Version {} not found in manifest for {}",
+                        resolved_version,
+                        name
+                    ))
+                })?;
+                Ok((resolved_version, core))
+            }
+            FullManifestResult::NotModified => {
+                // 304 fallback: ETag matched, full payload not refetched.
+                // Resolve via the lightweight versions cache, then hit the
+                // network for the single requested version. Direct call into
+                // `manifest::fetch_version_manifest` (not `self.resolve_version_manifest`)
+                // to avoid re-entering the inflight_version gate; the outer
+                // `inflight_version<(name, spec)>` already serializes us.
+                let versions_info = self.cache.get_versions(name).ok_or_else(|| {
+                    RegistryError(anyhow!("Versions cache not found for {}", name))
+                })?;
+                let resolved_version = resolve_target_version(
+                    &versions_info.versions.dist_tags,
+                    &versions_info.versions.version_list,
+                    spec,
+                )
+                .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
+                let manifest =
+                    manifest::fetch_version_manifest(manifest::FetchVersionManifestOptions {
+                        registry_url: &self.registry_url,
+                        name,
+                        spec: &resolved_version,
+                        format: manifest::MetadataFormat::Complete,
+                    })
+                    .await
+                    .map_err(RegistryError)?;
+                Ok((resolved_version, manifest))
+            }
+        }
     }
 }
 
@@ -453,208 +531,18 @@ impl RegistryClient for UnifiedRegistry {
             );
         }
 
-        // Always check memory cache first (project cache is pre-loaded here)
-        if let Some(manifest) = self.cache.get_version_manifest(&fetch_name, &fetch_spec) {
-            tracing::debug!(
-                "Memory cache hit for version manifest: {}@{}",
-                fetch_name,
-                fetch_spec
-            );
-            return Ok(ResolvedPackage {
-                name: name.to_string(),
-                version: manifest.version.clone(),
-                manifest,
-            });
-        }
-
-        // Check full manifest cache (from preload phase)
-        // This avoids redundant HTTP requests when preload already fetched the full manifest
-        if let Some(full_manifest) = self.cache.get_full_manifest(&fetch_name) {
-            tracing::debug!(
-                "Full manifest cache HIT for {}@{}, resolving from cached manifest",
-                fetch_name,
-                fetch_spec
-            );
-            tracing::debug!(
-                "Using cached full manifest for {}@{}",
-                fetch_name,
-                fetch_spec
-            );
-            let version_list: Vec<String> = full_manifest.versions.clone();
-            let resolved_version =
-                resolve_target_version(&full_manifest.dist_tags, &version_list, &fetch_spec)
-                    .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
-            let version_manifest = full_manifest
-                .get_core_version(&resolved_version)
-                .map(Arc::new)
-                .ok_or_else(|| {
-                    RegistryError(anyhow!(
-                        "Version {} not found in manifest for {}",
-                        resolved_version,
-                        fetch_name
-                    ))
-                })?;
-            // Cache version_manifest for project cache export
-            self.cache.set_version_manifest(
-                fetch_name.to_string(),
-                fetch_spec.to_string(),
-                version_manifest.clone(),
-            );
-            // Write to disk cache for non-semver registries
-            if !self.supports_semver {
-                self.cache
-                    .set_version_manifest_to_disk(&fetch_name, &resolved_version, &version_manifest)
-                    .await;
-            }
-            return Ok(ResolvedPackage {
-                name: name.to_string(),
-                version: resolved_version,
-                manifest: version_manifest,
-            });
-        }
-
-        if self.supports_semver {
-            // Semver-supporting registry: use cached version manifest
-            tracing::debug!("Using semver resolution for {}@{}", fetch_name, fetch_spec);
-            let manifest = self
-                .resolve_version_manifest(&fetch_name, &fetch_spec)
-                .await?;
-            Ok(ResolvedPackage {
-                name: name.to_string(),
-                version: manifest.version.clone(),
-                manifest,
-            })
-        } else {
-            // 1. Try to resolve using cached versions (avoid network request)
-            if let Some(versions_info) = self.cache.get_versions(&fetch_name)
-                && let Ok(resolved_version) = resolve_target_version(
-                    &versions_info.versions.dist_tags,
-                    &versions_info.versions.version_list,
-                    &fetch_spec,
-                )
-            {
-                // Check if we have the version manifest cached
-                if let Some(manifest) = self
-                    .cache
-                    .get_version_manifest(&fetch_name, &resolved_version)
-                {
-                    tracing::debug!(
-                        "Using cached versions + manifest for {}@{} => {}",
-                        fetch_name,
-                        fetch_spec,
-                        resolved_version
-                    );
-                    return Ok(ResolvedPackage {
-                        name: name.to_string(),
-                        version: resolved_version,
-                        manifest,
-                    });
-                }
-
-                // Have versions cache but not version manifest, fetch it
-                if let Ok(manifest) = self
-                    .resolve_version_manifest(&fetch_name, &resolved_version)
-                    .await
-                {
-                    tracing::debug!(
-                        "Using cached versions, fetched manifest for {}@{} => {}",
-                        fetch_name,
-                        fetch_spec,
-                        resolved_version
-                    );
-                    // Cache for project cache export
-                    self.cache.set_version_manifest(
-                        fetch_name.to_string(),
-                        fetch_spec.to_string(),
-                        manifest.clone(),
-                    );
-                    return Ok(ResolvedPackage {
-                        name: name.to_string(),
-                        version: resolved_version,
-                        manifest,
-                    });
-                }
-            }
-
-            // Try to get full manifest, handle 304 case specially
-            let resolve_result = match self.resolve_full_manifest(&fetch_name).await? {
-                FullManifestResult::Full(full_manifest) => {
-                    // Got full manifest, resolve from it
-                    let version_list: Vec<String> = full_manifest.versions.clone();
-
-                    if version_list.is_empty() {
-                        return Err(RegistryError(anyhow!(
-                            "No versions available for {}",
-                            fetch_name
-                        )));
-                    }
-
-                    let resolved_version = resolve_target_version(
-                        &full_manifest.dist_tags,
-                        &version_list,
-                        &fetch_spec,
-                    )
-                    .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
-
-                    let version_manifest = full_manifest
-                        .get_core_version(&resolved_version)
-                        .map(Arc::new)
-                        .ok_or_else(|| {
-                            RegistryError(anyhow!(
-                                "Version {} not found in manifest for {}",
-                                resolved_version,
-                                fetch_name
-                            ))
-                        })?;
-
-                    (resolved_version, version_manifest)
-                }
-                FullManifestResult::NotModified => {
-                    // 304 case: use versions cache to resolve, then fetch version manifest
-                    tracing::debug!("Using versions cache for {}@{}", fetch_name, fetch_spec);
-
-                    let versions_info = self.cache.get_versions(&fetch_name).ok_or_else(|| {
-                        RegistryError(anyhow!("Versions cache not found for {}", fetch_name))
-                    })?;
-
-                    let resolved_version = resolve_target_version(
-                        &versions_info.versions.dist_tags,
-                        &versions_info.versions.version_list,
-                        &fetch_spec,
-                    )
-                    .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
-
-                    // Fetch individual version manifest
-                    let version_manifest = self
-                        .resolve_version_manifest(&fetch_name, &resolved_version)
-                        .await?;
-
-                    (resolved_version, version_manifest)
-                }
-            };
-
-            let (resolved_version, version_manifest) = resolve_result;
-
-            // Cache in memory for project cache export
-            self.cache.set_version_manifest(
-                fetch_name.to_string(),
-                fetch_spec.to_string(),
-                version_manifest.clone(),
-            );
-
-            // Write to disk cache (only for non-semver registries)
-            if !self.supports_semver {
-                self.cache
-                    .set_version_manifest_to_disk(&fetch_name, &resolved_version, &version_manifest)
-                    .await;
-            }
-
-            Ok(ResolvedPackage {
-                name: name.to_string(),
-                version: resolved_version,
-                manifest: version_manifest,
-            })
-        }
+        // Single entry point: `resolve_version_manifest` covers both semver
+        // (direct version-manifest fetch) and non-semver (full-manifest +
+        // extract) paths, with `inflight_version<(name, spec)>` ensuring one
+        // fetch+extraction per `(name, spec)` regardless of registry type.
+        let manifest = self
+            .resolve_version_manifest(&fetch_name, &fetch_spec)
+            .await?;
+        Ok(ResolvedPackage {
+            name: name.to_string(),
+            version: manifest.version.clone(),
+            manifest,
+        })
     }
 }
 

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -378,19 +378,20 @@ pub mod mock {
                 .get(name)
                 .ok_or_else(|| MockError(format!("Package not found: {}", name)))?;
 
-            // Build JSON and serialize to raw bytes for on-demand extraction
-            let json = serde_json::json!({
-                "name": &pkg.name,
-                "dist-tags": &pkg.dist_tags,
-                "versions": &pkg.versions,
-            });
-            let raw = serde_json::to_vec(&json).expect("mock JSON serialization");
+            // Serialize the per-version objects to bytes, parse to OwnedValue,
+            // then hand the resulting subtree to FullManifest. Mirrors how
+            // `service::manifest::fetch_full_manifest` builds the live manifest.
+            let versions_json =
+                serde_json::to_vec(&pkg.versions).expect("mock versions JSON serialization");
+            let mut buf = versions_json;
+            let versions_tree =
+                simd_json::to_owned_value(&mut buf).expect("mock versions JSON parse");
 
             Ok(Arc::new(FullManifest {
                 name: pkg.name.clone(),
                 dist_tags: pkg.dist_tags.clone(),
                 versions: pkg.versions.keys().cloned().collect(),
-                raw: Arc::from(raw),
+                versions_tree: Arc::new(versions_tree),
                 ..Default::default()
             }))
         }

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -135,12 +135,13 @@ pub trait RegistryClient {
 
     /// Fetch full package manifest from registry.
     ///
-    /// Returns the complete package manifest with all versions.
-    /// Required for registries that don't support semver resolution.
+    /// Returns the complete package manifest with all versions, wrapped in
+    /// an `Arc` so callers share the (potentially large) payload without
+    /// cloning.
     fn fetch_full_manifest(
         &self,
         name: &str,
-    ) -> impl Future<Output = Result<FullManifest, Self::Error>>;
+    ) -> impl Future<Output = Result<Arc<FullManifest>, Self::Error>>;
 
     /// Fetch specific version manifest from registry.
     ///
@@ -272,30 +273,9 @@ pub trait RegistryClient {
             let manifest = self.fetch_full_manifest(name).await?;
             Ok(VersionsInfo {
                 version_list: manifest.versions.clone(),
-                dist_tags: manifest.dist_tags,
+                dist_tags: manifest.dist_tags.clone(),
             })
         }
-    }
-
-    /// Get cached full manifest if available (synchronous, memory cache only).
-    ///
-    /// This method is used by preload to extract version manifests from cached
-    /// full manifests without additional network requests.
-    ///
-    /// Default implementation returns None (no caching).
-    fn get_cached_full_manifest(&self, _name: &str) -> Option<FullManifest> {
-        None
-    }
-
-    /// Get cached versions info if available (synchronous, memory cache only).
-    ///
-    /// This method is used by preload to handle 304 responses efficiently.
-    /// When fetch_full_manifest returns 304, the versions info is cached in memory,
-    /// and this method can retrieve it without additional network requests.
-    ///
-    /// Default implementation returns None (no caching).
-    fn get_cached_versions(&self, _name: &str) -> Option<VersionsInfo> {
-        None
     }
 
     /// Cache a resolved version manifest for later use.
@@ -392,7 +372,7 @@ pub mod mock {
     impl RegistryClient for MockRegistryClient {
         type Error = MockError;
 
-        async fn fetch_full_manifest(&self, name: &str) -> Result<FullManifest, Self::Error> {
+        async fn fetch_full_manifest(&self, name: &str) -> Result<Arc<FullManifest>, Self::Error> {
             let pkg = self
                 .packages
                 .get(name)
@@ -406,13 +386,13 @@ pub mod mock {
             });
             let raw = serde_json::to_vec(&json).expect("mock JSON serialization");
 
-            Ok(FullManifest {
+            Ok(Arc::new(FullManifest {
                 name: pkg.name.clone(),
                 dist_tags: pkg.dist_tags.clone(),
                 versions: pkg.versions.keys().cloned().collect(),
                 raw: Arc::from(raw),
                 ..Default::default()
-            })
+            }))
         }
     }
 }

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -378,20 +378,19 @@ pub mod mock {
                 .get(name)
                 .ok_or_else(|| MockError(format!("Package not found: {}", name)))?;
 
-            // Serialize the per-version objects to bytes, parse to OwnedValue,
-            // then hand the resulting subtree to FullManifest. Mirrors how
-            // `service::manifest::fetch_full_manifest` builds the live manifest.
-            let versions_json =
-                serde_json::to_vec(&pkg.versions).expect("mock versions JSON serialization");
-            let mut buf = versions_json;
-            let versions_tree =
-                simd_json::to_owned_value(&mut buf).expect("mock versions JSON parse");
+            // Build JSON and serialize to raw bytes for on-demand extraction
+            let json = serde_json::json!({
+                "name": &pkg.name,
+                "dist-tags": &pkg.dist_tags,
+                "versions": &pkg.versions,
+            });
+            let raw = serde_json::to_vec(&json).expect("mock JSON serialization");
 
             Ok(Arc::new(FullManifest {
                 name: pkg.name.clone(),
                 dist_tags: pkg.dist_tags.clone(),
                 versions: pkg.versions.keys().cloned().collect(),
-                versions_tree: Arc::new(versions_tree),
+                raw: Arc::from(raw),
                 ..Default::default()
             }))
         }

--- a/crates/ruborist/src/util/mod.rs
+++ b/crates/ruborist/src/util/mod.rs
@@ -1,0 +1,6 @@
+//! Shared utility primitives for ruborist and downstream consumers.
+
+pub mod oncemap;
+
+pub use crate::model::util::{PackageNameStr, parse_package_spec, read_package_json};
+pub use oncemap::OnceMap;

--- a/crates/ruborist/src/util/oncemap.rs
+++ b/crates/ruborist/src/util/oncemap.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 //! OnceMap: A concurrent map that ensures each key's work is done exactly once.
 //!
 //! Based on the pattern from uv package manager:
@@ -37,6 +36,14 @@
 //!       lib-a fetches react ──► network request
 //!       lib-z waits on lib-a ──► shares result (no duplicate!)
 //! ```
+//!
+//! # Failure semantics
+//!
+//! When `init` returns `None` (or `Err` via `get_or_try_init`), the entry is
+//! removed and waiters wake up to observe `None` / `Err` themselves. Each
+//! waiter retries by re-entering `get_or_init`/`get_or_try_init`, so a single
+//! transient failure isn't broadcast as a shared error to every concurrent
+//! caller.
 
 use dashmap::{DashMap, mapref::entry::Entry};
 use std::future::Future;
@@ -71,6 +78,12 @@ pub struct OnceMap<K, V> {
     waiters: DashMap<K, Arc<Notify>>,
 }
 
+impl<K, V> std::fmt::Debug for OnceMap<K, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OnceMap").finish_non_exhaustive()
+    }
+}
+
 impl<K, V> Default for OnceMap<K, V>
 where
     K: Eq + Hash + Clone,
@@ -95,7 +108,6 @@ where
     /// Register a key as pending (Waiting state) without starting work.
     /// Returns the Notify handle if newly registered, None if already exists.
     pub fn register(&self, key: K) -> Option<Arc<Notify>> {
-        use dashmap::mapref::entry::Entry;
         match self.map.entry(key) {
             Entry::Occupied(_) => None,
             Entry::Vacant(vacant) => {
@@ -272,6 +284,89 @@ where
         self.notify_all(&key, &notify);
         arc_value
     }
+
+    /// Fallible variant of [`get_or_init`].
+    ///
+    /// Concurrent callers single-flight the work; on `Err` the entry is
+    /// removed and each waiter resumes by re-running its own `init` closure
+    /// (since the original error can't be cloned across waiters and we'd
+    /// rather have each caller see a fresh error than a stale shared one).
+    pub async fn get_or_try_init<E, F, Fut>(&self, key: K, init: F) -> Result<Arc<V>, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<V, E>>,
+    {
+        // Fast path: check if already done
+        if let Some(entry) = self.map.get(&key)
+            && let Value::Done(result) = entry.value()
+        {
+            return Ok(Arc::clone(result));
+        }
+
+        // Try to register as the worker
+        let notify = Arc::new(Notify::new());
+        let entry = self.map.entry(key.clone());
+
+        let is_worker = match entry {
+            Entry::Occupied(occupied) => {
+                match occupied.get() {
+                    Value::Done(result) => {
+                        return Ok(Arc::clone(result));
+                    }
+                    Value::Waiting(existing_notify) => {
+                        let existing_notify = Arc::clone(existing_notify);
+                        let notified = existing_notify.notified();
+                        drop(occupied);
+
+                        if let Some(entry) = self.map.get(&key)
+                            && let Value::Done(result) = entry.value()
+                        {
+                            return Ok(Arc::clone(result));
+                        }
+
+                        notified.await;
+
+                        if let Some(entry) = self.map.get(&key)
+                            && let Value::Done(result) = entry.value()
+                        {
+                            return Ok(Arc::clone(result));
+                        }
+                        // Worker failed; promote ourselves to retry as a fresh worker.
+                        false
+                    }
+                }
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(Value::Waiting(Arc::clone(&notify)));
+                true
+            }
+        };
+
+        // If we observed a failed prior attempt, retry recursively. Recursion
+        // depth is bounded by concurrent retries on the same key, which is
+        // typically tiny; pinning avoids the boxed-future cost in the common
+        // single-pass case.
+        if !is_worker {
+            return Box::pin(self.get_or_try_init(key, init)).await;
+        }
+
+        // Execute the work
+        let result = init().await;
+
+        match result {
+            Ok(v) => {
+                let arc = Arc::new(v);
+                self.map.insert(key.clone(), Value::Done(Arc::clone(&arc)));
+                self.notify_all(&key, &notify);
+                Ok(arc)
+            }
+            Err(e) => {
+                self.map.remove(&key);
+                self.notify_all(&key, &notify);
+                Err(e)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -380,38 +475,6 @@ mod tests {
     /// This test verifies the fix for a race condition where a waiter could
     /// miss the notification if the worker completed between the waiter
     /// releasing the lock and registering for notifications.
-    ///
-    /// Timeline of the race condition (before fix):
-    /// ```text
-    /// Worker                          Waiter
-    /// ──────                          ──────
-    /// 1. register key
-    ///    insert Waiting(notify)
-    ///    start work...
-    ///                                 2. sees Waiting state
-    ///                                    clone notify
-    ///                                    drop(lock) ← release lock
-    ///
-    ///                                    ┌─────────────────┐
-    ///                                    │  DANGER WINDOW  │
-    ///                                    │  (not listening │
-    ///                                    │   for notify)   │
-    ///                                    └─────────────────┘
-    ///
-    /// 3. work done!
-    ///    insert Done(value)
-    ///    notify_waiters() ← sent!
-    ///    (but no one listening)
-    ///
-    ///                                 4. notified = notify.notified()
-    ///                                    ← too late! already notified
-    ///
-    ///                                 5. notified.await
-    ///                                    ← waits forever, deadlock!
-    /// ```
-    ///
-    /// The fix: register `notified()` BEFORE releasing the lock, then
-    /// double-check if the value was inserted.
     #[tokio::test]
     async fn test_no_missed_notifications() {
         use tokio::sync::Barrier;
@@ -419,32 +482,23 @@ mod tests {
         let map = Arc::new(OnceMap::<String, i32>::new());
         let barrier = Arc::new(Barrier::new(2));
 
-        // Spawn the worker task
         let map_clone = Arc::clone(&map);
         let barrier_clone = Arc::clone(&barrier);
         let worker = tokio::spawn(async move {
             map_clone
                 .get_or_init("key".to_string(), || async move {
-                    // Wait for waiter to be ready
                     barrier_clone.wait().await;
-                    // Small delay to let waiter release lock
                     tokio::time::sleep(Duration::from_millis(5)).await;
                     Some(42)
                 })
                 .await
         });
 
-        // Spawn waiter task
         let map_clone = Arc::clone(&map);
         let barrier_clone = Arc::clone(&barrier);
         let waiter = tokio::spawn(async move {
-            // Small delay to ensure worker registers first
             tokio::time::sleep(Duration::from_millis(1)).await;
-
-            // Signal worker to proceed
             barrier_clone.wait().await;
-
-            // This should not hang - if it does, the race condition exists
             map_clone
                 .get_or_init("key".to_string(), || async move {
                     panic!("Waiter should not execute work");
@@ -452,14 +506,86 @@ mod tests {
                 .await
         });
 
-        // Use timeout to detect deadlock
         let timeout = Duration::from_secs(2);
         let results = tokio::time::timeout(timeout, futures::future::join(worker, waiter))
             .await
             .expect("Test timed out - possible deadlock due to missed notification");
 
-        // Both should get the same result
         assert_eq!(*results.0.unwrap().unwrap(), 42);
         assert_eq!(*results.1.unwrap().unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn test_try_init_dedupes_success() {
+        let map = Arc::new(OnceMap::<String, i32>::new());
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = vec![];
+        for _ in 0..8 {
+            let map = Arc::clone(&map);
+            let call_count = Arc::clone(&call_count);
+            handles.push(tokio::spawn(async move {
+                map.get_or_try_init::<&'static str, _, _>("k".to_string(), || async move {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    call_count.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, &'static str>(7)
+                })
+                .await
+            }));
+        }
+        for h in handles {
+            assert_eq!(*h.await.unwrap().unwrap(), 7);
+        }
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_try_init_failure_allows_retry() {
+        let map: OnceMap<String, i32> = OnceMap::new();
+        let result = map
+            .get_or_try_init::<&'static str, _, _>("k".to_string(), || async move { Err("boom") })
+            .await;
+        assert_eq!(result.unwrap_err(), "boom");
+
+        let result = map
+            .get_or_try_init::<&'static str, _, _>("k".to_string(), || async move {
+                Ok::<_, &'static str>(9)
+            })
+            .await;
+        assert_eq!(*result.unwrap(), 9);
+    }
+
+    #[tokio::test]
+    async fn test_try_init_waiter_retries_after_worker_error() {
+        let map = Arc::new(OnceMap::<String, i32>::new());
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let map1 = Arc::clone(&map);
+        let attempts1 = Arc::clone(&attempts);
+        let worker = tokio::spawn(async move {
+            map1.get_or_try_init::<&'static str, _, _>("k".to_string(), || async move {
+                attempts1.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Err::<i32, _>("worker failed")
+            })
+            .await
+        });
+
+        let map2 = Arc::clone(&map);
+        let attempts2 = Arc::clone(&attempts);
+        let waiter = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            map2.get_or_try_init::<&'static str, _, _>("k".to_string(), || async move {
+                attempts2.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &'static str>(11)
+            })
+            .await
+        });
+
+        let (w, ww) = futures::future::join(worker, waiter).await;
+        assert_eq!(w.unwrap().unwrap_err(), "worker failed");
+        // Waiter sees the failure, promotes itself to a fresh worker, and succeeds.
+        assert_eq!(*ww.unwrap().unwrap(), 11);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 }


### PR DESCRIPTION
## Summary

Six-commit perf+refactor stack on `crates/ruborist` and `crates/pm` cache+resolve hot path. Targets the BFS preload window during cold installs.

| # | Commit | Effect |
|---|---|---|
| 1 | `perf(ruborist): single-flight manifest fetches via OnceMap` | Promotes `OnceMap` from `crates/pm` into `crates/ruborist/src/util` (gains a fallible `get_or_try_init<E>` variant). Wraps `UnifiedRegistry::resolve_full_manifest` / `resolve_version_manifest` so concurrent resolves for the same `name` or `(name, spec)` collapse to one network round-trip. Also replaces `resolver/common.rs::DedupCache<T>` (`tokio::Mutex<HashMap<OnceCell>>`) with `OnceMap<String, T>`. Collapses the duplicate cache+fetch ladder in `RegistryClient::fetch_version_manifest`. |
| 2 | `perf(pm): drop full-manifest clone on read; shard cache via DashMap` | `MemoryCacheInner` three tables migrated `RwLock<HashMap<…>>` → `DashMap<…, Arc<…>>`. `get_full_manifest` / `get_versions` now return `Arc<…>` (no deep clone on cache hit). `ProjectCache::data` resharded from a single `RwLock` to `DashMap<String, Arc<Mutex<ProjectPackageCache>>>`. Trait `RegistryClient::fetch_full_manifest` returns `Arc<FullManifest>`; two unused trait methods deleted. |
| 3 | `perf(pm): close inflight_version coverage gap on non-semver path` | Folds the non-semver "extract from full manifest" path into `resolve_version_manifest`'s `inflight_version` gate. `resolve_package` becomes a 12-line wrapper. Concurrent resolves of the same `(name, spec)` no longer redundantly extract + Arc-allocate. |
| 4 | `perf(pm): pre-parse FullManifest versions subtree, drop per-extract reparse` | Replaces `raw: Arc<[u8]>` with `versions_tree: Arc<simd_json::OwnedValue>`; `extract_version` becomes a tree lookup + zero-clone `T::deserialize(&OwnedValue)`. *(Reverted in commit 6 — see notes.)* |
| 5 | `refactor(pm): inflight OnceMap as gate-only, single source of truth in cache` | OnceMap entries reduced to `()`; the canonical `Arc<…>` lives only in `PackageCache`. Worker writes cache as a side effect, gate releases, waiters and worker re-read cache. Eliminates the double `Arc<CoreVersionManifest>` allocation per `(name, spec)` and the deep clone the previous setup needed to satisfy OnceMap's owned-`V` API. |
| 6 | `revert(pm): drop pre-parsed versions_tree, keep zero-clone deserialize` | Reverts commit 4's storage shape (back to `raw: Arc<[u8]>`), keeps the zero-clone `T::deserialize(&BorrowedValue)` improvement. CI bench on commit-4-included revealed the OwnedValue tree expanded ~2.5× in RAM (`p1_resolve` RSS 1.07G vs utoo-npm 430M); reverting brings RSS back to baseline. With OnceMap deduping each `(name, spec)` to a single extract, the per-extract full-tree parse cost is bounded and acceptable. |

## Why

The hot path in monorepo resolves had layers of unnecessary work:

1. `resolve_full_manifest` / `resolve_version_manifest` did `cache.get → fetch → cache.set` with no inflight gating: concurrent BFS workers requesting the same package each fired their own HTTP request.
2. `RegistryClient::fetch_version_manifest` trait impl had a *second* independent cache+fetch ladder running in parallel with `resolve_version_manifest`.
3. `MemoryCacheInner` used `parking_lot::RwLock<HashMap<…>>`; under BFS preload concurrency every writer blocked all readers, even on unrelated keys. `get_full_manifest` returned an owned `FullManifest` via `.cloned()` — every cache hit deep-cloned the inner HashMaps + Vec + dist-tags.
4. Non-semver `resolve_package` path bypassed `inflight_version`: N concurrent BFS workers redundantly extracted + Arc-allocated the same version manifest from the shared full manifest.
5. The `inflight_*` OnceMaps stored manifest data inside the gate value, duplicating what was already in `PackageCache` (two independent Arc allocations + one deep clone per resolve).

After this PR every `(name, spec)` resolution funnels through one inflight gate that holds `()`, with the single canonical `Arc<…>` living in PackageCache. Reads are sharded + lock-free; writes only contend within a single DashMap shard.

## Bench (CI sticky comment, `5c43914`)

### Wall time — macOS (`macos-latest`)

| Phase / registry | utoo wall | utoo-npm wall | wall ratio |
|---|---|---|---|
| **npmjs p1_resolve** | **4.70s** | 6.15s | **0.76** ✅ utoo快24% |
| **npmjs p3_cold_install** | **10.64s** | 12.47s | **0.85** ✅ utoo快15% |
| **npmmirror p0_full_cold** | **22.41s** | 24.88s | **0.90** ✅ utoo快10% |
| **npmmirror p1_resolve** | **6.46s** | 9.30s | **0.69** ✅ utoo快31% |
| **npmmirror p3_cold_install** | **22.94s** | 27.62s | **0.83** ✅ utoo快17% |
| npmjs p0_full_cold | 16.88s | 14.66s | 1.15 |
| npmjs p4_warm_link | 5.31s | 4.96s | 1.07 |

5/7 hot phases utoo is **10–31% faster** than utoo-npm.

### Wall time — Linux (`ubuntu-latest`, npmjs.org)

| Phase | utoo wall | utoo-npm wall | wall ratio |
|---|---|---|---|
| p1_resolve | 23.24s | 20.81s | **1.12** (vs baseline #2856 1.24, **−12 pt**) |
| **p3_cold_install** | **6.40s** | 9.32s | **0.69** ✅ utoo快31% |
| p4_warm_link | 2.74s | 2.56s | 1.07 |
| p0_full_cold | 28.57s | 23.56s | 1.21 |

### RSS

The headline RSS story is **regression rescue**, not steady-state shrinkage:

| Snapshot (p1_resolve linux npmjs) | utoo RSS | Note |
|---|---|---|
| **baseline #2856 (`360afdd`, pre-PR)** | ~429M | starting point |
| **mid-PR with commit 4 (`99e5fe0`)** | **1.07G** ❌ | OwnedValue versions_tree expanded raw bytes ~2.5×; caught by CI bench |
| **after commit 6 revert (`5c43914`)** | **433M** ✅ | restored to baseline; commit 4's storage shape rolled back, zero-clone deserialize kept |

Per-`(name, spec)` shrinkage from gate-only (commit 5: kills the duplicate `Arc<CoreVersionManifest>` between OnceMap and PackageCache) is theoretical ~5–15 MB total on ant-design (~500 unique pairs × ~5–20 KB each), which is below the CI runner's run-to-run RSS noise floor (~±5–10%). So bench shows utoo RSS within ±1–10% of utoo-npm depending on phase — some phases utoo is lower, some higher, no systematic regression:

| Phase | utoo RSS | utoo-npm RSS | delta |
|---|---|---|---|
| linux npmjs **p0_full_cold** | 1.22G | 1.30G | **−6%** ✅ |
| linux npmjs p1_resolve | 433M | 428M | +1% |
| linux npmjs p3_cold_install | 939M | 857M | +10% ⚠️ |
| mac npmjs **p3_cold_install** | 694M | 725M | **−4%** ✅ |
| mac npmjs p1_resolve | 551M | 545M | +1% |
| mac npmjs p0_full_cold | 1.09G | 1008M | +8% |
| mac npmmirror p0_full_cold | 809M | 698M | +16% ⚠️ |

Where utoo is higher (≤+16%): mostly DashMap shard metadata overhead (default ~32 shards × per-shard HashMap allocation) + per-run noise. The transient-peak savings (no deep `FullManifest::clone()` during BFS) are real but don't move the `time -l` peak much because the deep-clone copies are short-lived and rarely overlap.

If steady-state RSS is the priority for a follow-up, the levers we haven't pulled yet:

- **Switch global allocator to mimalloc** (currently glibc malloc on Linux / system malloc on mac). bun uses mimalloc; expected 5–15% RSS + wall improvement on multithreaded JSON parse / HashMap-heavy workloads.
- **Tighter `DashMap` shard count** (`with_shard_amount`) — default 32 may be excessive for our cache size; trimming saves shard-overhead bytes.
- **`SmallVec`/`InternedString` for HashMap keys** in cache (`<name>@<spec>` strings dedup well; interning saves ~100 bytes per duplicate spec).

## Out of scope (followup PR)

- **Cache decoupling between pm and ruborist** — `PackageCache`'s disk side effects (`set_*_to_disk`) currently live in `crates/ruborist`; ideally ruborist becomes a pure resolver and pm subscribes to resolve events / drains a "pending writes" queue and persists asynchronously. Work prototyped locally:
  - `tokio::task::spawn_blocking` + sync `std::fs` for disk writes (moves JSON serialize off main runtime workers)
  - `BufWriter` + `serde_json::to_writer` (compact, no intermediate `String` alloc)
  - `DashSet<PathBuf>` for `created_dirs` to skip redundant `create_dir_all` syscalls
  - Local A/B showed +0.4s wall headroom from gate detach — saved for the cleanup PR
- **bun-style p1_resolve speedup** — bun's pure-resolve is still 13% faster on linux / 46% faster on mac. Closing that gap needs deeper changes (mimalloc global allocator, streaming-style JSON parse to skip materialization, custom HTTP fast path).
- **HTTP/2 stream limits, single-version manifest ETag, allocator selection** — separate, smaller followups.

## Test plan

- [x] `cargo fmt --check`, `tombi format --check`
- [x] `cargo clippy --all-targets -p utoo-pm -p utoo-ruborist -- -D warnings --no-deps`
- [x] `cargo test -p utoo-pm -p utoo-ruborist --lib` — 177 passing (incl. 3 new `get_or_try_init` tests)
- [x] WASM build (`utooweb-ci-build-wasm`) green
- [x] CI bench (`benchmark` label, both linux + mac sticky comments above)
- [x] Local p1 bench (5-run, ant-design, registry.npmjs.org): RSS 569M ≈ baseline 562M, wall internal ~6.93s ≈ utoo-npm 7.08s

🤖 Generated with [Claude Code](https://claude.com/claude-code)