### PR TITLE
fix(pack): apply postcss before inline css

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -6,9 +6,12 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack::module_options::{
-    CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleOptionsContext,
-    ModuleRule, TypescriptTransformOptions, side_effect_free_packages_glob,
+use turbopack::{
+    evaluate_context::{config_tracing_module_context, node_evaluate_asset_context},
+    module_options::{
+        CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleOptionsContext,
+        ModuleRule, TypescriptTransformOptions, side_effect_free_packages_glob,
+    },
 };
 use turbopack_browser::{BrowserChunkingContext, CurrentChunkMethod};
 use turbopack_core::{
@@ -19,13 +22,15 @@ use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment},
     file_source::FileSource,
+    ident::Layer,
     module_graph::binding_usage_info::OptionBindingUsageInfo,
+    resolve::options::{ImportMap, ImportMapping},
 };
 use turbopack_css::chunk::CssChunkType;
 use turbopack_ecmascript::{TypeofWindow, chunk::EcmascriptChunkType};
 use turbopack_node::{
     execution_context::ExecutionContext,
-    transforms::postcss::{PostCssConfigLocation, PostCssTransformOptions},
+    transforms::postcss::{PostCssConfigLocation, PostCssTransform, PostCssTransformOptions},
 };
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
@@ -69,6 +74,13 @@ use super::{
     react_refresh::assert_can_resolve_react_refresh, runtime_entry::RuntimeEntry,
     transforms::get_client_transforms_rules,
 };
