### PR TITLE
refactor(pm): unify lifecycle execution via run_lifecycle primitive

### DIFF
--- a/crates/pm/src/model/package.rs
+++ b/crates/pm/src/model/package.rs
@@ -33,19 +33,6 @@ pub enum LifecycleHook {
     Postpublish,
 }
 
-impl LifecycleHook {
-    /// Hooks executed for the project root during install.
-    pub const PROJECT_INSTALL_HOOKS: &[Self] = &[
-        Self::Preinstall,
-        Self::Install,
-        Self::Postinstall,
-        Self::Prepublish,
-        Self::Preprepare,
-        Self::Prepare,
-        Self::Postprepare,
-    ];
-}
-
 /// Lifecycle scripts extracted from package.json.
 /// Only contains known npm lifecycle hooks; arbitrary user scripts are in `PackageInfo.scripts`.
 #[derive(Debug, Default, Clone)]

--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -12,8 +12,15 @@ use utoo_ruborist::lock::PackageLock;
 use utoo_ruborist::manifest::ScriptsView;
 use utoo_ruborist::model::package_json::parse_bin_field;
 
-use super::script::{ScriptOutput, ScriptService};
+use super::script::{LifecycleSink, ScriptOutput, ScriptService};
 use super::workspace::{ResolvedWorkspaces, WorkspaceFilter, WorkspaceService};
+
+/// npm install lifecycle, expressed as the three event chains npm runs in
+/// order. Each maps to `pre<event>` / `<event>` / `post<event>`, together
+/// covering preinstall, install, postinstall, prepublish, preprepare,
+/// prepare, postprepare — at the npm-event granularity that
+/// [`ScriptService::run_lifecycle`] expects.
+const NPM_INSTALL_EVENTS: &[&str] = &["install", "prepublish", "prepare"];
 
 /// Execution queues for package scripts and binary linking
 /// Each entry is (PackageInfo, is_optional) where is_optional indicates if the package
@@ -31,14 +38,7 @@ pub struct PackageService;
 impl PackageService {
     pub async fn process_project_hooks(root_path: &Path) -> Result<()> {
         let package_info = PackageInfo::load(root_path).await?;
-
-        for &hook in LifecycleHook::PROJECT_INSTALL_HOOKS {
-            ScriptService::execute_script(&package_info, hook, ScriptOutput::Verbose)
-                .await
-                .with_context(|| format!("Failed to execute project hook {hook}"))?;
-        }
-
-        Ok(())
+        Self::run_install_lifecycle(&package_info, None).await
     }
 
     /// Run install lifecycle hooks for each workspace package in topological
@@ -68,16 +68,34 @@ impl PackageService {
                 let (_, package) = by_name
                     .remove(&name)
                     .expect("workspace name from layers must be in workspaces map");
-                for &hook in LifecycleHook::PROJECT_INSTALL_HOOKS {
-                    ScriptService::execute_script(&package, hook, ScriptOutput::Verbose)
-                        .await
-                        .with_context(|| {
-                            format!("Failed to execute workspace hook {hook} for {name}")
-                        })?;
-                }
+                Self::run_install_lifecycle(&package, Some(&name)).await?;
             }
         }
 
+        Ok(())
+    }
+
+    /// Run npm's install lifecycle (`install` / `prepublish` / `prepare`
+    /// events, each expanding into `pre*`/main/`post*`) on a single package.
+    /// `workspace_label`, when present, tags announce lines as `[name]`.
+    async fn run_install_lifecycle(
+        package: &PackageInfo,
+        workspace_label: Option<&str>,
+    ) -> Result<()> {
+        for &event in NPM_INSTALL_EVENTS {
+            ScriptService::run_lifecycle(
+                package,
+                event,
+                &[],
+                LifecycleSink::Stream { workspace_label },
+                false,
+            )
+            .await
+            .with_context(|| match workspace_label {
+                Some(label) => format!("Failed to execute {event} lifecycle for {label}"),
+                None => format!("Failed to execute project {event} lifecycle"),
+            })?;
+        }
         Ok(())
     }
 
@@ -589,7 +607,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Failed to execute project hook")
+                .contains("Failed to execute project")
         );
     }
 

--- a/crates/pm/src/service/script.rs
+++ b/crates/pm/src/service/script.rs
@@ -36,6 +36,24 @@ pub enum MissingScript {
     Skip,
 }
 
