### PR TITLE
perf(pm): dedup version-manifest disk writes via OnceMap

### DIFF
--- a/crates/pm/src/util/manifest_store.rs
+++ b/crates/pm/src/util/manifest_store.rs
@@ -16,16 +16,27 @@ use async_trait::async_trait;
 use serde::Serialize;
 use utoo_ruborist::model::manifest::CoreVersionManifest;
 use utoo_ruborist::service::{ManifestStore, VersionsInfo};
+use utoo_ruborist::util::OnceMap;
 
 use crate::util::json::read_json_file;
 
 pub struct DiskManifestStore {
     cache_dir: PathBuf,
+    /// Dedup `(name, resolved_version)` disk writes. The upstream
+    /// `inflight_version<(name, original_spec)>` gate keys on the original
+    /// spec, so two specs (`^4.17.0`, `~4.17.20`) resolving to the same
+    /// `4.17.21` each call `store_version_manifest` and would otherwise
+    /// spawn duplicate `write_json` tasks racing on truncate of the same
+    /// path. `OnceMap::register` is a sync, atomic "first wins" check.
+    inflight_version_writes: Arc<OnceMap<(String, String), ()>>,
 }
 
 impl DiskManifestStore {
     pub fn new(cache_dir: PathBuf) -> Self {
-        Self { cache_dir }
+        Self {
+            cache_dir,
+            inflight_version_writes: Arc::new(OnceMap::new()),
+        }
     }
 
     fn versions_path(&self, name: &str) -> PathBuf {
@@ -67,8 +78,21 @@ impl ManifestStore for DiskManifestStore {
         version: &str,
         manifest: Arc<CoreVersionManifest>,
     ) {
+        let key = (name.to_string(), version.to_string());
+        let Some(notify) = self.inflight_version_writes.register(key.clone()) else {
+            // Another caller already enqueued this write — skip the
+            // duplicate serialize + spawn + truncate-race.
+            return;
+        };
         let path = self.manifest_path(name, version);
-        tokio::spawn(async move { write_json(&path, &*manifest).await });
+        // Move an `Arc` clone of the OnceMap into the task so we can
+        // transition Waiting → Done after the write completes; this also
+        // notifies any future `wait_if_pending` callers.
+        let inflight = Arc::clone(&self.inflight_version_writes);
+        tokio::spawn(async move {
+            write_json(&path, &*manifest).await;
+            inflight.complete(key, Some(()), notify);
+        });
     }
 }
 


### PR DESCRIPTION
## Problem

`DiskManifestStore::store_version_manifest` is called from `service/registry.rs:388` inside the `inflight_version<(name, original_spec)>` gate. The gate keys on the **original spec**, but the disk write keys on the **resolved version**. Two sibling specs (`^4.17.0`, `~4.17.20`) resolving to the same `4.17.21` each pass through different gates and both spawn `write_json` for the same path:

```text
spec="^4.17.0"  ──┬─ inflight gate 1 ─→ resolved 4.17.21 ─→ tokio::spawn write 4.17.21.json
spec="~4.17.20" ──┴─ inflight gate 2 ─→ resolved 4.17.21 ─→ tokio::spawn write 4.17.21.json
spec="4.x"      ────  inflight gate 3 ─→ resolved 4.17.21 ─→ tokio::spawn write 4.17.21.json
```

Each duplicate does:
- redundant `serde_json::to_vec` (~5 KB × N)
- redundant disk write
- truncate-race window where a concurrent reader sees partial JSON (read fails → cache miss)

`store_versions` (versions.json) is safe — it sits inside `inflight_full<name>` whose key matches the write key.

## Fix

Add an `OnceMap<(name, resolved_version), ()>` to `DiskManifestStore`. Reuse the existing `OnceMap::register` (sync, atomic "first wins") that ruborist already uses for `inflight_full` / `inflight_version`. Subsequent callers for the same `(name, version)` get `None` from `register` and skip the spawn entirely.

```rust
let Some(notify) = self.inflight_version_writes.register(key.clone()) else {
    return;  // duplicate, skip
};
let inflight = Arc::clone(&self.inflight_version_writes);
tokio::spawn(async move {
    write_json(&path, &*manifest).await;
    inflight.complete(key, Some(()), notify);
});
```

## Impact

ant-design preload: ~600 specs → ~250 unique versions → ~350 redundant `spawn + serialize + write` cycles eliminated, ~1.75 MB redundant disk write avoided. Wall-clock impact within σ (writes are fire-and-forget off the resolve hot path), but reduces CPU/IO contention with preload workers and closes the truncate-race window.

## Test plan

- [x] `cargo build --profile release-local -p utoo-pm` clean
- [x] `cargo clippy -p utoo-pm -p utoo-ruborist --all-targets -- -D warnings --no-deps` clean
- [x] `cargo test -p utoo-pm` — 245 passed, 0 failed
- [ ] CI \`bench-phases-linux\` — confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)