### PR TITLE
experiment(pm): tokio current_thread runtime — vCtx -50% but wall +0.1-4.7s [DO NOT MERGE]

### DIFF
--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -345,13 +345,25 @@ enum Commands {
 fn main() {
     crate::util::sysconf::init();
 
-    let worker_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(4);
-
-    let result = tokio::runtime::Builder::new_multi_thread()
+    // Experiment: drop tokio's multi-thread work-stealing in favor of
+    // a single-thread async runtime. Hypothesis: the bulk of utoo's
+    // ~150K vCtx vs bun's ~17K is tokio worker-stealing — async tasks
+    // bouncing between worker threads to balance load. Single-thread
+    // runtime keeps all async work on one OS thread; the blocking
+    // pool (still enabled via `enable_all`) handles `spawn_blocking`
+    // for fs ops, and rayon's pool handles CPU-bound extract.
+    //
+    // Network I/O is unaffected: the same epoll/kqueue multiplexer
+    // drives 64-concurrent downloads, just from one thread instead
+    // of N. CPU-bound work is already off-loaded via rayon, so the
+    // single async thread should mostly poll and dispatch.
+    //
+    // Risk: any unexpected CPU-bound await would now serialize the
+    // whole runtime instead of stealing into another worker. Watch
+    // for wall-time regression on workloads that previously hid
+    // small CPU spikes inside multi-thread parallelism.
+    let result = tokio::runtime::Builder::new_current_thread()
         .enable_all()
-        .worker_threads(worker_threads)
         .build()
         .expect("failed to build tokio runtime")
         .block_on(async_main());


### PR DESCRIPTION
## Result: hypothesis partially validated, wall time DISPROVEN

Will not merge. Documenting findings for future runtime experiments.

## Findings (n=2)

### vCtx — work-stealing IS a real cost (especially async-heavy phases)

| Phase | current_thread vCtx | multi_thread vCtx | Δ |
|---|---|---|---|
| p1_resolve | 34K | 73K | **−53%** |
| p3_cold_install | 78K | 146K | **−46%** |
| p0_full_cold | 118K | 146K | −19% |
| p4_warm_link | 42K | 45K | −7% |

The work-stealing hypothesis is confirmed: removing it cuts vCtx ~50% on phases dominated by pure async work (BFS resolve, lock-driven cold install). Phases dominated by spawn_blocking (p0 full e2e, p4 warm link) are barely affected.

But: utoo at 118K vCtx is still **~7× bun's 16K**. The remaining vCtx comes from `spawn_blocking` pool round-trips + rayon, not work-stealing.

### iCtx — mixed, p0 regressed

| Phase | current_thread iCtx | multi_thread iCtx | Δ |
|---|---|---|---|
| p0_full_cold | 135K | 120K | **+13%** |
| p3_cold_install | 68K | 85K | −20% |
| p4_warm_link | 13K | 20K | −35% |

p0 iCtx going UP is the smoking gun: with all async work on one OS thread, the single tokio thread becomes a serialization point for spawn_blocking dispatches → kernel preempts more often.

### Wall time — uniformly equal-or-worse on stable phases

| Phase | Δ wall | σ note |
|---|---|---|
| p0 | **+4.72s** | utoo σ ±5.0, but +Δ direction consistent across runs |
| p1 | +0.12s | small |
| p3 | -3.03s | baseline σ ±3.37, run 2 was an outlier — inconclusive |
| p4 | +0.09s | small |

## Why wall didn't win despite vCtx winning

Network I/O is dominant (~7s of 10s p0). Multi-thread tokio parallelizes BOTH async polling AND CPU-bound async fragments. With current_thread:
- Network I/O: same throughput (epoll multiplexes from one thread)
- async polling: one thread instead of N → no work-stealing wasted ctx, but…
- async coordination + spawn_blocking dispatch: serialized on one thread → bottleneck

For utoo's workload on this CI runner: **the parallelism loss costs more than ctx switch savings**.

## What ACTUALLY would matter

To match bun's 16K vCtx, work-stealing removal alone is not enough. Required combination:

1. **Drop work-stealing** (this experiment proves: 50% of async-phase vCtx comes from here)
2. **Eliminate spawn_blocking** (the remaining ~100K vCtx + iCtx growth observed in p0)

Option (2) means moving fs operations to io_uring/IOCP via `compio` or `tokio-uring`. That's a major refactor across `cloner.rs`, `extractor.rs`, `downloader.rs`. Not a 5-line change.

## Decision

Don't merge. Don't pursue tokio runtime model in isolation — single change has equal-or-negative wall impact.

Future experiment if pursued: `compio` (cross-platform io_uring/IOCP) + current_thread combined. That is the realistic path to bun-tier ctx counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)