+/// Where the output of a [`ScriptService::run_lifecycle`] call goes.
+///
+/// Capture mode borrows the caller's buffers so that on a partial failure
+/// (one of pre/main/post bails) the caller still has whatever bytes were
+/// captured up to the failing step — used to print a `✗ [ws] …` block with
+/// the error tail under [`run_in_layers`].
+pub enum LifecycleSink<'a> {
+    /// Stream stdout/stderr to the terminal in real time.
+    /// `workspace_label` is shown in the `> [label] cmd` announce line.
+    Stream { workspace_label: Option<&'a str> },
+    /// Capture stdout/stderr into the caller's buffers.
+    Capture {
+        workspace_label: &'a str,
+        header: &'a mut String,
+        body: &'a mut Vec<u8>,
+    },
+}
+
 /// Build a `Command` with the standard npm env vars for script execution.
 async fn build_script_command(
     package: &PackageInfo,
@@ -382,6 +400,88 @@ impl ScriptService {
         Ok(())
     }
 
+    /// Run the npm event chain `pre<event>` / `<event>` / `post<event>` for a
+    /// single package. Each step is independent — any of the three can be
+    /// missing and the others still run. This mirrors npm's lifecycle
+    /// semantics (e.g. `install` event = preinstall + install + postinstall).
+    ///
+    /// `main_required = true` makes a missing main script an error (matches
+    /// `npm run <name>` which bails when `<name>` is undefined). With
+    /// `main_required = false`, the function silently runs whatever subset
+    /// of the three exists, returning `ran_any = false` when none do.
+    ///
+    /// On error, [`LifecycleSink::Capture`]'s buffers retain whatever was
+    /// captured up to the failing step.
+    pub async fn run_lifecycle(
+        package: &PackageInfo,
+        event: &str,
+        args: &[&str],
+        mut sink: LifecycleSink<'_>,
+        main_required: bool,
+    ) -> Result<bool> {
+        let pre_name = format!("pre{event}");
+        let post_name = format!("post{event}");
+
+        let main_script = package.scripts.get(event).cloned();
+        let pre_script = package.scripts.get(&pre_name).cloned();
+        let post_script = package.scripts.get(&post_name).cloned();
+
+        if main_required && main_script.is_none() {
+            anyhow::bail!("Script '{event}' not found in package.json");
+        }
+
+        // Each step: (script_name, content, args). Only the main step takes
+        // user args; pre/post are always argless (matches npm semantics).
+        let no_args: &[&str] = &[];
+        let steps: [(&str, Option<String>, &[&str]); 3] = [
+            (pre_name.as_str(), pre_script, no_args),
+            (event, main_script, args),
+            (post_name.as_str(), post_script, no_args),
+        ];
+
+        let mut ran_any = false;
+        for (step_name, script_opt, step_args) in steps {
+            let Some(content) = script_opt else { continue };
+            ran_any = true;
+
+            match &mut sink {
+                LifecycleSink::Stream { workspace_label } => {
+                    let args_str = step_args.join(" ");
+                    announce_script(*workspace_label, &content, &args_str);
+                    Self::execute_custom_script(package, step_name, &content, step_args.to_vec())
+                        .await
+                        .with_context(|| format!("Failed to execute {step_name}"))?;
+                }
+                LifecycleSink::Capture {
+                    workspace_label,
+                    header,
+                    body,
+                } => {
+                    let _ = writeln!(
+                        header,
+                        "[{}] {} {}",
+                        workspace_label,
+                        content,
+                        step_args.join(" ")
+                    );
+                    let cap = Self::execute_custom_script_captured(
+                        package,
+                        step_name,
+                        &content,
+                        step_args.to_vec(),
+                    )
+                    .await?;
+                    append_captured(body, &cap.stdout, &cap.stderr);
+                    if !cap.status.success() {
+                        anyhow::bail!("Failed to execute {step_name}");
+                    }
+                }
+            }
+        }
+
+        Ok(ran_any)
+    }
+
     /// Like [`Self::execute_custom_script`], but captures stdout/stderr
     /// instead of streaming to the terminal.
     pub async fn execute_custom_script_captured(
@@ -430,34 +530,18 @@ impl ScriptService {
         };
 
         let package = PackageInfo::load(&package_path).await?;
+        let args = script_args.unwrap_or_default();
 
-        let pre_script_name = format!("pre{script_name}");
-        if let Some(pre_script) = package.scripts.get(&pre_script_name) {
-            announce_script(workspace, pre_script, "");
-            Self::execute_custom_script(&package, &pre_script_name, pre_script, vec![])
-                .await
-                .with_context(|| format!("Failed to execute pre script {pre_script_name}"))?;
-        }
-
-        let script_content = package
-            .scripts
-            .get(script_name)
-            .ok_or_else(|| anyhow::anyhow!("Script '{script_name}' not found in package.json"))?;
-
-        let script_args = script_args.unwrap_or_default();
-        let script_args_str = script_args.join(" ");
-        announce_script(workspace, script_content, &script_args_str);
-        Self::execute_custom_script(&package, script_name, script_content, script_args)
-            .await
-            .with_context(|| format!("Failed to execute script {script_name}"))?;
-
-        let post_script_name = format!("post{script_name}");
-        if let Some(post_script) = package.scripts.get(&post_script_name) {
-            announce_script(workspace, post_script, "");
-            Self::execute_custom_script(&package, &post_script_name, post_script, vec![])
-                .await
-                .with_context(|| format!("Failed to execute post script {post_script_name}"))?;
-        }
+        Self::run_lifecycle(
+            &package,
+            script_name,
+            &args,
+            LifecycleSink::Stream {
+                workspace_label: workspace,
+            },
+            true,
+        )
+        .await?;
 
         Ok(())
     }
@@ -560,82 +644,43 @@ async fn run_script_captured(
     let mut header = String::new();
     let mut body = Vec::new();
 
-    let inner = async {
+    let outcome = async {
         let package = PackageInfo::load(workspace_dir).await?;
 
-        if !package.scripts.contains_key(script_name) {
-            if missing == MissingScript::Skip {
-                return Ok(false);
-            }
+        // CLI surfaces a friendlier "missing script" hint than run_lifecycle's
+        // generic error, so short-circuit Fail-mode missing here.
+        if !package.scripts.contains_key(script_name) && missing == MissingScript::Fail {
             anyhow::bail!(
                 "Missing script: \"{script_name}\"\n\nTo see a list of scripts, run:\n  utoo run --workspace={workspace_name}"
             );
         }
 
-        let pre_script_name = format!("pre{script_name}");
-        if let Some(pre_script) = package.scripts.get(&pre_script_name) {
-            let _ = writeln!(header, "[{workspace_name}] {pre_script}");
-            let cap = ScriptService::execute_custom_script_captured(
-                &package,
-                &pre_script_name,
-                pre_script,
-                vec![],
-            )
-            .await?;
-            append_captured(&mut body, &cap.stdout, &cap.stderr);
-            if !cap.status.success() {
-                anyhow::bail!("Failed to execute pre script {pre_script_name}");
-            }
-        }
-
-        let script_content = package
-            .scripts
-            .get(script_name)
-            .ok_or_else(|| anyhow::anyhow!("Script '{script_name}' not found in package.json"))?;
-
-        let script_args_refs: Vec<&str> = script_args
+        let args_refs: Vec<&str> = script_args
             .as_deref()
             .unwrap_or_default()
             .iter()
             .map(|s| s.as_str())
             .collect();
-        let _ = writeln!(
-            header,
-            "[{workspace_name}] {script_content} {}",
-            script_args_refs.join(" ")
-        );
-        let cap = ScriptService::execute_custom_script_captured(
+
+        ScriptService::run_lifecycle(
             &package,
             script_name,
-            script_content,
-            script_args_refs,
+            &args_refs,
+            LifecycleSink::Capture {
+                workspace_label: workspace_name,
+                header: &mut header,
+                body: &mut body,
+            },
+            // We already short-circuited Fail-mode missing above, so let
+            // run_lifecycle treat a missing main as a no-op and rely on
+            // `ran_any` below.
+            false,
         )
-        .await?;
-        append_captured(&mut body, &cap.stdout, &cap.stderr);
-        if !cap.status.success() {
-            anyhow::bail!("Failed to execute script {script_name}");
-        }
+        .await
+    }
+    .await;
 
-        let post_script_name = format!("post{script_name}");
-        if let Some(post_script) = package.scripts.get(&post_script_name) {
-            let _ = writeln!(header, "[{workspace_name}] {post_script}");
-            let cap = ScriptService::execute_custom_script_captured(
-                &package,
-                &post_script_name,
-                post_script,
-                vec![],
-            )
-            .await?;
-            append_captured(&mut body, &cap.stdout, &cap.stderr);
-            if !cap.status.success() {
-                anyhow::bail!("Failed to execute post script {post_script_name}");
-            }
-        }
-
-        Ok::<bool, anyhow::Error>(true)
-    };
-
-    match inner.await {
+    match outcome {
         Ok(true) => WorkspaceOutcome::Ran {
             name: workspace_name.to_string(),
             header,


### PR DESCRIPTION
## Summary

Collapses the duplicate `pre<event>` / `<event>` / `post<event>` chain implementations behind a single `ScriptService::run_lifecycle(package, event, args, sink, main_required)` primitive. The npm-event granularity (install / prepublish / prepare) replaces the per-hook 7-element loop that the workspace + project install paths walked.

Stacked on top of #2839 — base set to that branch so this PR shows only the refactor diff. Once #2839 lands the base will auto-update to \`next\`.

## Why

Before: three near-identical implementations of the npm-event chain.
- `run_script` (Verbose stream, main required)
- `run_script_captured` (Capture, main optional via MissingScript)
- 7 calls to \`execute_script\` per workspace + 7 for the root project

After: one primitive parameterised by sink (Stream/Capture) and \`main_required\`. Workspace + root install paths now run 3 npm events via a shared helper, dropping the per-hook loop.

## Changes

- \`service/script.rs\`
  - \`LifecycleSink\` (Stream / Capture-with-borrowed-buffers) + \`run_lifecycle\`
  - \`run_script\` shrinks to a thin wrapper (Stream sink, \`main_required: true\`)
  - \`run_script_captured\` shrinks to a thin wrapper (Capture sink with caller-owned \`header\`/\`body\`, friendlier missing-script CLI hint preserved)
- \`service/package.rs\`
  - New \`NPM_INSTALL_EVENTS\` const = \`["install", "prepublish", "prepare"]\`
  - \`process_workspace_install_hooks\` / \`process_project_hooks\` route through a shared \`run_install_lifecycle\` helper
- \`model/package.rs\`
  - Drop \`LifecycleHook::PROJECT_INSTALL_HOOKS\` constant (no remaining users)

## Out of scope

Dependency-side \`execute_script_queue\` (per-hook slicing + \`join_all\`) and publish/pack lifecycles keep using \`execute_script\` — they address single hooks by enum, not npm events.

## Behaviour preserved

Verified against \`target/release/utoo\` on the e2e fixtures:
- workspace-prepare: lib-a prepare → lib-b prepare → app prepare topological order ✓
- workspace-prepare: lib-a postinstall ran ✓
- workspace-anonymous: name-from-folder fallback ✓
- \`--ignore-scripts\` skips all hooks (bin link still runs) ✓
- \`ut run build --workspaces\`: layered output identical ✓
- \`ut run --workspace foo\`: single-workspace layered path ✓
- \`ut run test --workspaces --if-present\`: silent skip on missing ✓
- \`ut run nonexistent --workspaces\`: Fail-mode missing-script error preserved ✓
- \`cargo fmt\` / \`cargo clippy --no-deps -- -D warnings\` clean
- \`cargo test -p utoo-pm -- --test-threads=1\`: 249 passed (parallel runs hit a pre-existing cwd race in unrelated tests)

## Diff stat

\`\`\`
crates/pm/src/model/package.rs   |  13 ---
crates/pm/src/service/package.rs |  52 +++++++---
crates/pm/src/service/script.rs  | 219 +++++++++++++++++++++++----------------
3 files changed, 167 insertions(+), 117 deletions(-)
\`\`\`

The script.rs net +50 includes the new \`run_lifecycle\` plus its docs; the two wrappers shed ~100 lines.

## Test plan

- [x] \`cargo test -p utoo-pm -- --test-threads=1\`
- [x] \`cargo fmt --check\` / \`cargo clippy --all-targets --no-deps -- -D warnings\`
- [x] Manual e2e: workspace-prepare, workspace-anonymous, run-workspaces, --ignore-scripts
- [ ] Full \`./e2e/utoo-pm.sh\` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)