### PR TITLE
fix(pack): centralize webpack stats.json generation to avoid conflicting effects

### DIFF
--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -15,7 +15,6 @@ use pack_core::util::convert_to_project_relative;
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, JoinIterExt, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
-use turbo_tasks_fs::{File, FileContent};
 use turbopack::{
     ModuleAssetContext, module_options::ModuleOptionsContext, transition::TransitionOptions,
 };
@@ -23,7 +22,6 @@ use turbopack_core::chunk::ChunkingContextExt;
 use turbopack_core::output::OutputAssetsWithReferenced;
 use turbopack_core::resolve::origin::ResolveOrigin;
 use turbopack_core::{
-    asset::AssetContent,
     chunk::{
         ChunkingContext, EvaluatableAsset, EvaluatableAssets, availability_info::AvailabilityInfo,
     },
@@ -40,13 +38,11 @@ use turbopack_core::{
         origin::{PlainResolveOrigin, ResolveOriginExt},
         parse::Request,
     },
-    virtual_output::VirtualOutputAsset,
 };
 
 use crate::{
     endpoint::{Endpoint, EndpointOutput, EndpointOutputPaths},
     project::Project,
-    webpack_stats::generate_webpack_stats,
 };
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
@@ -507,46 +503,10 @@ impl Endpoint for AppEndpoint {
                 client_paths: vec![],
             };
 
