### PR TITLE
perf(pm): manifest resolve hot-path — rayon offload + network layer (h1+pool+dns)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11805,6 +11805,7 @@ dependencies = [
  "parking_lot",
  "pathdiff",
  "petgraph 0.6.5",
+ "rayon",
  "reqwest 0.12.24",
  "rustls",
  "rustls-native-certs",

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -54,7 +54,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-
 
 # Native-only dependencies (not compiled for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libc  = "0.2"
+libc = "0.2"
 # Dedicated CPU thread pool for simd_json manifest parsing — keeps the
 # tokio runtime free of CPU-bound work so in-flight network IO is not
 # blocked by sibling parses. WASM falls back to inline parse.

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -54,11 +54,11 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-
 
 # Native-only dependencies (not compiled for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libc = "0.2"
+libc  = "0.2"
 # Dedicated CPU thread pool for simd_json manifest parsing — keeps the
 # tokio runtime free of CPU-bound work so in-flight network IO is not
 # blocked by sibling parses. WASM falls back to inline parse.
-rayon = "1.10"
+rayon = { workspace = true }
 
 # Browser handles TLS via the fetch API, so reqwest needs no rustls
 # feature on this target.

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -54,7 +54,11 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-
 
 # Native-only dependencies (not compiled for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libc = "0.2"
+libc  = "0.2"
+# Dedicated CPU thread pool for simd_json manifest parsing — keeps the
+# tokio runtime free of CPU-bound work so in-flight network IO is not
+# blocked by sibling parses. WASM falls back to inline parse.
+rayon = "1.10"
 
 # Browser handles TLS via the fetch API, so reqwest needs no rustls
 # feature on this target.

--- a/crates/ruborist/src/model/manifest.rs
+++ b/crates/ruborist/src/model/manifest.rs
@@ -149,6 +149,30 @@ impl FullManifest {
     }
 }
 
+/// Re-parse the raw manifest bytes on rayon's CPU thread pool to extract
+/// a single version. Each resolved package triggers one full re-parse via
+/// `simd_json::to_borrowed_value`, which on hot paths (300+ resolves per
+/// install) accumulates into the dominant CPU bucket.
+///
+/// Wasm32 falls back to inline parse — no rayon, no thread pool.
+pub async fn extract_core_version_off_runtime(
+    full: std::sync::Arc<FullManifest>,
+    version: String,
+) -> Option<CoreVersionManifest> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        rayon::spawn(move || {
+            let _ = tx.send(full.get_core_version(&version));
+        });
+        rx.await.ok().flatten()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        full.get_core_version(&version)
+    }
+}
+
 /// Deserialize a versions map by extracting only the keys, skipping all values.
 ///
 /// Uses `IgnoredAny` to skip over version manifest JSON objects without allocating,

--- a/crates/ruborist/src/model/manifest.rs
+++ b/crates/ruborist/src/model/manifest.rs
@@ -149,30 +149,33 @@ impl FullManifest {
     }
 }
 
-/// Re-parse the raw manifest bytes on rayon's CPU thread pool to extract
-/// a single version. Each resolved package triggers one full re-parse via
-/// `simd_json::to_borrowed_value`, which on hot paths (300+ resolves per
-/// install) accumulates into the dominant CPU bucket.
+/// Extract a single version from `FullManifest` on rayon's CPU pool
+/// (native) or inline (wasm32). The native path keeps the tokio runtime
+/// free of `simd_json::to_borrowed_value` work so sibling manifest
+/// fetches keep driving network IO while this one re-parses.
 ///
