### PR TITLE
fix(pm): postinstall OS detection for Windows kernel-version drift

### DIFF
--- a/.github/workflows/pm-ci.yml
+++ b/.github/workflows/pm-ci.yml
@@ -104,6 +104,10 @@ jobs:
         if: ${{ matrix.settings.setup }}
         shell: bash
       
+      - name: Postinstall OS-detection e2e
+        run: sh e2e/postinstall-os-detect.sh
+        shell: bash
+
       - name: Setup Utoo
         uses: utooland/setup-utoo@v1
 

--- a/e2e/postinstall-os-detect.sh
+++ b/e2e/postinstall-os-detect.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# E2E test for vendor/templates/postinstall*.sh.template OS detection.
+#
+# Runs each template under a sandboxed shell with `uname` and env vars
+# (OSTYPE, PROCESSOR_ARCHITECTURE) mocked, then asserts the computed
+# (OS, ARCH) tuple. Side-effecting commands (cp, mkdir, chmod, npm, rm)
+# are stubbed so the script runs fast and offline.
+#
+# Regression target: GitHub `windows-latest` rolling from Server 2022
+# (`MINGW64_NT-10.0-20348`) to Server 2025 (`MINGW64_NT-10.0-26100`)
+# previously produced `@utoo/utoo-mingw64_nt-10.0-26100-x64` (404 on
+# npm). All Windows kernel slugs must collapse to OS=win32.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE_PM="$REPO_ROOT/vendor/templates/postinstall.sh.template"
+TEMPLATE_UTOO="$REPO_ROOT/vendor/templates/postinstall.utoo.sh.template"
+
+PASS=0
+FAIL=0
+
+run_detection() {
+    template=$1
+    mock_uname_s=$2
+    mock_uname_m=$3
+    mock_ostype=$4
+    mock_proc_arch=$5
+
+    tmpl=$(sed 's|{{name}}|utoo|g' "$template")
+
+    MOCK_UNAME_S="$mock_uname_s" \
+    MOCK_UNAME_M="$mock_uname_m" \
+    OSTYPE="$mock_ostype" \
+    PROCESSOR_ARCHITECTURE="$mock_proc_arch" \
+    sh 2>/dev/null <<SH_EOF
+uname() {
+    if [ "\$#" -eq 0 ]; then printf '%s\n' "\$MOCK_UNAME_S"; return 0; fi
+    case "\$1" in
+        -s) printf '%s\n' "\$MOCK_UNAME_S" ;;
+        -m) printf '%s\n' "\$MOCK_UNAME_M" ;;
+        *) printf '%s\n' "\$MOCK_UNAME_S" ;;
+    esac
+}
+# Neutralize side effects so the install path can fail fast and the
+# trap fires with OS/ARCH already populated.
+mkdir() { :; }
+cp() { :; }
+chmod() { :; }
+rm() { :; }
+npm() { return 1; }
+find_node_modules() { return 1; }
+trap 'printf "RESULT OS=%s ARCH=%s\n" "\${OS:-}" "\${ARCH:-}"' EXIT
+
+$tmpl
+SH_EOF
+}
+
+assert_detection() {
+    label=$1
+    template=$2
+    mock_uname_s=$3
+    mock_uname_m=$4
+    mock_ostype=$5
+    mock_proc_arch=$6
+    expected_os=$7
+    expected_arch=$8
+
+    out=$(run_detection "$template" "$mock_uname_s" "$mock_uname_m" "$mock_ostype" "$mock_proc_arch")
+    actual=$(printf '%s\n' "$out" | grep '^RESULT ' | tail -1)
+    expected="RESULT OS=$expected_os ARCH=$expected_arch"
+
+    if [ "$actual" = "$expected" ]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' \
+            "$label" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+for template in "$TEMPLATE_PM" "$TEMPLATE_UTOO"; do
+    printf '\n== %s ==\n' "$(basename "$template")"
+
+    # Unix
+    assert_detection "linux x86_64"  "$template" "Linux"  "x86_64"  "linux-gnu" "" "linux"  "x64"
+    assert_detection "linux aarch64" "$template" "Linux"  "aarch64" "linux-gnu" "" "linux"  "arm64"
+    assert_detection "darwin x86_64" "$template" "Darwin" "x86_64"  "darwin22"  "" "darwin" "x64"
+    assert_detection "darwin arm64"  "$template" "Darwin" "arm64"   "darwin22"  "" "darwin" "arm64"
+
+    # Windows: kernel-version drift must collapse to OS=win32.
+    # OSTYPE is empty (PowerShell-spawned sh) so the legacy $OSTYPE
+    # branch can no longer rescue us — uname-prefix matching must.
+    assert_detection "win32 mingw64 server2022" "$template" \
+        "MINGW64_NT-10.0-20348" "x86_64" "" "AMD64" "win32" "x64"
+    assert_detection "win32 mingw64 server2025" "$template" \
+        "MINGW64_NT-10.0-26100" "x86_64" "" "AMD64" "win32" "x64"
+    assert_detection "win32 cygwin" "$template" \
+        "CYGWIN_NT-10.0" "x86_64" "" "AMD64" "win32" "x64"
+    assert_detection "win32 msys" "$template" \
+        "MSYS_NT-10.0" "x86_64" "" "AMD64" "win32" "x64"
+    assert_detection "win32 arm64" "$template" \
+        "MINGW64_NT-10.0-26100" "x86_64" "" "ARM64" "win32" "arm64"
+
+    # Legacy: OSTYPE=msys still works when uname is unhelpful.
+    assert_detection "win32 OSTYPE=msys fallback" "$template" \
+        "" "x86_64" "msys" "AMD64" "win32" "x64"
+
+    # uname empty + non-Windows OSTYPE → "unknown" fallback rather
+    # than a malformed `@utoo/utoo--x64` package name.
+    assert_detection "unknown OS fallback" "$template" \
+        "" "x86_64" "" "" "unknown" "x64"
+done
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/vendor/templates/postinstall.sh.template
+++ b/vendor/templates/postinstall.sh.template
@@ -28,7 +28,7 @@ if [ "$IS_WIN" = "1" ]; then
         ARCH="x64"
     fi
 else
-    OS=$(echo "$UNAME_S" | tr '[:upper:]' '[:lower:]')
+    OS=$(echo "${UNAME_S:-unknown}" | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m)
 
     if [ "$ARCH" = "x86_64" ]; then

--- a/vendor/templates/postinstall.sh.template
+++ b/vendor/templates/postinstall.sh.template
@@ -1,7 +1,23 @@
 #!/bin/sh
 
 # get cpu & os info
-if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "win32" ]; then
+# Detect Windows via uname output (MINGW*/MSYS*/CYGWIN*) so kernel-version
+# bumps on the host (e.g. Server 2022 -> 2025) don't change the package name.
+UNAME_S=$(uname -s 2>/dev/null || echo "")
+case "$UNAME_S" in
+    MINGW*|MSYS*|CYGWIN*)
+        IS_WIN=1
+        ;;
+    *)
+        if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "win32" ]; then
+            IS_WIN=1
+        else
+            IS_WIN=0
+        fi
+        ;;
+esac
+
+if [ "$IS_WIN" = "1" ]; then
     OS="win32"
     # Use PROCESSOR_ARCHITECTURE on Windows
     if [ "$PROCESSOR_ARCHITECTURE" = "AMD64" ] || [ "$PROCESSOR_ARCHITECTURE" = "x86_64" ]; then
