### PR TITLE
perf(pm): candidate D — skip preload, BFS-only minimal change

### DIFF
--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -344,9 +344,15 @@ enum Commands {
 fn main() {
     crate::util::sysconf::init();
 
+    // Floor at 4 worker threads even on 1-2 core CI runners. Without
+    // this the install pipeline (resolve + download + clone) competes
+    // for too few worker threads on GHA ubuntu-latest (num_cpus = 2),
+    // producing tail-stretching outliers (eff_par_full collapse 73-77
+    // → 40 on outlier runs, p0/p1 wall +3-5s).
     let worker_threads = std::thread::available_parallelism()
         .map(|n| n.get())
-        .unwrap_or(4);
+        .unwrap_or(4)
+        .max(4);
 
     let result = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -234,22 +234,32 @@ where
         registry.supports_semver(),
     );
 
-    let skip_preload = cache_count > 0;
+    // Candidate D: always skip the standalone preload phase. BFS
+    // resolves on demand via UnifiedRegistry — `OnceMap` single-flight
+    // de-dupes concurrent fetches per (name, spec), so the wave-shape
+    // parallelism of preload is approximated by BFS's per-level
+    // concurrency. Saves the redundant per-fetch cost preload paid
+    // when the resolved BFS spec already overlaps the preload set.
+    //
+    // Trade-off: BFS's wave-shape is bounded by graph topology
+    // (parents must finish before children start). Preload had no
+    // such bound — it walked all root + workspace deps in one sweep.
+    // For wide-flat trees BFS catches up; for deep-narrow trees it
+    // may underutilize concurrency. Bench data on ant-design will
+    // tell us which side dominates.
     let mut config = BuildDepsConfig::default()
         .with_peer_deps(peer_deps)
         .with_concurrency(concurrency)
-        .with_skip_preload(skip_preload)
+        .with_skip_preload(true)
         .with_catalogs(catalogs);
     if let Some(dir) = cache_dir {
         config = config.with_cache_dir(dir);
     }
 
-    if skip_preload {
-        tracing::debug!(
-            "Skipping preload phase (project cache has {} entries)",
-            cache_count
-        );
-    }
+    tracing::debug!(
+        "Skipping preload phase (candidate D: BFS-only; project cache has {} entries)",
+        cache_count
+    );
 
     // Preserve the typed error via `Error::new` + `.context(...)` so CLI
     // renderers (e.g. pm's format_print) can downcast and pretty-print the


### PR DESCRIPTION
Minimal change on origin/next: skip the standalone preload phase, let BFS resolve on demand via OnceMap+UnifiedRegistry. Adds worker_threads ≥ 4. No service-layer rewrite. A/B vs PR #2920 to measure if preload's wave-shape parallelism is necessary or if BFS-on-demand catches up via OnceMap single-flight.