-            let should_create_webpack_stats = *this.project.should_create_webpack_stats().await?;
-
-            let mut output_assets = if !should_create_webpack_stats {
-                output_assets
-            } else {
-                let webpack_stats = generate_webpack_stats(output_assets, this.project.dist_root());
-                let webpack_stats_read = webpack_stats.await?;
-                let dist_root_owned = this.project.dist_root().owned().await?;
-                let stats_json = serde_json::to_string_pretty(&*webpack_stats_read)?;
-                let stats_output = VirtualOutputAsset::new(
-                    dist_root_owned.join("stats.json")?,
-                    AssetContent::file(FileContent::from(File::from(stats_json)).cell()),
-                )
-                .to_resolved()
-                .await?;
-                output_assets.concatenate(*ResolvedVc::cell(vec![ResolvedVc::upcast(stats_output)]))
-            };
+            let mut output_assets = output_assets;
 
             if let Some(server_output) = server_output {
-                if should_create_webpack_stats {
-                    let server_stats =
-                        generate_webpack_stats(server_output, this.project.server_dist_root());
-                    let server_stats_read = server_stats.await?;
-                    let server_dist_root_owned = this.project.server_dist_root().owned().await?;
-                    let server_stats_json = serde_json::to_string_pretty(&*server_stats_read)?;
-                    let server_stats_output = VirtualOutputAsset::new(
-                        server_dist_root_owned.join("stats.json")?,
-                        AssetContent::file(FileContent::from(File::from(server_stats_json)).cell()),
-                    )
-                    .to_resolved()
-                    .await?;
-                    output_assets =
-                        output_assets
-                            .concatenate(server_output)
-                            .concatenate(*ResolvedVc::cell(vec![ResolvedVc::upcast(
-                                server_stats_output,
-                            )]));
-                } else {
-                    output_assets = output_assets.concatenate(server_output);
-                }
+                output_assets = output_assets.concatenate(server_output);
             }
 
             Ok(EndpointOutput {

--- a/crates/pack-api/src/entrypoint.rs
+++ b/crates/pack-api/src/entrypoint.rs
@@ -1,10 +1,13 @@
 use anyhow::Result;
 use std::sync::Arc;
 use turbo_tasks::{Effects, FxIndexSet, ReadRef, ResolvedVc, TryJoinIterExt, Vc, take_effects};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
+    asset::AssetContent,
     diagnostics::PlainDiagnostic,
     issue::PlainIssue,
     output::{OutputAsset, OutputAssets},
+    virtual_output::VirtualOutputAsset,
 };
 
 use crate::{
@@ -12,6 +15,7 @@ use crate::{
     operation::EntrypointsOperation,
     project::ProjectContainer,
     utils::{get_diagnostics, get_issues},
+    webpack_stats::generate_webpack_stats,
 };
 
 #[turbo_tasks::value(shared)]
@@ -58,7 +62,6 @@ pub async fn all_output_assets_operation(
 ) -> Result<Vc<OutputAssets>> {
     let project = container.project();
 
-    // Get assets from all endpoints
     let endpoint_assets = project
         .get_all_endpoints()
         .await?
@@ -72,7 +75,55 @@ pub async fn all_output_assets_operation(
         .flat_map(|assets| assets.iter().copied())
         .collect();
 
-    Ok(Vc::cell(output_assets.into_iter().collect()))
+    let output_assets: Vc<OutputAssets> = Vc::cell(output_assets.into_iter().collect());
+
+    if !*container.project().should_create_webpack_stats().await? {
+        return Ok(output_assets);
+    }
+
+    let dist_root = container.project().dist_root();
+    let server_dist_root_vc = container.project().server_dist_root();
+    let dist_root_read = dist_root.await?;
+    let server_dist_root_read = server_dist_root_vc.await?;
+    let same_root = dist_root_read.path == server_dist_root_read.path;
+
+    let mut stats_outputs: Vec<ResolvedVc<Box<dyn OutputAsset>>> = Vec::new();
+
+    if same_root {
+        stats_outputs.push(make_stats_output(output_assets, dist_root).await?);
+    } else {
+        let mut client: Vec<ResolvedVc<Box<dyn OutputAsset>>> = Vec::new();
+        let mut server: Vec<ResolvedVc<Box<dyn OutputAsset>>> = Vec::new();
+        for asset in output_assets.await?.iter().copied() {
+            if asset.path().await?.is_inside_ref(&server_dist_root_read) {
+                server.push(asset);
+            } else {
+                client.push(asset);
+            }
+        }
+        stats_outputs.push(make_stats_output(Vc::cell(client), dist_root).await?);
+        if !server.is_empty() {
+            stats_outputs.push(make_stats_output(Vc::cell(server), server_dist_root_vc).await?);
+        }
+    }
+
+    Ok(output_assets.concatenate(*ResolvedVc::cell(stats_outputs)))
+}
+
+async fn make_stats_output(
+    assets: Vc<OutputAssets>,
+    dist_root: Vc<FileSystemPath>,
+) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
+    let webpack_stats = generate_webpack_stats(assets, dist_root).await?;
+    let stats_json = serde_json::to_string_pretty(&*webpack_stats)?;
+    let dist_root_owned = dist_root.owned().await?;
+    let stats_output = VirtualOutputAsset::new(
+        dist_root_owned.join("stats.json")?,
+        AssetContent::file(FileContent::from(File::from(stats_json)).cell()),
+    )
+    .to_resolved()
+    .await?;
+    Ok(ResolvedVc::upcast(stats_output))
 }
 
 #[turbo_tasks::value(shared, serialization = "skip")]

--- a/crates/pack-api/src/entrypoint.rs
+++ b/crates/pack-api/src/entrypoint.rs
@@ -82,16 +82,16 @@ pub async fn all_output_assets_operation(
     }
 
     let dist_root = container.project().dist_root();
-    let server_dist_root_vc = container.project().server_dist_root();
-    let dist_root_read = dist_root.await?;
-    let server_dist_root_read = server_dist_root_vc.await?;
-    let same_root = dist_root_read.path == server_dist_root_read.path;
+    let server_config = container.project().config().server().await?;
+    let has_server = server_config.entry.is_some() || server_config.function.is_some();
 
     let mut stats_outputs: Vec<ResolvedVc<Box<dyn OutputAsset>>> = Vec::new();
 
-    if same_root {
+    if !has_server {
         stats_outputs.push(make_stats_output(output_assets, dist_root).await?);
     } else {
+        let server_dist_root_vc = container.project().server_dist_root();
+        let server_dist_root_read = server_dist_root_vc.await?;
         let mut client: Vec<ResolvedVc<Box<dyn OutputAsset>>> = Vec::new();
         let mut server: Vec<ResolvedVc<Box<dyn OutputAsset>>> = Vec::new();
         for asset in output_assets.await?.iter().copied() {

--- a/crates/pack-api/src/library.rs
+++ b/crates/pack-api/src/library.rs
@@ -13,12 +13,10 @@ use pack_core::util::convert_to_project_relative;
 use tracing::{Instrument, trace_span};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, JoinIterExt, ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{File, FileContent};
 use turbopack::{
     ModuleAssetContext, module_options::ModuleOptionsContext, transition::TransitionOptions,
 };
 use turbopack_core::{
-    asset::AssetContent,
     chunk::{
         ChunkGroupResult, ChunkingContext, EvaluatableAsset, EvaluatableAssets,
         availability_info::AvailabilityInfo,
@@ -35,14 +33,12 @@ use turbopack_core::{
         origin::{PlainResolveOrigin, ResolveOrigin, ResolveOriginExt},
         parse::Request,
     },
-    virtual_output::VirtualOutputAsset,
 };
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
 use crate::{
     endpoint::{Endpoint, EndpointOutput, EndpointOutputPaths},
     project::Project,
-    webpack_stats::generate_webpack_stats,
 };
 
 #[turbo_tasks::value]
@@ -373,24 +369,6 @@ impl Endpoint for LibraryEndpoint {
                 server_entry_path: dist_root.path.clone(),
                 server_paths: vec![],
                 client_paths: vec![],
-            };
-
-            let should_create_webpack_stats = *this.project.should_create_webpack_stats().await?;
-
-            let output_assets = if !should_create_webpack_stats {
-                output_assets
-            } else {
-                let webpack_stats = generate_webpack_stats(output_assets, this.project.dist_root());
-                let webpack_stats_read = webpack_stats.await?;
-                let dist_root_owned = this.project.dist_root().owned().await?;
-                let stats_json = serde_json::to_string_pretty(&*webpack_stats_read)?;
-                let stats_output = VirtualOutputAsset::new(
-                    dist_root_owned.join("stats.json")?,
-                    AssetContent::file(FileContent::from(File::from(stats_json)).cell()),
-                )
-                .to_resolved()
-                .await?;
-                output_assets.concatenate(*ResolvedVc::cell(vec![ResolvedVc::upcast(stats_output)]))
             };
 
             Ok(EndpointOutput {

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/config.json
@@ -1,0 +1,39 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/app.ts",
+        "name": "app"
+      },
+      {
+        "import": "input/a.ts",
+        "name": "a",
+        "library": { "name": "a" }
+      },
+      {
+        "import": "input/b.ts",
+        "name": "b",
+        "library": { "name": "b" }
+      }
+    ],
+    "output": {
+      "path": "output/client"
+    },
+    "server": {
+      "entry": "input/server.ts",
+      "output": {
+        "path": "output/server",
+        "filename": "main.js"
+      },
+      "function": {
+        "clientProxy": "./input/transport.ts",
+        "serverRegister": "./input/register.ts"
+      }
+    },
+    "optimization": {
+      "minify": false,
+      "moduleIds": "named"
+    },
+    "stats": true
+  }
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/a.ts
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/a.ts
@@ -1,0 +1,1 @@
+export const a = "value-a";

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/app.ts
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/app.ts
@@ -1,0 +1,4 @@
+import { a } from "./a";
+import { b } from "./b";
+
+console.log("app entry", a, b);

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/b.ts
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/b.ts
@@ -1,0 +1,1 @@
+export const b = "value-b";

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/register.ts
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/register.ts
@@ -1,0 +1,6 @@
+export const RUNTIME_ACTIONS = new Map<string, Function>();
+
+export function registerServerReference(action: Function, id: string, name: string) {
+  console.log(`[Register] Action ${name} (${id}) registered.`);
+  RUNTIME_ACTIONS.set(id, action);
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/server.ts
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/server.ts
@@ -1,0 +1,1 @@
+console.log("server entry");

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/transport.ts
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/input/transport.ts
@@ -1,0 +1,6 @@
+export function createServerReference(id: string, name: string) {
+  return async function (...args: any[]) {
+    console.log(`[Transport] Call ${name} (${id}) with`, args);
+    return { ok: true };
+  };
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/a.js
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/a.js
@@ -1,0 +1,21 @@
+((__UTOOPACK__) => {
+// Dummy runtime
+})([
+["a.js",
+
+"[project]/basic/stats_with_server_and_libraries/input/a.ts [library-client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const a = "value-a";
+__turbopack_context__.s([
+    "a",
+    0,
+    a
+]);
+}),
+],
+["a.js", {"otherChunks":[],"runtimeModuleIds":["[project]/basic/stats_with_server_and_libraries/input/a.ts [library-client] (ecmascript)"]}],
+]);
+
+
+//# sourceMappingURL=a.js.map

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/a.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/a.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 8, "column": 0}, "map": {"version":3,"sources":["./../basic/stats_with_server_and_libraries/input/a.ts"],"sourcesContent":["export const a = \"value-a\";\n"],"names":["a"],"mappings":"AAAO,MAAMA,IAAI"}}]
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/app.js
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/app.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_0d05fffe.js"],"runtimeModuleIds":["[project]/basic/stats_with_server_and_libraries/input/app.ts [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/app.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/app.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/b.js
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/b.js
@@ -1,0 +1,21 @@
+((__UTOOPACK__) => {
+// Dummy runtime
+})([
+["b.js",
+
+"[project]/basic/stats_with_server_and_libraries/input/b.ts [library-client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const b = "value-b";
+__turbopack_context__.s([
+    "b",
+    0,
+    b
+]);
+}),
+],
+["b.js", {"otherChunks":[],"runtimeModuleIds":["[project]/basic/stats_with_server_and_libraries/input/b.ts [library-client] (ecmascript)"]}],
+]);
+
+
+//# sourceMappingURL=b.js.map

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/b.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/b.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 8, "column": 0}, "map": {"version":3,"sources":["./../basic/stats_with_server_and_libraries/input/b.ts"],"sourcesContent":["export const b = \"value-b\";\n"],"names":["b"],"mappings":"AAAO,MAAMA,IAAI"}}]
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/input_0d05fffe.js
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/input_0d05fffe.js
@@ -1,0 +1,34 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/basic/stats_with_server_and_libraries/input/a.ts [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const a = "value-a";
+__turbopack_context__.s([
+    "a",
+    0,
+    a
+]);
+}),
+"[project]/basic/stats_with_server_and_libraries/input/b.ts [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const b = "value-b";
+__turbopack_context__.s([
+    "b",
+    0,
+    b
+]);
+}),
+"[project]/basic/stats_with_server_and_libraries/input/app.ts [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$stats_with_server_and_libraries$2f$input$2f$a$2e$ts__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/basic/stats_with_server_and_libraries/input/a.ts [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$stats_with_server_and_libraries$2f$input$2f$b$2e$ts__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/basic/stats_with_server_and_libraries/input/b.ts [client] (ecmascript)");
+;
+;
+console.log("app entry", __TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$stats_with_server_and_libraries$2f$input$2f$a$2e$ts__$5b$client$5d$__$28$ecmascript$29$__["a"], __TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$stats_with_server_and_libraries$2f$input$2f$b$2e$ts__$5b$client$5d$__$28$ecmascript$29$__["b"]);
+__turbopack_context__.s([]);
+}),
+]);
+
+//# sourceMappingURL=input_0d05fffe.js.map

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/input_0d05fffe.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/input_0d05fffe.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/stats_with_server_and_libraries/input/a.ts"],"sourcesContent":["export const a = \"value-a\";\n"],"names":["a"],"mappings":"AAAO,MAAMA,IAAI"}},
+    {"offset": {"line": 14, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/stats_with_server_and_libraries/input/b.ts"],"sourcesContent":["export const b = \"value-b\";\n"],"names":["b"],"mappings":"AAAO,MAAMA,IAAI"}},
+    {"offset": {"line": 24, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/stats_with_server_and_libraries/input/app.ts"],"sourcesContent":["import { a } from \"./a\";\nimport { b } from \"./b\";\n\nconsole.log(\"app entry\", a, b);\n"],"names":["console","log"],"mappings":"AAAA;AACA;;;AAEAA,QAAQC,GAAG,CAAC,aAAa,uJAAC,EAAE,uJAAC"}}]
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/stats.json
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/stats.json
@@ -1,0 +1,232 @@
+{
+  "entrypoints": {
+    "./a": {
+      "name": "./a",
+      "chunks": [
+        "./a.js"
+      ],
+      "assets": [
+        {
+          "name": "./a.js"
+        }
+      ]
+    },
+    "./b": {
+      "name": "./b",
+      "chunks": [
+        "./b.js"
+      ],
+      "assets": [
+        {
+          "name": "./b.js"
+        }
+      ]
+    },
+    "app": {
+      "name": "app",
+      "chunks": [
+        "app.js",
+        "input_0d05fffe.js"
+      ],
+      "assets": [
+        {
+          "name": "app.js"
+        },
+        {
+          "name": "input_0d05fffe.js"
+        }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "./a.js",
+      "size": 447,
+      "hash": "",
+      "files": [
+        "./a.js"
+      ]
+    },
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "./b.js",
+      "size": 447,
+      "hash": "",
+      "files": [
+        "./b.js"
+      ]
+    },
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "app.js",
+      "size": 307,
+      "hash": "",
+      "files": [
+        "app.js"
+      ]
+    },
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "input_0d05fffe.js",
+      "size": 1616,
+      "hash": "",
+      "files": [
+        "input_0d05fffe.js"
+      ]
+    }
+  ],
+  "assets": [
+    {
+      "type": "asset",
+      "name": "a.js",
+      "info": {},
+      "size": 447,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "a.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "a.js.map",
+      "info": {},
+      "size": 280,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "a.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "app.js",
+      "info": {},
+      "size": 307,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "app.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "app.js.map",
+      "info": {},
+      "size": 53,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "app.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "b.js",
+      "info": {},
+      "size": 447,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "b.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "b.js.map",
+      "info": {},
+      "size": 280,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "b.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "input_0d05fffe.js",
+      "info": {},
+      "size": 1616,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "input_0d05fffe.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "input_0d05fffe.js.map",
+      "info": {},
+      "size": 908,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "input_0d05fffe.js.map"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "name": "basic/stats_with_server_and_libraries/input/a.ts",
+      "id": "basic/stats_with_server_and_libraries/input/a.ts",
+      "chunks": [
+        "input_0d05fffe.js"
+      ],
+      "size": 28
+    },
+    {
+      "name": "basic/stats_with_server_and_libraries/input/a.ts",
+      "id": "basic/stats_with_server_and_libraries/input/a.ts",
+      "chunks": [
+        "./a.js"
+      ],
+      "size": 28
+    },
+    {
+      "name": "basic/stats_with_server_and_libraries/input/app.ts",
+      "id": "basic/stats_with_server_and_libraries/input/app.ts",
+      "chunks": [
+        "input_0d05fffe.js",
+        "app.js"
+      ],
+      "size": 83
+    },
+    {
+      "name": "basic/stats_with_server_and_libraries/input/b.ts",
+      "id": "basic/stats_with_server_and_libraries/input/b.ts",
+      "chunks": [
+        "input_0d05fffe.js"
+      ],
+      "size": 28
+    },
+    {
+      "name": "basic/stats_with_server_and_libraries/input/b.ts",
+      "id": "basic/stats_with_server_and_libraries/input/b.ts",
+      "chunks": [
+        "./b.js"
+      ],
+      "size": 28
+    }
+  ]
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/server/index.js
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/server/index.js
@@ -1,0 +1,15 @@
+((__UTOOPACK__) => {
+// Dummy runtime
+})([
+["index.js",
+
+"[project]/basic/stats_with_server_and_libraries/input/server.ts [server] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+console.log("server entry");
+}),
+],
+["index.js", {"otherChunks":[],"runtimeModuleIds":["[project]/basic/stats_with_server_and_libraries/input/server.ts [server] (ecmascript)"]}],
+]);
+
+
+//# sourceMappingURL=index.js.map

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/server/index.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/server/index.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 7, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/stats_with_server_and_libraries/input/server.ts"],"sourcesContent":["console.log(\"server entry\");\n"],"names":["console","log"],"mappings":"AAAAA,QAAQC,GAAG,CAAC"}}]
+}

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/server/stats.json
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/server/stats.json
@@ -1,0 +1,65 @@
+{
+  "entrypoints": {
+    "./index": {
+      "name": "./index",
+      "chunks": [
+        "./index.js"
+      ],
+      "assets": [
+        {
+          "name": "./index.js"
+        }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "./index.js",
+      "size": 412,
+      "hash": "",
+      "files": [
+        "./index.js"
+      ]
+    }
+  ],
+  "assets": [
+    {
+      "type": "asset",
+      "name": "index.js",
+      "info": {},
+      "size": 412,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "index.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "index.js.map",
+      "info": {},
+      "size": 322,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "index.js.map"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "name": "basic/stats_with_server_and_libraries/input/server.ts",
+      "id": "basic/stats_with_server_and_libraries/input/server.ts",
+      "chunks": [
+        "./index.js"
+      ],
+      "size": 29
+    }
+  ]
+}

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -9,11 +9,6 @@ export declare class ExternalObject<T> {
     [K: symbol]: T
   }
 }
