### PR TITLE
fix(pm): allow install on package.json without name/version

### DIFF
--- a/crates/pm/src/cmd/link.rs
+++ b/crates/pm/src/cmd/link.rs
@@ -16,6 +16,12 @@ pub async fn link_current_to_global(cwd: &Path, prefix: Option<&str>) -> Result<
             project_path.display()
         )
     })?;
+    if package_info.name.is_empty() {
+        anyhow::bail!(
+            "Cannot link to global: package.json at {} is missing a 'name' field",
+            project_path.display()
+        );
+    }
 
     // Install dependencies
     install(ScriptPolicy::Run, &project_path)

--- a/crates/pm/src/cmd/link.rs
+++ b/crates/pm/src/cmd/link.rs
@@ -18,7 +18,7 @@ pub async fn link_current_to_global(cwd: &Path, prefix: Option<&str>) -> Result<
     })?;
     if package_info.name.is_empty() {
         anyhow::bail!(
-            "Cannot link to global: package.json at {} is missing a 'name' field",
+            "Cannot link to global: package.json at {} requires a non-empty 'name' field",
             project_path.display()
         );
     }

--- a/crates/pm/src/model/package.rs
+++ b/crates/pm/src/model/package.rs
@@ -89,10 +89,10 @@ impl PublishMeta {
             );
         }
         if self.name.is_empty() {
-            bail!("Cannot publish: package.json is missing a 'name' field");
+            bail!("Cannot publish: package.json requires a non-empty 'name' field");
         }
         if self.version.is_empty() {
-            bail!("Cannot publish: package.json is missing a 'version' field");
+            bail!("Cannot publish: package.json requires a non-empty 'version' field");
         }
         if self
             .publish_config

--- a/crates/pm/src/model/package.rs
+++ b/crates/pm/src/model/package.rs
@@ -64,6 +64,8 @@ impl LifecycleScripts {
 pub struct PublishMeta {
     pub private: bool,
     #[serde(default)]
+    pub name: String,
+    #[serde(default)]
     pub version: String,
     #[serde(rename = "publishConfig")]
     pub publish_config: PublishConfig,
@@ -73,6 +75,7 @@ impl PublishMeta {
     pub fn from_package_json(pkg: &PackageJson) -> Self {
         Self {
             private: pkg.private.unwrap_or(false),
+            name: pkg.name.clone(),
             version: pkg.version.clone(),
             publish_config: pkg.publish_config.clone().unwrap_or_default(),
         }
@@ -84,6 +87,12 @@ impl PublishMeta {
                 "This package has been marked as private.\n\
                  Remove the 'private' field from package.json to publish it."
             );
+        }
+        if self.name.is_empty() {
+            bail!("Cannot publish: package.json is missing a 'name' field");
+        }
+        if self.version.is_empty() {
+            bail!("Cannot publish: package.json is missing a 'version' field");
         }
         if self
             .publish_config
@@ -162,10 +171,11 @@ impl PackageInfo {
     }
 
     /// Build from the full PackageJson (cached path, project/workspace packages).
+    ///
+    /// Project root and workspaces may legitimately omit `name` — npm allows
+    /// running `install`/lifecycle scripts on `{}` package.json. Callers that
+    /// actually require a name (publish, link-to-global) validate explicitly.
     pub fn from_package_json(path: &Path, pkg: &PackageJson) -> Result<Self> {
-        if pkg.name.is_empty() {
-            anyhow::bail!("Failed to get package name from package.json");
-        }
         Ok(PackageInfo {
             path: path.to_path_buf(),
             bin_files: pkg.bin_entries(),
@@ -311,6 +321,18 @@ mod tests {
         let package_info = PackageInfo::from_path(&package_dir).await.unwrap();
 
         assert_eq!(package_info.name, "@scope/test-package");
+    }
+
+    #[tokio::test]
+    async fn test_package_info_from_package_json_allows_missing_name() {
+        // `utoo install <pkg>` against a `{}` package.json must succeed —
+        // npm allows installing into an unnamed project, and the project
+        // root never needs a name to run lifecycle hooks. Callers that do
+        // need a name (publish, link-to-global) check explicitly.
+        let pkg = PackageJson::default();
+        let info = PackageInfo::from_package_json(Path::new("/tmp"), &pkg)
+            .expect("project root without name must load");
+        assert_eq!(info.name, "");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `utoo install <pkg>` against a `{}` package.json failed with `Failed to get package name from package.json`. npm allows installing into an unnamed project, and the project root never needs a name to run install lifecycle hooks — the bail in `PackageInfo::from_package_json` was too strict.
- The check moved to the two call sites that genuinely require a name: `publish` (now in `PublishMeta::validate`, alongside the existing `private` / `publishConfig.access` bails) and `link-to-global` (in `cmd/link.rs`).

## Repro (before)

```sh
mkdir /tmp/x && cd /tmp/x && echo '{}' > package.json
utoo install lodash
# ERROR Failed to install packages: Failed to get package name from package.json
```

## After

```sh
utoo install lodash       # ✓ installs, writes dependencies into package.json
utoo publish              # ✗ "Cannot publish: package.json is missing a 'name' field"
utoo link                 # ✗ "Cannot link to global: package.json at … is missing a 'name' field"
```

## Test plan

- [x] New unit test `test_package_info_from_package_json_allows_missing_name`
- [x] Existing `test_process_workspace_install_hooks_anonymous_workspaces` and project-hooks suite still pass
- [x] `cargo clippy --all-targets -- -D warnings --no-deps` clean
- [x] Manual: install / publish / link verified on `{}` package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)