### PR TITLE
perf(pm): inflight_version OnceMap as gate-only, drop deep clones

### DIFF
--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -431,13 +431,11 @@ impl UnifiedRegistry {
         // Gate released — populated either by us, a prior waiter, or a previous
         // run that hit memory/disk cache. A missing entry here would only occur
         // under cache eviction (we don't currently evict).
-        self.cache
-            .get_version_manifest(name, spec)
-            .ok_or_else(|| {
-                RegistryError(anyhow!(
-                    "version manifest for {name}@{spec} vanished from cache after fetch"
-                ))
-            })
+        self.cache.get_version_manifest(name, spec).ok_or_else(|| {
+            RegistryError(anyhow!(
+                "version manifest for {name}@{spec} vanished from cache after fetch"
+            ))
+        })
     }
 
     /// Resolve `(name, spec)` for non-semver registries by reading the full

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -87,7 +87,12 @@ pub struct UnifiedRegistry {
     /// Single-flight gate for version-manifest fetches keyed by `(name, spec)`.
     /// `name@spec` is used because semver registries resolve spec server-side,
     /// so two requests with the same name but different specs must not share.
-    inflight_version: Arc<OnceMap<(String, String), CoreVersionManifest>>,
+    /// Stores `()` — the canonical `Arc<CoreVersionManifest>` lives in
+    /// `PackageCache::version_manifests`. Cheaper than storing the value:
+    /// every code path that would otherwise need an owned `CoreVersionManifest`
+    /// to satisfy the `OnceMap` value slot now flows through the cache, where
+    /// reads are Arc-bumps with no deep clone.
+    inflight_version: Arc<OnceMap<(String, String), ()>>,
 }
 
 /// Builder for `UnifiedRegistry`.
@@ -348,26 +353,32 @@ impl UnifiedRegistry {
             return Ok(manifest);
         }
 
