### PR TITLE
perf(pm): drop redundant in-memory versions_info fill on 200 path

### DIFF
--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -245,6 +245,15 @@ impl UnifiedRegistry {
                 .map_err(RegistryError)?
                 {
                     manifest::FetchManifestResult::Ok(manifest, new_etag) => {
+                        // Build a `VersionsInfo` strictly for the disk-persist
+                        // task. We do NOT also fill the in-memory
+                        // `versions_info` cache slot on the 200 path: readers
+                        // (`resolve_via_full_manifest::Full`) now go through
+                        // `VersionsRef::from(&Arc<FullManifest>)` for this
+                        // case, so the `full_manifests` slot is the single
+                        // source of truth in memory. The `versions_info` slot
+                        // is reserved for the 304 path (or disk-loaded warm
+                        // cache from a previous run).
                         let versions_info = Arc::new(VersionsInfo {
                             versions: Versions {
                                 version_list: manifest.versions.clone(),
@@ -255,8 +264,6 @@ impl UnifiedRegistry {
                         });
                         self.cache
                             .set_full_manifest(name.to_string(), Arc::new(manifest));
-                        self.cache
-                            .set_versions(name.to_string(), Arc::clone(&versions_info));
                         // Fire-and-forget: store may spawn its own task.
                         self.store.store_versions(name, versions_info);
                     }
@@ -277,6 +284,10 @@ impl UnifiedRegistry {
                             .await
                             .map_err(RegistryError)?;
 
+                            // Same shape as the 200 branch: only the
+                            // canonical `full_manifests` slot is filled in
+                            // memory; the disk-persist task gets its own
+                            // `Arc<VersionsInfo>`.
                             let versions_info = Arc::new(VersionsInfo {
                                 versions: Versions {
                                     version_list: manifest.versions.clone(),
@@ -287,8 +298,6 @@ impl UnifiedRegistry {
                             });
                             self.cache
                                 .set_full_manifest(name.to_string(), Arc::new(manifest));
-                            self.cache
-                                .set_versions(name.to_string(), Arc::clone(&versions_info));
                             self.store.store_versions(name, versions_info);
                         }
                     }


### PR DESCRIPTION
## Summary

Follow-up to **PR #2878** (`VersionsRef<'a>` view abstraction). Now that `resolve_via_full_manifest`'s Full branch reads `versions` / `dist_tags` directly from the cached `Arc<FullManifest>` via the view, the in-memory `versions_info` cache slot is no longer needed on the 200 path — the `full_manifests` slot is the single source of truth in memory for fresh fetches.

The `versions_info` slot now serves a single purpose: warm-cache storage for the 304 path (populated either by a previous run's disk store or by the current run's 304 hit).

**Stacked on top of #2878.** Base: `next` (logically depends on #2878 landing first since the read-side decoupling is what makes this safe).

1 file changed, +13/−4 lines.

## What changed

`resolve_full_manifest`'s 200 branch and the corruption-fallback inside the 304 branch both stop calling `self.cache.set_versions(name, …)` after a successful 200 fetch.

The `Arc<VersionsInfo>` is still constructed for the disk-persist task — that path is unchanged, only the in-memory double-fill is gone.

```rust
// Before:
self.cache.set_full_manifest(name.to_string(), Arc::new(manifest));
self.cache.set_versions(name.to_string(), Arc::clone(&versions_info));  // ← removed
self.store.store_versions(name, versions_info);

// After:
self.cache.set_full_manifest(name.to_string(), Arc::new(manifest));
self.store.store_versions(name, versions_info);
```

## Why this is safe (discriminator unchanged)

`resolve_full_manifest`'s post-gate discriminator still works correctly:

- **200 path**: `full_manifests` populated → returns `Full(manifest)` ✅
- **304 path**: only `versions_info` populated (filled in the 304 branch from the disk-loaded `store_versions`) → returns `NotModified` ✅

`resolve_via_full_manifest::Full` reads through `VersionsRef::from(&Arc<FullManifest>)` — doesn't touch the `versions_info` slot.
`resolve_via_full_manifest::NotModified` reads `cache.get_versions(name)` — only runs in the 304 case where `versions_info` IS filled.

## Bench expectation

Saves one `Arc::clone` per fetch (the in-memory `set_versions` call). The deep clones for disk persist are still in the worker closure — that's a separate, more invasive optimization (would require `ManifestStore::store_versions` API change to defer the clone into the spawned task) and is left for a future PR if perf becomes the goal.

**This PR's value is architectural**: eliminating the duplicate in-memory representation of versions/dist_tags, isolating `versions_info` slot to its single legitimate use case (304 / cross-run warm cache). Bench signal will be small (within σ); the cleanup is what matters.

## Why a separate PR

Per the saga-of-#2877:

- **#2877** (closed) tried to fix the duplicate-storage with `mem::take`, which broke `Arc<FullManifest>` field integrity → BC break that Gemini correctly flagged.
- **#2878** introduced the read-side abstraction (`VersionsRef<'a>` view) so readers don't depend on which slot holds the data — but kept the write-side double-fill intact for safety.
- **This PR** finally drops the write-side double-fill, now safe because readers go through the view.

Each PR is independently reviewable and bench-able; the chain decouples the architectural concern (read-side abstraction in #2878) from the storage cleanup (this PR).

## Test plan

- [x] `cargo clippy -p utoo-ruborist -p utoo-pm --all-targets -- -D warnings --no-deps` clean
- [x] `cargo test -p utoo-ruborist`: 162 + 10 doctests pass
- [x] `cargo test -p utoo-pm`: 245 pass
- [ ] CI `pm-bench-phases-linux` — expecting neutral on p1_resolve (within σ); architectural cleanup, not perf optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)