-/// Returns `Arc<CoreVersionManifest>` so callers (e.g. UnifiedRegistry's
-/// version-manifest cache) can store and clone the result without
-/// deep-copying the underlying `HashMap`s. Wasm32 falls back to inline
-/// parse — no rayon, no thread pool.
+/// Returns `(version, Option<Arc<CoreVersionManifest>>)` — the input
+/// `version` is handed back to the caller alongside the result so it
+/// can be reused for the error path and the outer return without a
+/// clone. The native path requires `'static` for the rayon closure,
+/// so the closure owns the string for its duration.
 pub async fn extract_core_version_off_runtime(
-    full: std::sync::Arc<FullManifest>,
+    full: Arc<FullManifest>,
     version: String,
-) -> Option<std::sync::Arc<CoreVersionManifest>> {
+) -> (String, Option<Arc<CoreVersionManifest>>) {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let _ = tx.send(full.get_core_version(&version).map(std::sync::Arc::new));
+            let core = full.get_core_version(&version).map(Arc::new);
+            let _ = tx.send((version, core));
         });
-        rx.await.ok().flatten()
+        rx.await.expect("rayon parse worker dropped before sending")
     }
     #[cfg(target_arch = "wasm32")]
     {
-        full.get_core_version(&version).map(std::sync::Arc::new)
+        let core = full.get_core_version(&version).map(Arc::new);
+        (version, core)
     }
 }
 

--- a/crates/ruborist/src/model/manifest.rs
+++ b/crates/ruborist/src/model/manifest.rs
@@ -154,22 +154,25 @@ impl FullManifest {
 /// `simd_json::to_borrowed_value`, which on hot paths (300+ resolves per
 /// install) accumulates into the dominant CPU bucket.
 ///
-/// Wasm32 falls back to inline parse — no rayon, no thread pool.
+/// Returns `Arc<CoreVersionManifest>` so callers (e.g. UnifiedRegistry's
+/// version-manifest cache) can store and clone the result without
+/// deep-copying the underlying `HashMap`s. Wasm32 falls back to inline
+/// parse — no rayon, no thread pool.
 pub async fn extract_core_version_off_runtime(
     full: std::sync::Arc<FullManifest>,
     version: String,
-) -> Option<CoreVersionManifest> {
+) -> Option<std::sync::Arc<CoreVersionManifest>> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let _ = tx.send(full.get_core_version(&version));
+            let _ = tx.send(full.get_core_version(&version).map(std::sync::Arc::new));
         });
         rx.await.ok().flatten()
     }
     #[cfg(target_arch = "wasm32")]
     {
-        full.get_core_version(&version)
+        full.get_core_version(&version).map(std::sync::Arc::new)
     }
 }
 

--- a/crates/ruborist/src/resolver/preload.rs
+++ b/crates/ruborist/src/resolver/preload.rs
@@ -15,7 +15,7 @@ use crate::traits::progress::{BuildEvent, EventReceiver};
 use crate::traits::registry::RegistryClient;
 
 /// Default concurrency limit for manifest fetching
-pub const DEFAULT_CONCURRENCY: usize = 64;
+pub const DEFAULT_CONCURRENCY: usize = 128;
 
 /// A dependency spec: (name, version_spec)
 pub type Dep = (String, String);

--- a/crates/ruborist/src/service/dns.rs
+++ b/crates/ruborist/src/service/dns.rs
@@ -14,6 +14,7 @@
 mod native {
     use std::collections::HashMap;
     use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, LazyLock};
     use std::time::{Duration, Instant};
 
@@ -70,6 +71,12 @@ mod native {
         cache: Arc<Mutex<HashMap<String, CacheEntry>>>,
         inflight: Arc<Mutex<HashMap<String, Arc<InflightEntry>>>>,
         ttl: Duration,
+        /// Round-robin counter used to rotate the returned address order
+        /// on every `resolve` call. Spreads concurrent pool connections
+        /// across all DNS A records (e.g. antgroup registry returns 8
+        /// IPs) instead of pinning every new connection to the first IP
+        /// like reqwest does by default.
+        rr_counter: AtomicUsize,
     }
 
     impl CachingResolver {
@@ -79,8 +86,26 @@ mod native {
                 cache: Arc::new(Mutex::new(HashMap::new())),
                 inflight: Arc::new(Mutex::new(HashMap::new())),
                 ttl,
+                rr_counter: AtomicUsize::new(0),
             }
         }