-export type Lockfile = { __napiType: "Lockfile" }
-export declare function lockfileTryAcquireSync(path: string, content?: string | undefined | null): Lockfile | null
-export declare function lockfileTryAcquire(path: string, content?: string | undefined | null): Promise<Lockfile | null>
-export declare function lockfileUnlockSync(lockfile: Lockfile): void
-export declare function lockfileUnlock(lockfile: Lockfile): Promise<void>
 export declare function registerWorkerScheduler(creator: (arg: NapiWorkerCreation) => any, terminator: (arg: NapiWorkerTermination) => any): void
 export declare function workerCreated(workerId: number): void
 export interface NapiWorkerCreation {
@@ -33,6 +28,10 @@ export interface NapiTaskMessage {
 }
 export declare function recvTaskMessageInWorker(workerId: number): Promise<NapiTaskMessage>
 export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
+export declare function lockfileTryAcquireSync(path: string, content?: string | undefined | null): { __napiType: "Lockfile" } | null
+export declare function lockfileTryAcquire(path: string, content?: string | undefined | null): Promise<{ __napiType: "Lockfile" } | null>
+export declare function lockfileUnlockSync(lockfile: { __napiType: "Lockfile" }): void
+export declare function lockfileUnlock(lockfile: { __napiType: "Lockfile" }): Promise<void>
 export interface NapiEndpointConfig {
   
 }

--- a/packages/pack/src/binding.js
+++ b/packages/pack/src/binding.js
@@ -310,16 +310,16 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { lockfileTryAcquireSync, lockfileTryAcquire, lockfileUnlockSync, lockfileUnlock, registerWorkerScheduler, workerCreated, recvTaskMessageInWorker, sendTaskMessage, endpointWriteToDisk, endpointServerChangedSubscribe, endpointClientChangedSubscribe, projectNew, projectUpdate, projectOnExit, projectShutdown, projectWriteAllEntrypointsToDisk, projectEntrypointsSubscribe, projectHmrEvents, projectHmrIdentifiersSubscribe, projectUpdateInfoSubscribe, projectTraceSource, projectGetSourceForAsset, projectGetSourceMap, projectGetSourceMapSync, rootTaskDispose, initCustomTraceSubscriber, teardownTraceSubscriber } = nativeBinding
+const { registerWorkerScheduler, workerCreated, recvTaskMessageInWorker, sendTaskMessage, lockfileTryAcquireSync, lockfileTryAcquire, lockfileUnlockSync, lockfileUnlock, endpointWriteToDisk, endpointServerChangedSubscribe, endpointClientChangedSubscribe, projectNew, projectUpdate, projectOnExit, projectShutdown, projectWriteAllEntrypointsToDisk, projectEntrypointsSubscribe, projectHmrEvents, projectHmrIdentifiersSubscribe, projectUpdateInfoSubscribe, projectTraceSource, projectGetSourceForAsset, projectGetSourceMap, projectGetSourceMapSync, rootTaskDispose, initCustomTraceSubscriber, teardownTraceSubscriber } = nativeBinding
 
-module.exports.lockfileTryAcquireSync = lockfileTryAcquireSync
-module.exports.lockfileTryAcquire = lockfileTryAcquire
-module.exports.lockfileUnlockSync = lockfileUnlockSync
-module.exports.lockfileUnlock = lockfileUnlock
 module.exports.registerWorkerScheduler = registerWorkerScheduler
 module.exports.workerCreated = workerCreated
 module.exports.recvTaskMessageInWorker = recvTaskMessageInWorker
 module.exports.sendTaskMessage = sendTaskMessage
+module.exports.lockfileTryAcquireSync = lockfileTryAcquireSync
+module.exports.lockfileTryAcquire = lockfileTryAcquire
+module.exports.lockfileUnlockSync = lockfileUnlockSync
+module.exports.lockfileUnlock = lockfileUnlock
 module.exports.endpointWriteToDisk = endpointWriteToDisk
 module.exports.endpointServerChangedSubscribe = endpointServerChangedSubscribe
 module.exports.endpointClientChangedSubscribe = endpointClientChangedSubscribe


### PR DESCRIPTION
## Summary

- Move `stats.json` generation from per-endpoint output functions (`library.rs`, `app.rs`) into `all_output_assets_operation` in `entrypoint.rs`, where the full merged asset set is available
- Partition assets by client vs server root and generate separate `dist_root/stats.json` and `server_dist_root/stats.json` when the roots differ; extract a `make_stats_output` helper to reduce duplication
- Add snapshot test covering app entry + multiple library entries + server output with `stats: true`

## Root Cause

When multiple `LibraryEndpoint`s each generated a `VirtualOutputAsset` at `dist_root/stats.json` with different content, all were collected by `all_output_assets_operation` and passed to `emit_all_output_assets`. TurboTasks detected two effects writing to the same path with different content and raised _"Conflicting effects for the same key"_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)