### PR TITLE
fix(pm): add reqwest socks feature for SOCKS5 proxy support

### DIFF
--- a/crates/pm/Cargo.toml
+++ b/crates/pm/Cargo.toml
@@ -51,6 +51,7 @@ reqwest            = { version = "0.12", default-features = false, features = [
   "http2",
   "json",
   "rustls-tls",
+  "socks",
   "stream",
 ] }
 serde              = { workspace = true }


### PR DESCRIPTION
## Summary

Tarball downloads hung indefinitely when `ALL_PROXY` pointed to a SOCKS5 proxy. The `pm` crate's reqwest dependency was missing the `socks` feature, while `ruborist` (manifest fetch) already had it — so resolve succeeded and masked the install-phase failure.

## Root cause

- `crates/pm/Cargo.toml` reqwest features: `["gzip", "hickory-dns", "http2", "json", "rustls-tls", "stream"]` — no `socks`
- `crates/ruborist/Cargo.toml` reqwest features: `["http2", "json", "socks"]`
- With `ALL_PROXY=socks5://...`, reqwest's URL parse fails when the feature is absent. Each download retries 10× and gives up; on a 7k+ package tree this looks like a hang.

## Reproduction

`ALL_PROXY=socks5://127.0.0.1:6153 utoo install` on a 7553-pkg project:

| Build | Wall time | Result |
|---|---|---|
| utoo 1.0.30 (current) | killed @ 4:00 | 0 packages installed, all sockets CLOSED |
| utoo (this PR) | ~2-3 min | 7553 added, 4863 downloaded ✓ |
| bun 1.3.3 | killed @ 13:38 | 5803/7553 cached, link never started |

## Test plan

- [x] CI builds & lockfile resolves
- [x] Smoke test against a project while a SOCKS5 proxy is set in env
- [x] Verify resolve + install both reach the proxy (manifest fetch already worked; install now works too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)