-        // 2. Single-flight: concurrent resolves for the same (name, spec) share
-        //    the disk-cache check + network fetch + full-manifest extraction.
-        //    PackageCache is populated as a side effect for fast-path hits on
-        //    subsequent calls.
+        // 2. Single-flight gate: concurrent resolves for the same (name, spec)
+        //    share the disk-cache check + network fetch + full-manifest
+        //    extraction. The gate value is `()`; the canonical
+        //    `Arc<CoreVersionManifest>` lives in `PackageCache::version_manifests`
+        //    and is read back after the gate releases (Arc bump, no clone).
         self.inflight_version
             .get_or_try_init::<RegistryError, _, _>(
                 (name.to_string(), spec.to_string()),
                 || async {
                     // Re-check memory cache inside the worker (covers the brief
                     // window between fast-path miss and shard-lock acquire).
-                    if let Some(manifest) = self.cache.get_version_manifest(name, spec) {
-                        return Ok((*manifest).clone());
+                    if self.cache.get_version_manifest(name, spec).is_some() {
+                        return Ok(());
                     }
 
                     if !self.supports_semver
-                        && let Some(manifest) =
-                            self.cache.get_version_manifest_from_disk(name, spec).await
+                        && self
+                            .cache
+                            .get_version_manifest_from_disk(name, spec)
+                            .await
+                            .is_some()
                     {
+                        // `get_version_manifest_from_disk` populates the memory
+                        // cache as a side effect.
                         tracing::debug!("Disk cache hit for version manifest: {}@{}", name, spec);
-                        return Ok((*manifest).clone());
+                        return Ok(());
                     }
 
                     if !self.supports_semver {
@@ -377,23 +388,23 @@ impl UnifiedRegistry {
                         // same name share one full-manifest fetch.
                         let (resolved_version, manifest) =
                             self.resolve_via_full_manifest(name, spec).await?;
-                        let arc = Arc::new(manifest.clone());
+                        let arc = Arc::new(manifest);
                         self.cache.set_version_manifest(
                             name.to_string(),
                             spec.to_string(),
-                            arc.clone(),
+                            Arc::clone(&arc),
                         );
                         if resolved_version != spec {
                             self.cache.set_version_manifest(
                                 name.to_string(),
                                 resolved_version.clone(),
-                                arc.clone(),
+                                Arc::clone(&arc),
                             );
                         }
                         self.cache
                             .set_version_manifest_to_disk(name, &resolved_version, &arc)
                             .await;
-                        return Ok(manifest);
+                        return Ok(());
                     }
 
                     tracing::debug!("Cache miss for {}@{}, fetching from network", name, spec);
@@ -410,12 +421,23 @@ impl UnifiedRegistry {
                     self.cache.set_version_manifest(
                         name.to_string(),
                         spec.to_string(),
-                        Arc::new(manifest.clone()),
+                        Arc::new(manifest),
                     );
-                    Ok(manifest)
+                    Ok(())
                 },
             )
-            .await
+            .await?;
+
+        // Gate released — populated either by us, a prior waiter, or a previous
+        // run that hit memory/disk cache. A missing entry here would only occur
+        // under cache eviction (we don't currently evict).
+        self.cache
+            .get_version_manifest(name, spec)
+            .ok_or_else(|| {
+                RegistryError(anyhow!(
+                    "version manifest for {name}@{spec} vanished from cache after fetch"
+                ))
+            })
     }
 
     /// Resolve `(name, spec)` for non-semver registries by reading the full


### PR DESCRIPTION
## Summary

Stacks on top of #2862. `inflight_version: OnceMap<(String, String), CoreVersionManifest>` stored the manifest in the gate's value slot; every code path inside the init closure had to materialise an owned `CoreVersionManifest` (deep clone of deps, peer/optional deps, scripts, dist) just to satisfy the OnceMap V slot, even though `version_manifests` already holds the canonical Arc.

Switch the gate to `OnceMap<(String, String), ()>`. The closure returns `Ok(())` from every branch; the canonical Arc stays in `PackageCache::version_manifests`. After the gate releases, the outer function reads the cache once (Arc bump) and returns. Worker and waiters take the same final path.

`InflightFull` (the full-manifest discriminator enum) is left as-is — 1-byte `Copy`, no clone cost, and the 304 vs 200 distinction is needed at gate-release time.

## Local measurement (M-series macOS, ant-design / npmmirror, 8x interleaved)

baseline = `perf/ruborist-oncemap-single-flight` HEAD (commits `4f733634` Arc+DashMap, `6f3848cd` non-semver gate coverage)

| | min | max | mean | median | σ |
|---|---:|---:|---:|---:|---:|
| baseline | 4.26 | 9.04 | 5.37 | 4.92 | 1.54 |
| + gate-only (this PR) | 4.48 | 5.05 | 4.70 | **4.64** | **0.20** |

- Δ median **−0.28 s, −6%**
- σ tightens **1.54 → 0.20 (7.7×)** — main qualitative win
- max-of-8 drops 9.04 s → 5.05 s; the long tail from clone-induced shard-lock contention is gone

The mean shift is modest because Arc-wrap and DashMap (#2862's `4f733634`) had already taken the big absolute wins. Eliminating the remaining clones flattens the distribution.

## Diff

`crates/ruborist/src/service/registry.rs` only — type change on `inflight_version`, every `Ok(manifest)` / `(*manifest).clone()` / `Arc::new(manifest.clone())` site converted to `Ok(())` + `Arc::new(manifest)` + `Arc::clone(&arc)`, plus a final `cache.get_version_manifest(name, spec).ok_or_else(...)` after the gate.

## Stacking

Depends on #2862 (`perf/ruborist-oncemap-single-flight`) — base branch is set to that PR's branch so the diff shown is just my two commits. Will rebase to `next` once #2862 lands.

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings --no-deps -p utoo-pm -p utoo-ruborist` clean
- [x] `cargo test -p utoo-ruborist` all pass
- [x] Local 8x interleaved p1_resolve bench (above)
- [ ] CI `pm-bench-phases` (label: benchmark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)