### PR TITLE
perf(pm): worker_threads ≥ 4 only — A/B vs PR #2920

### DIFF
--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -344,9 +344,19 @@ enum Commands {
 fn main() {
     crate::util::sysconf::init();
 
+    // Floor at 4 worker threads even on 1-2 core CI runners. The
+    // install hot path multiplexes resolve / download / clone /
+    // extract task families on the tokio multi-thread runtime; with
+    // num_cpus = 2 (default on GHA ubuntu-latest) and 2 worker
+    // threads, CPU-heavy tasks can monopolize a worker for tens of
+    // ms at a time, starving the resolve loop's socket polling and
+    // producing TCP zwin events that stretch p0 / p1 tail wall by
+    // 3-5s on the affected run. Floor of 4 gives the runtime
+    // headroom on CI; no-op on 4+ core machines.
     let worker_threads = std::thread::available_parallelism()
         .map(|n| n.get())
-        .unwrap_or(4);
+        .unwrap_or(4)
+        .max(4);
 
     let result = tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
## A/B Experiment Plan A

Branched from \`origin/next\` with **only** \`worker_threads = max(num_cpus, 4)\`.

Goal: test whether the simplest possible runtime tuning closes the p0 outlier gap on its own — i.e. whether the entire \`mb_fetch_with_graph\` channel rewrite (PR #2916/#2920) was overkill.

## Test plan
- [ ] bench-phases-linux N=2: confirm p0 σ
- [ ] bench-phases-mac N=1: cross-platform check
- [ ] Compare numbers to PR #2920 (full channel + spawn_blocking + worker_threads)

## Hypothesis outcomes

| Outcome | Conclusion |
|---|---|
| matches PR #2920 | Channel rewrite was overkill — keep just this commit |
| matches origin/next | mb_fetch_with_graph + spawn_blocking really are needed → run Plan B |
| in between | Each piece contributes; need finer A/B |

🤖 Generated with [Claude Code](https://claude.com/claude-code)