### PR TITLE
chore(pm): drop [bin-link] stdout summary

### DIFF
--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -350,13 +350,8 @@ impl PackageService {
     ///      data on ant-design (228 bins) showed 36ms async → 6ms sync; adding
     ///      try_join_all/rayon parallelism only saved an additional 2-3ms over
     ///      sync, well within stddev — not worth the concurrency complexity.
-    ///
-    /// Emits one `[bin-link]` line on stdout summarising the batch (captured
-    /// by `bench/pm-bench-phases.sh` via hyperfine `--show-output`).
     async fn execute_binary_linking(queue: &[(Rc<PackageInfo>, bool)]) -> Result<()> {
         use std::collections::HashSet;
-
-        let bin_link_start = std::time::Instant::now();
 
         // Sort by package path for deterministic dedupe winners across runs
         // (`collect_packages_from_lock` walks a HashMap, so input order is
@@ -365,10 +360,6 @@ impl PackageService {
         ordered.sort_by(|a, b| a.0.path.cmp(&b.0.path));
 
         let mut seen: HashSet<PathBuf> = HashSet::new();
-        let mut total: u64 = 0;
-        let mut deduped: u64 = 0;
-        let mut skipped_missing: u64 = 0;
-        let mut processed: u64 = 0;
 
         for (package, _is_optional) in ordered {
             if package.bin_files.is_empty() {
@@ -380,11 +371,8 @@ impl PackageService {
                 .get_bin_dir()
                 .with_context(|| format!("Failed to get bin directory for {}", package.name))?;
             for (bin_name, relative_path) in &package.bin_files {
-                total += 1;
-
                 let link_path = bin_dir.join(bin_name);
                 if !seen.insert(link_path.clone()) {
-                    deduped += 1;
                     continue;
                 }
 
@@ -394,7 +382,6 @@ impl PackageService {
                         "Binary file {} does not exist, skipping",
                         target_path.display()
                     );
-                    skipped_missing += 1;
                     continue;
                 }
 
@@ -416,16 +403,7 @@ impl PackageService {
                         link_path.display()
                     )
                 })?;
-                processed += 1;
             }
-        }
-
-        if total > 0 {
-            let wall = bin_link_start.elapsed();
-            println!(
-                "[bin-link] total={total} processed={processed} skipped_missing={skipped_missing} deduped={deduped} wall_ms={}",
-                wall.as_millis()
-            );
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- The `println!(\"[bin-link] ...\")` added in #2884 hits stdout on every `ut install`, but nothing actually consumes it — `bench/pm-bench-phases.sh` enables hyperfine `--show-output` but doesn't grep for the line.
- Remove the print, the wall-time/total/processed/skipped/deduped counters that only fed it, and the doc comment claim that bench captures it.
- Sort + dedupe + sync `link_bin` core logic is unchanged.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
- [ ] `ut install` on a project with bins — stdout no longer shows `[bin-link] ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)