@@ -11,15 +27,15 @@ if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "win32" ]; then
     else
         ARCH="x64"
     fi
-else  
-    OS=$(uname -s | tr '[:upper:]' '[:lower:]')  
-    ARCH=$(uname -m)  
-      
-    if [ "$ARCH" = "x86_64" ]; then  
-        ARCH="x64"  
-    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then  
-        ARCH="arm64"  
-    fi  
+else
+    OS=$(echo "$UNAME_S" | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+
+    if [ "$ARCH" = "x86_64" ]; then
+        ARCH="x64"
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+        ARCH="arm64"
+    fi
 fi
 
 if [ "$ARCH" = "x86_64" ]; then

--- a/vendor/templates/postinstall.utoo.sh.template
+++ b/vendor/templates/postinstall.utoo.sh.template
@@ -1,7 +1,23 @@
 #!/bin/sh
 
 # Get CPU & OS info - POSIX compatible (works with sh on Windows Git)
-if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "win32" ]; then
+# Detect Windows via uname output (MINGW*/MSYS*/CYGWIN*) so kernel-version
+# bumps on the host (e.g. Server 2022 -> 2025) don't change the package name.
+UNAME_S=$(uname -s 2>/dev/null || echo "")
+case "$UNAME_S" in
+    MINGW*|MSYS*|CYGWIN*)
+        IS_WIN=1
+        ;;
+    *)
+        if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "win32" ]; then
+            IS_WIN=1
+        else
+            IS_WIN=0
+        fi
+        ;;
+esac
+
+if [ "$IS_WIN" = "1" ]; then
     OS="win32"
     # On Windows, use PROCESSOR_ARCHITECTURE
     if [ "$PROCESSOR_ARCHITECTURE" = "AMD64" ] || [ "$PROCESSOR_ARCHITECTURE" = "x86_64" ]; then