+    }
+
+    /// Rotate `addrs` left by `offset` positions, producing a fresh Vec so
+    /// reqwest's connect loop tries a different IP on every new connection.
+    ///
+    /// e.g. `[A, B, C, D]` with offset 2 → `[C, D, A, B]`.
+    fn rotate_addrs(addrs: &[SocketAddr], offset: usize) -> Vec<SocketAddr> {
+        if addrs.is_empty() {
+            return Vec::new();
+        }
+        let n = addrs.len();
+        let start = offset % n;
+        addrs[start..]
+            .iter()
+            .chain(&addrs[..start])
+            .copied()
+            .collect()
     }
 
     /// Perform a system DNS lookup and cache the result.
@@ -132,10 +157,11 @@ mod native {
                 if let Some(entry) = cache.get(&hostname)
                     && entry.expires_at > Instant::now()
                 {
-                    let cached = entry.addrs.to_vec();
-                    return Box::pin(std::future::ready(
-                        Ok(Box::new(cached.into_iter()) as Addrs),
-                    ));
+                    let offset = self.rr_counter.fetch_add(1, Ordering::Relaxed);
+                    let rotated = rotate_addrs(&entry.addrs, offset);
+                    return Box::pin(std::future::ready(Ok(
+                        Box::new(rotated.into_iter()) as Addrs
+                    )));
                 }
             }
 
