### PR TITLE
perf(pm): add hyperfine --warmup 1 to phase-bench

### DIFF
--- a/bench/pm-bench-phases.sh
+++ b/bench/pm-bench-phases.sh
@@ -347,8 +347,17 @@ run_phase() {
 
   echo -e "  ${CYAN}$pm${NC} · $phase"
   export PROJECT_DIR UTOO_CACHE BUN_CACHE
+  # `--warmup 1`: untimed iteration before the timed runs so each PM enters
+  # its measurement window with DNS resolver cached, TLS session ticket
+  # primed, and the CDN edge POP populated. Without this, the first PM in
+  # the per-phase loop pays the cold-network tax (~+1s on p0) which the
+  # 3-run `--runs` mean cannot fully amortize, biasing the first PM
+  # systematically slow vs PMs that follow it. `--prepare` resets the
+  # filesystem state (lockfile / cache / node_modules) on every iteration
+  # — warmup included — so warmup leaves no on-disk artifact behind.
   if ! hyperfine \
     --runs "$RUNS" \
+    --warmup 1 \
     --prepare "bash $prep_script" \
     --export-json "$json" \
     --show-output \


### PR DESCRIPTION
## Why

The phases bench iterates PMs in fixed order (\`utoo, utoo-next, utoo-npm, bun\` per \`PM_LIST\`) within each phase. The first PM pays the cold-network tax — DNS resolver miss, TLS session ticket cold, npm CDN edge POP unpopulated — and \`--runs 3\` averages that cold iteration into the wall mean. PMs that run later inherit the warm state for free.

A standalone smoke test (\`pm-bench-pcap.sh\` from #2906, identical-binary run on \`chore/pcap-install-phase\`) confirmed the magnitude: the same utoo binary, run twice back-to-back, showed **+3s wall and +267 MB pcap delta on \`p3_install\` between the first and second run** — pure CDN/DNS/TLS warm-up effect, no code difference.

Folded through \`--runs 3\` averaging that's roughly **+1s on the first PM's p0 mean**, the same magnitude as the per-PR deltas on #2903 / #2904 / #2905 (TTY-gate +0.98, streaming +0.49, zero-copy +1.18). Those means are currently indistinguishable from ordering bias.

## Change

\`\`\`diff
   if ! hyperfine \\
     --runs \"\$RUNS\" \\
+    --warmup 1 \\
     --prepare \"bash \$prep_script\" \\
\`\`\`

\`hyperfine --warmup 1\` runs one untimed iteration through \`--prepare\` before the timed runs start, so each PM enters its measurement window with DNS / TLS / CDN already warm. Cross-PM ordering bias in the timed window collapses.

Cost: one extra iteration per PM × phase (≈ 33% bench job wall), well within tolerance.

## Smoke test

PR is benchmark-labeled. Both \`utoo\` (this branch) and \`utoo-next\` (origin/next) compile from the same Rust code on this PR — only the bench script differs — so any \`utoo-vs-utoo-next\` p0 mean delta in the resulting comment is the residual ordering bias post-warmup. Target is ~0s.

## Companion

- #2906 — pcap install-phase capture (same chore series, separate concern)
- This is independent of the PM-ordering question; if \`--warmup\` alone doesn't fully close the gap, round-robin via \`hyperfine -n A -n B -n C\` is the followup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)