@@ -11,15 +27,15 @@ if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "win32" ]; then
     else
         ARCH="x64"  # default
     fi
-else  
-    OS=$(uname -s | tr '[:upper:]' '[:lower:]')  
-    ARCH=$(uname -m)  
-    if [ "$ARCH" = "x86_64" ]; then  
-        ARCH="x64"  
-    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then  
-        ARCH="arm64"  
-    fi  
-fi  
+else
+    OS=$(echo "$UNAME_S" | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "x86_64" ]; then
+        ARCH="x64"
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+        ARCH="arm64"
+    fi
+fi
 
 # Function to find node_modules directory recursively
 find_node_modules() {

--- a/vendor/templates/postinstall.utoo.sh.template
+++ b/vendor/templates/postinstall.utoo.sh.template
@@ -28,7 +28,7 @@ if [ "$IS_WIN" = "1" ]; then
         ARCH="x64"  # default
     fi
 else
-    OS=$(echo "$UNAME_S" | tr '[:upper:]' '[:lower:]')
+    OS=$(echo "${UNAME_S:-unknown}" | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m)
     if [ "$ARCH" = "x86_64" ]; then
         ARCH="x64"


### PR DESCRIPTION
## Summary

- The `postinstall.sh` / `postinstall.utoo.sh` templates relied on `$OSTYPE` to detect Windows. When `sh` is invoked from PowerShell on GitHub Actions, `$OSTYPE` is not set, so the scripts fell back to `uname -s | tr` and produced package names like `@utoo/utoo-mingw64_nt-10.0-26100-x64`, which don't exist on npm.
- GitHub recently rolled `windows-latest` from Server 2022 (kernel `mingw64_nt-10.0-20348`) to Server 2025 (`mingw64_nt-10.0-26100`), so the kernel-version slug changed and the install started failing on downstream projects (e.g. [eggjs/egg CI](https://github.com/eggjs/egg/actions/runs/25241536336/job/74018173174)).
- Switch to `uname -s` prefix matching (`MINGW*` / `MSYS*` / `CYGWIN*`) and keep the existing `$OSTYPE` check as a secondary fallback, so the resolved OS is always `win32` regardless of host kernel version.

## Repro (before this PR)

On a fresh `windows-latest` runner:

```
$ sh -c 'echo "$OSTYPE"'
                       # empty when invoked from pwsh
$ uname -s
MINGW64_NT-10.0-26100
```

→ postinstall builds `@utoo/utoo-mingw64_nt-10.0-26100-x64` → npm 404.

## Test plan

- [ ] Verify on a downstream project (e.g. eggjs/egg) that `ut install --from pnpm` succeeds on `windows-latest` after this template ships in a new `utoo` release.
- [ ] Confirm Linux/macOS resolution still produces `linux-x64` / `darwin-arm64` etc. (no behavior change on those branches — `uname -s` prefix only matches the three Windows shell envs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)