+
+#[turbo_tasks::function]
+fn postcss_import_map(package_mapping: ResolvedVc<ImportMapping>) -> Vc<ImportMap> {
+    let mut import_map = ImportMap::default();
+    import_map.insert_exact_alias(RcStr::from("@vercel/turbopack/postcss"), package_mapping);
+    import_map.cell()
+}
 
 #[turbo_tasks::function]
 pub async fn get_client_compile_time_info(
@@ -227,8 +239,81 @@ pub async fn get_client_module_options_context(
         .await?;
     let target_browsers = env.runtime_versions();
 
-    let mut client_rules = get_client_transforms_rules(config, mode, false).await?;
-    let mut foreign_client_rules = get_client_transforms_rules(config, mode, true).await?;
+    let source_maps = if *config.source_maps().await? {
+        SourceMapsType::Full
+    } else {
+        SourceMapsType::None
+    };
+    let postcss_config_content = (*config.postcss_config_content().await?).clone();
+    let postcss_transform_options = Some(PostCssTransformOptions {
+        postcss_package: Some(get_postcss_package_mapping().to_resolved().await?),
+        config_location: PostCssConfigLocation::ProjectPathOrLocalPath,
+        config_content: postcss_config_content,
+        ..Default::default()
+    });
+
+    let postcss_foreign_transform_options =
+        postcss_transform_options
+            .as_ref()
+            .map(|postcss_transform_options| PostCssTransformOptions {
+                // For node_modules we don't want to resolve postcss config relative to the file being
+                // compiled, instead it only uses the project root postcss config.
+                config_location: PostCssConfigLocation::ProjectPath,
+                ..postcss_transform_options.clone()
+            });
+
+    let postcss_import_map =
+        postcss_import_map(*get_postcss_package_mapping().to_resolved().await?);
+    let inline_postcss_transform = if let Some(options) = postcss_transform_options.as_ref() {
+        Some(ResolvedVc::upcast(
+            PostCssTransform::new(
+                node_evaluate_asset_context(
+                    *execution_context,
+                    Some(postcss_import_map),
+                    None,
+                    Layer::new(rcstr!("webpack_loaders")),
+                    cfg!(all(target_family = "wasm", target_os = "unknown")),
+                ),
+                config_tracing_module_context(*execution_context),
+                *execution_context,
+                options.config_location,
+                options.config_content.clone(),
+                matches!(source_maps, SourceMapsType::Full),
+            )
+            .to_resolved()
+            .await?,
+        ))
+    } else {
+        None
+    };
+    let inline_foreign_postcss_transform =
+        if let Some(options) = postcss_foreign_transform_options.as_ref() {
+            Some(ResolvedVc::upcast(
+                PostCssTransform::new(
+                    node_evaluate_asset_context(
+                        *execution_context,
+                        Some(postcss_import_map),
+                        None,
+                        Layer::new(rcstr!("webpack_loaders")),
+                        cfg!(all(target_family = "wasm", target_os = "unknown")),
+                    ),
+                    config_tracing_module_context(*execution_context),
+                    *execution_context,
+                    options.config_location,
+                    options.config_content.clone(),
+                    matches!(source_maps, SourceMapsType::Full),
+                )
+                .to_resolved()
+                .await?,
+            ))
+        } else {
+            None
+        };
+
+    let mut client_rules =
+        get_client_transforms_rules(config, mode, false, inline_postcss_transform).await?;
+    let mut foreign_client_rules =
+        get_client_transforms_rules(config, mode, true, inline_foreign_postcss_transform).await?;
 
     // Ignore .d.ts files - they are TypeScript declaration files and should not be bundled
     let ignore_dts_rule = ModuleRule::new(
@@ -285,37 +370,10 @@ pub async fn get_client_module_options_context(
         ));
     }
 
-    let postcss_config_content = (*config.postcss_config_content().await?).clone();
-
-    let postcss_transform_options = Some(PostCssTransformOptions {
-        postcss_package: Some(get_postcss_package_mapping().to_resolved().await?),
-        config_location: PostCssConfigLocation::ProjectPathOrLocalPath,
-        config_content: postcss_config_content,
-        ..Default::default()
-    });
-
-    let postcss_foreign_transform_options =
-        postcss_transform_options
-            .as_ref()
-            .map(|postcss_transform_options| {
-                PostCssTransformOptions {
-                    // For node_modules we don't want to resolve postcss config relative to the file being
-                    // compiled, instead it only uses the project root postcss config.
-                    config_location: PostCssConfigLocation::ProjectPath,
-                    ..postcss_transform_options.clone()
-                }
-            });
-
     let enable_postcss_transform = postcss_transform_options
         .map(|postcss_transform_options| postcss_transform_options.resolved_cell());
     let enable_foreign_postcss_transform = postcss_foreign_transform_options
         .map(|postcss_foreign_transform_options| postcss_foreign_transform_options.resolved_cell());
-
-    let source_maps = if *config.source_maps().await? {
-        SourceMapsType::Full
-    } else {
-        SourceMapsType::None
-    };
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             enable_typeof_window_inlining: Some(TypeofWindow::Object),

--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -245,8 +245,9 @@ pub async fn get_client_module_options_context(
         SourceMapsType::None
     };
     let postcss_config_content = (*config.postcss_config_content().await?).clone();
+    let postcss_package_mapping = get_postcss_package_mapping().to_resolved().await?;
     let postcss_transform_options = Some(PostCssTransformOptions {
-        postcss_package: Some(get_postcss_package_mapping().to_resolved().await?),
+        postcss_package: Some(postcss_package_mapping),
         config_location: PostCssConfigLocation::ProjectPathOrLocalPath,
         config_content: postcss_config_content,
         ..Default::default()
@@ -262,26 +263,29 @@ pub async fn get_client_module_options_context(
                 ..postcss_transform_options.clone()
             });
 
-    let postcss_import_map =
-        postcss_import_map(*get_postcss_package_mapping().to_resolved().await?);
+    let postcss_import_map = postcss_import_map(*postcss_package_mapping);
+    let create_inline_postcss_transform = |options: &PostCssTransformOptions| {
+        PostCssTransform::new(
+            node_evaluate_asset_context(
+                *execution_context,
+                Some(postcss_import_map),
+                None,
+                Layer::new(rcstr!("webpack_loaders")),
+                cfg!(all(target_family = "wasm", target_os = "unknown")),
+            ),
+            config_tracing_module_context(*execution_context),
+            *execution_context,
+            options.config_location,
+            options.config_content.clone(),
+            matches!(source_maps, SourceMapsType::Full),
+        )
+    };
+
     let inline_postcss_transform = if let Some(options) = postcss_transform_options.as_ref() {
         Some(ResolvedVc::upcast(
-            PostCssTransform::new(
-                node_evaluate_asset_context(
-                    *execution_context,
-                    Some(postcss_import_map),
-                    None,
-                    Layer::new(rcstr!("webpack_loaders")),
-                    cfg!(all(target_family = "wasm", target_os = "unknown")),
-                ),
-                config_tracing_module_context(*execution_context),
-                *execution_context,
-                options.config_location,
-                options.config_content.clone(),
-                matches!(source_maps, SourceMapsType::Full),
-            )
-            .to_resolved()
-            .await?,
+            create_inline_postcss_transform(options)
+                .to_resolved()
+                .await?,
         ))
     } else {
         None
@@ -289,22 +293,9 @@ pub async fn get_client_module_options_context(
     let inline_foreign_postcss_transform =
         if let Some(options) = postcss_foreign_transform_options.as_ref() {
             Some(ResolvedVc::upcast(
-                PostCssTransform::new(
-                    node_evaluate_asset_context(
-                        *execution_context,
-                        Some(postcss_import_map),
-                        None,
-                        Layer::new(rcstr!("webpack_loaders")),
-                        cfg!(all(target_family = "wasm", target_os = "unknown")),
-                    ),
-                    config_tracing_module_context(*execution_context),
-                    *execution_context,
-                    options.config_location,
-                    options.config_content.clone(),
-                    matches!(source_maps, SourceMapsType::Full),
-                )
-                .to_resolved()
-                .await?,
+                create_inline_postcss_transform(options)
+                    .to_resolved()
+                    .await?,
             ))
         } else {
             None

--- a/crates/pack-core/src/client/transforms.rs
+++ b/crates/pack-core/src/client/transforms.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::ModuleRule;
+use turbopack_core::source_transform::SourceTransform;
 
 use crate::{
     config::Config,
@@ -15,6 +16,7 @@ pub async fn get_client_transforms_rules(
     config: Vc<Config>,
     mode: Vc<Mode>,
     foreign_code: bool,
+    postcss_transform: Option<ResolvedVc<Box<dyn SourceTransform>>>,
 ) -> Result<Vec<ModuleRule>> {
     let mut rules = vec![];
 
@@ -50,7 +52,9 @@ pub async fn get_client_transforms_rules(
             .unwrap_or(InjectType::Style);
 
         let minify = *config.minify(mode).await?;
-        rules.push(get_inline_css_rule(insert.into(), inject_type, minify).await?);
+        rules.push(
+            get_inline_css_rule(insert.into(), inject_type, minify, postcss_transform).await?,
+        );
     }
 
     Ok(rules)

--- a/crates/pack-core/src/shared/transforms/mod.rs
+++ b/crates/pack-core/src/shared/transforms/mod.rs
@@ -6,6 +6,7 @@ use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCo
 use turbopack_core::reference_type::{
     CssReferenceSubType, ReferenceTypeCondition, UrlReferenceSubType,
 };
+use turbopack_core::source_transform::SourceTransform;
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform};
 
 use image::{StructuredImageModuleType, module::BlurPlaceholderMode};
@@ -77,7 +78,24 @@ pub async fn get_inline_css_rule(
     insert: RcStr,
     inject_type: InjectType,
     minify: bool,
+    postcss_transform: Option<ResolvedVc<Box<dyn SourceTransform>>>,
 ) -> Result<ModuleRule> {
+    let mut effects = vec![];
+
+    if let Some(postcss_transform) = postcss_transform {
+        effects.push(ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
+            postcss_transform,
+        ])));
+    }
+
+    effects.push(ModuleRuleEffect::ModuleType(ModuleType::Custom(
+        ResolvedVc::upcast(
+            InlineCssModuleType::new(insert, inject_type, minify)
+                .to_resolved()
+                .await?,
+        ),
+    )));
+
     Ok(ModuleRule::new(
         RuleCondition::All(vec![
             RuleCondition::not(RuleCondition::ReferenceType(ReferenceTypeCondition::Url(
@@ -91,13 +109,7 @@ pub async fn get_inline_css_rule(
             ))),
             RuleCondition::ResourcePathEndsWith(".css".to_string()),
         ]),
-        vec![ModuleRuleEffect::ModuleType(ModuleType::Custom(
-            ResolvedVc::upcast(
-                InlineCssModuleType::new(insert, inject_type, minify)
-                    .to_resolved()
-                    .await?,
-            ),
-        ))],
+        effects,
     ))
 }
 

--- a/crates/pack-tests/tests/snapshot.rs
+++ b/crates/pack-tests/tests/snapshot.rs
@@ -19,7 +19,7 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
 };
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{Effects, OperationVc, ResolvedVc, TurboTasks, ValueToString, Vc, take_effects};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
@@ -120,6 +120,10 @@ async fn run(resource: PathBuf) -> Result<()> {
         noop_backing_storage(),
     ));
     tt.run_once(async move {
+        let project_options = project_options_from_resource(&resource)?;
+        let container_op = ProjectContainer::new_operation(rcstr!("project"), project_options.dev);
+        ProjectContainer::initialize(container_op, project_options).await?;
+
         #[turbo_tasks::function(operation)]
         async fn snapshot_issues_operation(out_op: OperationVc<FileSystemPath>) -> Result<Vc<()>> {
             let out_path = out_op
@@ -155,7 +159,7 @@ async fn run(resource: PathBuf) -> Result<()> {
             Ok(take_effects(out_op).await?.cell())
         }
 
-        let out_op = run_test_operation(resource.to_str().unwrap().into());
+        let out_op = run_test_operation(container_op);
         let snapshot_effects = snapshot_effects_operation(out_op)
             .read_strongly_consistent()
             .await?;
@@ -172,10 +176,9 @@ async fn run(resource: PathBuf) -> Result<()> {
     Ok(())
 }
 
-#[turbo_tasks::function(operation)]
-async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
-    let test_path = canonicalize(&resource)?;
-    assert!(test_path.exists(), "{resource} does not exist");
+fn project_options_from_resource(resource: &Path) -> Result<ProjectOptions> {
+    let test_path = canonicalize(resource)?;
+    assert!(test_path.exists(), "{} does not exist", resource.display());
     assert!(
         test_path.is_dir(),
         "{} is not a directory. Snapshot tests only support directories",
@@ -260,7 +263,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     // Convert the merged inner bundler config back to string for ProjectOptions
     let final_config_content = serde_json::to_string_pretty(&user_config)?;
 
-    let project_options = ProjectOptions {
+    Ok(ProjectOptions {
         root_path: Path::new(&*REPO_ROOT)
             .join("crates/pack-tests/tests/snapshot")
             .to_string_lossy()
@@ -288,11 +291,13 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .to_string_lossy()
             .to_string()
             .into(),
-    };
+    })
+}
 
-    // Initialize project container
-    let container_op = ProjectContainer::new_operation(rcstr!("project"), project_options.dev);
-    ProjectContainer::initialize(container_op, project_options).await?;
+#[turbo_tasks::function(operation)]
+async fn run_test_operation(
+    container_op: OperationVc<ProjectContainer>,
+) -> Result<Vc<FileSystemPath>> {
     let project_container = container_op.resolve().strongly_consistent().await?;
 
     // Run bundling operation using the same pattern as build.rs

--- a/crates/pack-tests/tests/snapshot/style/inline_css_postcss/config.json
+++ b/crates/pack-tests/tests/snapshot/style/inline_css_postcss/config.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "sourceMaps": false,
+    "styles": {
+      "inlineCss": {},
+      "postcss": {
+        "plugins": [
+          [
+            "postcss-plugin-px2rem",
+            {
+              "rootValue": 16,
+              "unitPrecision": 5,
+              "replace": true,
+              "mediaQuery": false,
+              "minPixelValue": 0
+            }
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/style/inline_css_postcss/input/index.js
+++ b/crates/pack-tests/tests/snapshot/style/inline_css_postcss/input/index.js
@@ -1,0 +1,3 @@
+import "./style.css";
+
+console.log("inline css postcss test");

--- a/crates/pack-tests/tests/snapshot/style/inline_css_postcss/input/style.css
+++ b/crates/pack-tests/tests/snapshot/style/inline_css_postcss/input/style.css
@@ -1,0 +1,5 @@
+.inline-postcss {
+  width: 32px;
+  height: 16px;
+  margin: 8px 4px;
+}

--- a/crates/pack-tests/tests/snapshot/style/inline_css_postcss/output/_root-of-the-server___60743e00.js
+++ b/crates/pack-tests/tests/snapshot/style/inline_css_postcss/output/_root-of-the-server___60743e00.js
@@ -1,0 +1,252 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[@utoo/pack-runtime]/inline_css/injectStylesIntoStyleTag.js [client] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+/**
+ * Injects styles into the DOM using <style> tags.
+ * This is a Rust-native reimplementation of webpack's style-loader.
+ * @see https://webpack.js.org/loaders/style-loader/
+ */ const isOldIE = function isOldIE() {
+    let memo;
+    return function memorize() {
+        if (typeof memo === "undefined") {
+            // Test for IE <= 9 as proposed by Browserhacks
+            // @see http://browserhacks.com/#hack-e71d8692f65334173fee715c222cb805
+            // Tests for existence of standard globals is to allow style-loader
+            // to operate correctly into non-standard environments
+            // @see https://github.com/webpack-contrib/style-loader/issues/177
+            memo = Boolean(window && document && document.all && !window.atob);
+        }
+        return memo;
+    };
+}();
+const getTargetElement = function() {
+    const memo = {};
+    return function memorize(target) {
+        if (typeof memo[target] === "undefined") {
+            let styleTarget = document.querySelector(target);
+            // Special case to return head of iframe instead of iframe itself
+            if (window.HTMLIFrameElement && styleTarget instanceof window.HTMLIFrameElement) {
+                try {
+                    // This will throw an exception if access to iframe is blocked
+                    // due to cross-origin restrictions
+                    styleTarget = styleTarget.contentDocument.head;
+                } catch (e) {
+                    // istanbul ignore next
+                    styleTarget = null;
+                }
+            }
+            memo[target] = styleTarget;
+        }
+        return memo[target];
+    };
+}();
+const stylesInDom = [];
+function getIndexByIdentifier(identifier) {
+    let result = -1;
+    for(let i = 0; i < stylesInDom.length; i++){
+        if (stylesInDom[i].identifier === identifier) {
+            result = i;
+            break;
+        }
+    }
+    return result;
+}
+function modulesToDom(list, options) {
+    const idCountMap = {};
+    const identifiers = [];
+    for(let i = 0; i < list.length; i++){
+        const item = list[i];
+        const id = options.base ? item[0] + options.base : item[0];
+        const count = idCountMap[id] || 0;
+        const identifier = id + " " + count.toString();
+        idCountMap[id] = count + 1;
+        const index = getIndexByIdentifier(identifier);
+        const obj = {
+            css: item[1],
+            media: item[2],
+            sourceMap: item[3]
+        };
+        if (index !== -1) {
+            stylesInDom[index].references++;
+            stylesInDom[index].updater(obj);
+        } else {
+            stylesInDom.push({
+                identifier: identifier,
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                updater: addStyle(obj, options),
+                references: 1
+            });
+        }
+        identifiers.push(identifier);
+    }
+    return identifiers;
+}
+function insertStyleElement(options) {
+    const style = document.createElement("style");
+    const attributes = options.attributes || {};
+    if (typeof attributes.nonce === "undefined") {
+        const nonce = // eslint-disable-next-line no-undef
+        typeof __webpack_nonce__ !== "undefined" ? __webpack_nonce__ : null;
+        if (nonce) {
+            attributes.nonce = nonce;
+        }
+    }
+    Object.keys(attributes).forEach(function(key) {
+        style.setAttribute(key, attributes[key]);
+    });
+    if (typeof options.insert === "function") {
+        options.insert(style);
+    } else {
+        const target = getTargetElement(options.insert || "head");
+        if (!target) {
+            throw new Error("Couldn't find a style target. This probably means that the value for the 'insert' parameter is invalid.");
+        }
+        target.appendChild(style);
+    }
+    return style;
+}
+function removeStyleElement(style) {
+    // istanbul ignore if
+    if (style.parentNode === null) {
+        return false;
+    }
+    style.parentNode.removeChild(style);
+}
+/* istanbul ignore next  */ const replaceText = function replaceText() {
+    const textStore = [];
+    return function replace(index, replacement) {
+        textStore[index] = replacement;
+        return textStore.filter(Boolean).join("\n");
+    };
+}();
+function applyToSingletonTag(style, index, remove, obj) {
+    const css = remove ? "" : obj.media ? "@media " + obj.media + " {" + obj.css + "}" : obj.css;
+    // For old IE
+    /* istanbul ignore if  */ if (style.styleSheet) {
+        style.styleSheet.cssText = replaceText(index, css);
+    } else {
+        const cssNode = document.createTextNode(css);
+        const childNodes = style.childNodes;
+        if (childNodes[index]) {
+            style.removeChild(childNodes[index]);
+        }
+        if (childNodes.length) {
+            style.insertBefore(cssNode, childNodes[index]);
+        } else {
+            style.appendChild(cssNode);
+        }
+    }
+}
+function applyToTag(style, _options, obj) {
+    let css = obj.css;
+    const media = obj.media;
+    const sourceMap = obj.sourceMap;
+    if (media) {
+        style.setAttribute("media", media);
+    } else {
+        style.removeAttribute("media");
+    }
+    if (sourceMap && typeof btoa !== "undefined") {
+        css += "\n/*# sourceMappingURL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
+    }
+    // For old IE
+    /* istanbul ignore if  */ if (style.styleSheet) {
+        style.styleSheet.cssText = css;
+    } else {
+        while(style.firstChild){
+            style.removeChild(style.firstChild);
+        }
+        style.appendChild(document.createTextNode(css));
+    }
+}
+let singleton = null;
+let singletonCounter = 0;
+function addStyle(obj, options) {
+    let style;
+    let update;
+    let remove;
+    if (options.singleton) {
+        const styleIndex = singletonCounter++;
+        style = singleton || (singleton = insertStyleElement(options));
+        update = applyToSingletonTag.bind(null, style, styleIndex, false);
+        remove = applyToSingletonTag.bind(null, style, styleIndex, true);
+    } else {
+        style = insertStyleElement(options);
+        update = applyToTag.bind(null, style, options);
+        remove = function() {
+            removeStyleElement(style);
+        };
+    }
+    update(obj);
+    return function updateStyle(newObj) {
+        if (newObj) {
+            if (newObj.css === obj.css && newObj.media === obj.media && newObj.sourceMap === obj.sourceMap) {
+                return;
+            }
+            update(obj = newObj);
+        } else {
+            remove();
+        }
+    };
+}
+module.exports = function(list, options) {
+    options = options || {};
+    // Force single-tag solution on IE6-9, which has a hard limit on the # of <style>
+    // tags it will allow on a page
+    if (!options.singleton && typeof options.singleton !== "boolean") {
+        options.singleton = isOldIE();
+    }
+    list = list || [];
+    let lastIdentifiers = modulesToDom(list, options);
+    return function update(newList) {
+        newList = newList || [];
+        if (Object.prototype.toString.call(newList) !== "[object Array]") {
+            return;
+        }
+        for(let i = 0; i < lastIdentifiers.length; i++){
+            const identifier = lastIdentifiers[i];
+            const index = getIndexByIdentifier(identifier);
+            stylesInDom[index].references--;
+        }
+        const newLastIdentifiers = modulesToDom(newList, options);
+        for(let i = 0; i < lastIdentifiers.length; i++){
+            const identifier = lastIdentifiers[i];
+            const index = getIndexByIdentifier(identifier);
+            if (stylesInDom[index].references === 0) {
+                stylesInDom[index].updater();
+                stylesInDom.splice(index, 1);
+            }
+        }
+        lastIdentifiers = newLastIdentifiers;
+    };
+};
+}),
+"[project]/style/inline_css_postcss/input/style.css.js [client] (inline css, ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b40$utoo$2f$pack$2d$runtime$5d2f$inline_css$2f$injectStylesIntoStyleTag$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[@utoo/pack-runtime]/inline_css/injectStylesIntoStyleTag.js [client] (ecmascript)");
+;
+var content = ".inline-postcss {\n  width: 2rem;\n  height: 1rem;\n  margin: .5rem .25rem;\n}\n";
+var options = {};
+options.insert = "head";
+options.singleton = false;
+var update = (0, __TURBOPACK__imported__module__$5b40$utoo$2f$pack$2d$runtime$5d2f$inline_css$2f$injectStylesIntoStyleTag$2e$js__$5b$client$5d$__$28$ecmascript$29$__["default"])([
+    [
+        "style/inline_css_postcss/input/style.css",
+        content,
+        undefined,
+        undefined
+    ]
+], options);
+var __TURBOPACK__default__export__ = {};
+__turbopack_context__.s([]);
+}),
+"[project]/style/inline_css_postcss/input/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$inline_css_postcss$2f$input$2f$style$2e$css$2e$js__$5b$client$5d$__$28$inline__css$2c$__ecmascript$29$__ = __turbopack_context__.i("[project]/style/inline_css_postcss/input/style.css.js [client] (inline css, ecmascript)");
+;
+console.log("inline css postcss test");
+__turbopack_context__.s([]);
+}),
+]);

--- a/crates/pack-tests/tests/snapshot/style/inline_css_postcss/output/main.js
+++ b/crates/pack-tests/tests/snapshot/style/inline_css_postcss/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["_root-of-the-server___60743e00.js"],"runtimeModuleIds":["[project]/style/inline_css_postcss/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime


### PR DESCRIPTION
## Summary

For smallfish widget px2rem HD. 

Before inlineCSS, the postcss transform should be executed like client does.


## Test Plan

update snapshot test case