@@ -155,6 +181,7 @@ mod native {
             // Clone Arcs for the 'static async block (required by Resolve trait).
             let cache = Arc::clone(&self.cache);
             let inflight_map = Arc::clone(&self.inflight);
+            let offset = self.rr_counter.fetch_add(1, Ordering::Relaxed);
 
             Box::pin(async move {
                 let result = inflight
@@ -167,13 +194,8 @@ mod native {
                 inflight_map.lock().remove(&hostname);
 
                 let resolved = result?;
-
-                // resolved is a &Arc<Vec<SocketAddr>> borrowed from the OnceCell,
-                // but Addrs requires a 'static owned iterator.
-                // to_vec() + into_iter() creates an owned copy; iter().copied()
-                // would borrow from the local reference and fail lifetime checks.
-                #[allow(clippy::unnecessary_to_owned)]
-                let addrs: Addrs = Box::new(resolved.to_vec().into_iter());
+                let rotated = rotate_addrs(resolved.as_ref(), offset);
+                let addrs: Addrs = Box::new(rotated.into_iter());
                 Ok(addrs)
             })
         }

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -165,8 +165,7 @@ pub fn client_builder() -> Result<reqwest::ClientBuilder> {
             // makes head-of-line blocking on one slow response stall the
             // whole manifest fetch phase. An H1 pool lets concurrent
             // manifest requests open independent TCP streams instead.
-            .http1_only()
-            .pool_max_idle_per_host(64);
+            .http1_only();
 
         #[cfg(target_os = "macos")]
         {

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -159,7 +159,14 @@ pub fn client_builder() -> Result<reqwest::ClientBuilder> {
         let mut builder = builder
             .no_proxy()
             .dns_resolver(shared_resolver())
-            .connect_timeout(CONNECT_TIMEOUT);
+            .connect_timeout(CONNECT_TIMEOUT)
+            // Force HTTP/1.1 with a connection pool. reqwest multiplexes all
+            // requests over a single HTTP/2 connection by default, which
+            // makes head-of-line blocking on one slow response stall the
+            // whole manifest fetch phase. An H1 pool lets concurrent
+            // manifest requests open independent TCP streams instead.
+            .http1_only()
+            .pool_max_idle_per_host(64);
 
         #[cfg(target_os = "macos")]
         {

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -13,6 +13,35 @@ use super::fetch::{
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
 
+/// Parse JSON bytes on rayon's CPU thread pool (native) or inline
+/// (wasm32). Keeps the tokio runtime free of `simd_json` CPU work so
+/// other in-flight manifest fetches can keep driving network IO while
+/// this one is parsing. Rayon's global pool work-steals across
+/// `num_cpus` threads, so concurrent manifest parses parallelise.
+async fn parse_json_off_runtime<T>(bytes: Vec<u8>) -> Result<T, anyhow::Error>
+where
+    T: serde::de::DeserializeOwned + Send + 'static,
+{
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        rayon::spawn(move || {
+            let mut buf = bytes;
+            let result = simd_json::serde::from_slice::<T>(&mut buf)
+                .map_err(|e| anyhow!("JSON parse error: {e}"));
+            // Receiver dropped means the awaiting future was cancelled.
+            let _ = tx.send(result);
+        });
+        rx.await
+            .map_err(|e| anyhow!("rayon parse channel closed: {e}"))?
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let mut buf = bytes;
+        simd_json::serde::from_slice::<T>(&mut buf).map_err(|e| anyhow!("JSON parse error: {e}"))
+    }
+}
+
 /// Result of a full manifest fetch with ETag support.
 /// Transient return value, immediately destructured — Box not needed.
 #[allow(clippy::large_enum_variant)]
@@ -89,11 +118,13 @@ pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<Fetch
                         .await
                         .map_err(|e| FetchError::Permanent(anyhow!("Response read error: {e}")))?
                         .to_vec();
-                    // Save raw bytes before simd_json mutates the parse buffer.
-                    let mut parse_buf = raw_bytes.clone();
-                    let mut manifest: FullManifest =
-                        simd_json::serde::from_slice(&mut parse_buf)
-                            .map_err(|e| FetchError::Permanent(anyhow!("JSON parse error: {e}")))?;
+                    // simd_json mutates the parse buffer; clone so the raw
+                    // bytes survive for `manifest.raw`. Parse runs off-runtime
+                    // on rayon (native) so it cannot block sibling fetches.
+                    let parse_buf = raw_bytes.clone();
+                    let mut manifest: FullManifest = parse_json_off_runtime(parse_buf)
+                        .await
+                        .map_err(FetchError::Permanent)?;
                     manifest.raw = std::sync::Arc::from(raw_bytes);
 
                     Ok(FetchManifestResult::Ok(manifest, new_etag))
@@ -173,13 +204,14 @@ pub async fn fetch_version_manifest(
                     .map_err(classify_reqwest_error)?;
 
                 if response.status().is_success() {
-                    let mut bytes = response
+                    let bytes = response
                         .bytes()
                         .await
                         .map_err(|e| FetchError::Permanent(anyhow!("Response read error: {e}")))?
                         .to_vec();
-                    simd_json::serde::from_slice(&mut bytes)
-                        .map_err(|e| FetchError::Permanent(anyhow!("JSON parse error: {e}")))
+                    parse_json_off_runtime::<CoreVersionManifest>(bytes)
+                        .await
+                        .map_err(FetchError::Permanent)
                 } else {
                     Err(classify_status(response.status(), &url))
                 }

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -14,11 +14,10 @@ use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
 
 /// Parse JSON bytes on rayon's CPU thread pool (native) or inline
-/// (wasm32). Keeps the tokio runtime free of `simd_json` CPU work so
-/// other in-flight manifest fetches can keep driving network IO while
-/// this one is parsing. Rayon's global pool work-steals across
-/// `num_cpus` threads, so concurrent manifest parses parallelise.
-async fn parse_json_off_runtime<T>(bytes: Vec<u8>) -> Result<T, anyhow::Error>
+/// (wasm32). Keeps the tokio runtime free of `simd_json` work so other
+/// in-flight manifest fetches keep driving network IO while this one
+/// parses.
+async fn parse_json_off_runtime<T>(mut bytes: Vec<u8>) -> Result<T, anyhow::Error>
 where
     T: serde::de::DeserializeOwned + Send + 'static,
 {
@@ -26,10 +25,8 @@ where
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let mut buf = bytes;
-            let result = simd_json::serde::from_slice::<T>(&mut buf)
+            let result = simd_json::serde::from_slice::<T>(&mut bytes)
                 .map_err(|e| anyhow!("JSON parse error: {e}"));
-            // Receiver dropped means the awaiting future was cancelled.
             let _ = tx.send(result);
         });
         rx.await
@@ -37,8 +34,7 @@ where
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut buf = bytes;
-        simd_json::serde::from_slice::<T>(&mut buf).map_err(|e| anyhow!("JSON parse error: {e}"))
+        simd_json::serde::from_slice::<T>(&mut bytes).map_err(|e| anyhow!("JSON parse error: {e}"))
     }
 }
 
@@ -119,8 +115,7 @@ pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<Fetch
                         .map_err(|e| FetchError::Permanent(anyhow!("Response read error: {e}")))?
                         .to_vec();
                     // simd_json mutates the parse buffer; clone so the raw
-                    // bytes survive for `manifest.raw`. Parse runs off-runtime
-                    // on rayon (native) so it cannot block sibling fetches.
+                    // bytes survive for `manifest.raw`.
                     let parse_buf = raw_bytes.clone();
                     let mut manifest: FullManifest = parse_json_off_runtime(parse_buf)
                         .await

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -440,7 +440,12 @@ impl UnifiedRegistry {
                 }
                 let resolved_version = resolve_target_version((&*full).into(), spec)
                     .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
-                let core = full.get_core_version(&resolved_version).ok_or_else(|| {
+                let core = crate::model::manifest::extract_core_version_off_runtime(
+                    Arc::clone(&full),
+                    resolved_version.clone(),
+                )
+                .await
+                .ok_or_else(|| {
                     RegistryError(anyhow!(
                         "Version {} not found in manifest for {}",
                         resolved_version,

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -42,7 +42,7 @@ fn current_timestamp_secs() -> u64 {
 use super::cache::{PackageCache, Versions, VersionsInfo};
 use super::manifest;
 use super::store::{ManifestStore, NoopStore};
-use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::model::manifest::{CoreVersionManifest, FullManifest, extract_core_version_off_runtime};
 use crate::resolver::semver::normalize_spec;
 use crate::resolver::version::resolve_target_version;
 use crate::traits::registry::{RegistryClient, RegistryError, ResolvedPackage, is_npm_registry};
@@ -439,20 +439,18 @@ impl UnifiedRegistry {
                 }
                 let resolved_version = resolve_target_version((&*full).into(), spec)
                     .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
-                // Short-circuit: a sibling spec may have already resolved to
-                // this same version and warmed the cache. Skip the rayon
-                // reparse (the dominant cost on the resolve hot path) and
-                // share the existing `Arc<CoreVersionManifest>` instead of
-                // deep-cloning its HashMaps.
+                // Race window: while we awaited `resolve_full_manifest` (gated
+                // by `inflight_full<name>`), a sibling spec for the same
+                // package may have resolved to this same version and populated
+                // `version_manifests` cache (writer at line 373-387 stores
+                // both `(name, spec)` and `(name, resolved_version)` keys).
+                // Reuse the Arc instead of paying the off-runtime reparse.
                 if let Some(cached) = self.cache.get_version_manifest(name, &resolved_version) {
                     return Ok((resolved_version, cached));
                 }
-                let core = crate::model::manifest::extract_core_version_off_runtime(
-                    Arc::clone(&full),
-                    resolved_version.clone(),
-                )
-                .await
-                .ok_or_else(|| {
+                let (resolved_version, core) =
+                    extract_core_version_off_runtime(full, resolved_version).await;
+                let core = core.ok_or_else(|| {
                     RegistryError(anyhow!(
                         "Version {} not found in manifest for {}",
                         resolved_version,

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -369,9 +369,8 @@ impl UnifiedRegistry {
                         // version from the full manifest. `resolve_full_manifest`
                         // is itself inflight-gated, so concurrent specs for the
                         // same name share one full-manifest fetch.
-                        let (resolved_version, manifest) =
+                        let (resolved_version, arc) =
                             self.resolve_via_full_manifest(name, spec).await?;
-                        let arc = Arc::new(manifest);
                         self.cache.set_version_manifest(
                             name.to_string(),
                             spec.to_string(),
@@ -432,7 +431,7 @@ impl UnifiedRegistry {
         &self,
         name: &str,
         spec: &str,
-    ) -> Result<(String, CoreVersionManifest), RegistryError> {
+    ) -> Result<(String, Arc<CoreVersionManifest>), RegistryError> {
         match self.resolve_full_manifest(name).await? {
             FullManifestResult::Full(full) => {
                 if full.versions.is_empty() {
@@ -440,6 +439,14 @@ impl UnifiedRegistry {
                 }
                 let resolved_version = resolve_target_version((&*full).into(), spec)
                     .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
+                // Short-circuit: a sibling spec may have already resolved to
+                // this same version and warmed the cache. Skip the rayon
+                // reparse (the dominant cost on the resolve hot path) and
+                // share the existing `Arc<CoreVersionManifest>` instead of
+                // deep-cloning its HashMaps.
+                if let Some(cached) = self.cache.get_version_manifest(name, &resolved_version) {
+                    return Ok((resolved_version, cached));
+                }
                 let core = crate::model::manifest::extract_core_version_off_runtime(
                     Arc::clone(&full),
                     resolved_version.clone(),
@@ -475,7 +482,7 @@ impl UnifiedRegistry {
                     })
                     .await
                     .map_err(RegistryError)?;
-                Ok((resolved_version, manifest))
+                Ok((resolved_version, Arc::new(manifest)))
             }
         }
     }

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -39,6 +39,8 @@ fn current_timestamp_secs() -> u64 {
     (js_sys::Date::now() / 1000.0) as u64
 }
 
+use dashmap::DashSet;
+
 use super::cache::{PackageCache, Versions, VersionsInfo};
 use super::manifest;
 use super::store::{ManifestStore, NoopStore};
@@ -84,6 +86,13 @@ pub struct UnifiedRegistry {
     /// `(name, spec)`. Same gate-only pattern: the canonical `Arc<…>`
     /// lives in `PackageCache.version_manifests`; the gate stores `()`.
     inflight_version: Arc<OnceMap<(String, String), ()>>,
+    /// Dedup set for `store_version_manifest` disk writes keyed by
+    /// `(name, resolved_version)`. `inflight_version` is keyed by
+    /// `(name, spec)`, so sibling specs (e.g. `^1.0.0` and `^1.2.0`)
+    /// resolving to the same version each fire the gate independently
+    /// and would otherwise issue duplicate writes for the same path.
+    /// First insert wins; subsequent specs skip the redundant write.
+    stored_version: Arc<DashSet<(String, String)>>,
 }
 
 /// Builder for `UnifiedRegistry`.
@@ -152,6 +161,7 @@ impl UnifiedRegistryBuilder {
             supports_semver,
             inflight_full: Arc::new(OnceMap::new()),
             inflight_version: Arc::new(OnceMap::new()),
+            stored_version: Arc::new(DashSet::new()),
         }
     }
 }
@@ -171,6 +181,7 @@ impl Clone for UnifiedRegistry {
             supports_semver: self.supports_semver,
             inflight_full: Arc::clone(&self.inflight_full),
             inflight_version: Arc::clone(&self.inflight_version),
+            stored_version: Arc::clone(&self.stored_version),
         }
     }
 }
@@ -383,11 +394,16 @@ impl UnifiedRegistry {
                                 Arc::clone(&arc),
                             );
                         }
-                        self.store.store_version_manifest(
-                            name,
-                            &resolved_version,
-                            Arc::clone(&arc),
-                        );
+                        if self
+                            .stored_version
+                            .insert((name.to_string(), resolved_version.clone()))
+                        {
+                            self.store.store_version_manifest(
+                                name,
+                                &resolved_version,
+                                Arc::clone(&arc),
+                            );
+                        }
                         return Ok(());
                     }
 


### PR DESCRIPTION
## Summary

Manifest resolve hot-path overhaul on rayon-only architecture (no worker-pool refactor), plus network-layer optimizations cherry-picked from PR #2818. After noise-adjusted measurement, this stack reaches within ~0.2s of the worker-pool baseline (#2818) on Linux ant-design / npmjs.

| Commit | Change |
|---|---|
| `2b54a57d` | rayon offload for `simd_json::serde::from_slice` (fetch path) + `extract_version` reparse |
| `b43ef5ce` | short-circuit `cache.get_version_manifest(name, resolved)` before rayon reparse |
| `eb95b56d` | preload concurrency 64 → 128 |
| `7f7f08b9` | HTTP/1.1 + connection pool for manifest fetching (cherry-pick from PR #2818) |
| `440c501a` | round-robin DNS addresses across connection pool (cherry-pick from PR #2818) |

## Why network-layer optimizations were added

Initial validation against worker-pool (#2818, p1=2.70s) showed rayon-only stuck at p1=3.6–4.8s — a ~1.0s gap that PR #2872's ablation revealed was **mostly network-layer, not architectural**:

| Variant (worker-pool path) | p1_resolve | Δ vs PR #2818 |
|---|---|---|
| #2818 full (h1+pool+dns) | 2.70s | — |
| #2872 (no dns) | 3.07s | +0.37s |
| revert h1+pool | 7.34s (σ 4.82, max 12.9s) | +4.64s ❌ |
| revert dns rr | 3.36s (σ 0.67, max 4.13s) | +0.66s ❌ |

reqwest's default H2 multiplexing causes head-of-line blocking on Cloudflare-fronted npmjs (1 slow tail response stalls the whole phase). A forced HTTP/1.1 pool with DNS round-robin across the multi-IP CDN restores parallelism.

## CI bench-phases-linux (Linux ant-design / npmjs, noise-adjusted)

Two samples on a slow-runner day; ratio normalization against bun in the same run isolates the runner-induced shift.

| Config | utoo p1 (raw) | bun p1 (raw) | utoo/bun | Normalized to bun typical (~2.0s) |
|---|---|---|---|---|
| **rayon + h1+pool+dns (this PR)** | 4.21s median | 2.99s | **1.40** | **~2.80s** |
| worker-pool full (#2818) | 2.70s | 2.06s | 1.31 | ~2.62s |
| worker-pool no-dns (#2872) | 3.07s | ~2.0s | ~1.54 | ~3.07s |
| rayon no-net (this PR before cherry-picks) | 3.58–4.79s | 1.91–2.57s | 1.86–1.87 | ~3.74s |
| bun | — | — | — | ~2.0s |

**Network optimizations recovered ~0.94s of the rayon-vs-worker-pool gap** (3.74s → 2.80s normalized).

**Worker-pool architecture itself contributes only ~0.18s** (worker-pool 2.62s vs rayon 2.80s normalized). Roughly the per-fetch tokio scheduling overhead.

## Architectural pillars

1. **CPU/IO separation** — every `simd_json` parse runs on rayon's global pool via `tokio::sync::oneshot`. Tokio runtime stays free of CPU work.
2. **Cache short-circuit** — sibling specs of the same package skip the rayon reparse on second resolve via `(name, resolved_version)` cache key.
3. **No worker-pool refactor** — `FuturesUnordered` orchestrator unchanged. `MaybeSend`/`MaybeSync` shim avoided.
4. **HTTP/1.1 + idle pool** — `pool_max_idle_per_host(64)`, `http1_only()`. Fixes H2 HOL blocking on Cloudflare-fronted registries.
5. **DNS round-robin** — atomic counter rotates the resolved address list per `resolve` call so concurrent pool connections distribute across all A records.
6. **Phase-specific concurrency** — preload (manifest GETs) at 128; tgz download keeps its own semaphore.

## Notes

- Worker-pool path (PR #2869 / #2818) still wins by ~0.2s normalized — accept residual gap in exchange for keeping `MaybeSend`/`MaybeSync`-free rayon architecture.
- h1+pool+dns commits are orthogonal to the architecture choice and could equally be extracted as a standalone PR if preferred.

## Test plan

- [x] `cargo build --profile release-local -p utoo-pm` clean
- [x] `cargo clippy -p utoo-ruborist -p utoo-pm --all-targets -- -D warnings --no-deps` clean
- [x] `cargo test -p utoo-ruborist --lib` (no regressions)
- [x] CI `bench-phases-linux` validated network-opts compounding (2 samples, ratio analysis)
- [x] CI `utooweb-ci-build-wasm` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)