### PR TITLE
fix(pack): add & as escape chunk filename character

### DIFF
--- a/crates/pack-core/src/library/chunking_context.rs
+++ b/crates/pack-core/src/library/chunking_context.rs
@@ -314,8 +314,9 @@ impl LibraryChunkingContext {
         let root = &this.root_path;
         if let Some(filename) = self.await?.filename.as_ref() {
             let mut filename = filename.to_string();
+            let name = escape_file_path(name);
             if match_name_placeholder(&filename) {
-                filename = replace_name_placeholder(&filename, name);
+                filename = replace_name_placeholder(&filename, &name);
             }
             if match_content_hash_placeholder(&filename) {
                 let content_hash = self.ecmascript_chunk_content_hash(ecmascript_chunk).await?;
@@ -445,11 +446,12 @@ impl ChunkingContext for LibraryChunkingContext {
                                 let query = QString::from(ident.await?.query.as_str());
 
                                 let name = query.get("name").unwrap_or(output_name.as_str());
+                                let name = escape_file_path(name);
 
                                 let mut filename = filename_template.to_string();
 
                                 if match_name_placeholder(&filename) {
-                                    filename = replace_name_placeholder(&filename, name);
+                                    filename = replace_name_placeholder(&filename, &name);
                                 }
 
                                 if match_content_hash_placeholder(&filename) {
@@ -550,9 +552,10 @@ impl ChunkingContext for LibraryChunkingContext {
                 let mut filename = filename_template.to_string();
 
                 let (_, name, ext) = source_path.split_file_stem_extension();
+                let name = escape_file_path(name);
 
                 if match_name_placeholder(&filename) {
-                    filename = replace_name_placeholder(&filename, name);
+                    filename = replace_name_placeholder(&filename, &name);
                 }
 
                 if match_content_hash_placeholder(&filename) {

--- a/crates/pack-tests/tests/snapshot/style/css-filename-escape/config.json
+++ b/crates/pack-tests/tests/snapshot/style/css-filename-escape/config.json
@@ -1,0 +1,11 @@
+{
+    "config": {
+        "entry": [
+            {
+                "import": "input/index.js",
+                "name": "main"
+            }
+        ],
+        "sourceMaps": false
+    }
+}

--- a/crates/pack-tests/tests/snapshot/style/css-filename-escape/input/RuleEdit&Vidw.less
+++ b/crates/pack-tests/tests/snapshot/style/css-filename-escape/input/RuleEdit&Vidw.less
@@ -1,0 +1,3 @@
+.rule-edit {
+  color: #1677ff;
+}

--- a/crates/pack-tests/tests/snapshot/style/css-filename-escape/input/index.js
+++ b/crates/pack-tests/tests/snapshot/style/css-filename-escape/input/index.js
@@ -1,0 +1,1 @@
+import "./RuleEdit&Vidw.less";

--- a/crates/pack-tests/tests/snapshot/style/css-filename-escape/output/input_RuleEdit_Vidw_less_29d5bafe.css
+++ b/crates/pack-tests/tests/snapshot/style/css-filename-escape/output/input_RuleEdit_Vidw_less_29d5bafe.css
@@ -1,0 +1,4 @@
+/* [project]/style/css-filename-escape/input/RuleEdit&Vidw.less.css [client] (css) */
+.rule-edit {
+  color: #1677ff;
+}

--- a/crates/pack-tests/tests/snapshot/style/css-filename-escape/output/input_index_d45174ac.js
+++ b/crates/pack-tests/tests/snapshot/style/css-filename-escape/output/input_index_d45174ac.js
@@ -1,0 +1,8 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/style/css-filename-escape/input/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+;
+__turbopack_context__.s([]);
+}),
+]);

--- a/crates/pack-tests/tests/snapshot/style/css-filename-escape/output/main.js
+++ b/crates/pack-tests/tests/snapshot/style/css-filename-escape/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_RuleEdit_Vidw_less_29d5bafe.css","input_index_d45174ac.js"],"runtimeModuleIds":["[project]/style/css-filename-escape/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime


### PR DESCRIPTION


## Summary

Should not bundle `&` into output chunk filename, it will cause cdn link failed(character translation)

ref pr: https://github.com/utooland/next.js/pull/146

## Test Plan

add snapshot test case
