### PR TITLE
experiment(pm): linux io_uring batched hardlink via compio — 50x REGRESSION [DO NOT MERGE]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,10 +1077,13 @@ dependencies = [
  "crossbeam-queue",
  "flume",
  "futures-util",
+ "io-uring",
+ "io_uring_buf_ring",
  "libc",
  "once_cell",
  "paste",
  "polling",
+ "slab",
  "socket2 0.6.3",
  "windows-sys 0.61.2",
 ]
@@ -4286,6 +4289,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "io_uring_buf_ring"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1838759bb8c2f24cf05a35429d83145c4aa6af43f8ad38477295e12a7320a80e"
+dependencies = [
+ "bytes",
+ "io-uring",
+ "rustix 1.1.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,12 +1045,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6829f76b635c05ef91f97dc44c3b27eb72f346179bd47c5018cd033d913420d"
 dependencies = [
  "compio-buf",
- "compio-driver 0.9.2",
- "compio-fs 0.9.0",
+ "compio-driver",
+ "compio-fs",
  "compio-io",
  "compio-log",
  "compio-net",
- "compio-runtime 0.9.5",
+ "compio-runtime",
 ]
 
 [[package]]
@@ -1089,27 +1089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compio-driver"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5c12800e82a01d12046ccc29b014e1cbbb2fbe38c52534e0d40d4fc58881d5"
-dependencies = [
- "cfg-if",
- "cfg_aliases",
- "compio-buf",
- "compio-log",
- "crossbeam-queue",
- "flume",
- "futures-util",
- "libc",
- "once_cell",
- "paste",
- "polling",
- "socket2 0.6.3",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "compio-fs"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,27 +1097,9 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "compio-buf",
- "compio-driver 0.9.2",
+ "compio-driver",
  "compio-io",
- "compio-runtime 0.9.5",
- "libc",
- "os_pipe",
- "widestring",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "compio-fs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c568022f90c2e2e8ea7ff4c4e8fde500753b5b9b6b6d870e25b5e656f9ea2892"
-dependencies = [
- "cfg-if",
- "cfg_aliases",
- "compio-buf",
- "compio-driver 0.10.0",
- "compio-io",
- "compio-runtime 0.10.1",
+ "compio-runtime",
  "libc",
  "os_pipe",
  "widestring",
@@ -1173,9 +1134,9 @@ checksum = "2e6ea7aa4a9f38d68dd0098a11232236cb3efd0ef3cab50ecdada3d745f1f776"
 dependencies = [
  "cfg-if",
  "compio-buf",
- "compio-driver 0.9.2",
+ "compio-driver",
  "compio-io",
- "compio-runtime 0.9.5",
+ "compio-runtime",
  "either",
  "libc",
  "once_cell",
@@ -1193,29 +1154,7 @@ dependencies = [
  "async-task",
  "cfg-if",
  "compio-buf",
- "compio-driver 0.9.2",
- "compio-log",
- "core_affinity",
- "crossbeam-queue",
- "futures-util",
- "libc",
- "once_cell",
- "pin-project-lite",
- "scoped-tls",
- "slab",
- "socket2 0.6.3",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "compio-runtime"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fd890a129a8086af857bbe18401689c130aa6ccfc7f3c029a7800f7256af3e"
-dependencies = [
- "async-task",
- "compio-buf",
- "compio-driver 0.10.0",
+ "compio-driver",
  "compio-log",
  "core_affinity",
  "crossbeam-queue",
@@ -12010,7 +11949,6 @@ dependencies = [
  "clap_complete",
  "colored 2.2.0",
  "compio",
- "compio-fs 0.10.0",
  "dashmap 6.1.0",
  "deno_semver",
  "dialoguer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1039,194 @@ dependencies = [
 ]
 
 [[package]]
+name = "compio"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6829f76b635c05ef91f97dc44c3b27eb72f346179bd47c5018cd033d913420d"
+dependencies = [
+ "compio-buf",
+ "compio-driver 0.9.2",
+ "compio-fs 0.9.0",
+ "compio-io",
+ "compio-log",
+ "compio-net",
+ "compio-runtime 0.9.5",
+]
+
+[[package]]
+name = "compio-buf"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ebb4036bf394915196c09362e4fd5581ee8bf0f3302ab598bff9d646aea2061"
+dependencies = [
+ "arrayvec",
+ "bytes",
+ "libc",
+]
+
+[[package]]
+name = "compio-driver"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f8915a1e560ab8be655c23771502a107d2802941a83fbf142734bed60a11441"
+dependencies = [
+ "cfg-if",
+ "cfg_aliases",
+ "compio-buf",
+ "compio-log",
+ "crossbeam-queue",
+ "flume",
+ "futures-util",
+ "libc",
+ "once_cell",
+ "paste",
+ "polling",
+ "socket2 0.6.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "compio-driver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5c12800e82a01d12046ccc29b014e1cbbb2fbe38c52534e0d40d4fc58881d5"
+dependencies = [
+ "cfg-if",
+ "cfg_aliases",
+ "compio-buf",
+ "compio-log",
+ "crossbeam-queue",
+ "flume",
+ "futures-util",
+ "libc",
+ "once_cell",
+ "paste",
+ "polling",
+ "socket2 0.6.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "compio-fs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea585c274239b9fd350a484c75a31fd0df5f031805b6664d83a98f5e8b019e2f"
+dependencies = [
+ "cfg-if",
+ "cfg_aliases",
+ "compio-buf",
+ "compio-driver 0.9.2",
+ "compio-io",
+ "compio-runtime 0.9.5",
+ "libc",
+ "os_pipe",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "compio-fs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c568022f90c2e2e8ea7ff4c4e8fde500753b5b9b6b6d870e25b5e656f9ea2892"
+dependencies = [
+ "cfg-if",
+ "cfg_aliases",
+ "compio-buf",
+ "compio-driver 0.10.0",
+ "compio-io",
+ "compio-runtime 0.10.1",
+ "libc",
+ "os_pipe",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "compio-io"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1e64c6d723589492a4f5041394301e9903466a606f6d9bcc11e406f9f07e9ec"
+dependencies = [
+ "compio-buf",
+ "futures-util",
+ "paste",
+]
+
+[[package]]
+name = "compio-log"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4e560213c1996b618da369b7c9109564b41af9033802ae534465c4ee4e132f"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "compio-net"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6ea7aa4a9f38d68dd0098a11232236cb3efd0ef3cab50ecdada3d745f1f776"
+dependencies = [
+ "cfg-if",
+ "compio-buf",
+ "compio-driver 0.9.2",
+ "compio-io",
+ "compio-runtime 0.9.5",
+ "either",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "compio-runtime"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467b43c646a60bae3bb3a55c2c200ea7c4416a63cc5a6070450aa6771b3c62e"
+dependencies = [
+ "async-task",
+ "cfg-if",
+ "compio-buf",
+ "compio-driver 0.9.2",
+ "compio-log",
+ "core_affinity",
+ "crossbeam-queue",
+ "futures-util",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "scoped-tls",
+ "slab",
+ "socket2 0.6.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "compio-runtime"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fd890a129a8086af857bbe18401689c130aa6ccfc7f3c029a7800f7256af3e"
+dependencies = [
+ "async-task",
+ "compio-buf",
+ "compio-driver 0.10.0",
+ "compio-log",
+ "core_affinity",
+ "crossbeam-queue",
+ "futures-util",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "scoped-tls",
+ "slab",
+ "socket2 0.6.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1409,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
 
 [[package]]
 name = "corosensei"
@@ -2252,6 +2457,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -5443,6 +5657,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5965,6 +6189,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11746,12 +11984,15 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored 2.2.0",
+ "compio",
+ "compio-fs 0.10.0",
  "dashmap 6.1.0",
  "deno_semver",
  "dialoguer",
  "dirs 4.0.0",
  "flate2",
  "futures",
+ "futures-util",
  "glob",
  "globset",
  "ignore",

--- a/crates/pm/Cargo.toml
+++ b/crates/pm/Cargo.toml
@@ -76,6 +76,11 @@ tokio = { workspace = true, features = ["full"] }
 # `compio_fs::hard_link` futures, which compio's io_uring driver
 # submits as batched SQEs in one `io_uring_enter` syscall.
 [target.'cfg(target_os = "linux")'.dependencies]
+# Use only the compio parent crate (re-exports compio-fs::*) so
+# compio-runtime resolves to a single version. Mixing direct
+# `compio-fs` + `compio` deps pulled two different compio-runtime
+# versions, so `compio_fs::hard_link`'s thread-local lookup landed
+# in a separate RUNTIME slot from `compio::runtime::Runtime` and
+# panicked with "not in a compio runtime".
 compio = { version = "0.16", default-features = false, features = ["runtime", "io-uring"] }
-compio-fs = { version = "0.10", default-features = false }
 futures-util = "0.3"

--- a/crates/pm/Cargo.toml
+++ b/crates/pm/Cargo.toml
@@ -69,3 +69,13 @@ mockito = "1.7.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["full"] }
+
+# Linux-only: compio + io_uring for batched fs operations.
+# Experiment branch only — currently used inside `hardlink_clone` to
+# replace the per-file `fs::hard_link` syscall loop with concurrent
+# `compio_fs::hard_link` futures, which compio's io_uring driver
+# submits as batched SQEs in one `io_uring_enter` syscall.
+[target.'cfg(target_os = "linux")'.dependencies]
+compio = { version = "0.16", default-features = false, features = ["runtime"] }
+compio-fs = { version = "0.10", default-features = false }
+futures-util = "0.3"

--- a/crates/pm/Cargo.toml
+++ b/crates/pm/Cargo.toml
@@ -76,6 +76,6 @@ tokio = { workspace = true, features = ["full"] }
 # `compio_fs::hard_link` futures, which compio's io_uring driver
 # submits as batched SQEs in one `io_uring_enter` syscall.
 [target.'cfg(target_os = "linux")'.dependencies]
-compio = { version = "0.16", default-features = false, features = ["runtime"] }
+compio = { version = "0.16", default-features = false, features = ["runtime", "io-uring"] }
 compio-fs = { version = "0.10", default-features = false }
 futures-util = "0.3"

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -194,7 +194,7 @@ mod hardlink_clone {
                 let futs = files.iter().enumerate().map(|(i, e)| {
                     let src = e.src.clone();
                     let dst = e.dst.clone();
-                    async move { (i, compio_fs::hard_link(src, dst).await) }
+                    async move { (i, compio::fs::hard_link(src, dst).await) }
                 });
                 join_all(futs).await
             })

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -138,6 +138,140 @@ mod hardlink_clone {
         Ok(())
     }
 
+    /// Phase-3 hardlink loop, abstracted across platforms.
+    ///
+    /// Linux: drives N concurrent `compio_fs::hard_link` futures so the
+    /// io_uring driver batches SQEs in a single `io_uring_enter` syscall
+    /// (vs N separate `linkat` syscalls in the std::fs version). On
+    /// EXDEV the function detects cross-device, latches `force_copy`,
+    /// and finishes the rest with `copy_file_sync` — same fallback
+    /// shape as the std::fs path.
+    ///
+    /// Other targets (non-macOS, non-Linux Unix + Windows): per-file
+    /// `fs::hard_link` loop, unchanged from the original implementation.
+    #[cfg(target_os = "linux")]
+    fn hardlink_phase(
+        files: &[CloneEntry],
+        force_copy: &mut bool,
+        src: &Path,
+        dst: &Path,
+    ) -> io::Result<()> {
+        use compio::runtime::Runtime as CompioRuntime;
+        use futures_util::future::join_all;
+
+        // Per-thread compio runtime — block_on requires &mut, so each
+        // tokio blocking thread gets its own io_uring instance, kept
+        // alive across calls. ~16KB per ring; tokio's blocking pool
+        // tops out around 64 active threads on this workload, so the
+        // overhead is bounded.
+        thread_local! {
+            static COMPIO_RT: std::cell::RefCell<Option<CompioRuntime>> =
+                const { std::cell::RefCell::new(None) };
+        }
+
+        // Empty input — nothing to do, also avoids paying runtime init.
+        if files.is_empty() {
+            return Ok(());
+        }
+
+        // If force_copy already latched (install-script package), do not
+        // touch compio at all — copy each file with std::fs.
+        if *force_copy {
+            for entry in files {
+                copy_file_sync(&entry.src, &entry.dst)?;
+            }
+            return Ok(());
+        }
+
+        // First pass: batch-issue hardlinks via compio. Collect per-file
+        // results so we can apply EXDEV / per-file fallback after.
+        let results: Vec<(usize, io::Result<()>)> = COMPIO_RT.with(|cell| {
+            let mut borrowed = cell.borrow_mut();
+            let rt = borrowed.get_or_insert_with(|| {
+                CompioRuntime::new().expect("failed to build compio runtime")
+            });
+            rt.block_on(async {
+                let futs = files.iter().enumerate().map(|(i, e)| {
+                    let src = e.src.clone();
+                    let dst = e.dst.clone();
+                    async move { (i, compio_fs::hard_link(src, dst).await) }
+                });
+                join_all(futs).await
+            })
+        });
+
+        // Second pass: apply EXDEV / per-file fallback in original order.
+        let mut warned_per_file = false;
+        for (i, result) in results {
+            if *force_copy {
+                copy_file_sync(&files[i].src, &files[i].dst)?;
+                continue;
+            }
+            if let Err(e) = result {
+                if e.kind() == io::ErrorKind::CrossesDevices {
+                    tracing::warn!(
+                        "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
+                        src.display(),
+                        dst.display(),
+                        e
+                    );
+                    *force_copy = true;
+                } else if !warned_per_file {
+                    tracing::warn!(
+                        "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
+                        files[i].src.display(),
+                        files[i].dst.display(),
+                        e
+                    );
+                    warned_per_file = true;
+                }
+                copy_file_sync(&files[i].src, &files[i].dst)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn hardlink_phase(
+        files: &[CloneEntry],
+        force_copy: &mut bool,
+        src: &Path,
+        dst: &Path,
+    ) -> io::Result<()> {
+        // Any other hardlink error (EMLINK on a single inode whose link
+        // count is exhausted, EPERM on a specific file, etc.) is
+        // per-file: copy this one and keep trying hardlink on the next.
+        // Warn only on the first such failure per package to avoid
+        // spamming hundreds of identical warnings.
+        let mut warned_per_file = false;
+        for entry in files {
+            if *force_copy {
+                copy_file_sync(&entry.src, &entry.dst)?;
+            } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
+                if e.kind() == io::ErrorKind::CrossesDevices {
+                    tracing::warn!(
+                        "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
+                        src.display(),
+                        dst.display(),
+                        e
+                    );
+                    *force_copy = true;
+                } else if !warned_per_file {
+                    tracing::warn!(
+                        "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
+                        entry.src.display(),
+                        entry.dst.display(),
+                        e
+                    );
+                    warned_per_file = true;
+                }
+                copy_file_sync(&entry.src, &entry.dst)?;
+            }
+        }
+        Ok(())
+    }
+
     fn collect_entries(
         src: &Path,
         dst: &Path,
@@ -205,38 +339,7 @@ mod hardlink_clone {
             // than /usr/local) is a property of the src/dst pair — every
             // remaining file would fail the same way, so latch `force_copy`
             // and skip hardlink for the rest of this clone.
-            //
-            // Any other hardlink error (EMLINK on a single inode whose link
-            // count is exhausted, EPERM on a specific file, etc.) is
-            // per-file: copy this one and keep trying hardlink on the next.
-            // We warn only on the first such failure per package to avoid
-            // spamming hundreds of identical warnings when an entire package
-            // can't be hardlinked.
-            let mut warned_per_file = false;
-            for entry in &files {
-                if force_copy {
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
-                    if e.kind() == io::ErrorKind::CrossesDevices {
-                        tracing::warn!(
-                            "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
-                            src.display(),
-                            dst.display(),
-                            e
-                        );
-                        force_copy = true;
-                    } else if !warned_per_file {
-                        tracing::warn!(
-                            "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
-                            entry.src.display(),
-                            entry.dst.display(),
-                            e
-                        );
-                        warned_per_file = true;
-                    }
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                }
-            }
+            hardlink_phase(&files, &mut force_copy, &src, &dst)?;
             Ok(())
         })
         .await?


### PR DESCRIPTION
## Result: experiment FAILED, 50x wall regression on install-heavy phases

Will not merge. Documenting findings.

## CI bench-phases-linux data

| Phase | utoo (compio) | utoo-next | Δ |
|---|---|---|---|
| p0_full_cold | 8.69s ±0.33 | 8.55s ±0.32 | +0.14 (noise) |
| p1_resolve | 3.36s ±0.03 | 3.21s ±0.11 | +0.15 (noise) |
| **p3_cold_install** | **51.85s ±16.79** | 13.80s ±4.69 | **+38s (~3.7x)** |
| **p4_warm_link** | **96.93s ±13.50** | 2.12s ±0.02 | **+94s (~46x)** |

## Hypothesized causes (not investigated further)

1. compio v0.16's io_uring `linkat` on GH runner kernel may fall back to spawn_blocking under the hood → double pool round-trip per call
2. Per-blocking-thread compio runtime setup cost amortized poorly when called once per package
3. Async future state machine + io_uring driver poll heavier than a sync `linkat` syscall (~10µs)
4. `join_all` over N compio futures may serialize on compio's single-thread driver instead of batching SQEs
5. p4_warm_link path validates package.json + relinks — the per-call compio overhead compounds across thousands of operations

## Conclusion

compio is NOT a drop-in replacement for `std::fs::hard_link` on this workload. The async io_uring abstraction adds far more overhead than it saves syscall traps.

To pursue io_uring fs benefits in utoo, would need:
- Direct `io-uring` crate usage with manual SQE batching (skip compio's runtime layer entirely)
- Or rewrite as compio-native runtime (not an incremental change)
- Or test on a different workload pattern (large file batches, not many small linkat ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)