### PR TITLE
perf(pm): main-loop BFS resolver with rayon-offloaded simd_json parse

### DIFF
--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -540,7 +540,7 @@ jobs:
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
-          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '2' }}
           PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
         run: |
           chmod +x bench/pm-bench-phases.sh
@@ -560,7 +560,7 @@ jobs:
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
-          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '2' }}
           PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
         run: |
           mkdir -p /tmp/pm-bench-output
@@ -629,7 +629,7 @@ jobs:
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
-          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '2' }}
           PM_LIST: 'utoo,utoo-npm,bun'
         run: |
           chmod +x bench/pm-bench-phases.sh
@@ -645,7 +645,7 @@ jobs:
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
-          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '2' }}
           PM_LIST: 'utoo,utoo-npm,bun'
         run: |
           mkdir -p /tmp/pm-bench-output

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -73,7 +73,7 @@ on:
       bench_runs:
         description: '[phases] Runs per phase'
         required: false
-        default: '3'
+        default: '2'
         type: string
 
 concurrency:

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -53,8 +53,12 @@ workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 # Native (non-macOS) targets: reqwest's default rustls + ring.
+# rustls + rustls-native-certs are direct deps so the multi-pool client
+# can share a TLS session cache across pools (see service/http.rs).
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "macos")))'.dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+reqwest             = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+rustls              = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+rustls-native-certs = "0.8"
 
 # Native-only dependencies (not compiled for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -845,11 +845,9 @@ async fn parse_full_manifest_off_runtime(raw_bytes: Vec<u8>) -> anyhow::Result<A
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn parse_core_manifest_off_runtime(
-    bytes: Vec<u8>,
-) -> anyhow::Result<Arc<CoreVersionManifest>> {
-    crate::service::parse_json_off_runtime::<CoreVersionManifest>(bytes)
-        .await
+fn parse_core_manifest_inline(mut bytes: Vec<u8>) -> anyhow::Result<Arc<CoreVersionManifest>> {
+    simd_json::serde::from_slice::<CoreVersionManifest>(&mut bytes)
+        .map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))
         .map(Arc::new)
 }
 
@@ -1243,7 +1241,7 @@ async fn apply_fetch_result(
         FetchDone::Version { name, spec, result } => {
             let key = (name, spec);
             let parsed: anyhow::Result<Arc<CoreVersionManifest>> = match result {
-                Ok(bytes) => parse_core_manifest_off_runtime(bytes).await,
+                Ok(bytes) => parse_core_manifest_inline(bytes),
                 Err(e) => Err(e),
             };
             match parsed {

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -846,12 +846,49 @@ where
     ResolveError::Registry(RegistryError(anyhow::anyhow!(message.into())).into())
 }
 
+/// Parse a FullManifest on the rayon pool. When `spec` is provided,
+/// also resolve the version and extract the CoreVersionManifest in
+/// the same rayon task — one roundtrip instead of two.
 #[cfg(not(target_arch = "wasm32"))]
-async fn parse_full_manifest_off_runtime(raw_bytes: Vec<u8>) -> anyhow::Result<Arc<FullManifest>> {
-    let parse_buf = raw_bytes.clone();
-    let mut manifest: FullManifest = crate::service::parse_json_off_runtime(parse_buf).await?;
-    manifest.raw = Arc::from(raw_bytes);
-    Ok(Arc::new(manifest))
+type FullParseResult = (
+    Arc<FullManifest>,
+    Option<(String, Arc<CoreVersionManifest>)>,
+);
+
+async fn parse_full_manifest_off_runtime(
+    raw_bytes: Vec<u8>,
+    spec: Option<&str>,
+) -> anyhow::Result<FullParseResult> {
+    use crate::resolver::version::resolve_target_version;
+
+    let spec_owned = spec.map(|s| s.to_string());
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    rayon::spawn(move || {
+        let result = (|| -> anyhow::Result<FullParseResult> {
+            let parse_buf = raw_bytes.clone();
+            let mut manifest: FullManifest =
+                simd_json::serde::from_slice::<FullManifest>(&mut parse_buf.into_boxed_slice())
+                    .map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))?;
+            manifest.raw = Arc::from(raw_bytes);
+            let full = Arc::new(manifest);
+
+            let speculative = if let Some(spec) = &spec_owned {
+                resolve_target_version((&*full).into(), spec)
+                    .ok()
+                    .and_then(|version| {
+                        full.get_core_version(&version)
+                            .map(|core| (spec.clone(), Arc::new(core)))
+                    })
+            } else {
+                None
+            };
+
+            Ok((full, speculative))
+        })();
+        let _ = tx.send(result);
+    });
+    rx.await
+        .map_err(|_| anyhow::anyhow!("rayon parse worker dropped"))?
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1250,39 +1287,24 @@ async fn apply_fetch_result(
 
     match done {
         FetchDone::Full { name, spec, result } => {
-            let parsed: anyhow::Result<Arc<FullManifest>> = match result {
-                Ok((bytes, _etag)) => parse_full_manifest_off_runtime(bytes).await,
+            let parsed = match result {
+                Ok((bytes, _etag)) => parse_full_manifest_off_runtime(bytes, spec.as_deref()).await,
                 Err(e) => Err(e),
             };
             match parsed {
-                Ok(full) => {
-                    // When the fetch carried a spec (from prefetch), resolve
-                    // the version now and cache the CoreVersionManifest so BFS
-                    // can skip the re-parse. This also triggers recursive
-                    // transitive prefetch — the key to deep speculative
-                    // discovery without BFS level gating.
-                    if let Some(spec) = &spec
-                        && let Ok(version) = resolve_target_version((&*full).into(), spec)
-                    {
-                        let (_, core) = crate::model::manifest::extract_core_version_off_runtime(
-                            Arc::clone(&full),
-                            version,
-                        )
-                        .await;
-                        if let Some(core) = core {
-                            let key = (name.clone(), spec.clone());
-                            version_cache.insert(key, Arc::clone(&core));
-                            schedule_transitive_prefetches(
-                                &core,
-                                preload_config,
-                                supports_semver,
-                                full_cache,
-                                version_cache,
-                                full_failures,
-                                version_failures,
-                                fetch_queues,
-                            );
-                        }
+                Ok((full, speculative)) => {
+                    if let Some((resolved_spec, core)) = speculative {
+                        version_cache.insert((name.clone(), resolved_spec), Arc::clone(&core));
+                        schedule_transitive_prefetches(
+                            &core,
+                            preload_config,
+                            supports_semver,
+                            full_cache,
+                            version_cache,
+                            full_failures,
+                            version_failures,
+                            fetch_queues,
+                        );
                     }
                     full_cache.insert(name.clone(), full);
                 }

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -1550,6 +1550,38 @@ where
                 &mut level_pending,
             )
             .await;
+
+            // At high concurrency many JoinHandles complete at once. Drain all
+            // already-ready results in one pass so we avoid redundant
+            // pump_fetches + level_pending iterations for each one.
+            loop {
+                let next = std::future::poll_fn(|cx| {
+                    use std::task::Poll;
+                    match fetches.poll_next_unpin(cx) {
+                        Poll::Ready(item) => Poll::Ready(item),
+                        Poll::Pending => Poll::Ready(None),
+                    }
+                })
+                .await;
+                let Some(result) = next else { break };
+                let done = result.map_err(|e| {
+                    registry_error::<R::Error>(format!("manifest fetch task failed: {e}"))
+                })?;
+                apply_fetch_result(
+                    done,
+                    &mut full_cache,
+                    &mut version_cache,
+                    &mut full_waiters,
+                    &mut version_waiters,
+                    &mut full_failures,
+                    &mut version_failures,
+                    &mut fetch_queues,
+                    &preload_config,
+                    supports_semver,
+                    &mut level_pending,
+                )
+                .await;
+            }
         }
 
         receiver.on_event(BuildEvent::LevelComplete {

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -788,15 +788,24 @@ enum FetchKey {
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 enum FetchRequest {
-    Full { name: String },
-    Version { name: String, spec: String },
+    Full {
+        name: String,
+        /// Semver spec from the dependency edge, carried so prefetch can
+        /// speculatively resolve the version when the manifest arrives and
+        /// trigger deep transitive prefetch without waiting for BFS.
+        spec: Option<String>,
+    },
+    Version {
+        name: String,
+        spec: String,
+    },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl FetchRequest {
     fn key(&self) -> FetchKey {
         match self {
-            Self::Full { name } => FetchKey::Full(name.clone()),
+            Self::Full { name, .. } => FetchKey::Full(name.clone()),
             Self::Version { name, spec } => FetchKey::Version(name.clone(), spec.clone()),
         }
     }
@@ -806,6 +815,7 @@ impl FetchRequest {
 enum FetchDone {
     Full {
         name: String,
+        spec: Option<String>,
         result: anyhow::Result<(Vec<u8>, Option<String>)>,
     },
     Version {
@@ -954,7 +964,7 @@ fn fetch_registry_manifest(registry_url: String, request: FetchRequest) -> Fetch
 
     tokio::spawn(async move {
         match request {
-            FetchRequest::Full { name } => {
+            FetchRequest::Full { name, spec } => {
                 let result = fetch_full_manifest_bytes(FetchManifestOptions {
                     registry_url: &registry_url,
                     name: &name,
@@ -968,7 +978,7 @@ fn fetch_registry_manifest(registry_url: String, request: FetchRequest) -> Fetch
                         Err(anyhow::anyhow!("304 Not Modified without etag context"))
                     }
                 });
-                FetchDone::Full { name, result }
+                FetchDone::Full { name, spec, result }
             }
             FetchRequest::Version { name, spec } => {
                 let result = fetch_version_manifest_bytes(FetchVersionManifestOptions {
@@ -1027,7 +1037,13 @@ fn schedule_registry_fetch(
             priority,
         );
     } else if !full_cache.contains_key(&real_name) && !full_failures.contains_key(&real_name) {
-        fetch_queues.enqueue(FetchRequest::Full { name: real_name }, priority);
+        fetch_queues.enqueue(
+            FetchRequest::Full {
+                name: real_name,
+                spec: Some(real_spec),
+            },
+            priority,
+        );
     }
 }
 
@@ -1233,13 +1249,35 @@ async fn apply_fetch_result(
     fetch_queues.complete(&done_key);
 
     match done {
-        FetchDone::Full { name, result } => {
+        FetchDone::Full { name, spec, result } => {
             let parsed: anyhow::Result<Arc<FullManifest>> = match result {
                 Ok((bytes, _etag)) => parse_full_manifest_off_runtime(bytes).await,
                 Err(e) => Err(e),
             };
             match parsed {
                 Ok(full) => {
+                    // When the fetch carried a spec (from prefetch), resolve
+                    // the version now and cache the CoreVersionManifest so BFS
+                    // can skip the re-parse. This also triggers recursive
+                    // transitive prefetch — the key to deep speculative
+                    // discovery without BFS level gating.
+                    if let Some(spec) = &spec
+                        && let Ok(version) = resolve_target_version((&*full).into(), spec)
+                        && let Some(core) = full.get_core_version(&version).map(Arc::new)
+                    {
+                        let key = (name.clone(), spec.clone());
+                        version_cache.insert(key, Arc::clone(&core));
+                        schedule_transitive_prefetches(
+                            &core,
+                            preload_config,
+                            supports_semver,
+                            full_cache,
+                            version_cache,
+                            full_failures,
+                            version_failures,
+                            fetch_queues,
+                        );
+                    }
                     full_cache.insert(name.clone(), full);
                 }
                 Err(e) => {
@@ -1452,6 +1490,52 @@ where
                             &edge,
                             registry_error(format!("{}: {error}", real_name)),
                         ));
+                    }
+
+                    // Check version_cache first — deep prefetch may have
+                    // already resolved the version from the FullManifest,
+                    // avoiding a redundant get_core_version re-parse.
+                    let vkey = (real_name.clone(), real_spec.clone());
+                    if let Some(manifest) = version_cache.get(&vkey).cloned() {
+                        let resolved = ResolvedPackage {
+                            name: edge.name.clone(),
+                            version: manifest.version.clone(),
+                            manifest,
+                        };
+                        let processed = if graph
+                            .check_override(parent, &edge.name, Some(&resolved.version))
+                            .is_some()
+                        {
+                            process_dependency(graph, registry, parent, &edge, config)
+                                .await
+                                .map_err(|inner| chain_err(graph, parent, &edge, inner))?
+                        } else {
+                            receiver.on_event(BuildEvent::PackageResolved(
+                                (&*resolved.manifest).into(),
+                            ));
+                            schedule_transitive_prefetches(
+                                &resolved.manifest,
+                                &preload_config,
+                                supports_semver,
+                                &full_cache,
+                                &version_cache,
+                                &full_failures,
+                                &version_failures,
+                                &mut fetch_queues,
+                            );
+                            process_dependency_with_resolved(
+                                graph, parent, &edge, &resolved, config,
+                            )
+                        };
+                        handle_processed(
+                            graph,
+                            receiver,
+                            parent,
+                            &edge,
+                            &processed,
+                            &mut next_level,
+                        );
+                        continue;
                     }
 
                     if let Some(full) = full_cache.get(&real_name).cloned() {

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -1263,20 +1263,26 @@ async fn apply_fetch_result(
                     // discovery without BFS level gating.
                     if let Some(spec) = &spec
                         && let Ok(version) = resolve_target_version((&*full).into(), spec)
-                        && let Some(core) = full.get_core_version(&version).map(Arc::new)
                     {
-                        let key = (name.clone(), spec.clone());
-                        version_cache.insert(key, Arc::clone(&core));
-                        schedule_transitive_prefetches(
-                            &core,
-                            preload_config,
-                            supports_semver,
-                            full_cache,
-                            version_cache,
-                            full_failures,
-                            version_failures,
-                            fetch_queues,
-                        );
+                        let (_, core) = crate::model::manifest::extract_core_version_off_runtime(
+                            Arc::clone(&full),
+                            version,
+                        )
+                        .await;
+                        if let Some(core) = core {
+                            let key = (name.clone(), spec.clone());
+                            version_cache.insert(key, Arc::clone(&core));
+                            schedule_transitive_prefetches(
+                                &core,
+                                preload_config,
+                                supports_semver,
+                                full_cache,
+                                version_cache,
+                                full_failures,
+                                version_failures,
+                                fetch_queues,
+                            );
+                        }
                     }
                     full_cache.insert(name.clone(), full);
                 }

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -732,11 +732,46 @@ pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
         config.skip_preload
     );
 
-    // Phase 1: Preload manifests in parallel (unless skipped)
-    run_preload_phase(graph, registry, &config, receiver).await;
+    // On native targets, run preload and BFS concurrently via futures::join!.
+    //
+    // Both futures share `registry`'s inflight_full/inflight_version OnceMaps:
+    // the first caller per package triggers a fetch; subsequent callers await
+    // the Notify and share the result. No duplicate requests, no channel
+    // serialization. When preload is still fetching, BFS edges hit the OnceMap
+    // Waiting state and resume as soon as the fetch completes.
+    //
+    // On wasm32 (single-threaded, no `join!` benefit), keep sequential order.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if !config.skip_preload {
+            let initial_deps = gather_preload_deps(graph, config.peer_deps);
+            if !initial_deps.is_empty() {
+                let preload_cfg = PreloadConfig {
+                    peer_deps: config.peer_deps,
+                    concurrency: config.concurrency,
+                };
+                let (preload_stats, bfs_result) = futures::join!(
+                    preload_manifests(initial_deps, registry, preload_cfg, receiver, |_, _| {}),
+                    run_bfs_phase(graph, registry, &config, receiver)
+                );
+                receiver.on_event(BuildEvent::PreloadComplete {
+                    success: preload_stats.success_count,
+                    failed: preload_stats.failed_count,
+                });
+                bfs_result?;
+            } else {
+                run_bfs_phase(graph, registry, &config, receiver).await?;
+            }
+        } else {
+            run_bfs_phase(graph, registry, &config, receiver).await?;
+        }
+    }
 
-    // Phase 2: BFS traversal to build the dependency tree
-    run_bfs_phase(graph, registry, &config, receiver).await?;
+    #[cfg(target_arch = "wasm32")]
+    {
+        run_preload_phase(graph, registry, &config, receiver).await;
+        run_bfs_phase(graph, registry, &config, receiver).await?;
+    }
 
     receiver.on_event(BuildEvent::Complete {
         total_nodes: graph.graph.node_count(),
@@ -745,7 +780,8 @@ pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
     Ok(())
 }
 
-/// Run the preload phase to warm up the cache with manifests.
+/// Run the preload phase to warm up the cache with manifests (wasm32 only).
+#[cfg(target_arch = "wasm32")]
 async fn run_preload_phase<R: RegistryClient, E: EventReceiver>(
     graph: &DependencyGraph,
     registry: &R,

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -23,17 +23,30 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
+use futures::stream::{FuturesUnordered, StreamExt};
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::{HashSet, VecDeque};
+
 #[cfg(feature = "http-tarball")]
 use anyhow::Context as _;
 
 use crate::model::graph::{DependencyGraph, FindResult, PackageNode};
 use crate::model::manifest::NodeManifest;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::model::manifest::{CoreVersionManifest, FullManifest};
 use crate::model::node::EdgeType;
 use crate::model::package_json::PackageJson;
-use crate::resolver::preload::{PreloadConfig, preload_manifests};
+use crate::resolver::preload::{PreloadConfig, extract_transitive_deps, preload_manifests};
 use crate::resolver::registry::{ResolveError, resolve_registry_dep};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::resolver::semver::normalize_spec;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::resolver::version::resolve_target_version;
 use crate::spec::{Catalogs, PackageSpec, Protocol};
 use crate::traits::progress::{BuildEvent, EventReceiver, NoopReceiver};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::traits::registry::RegistryError;
 use crate::traits::registry::{RegistryClient, ResolvedPackage};
 
 /// Dispatch a git/github spec to the real `gix`-backed resolver when the
@@ -732,39 +745,14 @@ pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
         config.skip_preload
     );
 
-    // On native targets, run preload and BFS concurrently via futures::join!.
-    //
-    // Both futures share `registry`'s inflight_full/inflight_version OnceMaps:
-    // the first caller per package triggers a fetch; subsequent callers await
-    // the Notify and share the result. No duplicate requests, no channel
-    // serialization. When preload is still fetching, BFS edges hit the OnceMap
-    // Waiting state and resume as soon as the fetch completes.
-    //
-    // On wasm32 (single-threaded, no `join!` benefit), keep sequential order.
     #[cfg(not(target_arch = "wasm32"))]
-    {
-        if !config.skip_preload {
-            let initial_deps = gather_preload_deps(graph, config.peer_deps);
-            if !initial_deps.is_empty() {
-                let preload_cfg = PreloadConfig {
-                    peer_deps: config.peer_deps,
-                    concurrency: config.concurrency,
-                };
-                let (preload_stats, bfs_result) = futures::join!(
-                    preload_manifests(initial_deps, registry, preload_cfg, receiver, |_, _| {}),
-                    run_bfs_phase(graph, registry, &config, receiver)
-                );
-                receiver.on_event(BuildEvent::PreloadComplete {
-                    success: preload_stats.success_count,
-                    failed: preload_stats.failed_count,
-                });
-                bfs_result?;
-            } else {
-                run_bfs_phase(graph, registry, &config, receiver).await?;
-            }
-        } else {
-            run_bfs_phase(graph, registry, &config, receiver).await?;
-        }
+    if !config.skip_preload && !registry.registry_url().is_empty() {
+        run_main_loop_bfs(graph, registry, &config, receiver).await?;
+    } else {
+        // Keep the existing path for warm project-cache runs and generic
+        // RegistryClient implementations that do not expose a raw registry URL.
+        run_preload_phase(graph, registry, &config, receiver).await;
+        run_bfs_phase(graph, registry, &config, receiver).await?;
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -780,8 +768,679 @@ pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
     Ok(())
 }
 
-/// Run the preload phase to warm up the cache with manifests (wasm32 only).
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(target_arch = "wasm32"))]
+type WaitingEdge = (NodeIndex, DependencyEdgeInfo);
+
+#[cfg(not(target_arch = "wasm32"))]
+enum FetchRequest {
+    Full { name: String },
+    Version { name: String, spec: String },
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+enum FetchDone {
+    Full {
+        name: String,
+        result: anyhow::Result<(Vec<u8>, Option<String>)>,
+    },
+    Version {
+        name: String,
+        spec: String,
+        result: anyhow::Result<Vec<u8>>,
+    },
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+type FetchFuture = tokio::task::JoinHandle<FetchDone>;
+
+#[cfg(not(target_arch = "wasm32"))]
+fn registry_error<E>(message: impl Into<String>) -> ResolveError<E>
+where
+    E: From<RegistryError>,
+{
+    ResolveError::Registry(RegistryError(anyhow::anyhow!(message.into())).into())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn parse_full_manifest_inline(raw_bytes: Vec<u8>) -> anyhow::Result<Arc<FullManifest>> {
+    let mut parse_buf = raw_bytes.clone();
+    let mut manifest: FullManifest = simd_json::serde::from_slice(&mut parse_buf)
+        .map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))?;
+    manifest.raw = Arc::from(raw_bytes);
+    Ok(Arc::new(manifest))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn parse_core_manifest_inline(mut bytes: Vec<u8>) -> anyhow::Result<Arc<CoreVersionManifest>> {
+    simd_json::serde::from_slice::<CoreVersionManifest>(&mut bytes)
+        .map(Arc::new)
+        .map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn fetch_registry_manifest(registry_url: String, request: FetchRequest) -> FetchFuture {
+    use crate::service::{
+        FetchManifestBytesResult, FetchManifestOptions, FetchVersionManifestOptions,
+        MetadataFormat, fetch_full_manifest_bytes, fetch_version_manifest_bytes,
+    };
+
+    tokio::spawn(async move {
+        match request {
+            FetchRequest::Full { name } => {
+                let result = fetch_full_manifest_bytes(FetchManifestOptions {
+                    registry_url: &registry_url,
+                    name: &name,
+                    format: MetadataFormat::Abbreviated,
+                    etag: None,
+                })
+                .await
+                .and_then(|result| match result {
+                    FetchManifestBytesResult::Ok(bytes, etag) => Ok((bytes, etag)),
+                    FetchManifestBytesResult::NotModified => {
+                        Err(anyhow::anyhow!("304 Not Modified without etag context"))
+                    }
+                });
+                FetchDone::Full { name, result }
+            }
+            FetchRequest::Version { name, spec } => {
+                let result = fetch_version_manifest_bytes(FetchVersionManifestOptions {
+                    registry_url: &registry_url,
+                    name: &name,
+                    spec: &spec,
+                    format: MetadataFormat::Abbreviated,
+                })
+                .await;
+                FetchDone::Version { name, spec, result }
+            }
+        }
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn pump_fetches(
+    fetches: &mut FuturesUnordered<FetchFuture>,
+    queue: &mut VecDeque<FetchRequest>,
+    registry_url: &str,
+    concurrency: usize,
+) {
+    while fetches.len() < concurrency {
+        let Some(request) = queue.pop_front() else {
+            break;
+        };
+        fetches.push(fetch_registry_manifest(registry_url.to_string(), request));
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+fn schedule_registry_fetch(
+    name: String,
+    spec: String,
+    supports_semver: bool,
+    full_cache: &HashMap<String, Arc<FullManifest>>,
+    version_cache: &HashMap<(String, String), Arc<CoreVersionManifest>>,
+    full_failures: &HashMap<String, String>,
+    version_failures: &HashMap<(String, String), String>,
+    inflight_full: &mut HashSet<String>,
+    inflight_version: &mut HashSet<(String, String)>,
+    fetch_queue: &mut VecDeque<FetchRequest>,
+) {
+    let (real_name, real_spec) = normalize_spec(&name, &spec);
+    if supports_semver {
+        let key = (real_name, real_spec);
+        if version_cache.contains_key(&key)
+            || version_failures.contains_key(&key)
+            || !inflight_version.insert(key.clone())
+        {
+            return;
+        }
+        fetch_queue.push_back(FetchRequest::Version {
+            name: key.0,
+            spec: key.1,
+        });
+    } else if !full_cache.contains_key(&real_name)
+        && !full_failures.contains_key(&real_name)
+        && inflight_full.insert(real_name.clone())
+    {
+        fetch_queue.push_back(FetchRequest::Full { name: real_name });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+fn schedule_transitive_prefetches(
+    manifest: &CoreVersionManifest,
+    preload_config: &PreloadConfig,
+    supports_semver: bool,
+    full_cache: &HashMap<String, Arc<FullManifest>>,
+    version_cache: &HashMap<(String, String), Arc<CoreVersionManifest>>,
+    full_failures: &HashMap<String, String>,
+    version_failures: &HashMap<(String, String), String>,
+    inflight_full: &mut HashSet<String>,
+    inflight_version: &mut HashSet<(String, String)>,
+    fetch_queue: &mut VecDeque<FetchRequest>,
+) {
+    for (name, spec) in extract_transitive_deps(manifest, preload_config) {
+        schedule_registry_fetch(
+            name,
+            spec,
+            supports_semver,
+            full_cache,
+            version_cache,
+            full_failures,
+            version_failures,
+            inflight_full,
+            inflight_version,
+            fetch_queue,
+        );
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn try_reuse_dependency(
+    graph: &mut DependencyGraph,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+) -> Option<ProcessResult> {
+    match graph.find_compatible_node(parent, &edge.name, &edge.spec) {
+        FindResult::Reuse(existing_index) => {
+            graph.mark_dependency_resolved(edge.edge_id, existing_index);
+            update_node_type_from_edge(graph, parent, existing_index, &edge.edge_type);
+            Some(ProcessResult::Reused(existing_index))
+        }
+        FindResult::Conflict(_) | FindResult::New(_) => None,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn process_dependency_with_resolved(
+    graph: &mut DependencyGraph,
+    node_index: NodeIndex,
+    edge_info: &DependencyEdgeInfo,
+    resolved: &ResolvedPackage,
+    config: &BuildDepsConfig,
+) -> ProcessResult {
+    match graph.find_compatible_node(node_index, &edge_info.name, &edge_info.spec) {
+        FindResult::Reuse(existing_index) => {
+            graph.mark_dependency_resolved(edge_info.edge_id, existing_index);
+            update_node_type_from_edge(graph, node_index, existing_index, &edge_info.edge_type);
+            ProcessResult::Reused(existing_index)
+        }
+        FindResult::Conflict(conflict_parent) | FindResult::New(conflict_parent) => {
+            let new_node = create_package_node(&edge_info.name, resolved, conflict_parent, graph);
+            let new_index = graph.add_node(new_node);
+            graph.add_physical_edge(conflict_parent, new_index);
+            graph.mark_dependency_resolved(edge_info.edge_id, new_index);
+            update_node_type_from_edge(graph, node_index, new_index, &edge_info.edge_type);
+            add_edges_from(
+                graph,
+                new_index,
+                &*resolved.manifest,
+                &EdgeContext::new(config.peer_deps, DevDeps::Exclude),
+            );
+            ProcessResult::Created(new_index)
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn chain_err<E>(
+    graph: &DependencyGraph,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    inner: ResolveError<E>,
+) -> ResolveError<E> {
+    let mut chain = graph.logical_ancestry(parent);
+    chain.push((edge.name.clone(), edge.spec.clone()));
+    ResolveError::WithChain {
+        chain,
+        source: Box::new(inner),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn handle_processed<E: EventReceiver>(
+    graph: &DependencyGraph,
+    receiver: &E,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    processed: &ProcessResult,
+    next_level: &mut Vec<NodeIndex>,
+) {
+    match processed {
+        ProcessResult::Created(idx) => {
+            if let Some(node) = graph.get_node(*idx) {
+                receiver.on_event(BuildEvent::Resolved {
+                    name: &edge.name,
+                    version: &node.version,
+                });
+                if let NodeManifest::Registry(ref manifest) = node.manifest {
+                    let parent_path = graph.get_node(parent).map(|p| p.path.as_path());
+                    receiver.on_event(BuildEvent::PackagePlaced {
+                        package: manifest.as_ref().into(),
+                        path: &node.path,
+                        parent_path,
+                    });
+                }
+            }
+            next_level.push(*idx);
+        }
+        ProcessResult::Reused(idx) => {
+            if let Some(node) = graph.get_node(*idx) {
+                receiver.on_event(BuildEvent::Reused {
+                    name: &edge.name,
+                    version: &node.version,
+                });
+            }
+        }
+        ProcessResult::Skipped => {
+            receiver.on_event(BuildEvent::Skipped {
+                name: &edge.name,
+                spec: &edge.spec,
+            });
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn resolve_from_full_manifest<RE>(
+    edge: &DependencyEdgeInfo,
+    full: &FullManifest,
+    real_spec: &str,
+    core_cache: &mut HashMap<(String, String), Arc<CoreVersionManifest>>,
+) -> Result<Option<ResolvedPackage>, ResolveError<RE>> {
+    if full.versions.is_empty() {
+        if edge.edge_type == EdgeType::Optional {
+            return Ok(None);
+        }
+        return Err(ResolveError::NoVersions(full.name.clone()));
+    }
+
+    let version = match resolve_target_version(full.into(), real_spec) {
+        Ok(version) => version,
+        Err(_) if edge.edge_type == EdgeType::Optional => return Ok(None),
+        Err(e) => {
+            return Err(ResolveError::Version(format!(
+                "{}@{}: {}",
+                edge.name, real_spec, e
+            )));
+        }
+    };
+
+    let cache_key = (full.name.clone(), version.clone());
+    let manifest = match core_cache.get(&cache_key).cloned() {
+        Some(manifest) => manifest,
+        None => {
+            let Some(manifest) = full.get_core_version(&version).map(Arc::new) else {
+                if edge.edge_type == EdgeType::Optional {
+                    return Ok(None);
+                }
+                return Err(ResolveError::ManifestNotFound {
+                    name: edge.name.clone(),
+                    version,
+                });
+            };
+            core_cache.insert(cache_key, Arc::clone(&manifest));
+            manifest
+        }
+    };
+
+    Ok(Some(ResolvedPackage {
+        name: edge.name.clone(),
+        version: manifest.version.clone(),
+        manifest,
+    }))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+fn apply_fetch_result(
+    done: FetchDone,
+    full_cache: &mut HashMap<String, Arc<FullManifest>>,
+    version_cache: &mut HashMap<(String, String), Arc<CoreVersionManifest>>,
+    full_waiters: &mut HashMap<String, Vec<WaitingEdge>>,
+    version_waiters: &mut HashMap<(String, String), Vec<WaitingEdge>>,
+    full_failures: &mut HashMap<String, String>,
+    version_failures: &mut HashMap<(String, String), String>,
+    inflight_full: &mut HashSet<String>,
+    inflight_version: &mut HashSet<(String, String)>,
+    fetch_queue: &mut VecDeque<FetchRequest>,
+    preload_config: &PreloadConfig,
+    supports_semver: bool,
+    level_pending: &mut VecDeque<WaitingEdge>,
+) {
+    match done {
+        FetchDone::Full { name, result } => {
+            inflight_full.remove(&name);
+            match result.and_then(|(bytes, _etag)| parse_full_manifest_inline(bytes)) {
+                Ok(full) => {
+                    full_cache.insert(name.clone(), full);
+                }
+                Err(e) => {
+                    full_failures.insert(name.clone(), format!("{e:#}"));
+                }
+            }
+            if let Some(waiters) = full_waiters.remove(&name) {
+                level_pending.extend(waiters);
+            }
+        }
+        FetchDone::Version { name, spec, result } => {
+            let key = (name, spec);
+            inflight_version.remove(&key);
+            match result.and_then(parse_core_manifest_inline) {
+                Ok(manifest) => {
+                    version_cache.insert(key.clone(), Arc::clone(&manifest));
+                    schedule_transitive_prefetches(
+                        &manifest,
+                        preload_config,
+                        supports_semver,
+                        full_cache,
+                        version_cache,
+                        full_failures,
+                        version_failures,
+                        inflight_full,
+                        inflight_version,
+                        fetch_queue,
+                    );
+                }
+                Err(e) => {
+                    version_failures.insert(key.clone(), format!("{e:#}"));
+                }
+            }
+            if let Some(waiters) = version_waiters.remove(&key) {
+                level_pending.extend(waiters);
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn run_main_loop_bfs<R, E>(
+    graph: &mut DependencyGraph,
+    registry: &R,
+    config: &BuildDepsConfig,
+    receiver: &E,
+) -> Result<(), ResolveError<R::Error>>
+where
+    R: RegistryClient,
+    E: EventReceiver,
+{
+    use crate::spec::SpecStr;
+
+    let registry_url = registry.registry_url().trim_end_matches('/').to_string();
+    let supports_semver = registry.supports_semver_resolution();
+    let concurrency = config.concurrency.max(1);
+    let preload_config = PreloadConfig {
+        peer_deps: config.peer_deps,
+        concurrency,
+    };
+
+    let mut full_cache: HashMap<String, Arc<FullManifest>> = HashMap::new();
+    let mut version_cache: HashMap<(String, String), Arc<CoreVersionManifest>> = HashMap::new();
+    let mut core_cache: HashMap<(String, String), Arc<CoreVersionManifest>> = HashMap::new();
+    let mut full_waiters: HashMap<String, Vec<WaitingEdge>> = HashMap::new();
+    let mut version_waiters: HashMap<(String, String), Vec<WaitingEdge>> = HashMap::new();
+    let mut full_failures: HashMap<String, String> = HashMap::new();
+    let mut version_failures: HashMap<(String, String), String> = HashMap::new();
+    let mut inflight_full: HashSet<String> = HashSet::new();
+    let mut inflight_version: HashSet<(String, String)> = HashSet::new();
+    let mut fetch_queue: VecDeque<FetchRequest> = VecDeque::new();
+    let mut fetches: FuturesUnordered<FetchFuture> = FuturesUnordered::new();
+
+    let root_idx = graph.root_index;
+    let mut current_level = vec![root_idx];
+
+    while !current_level.is_empty() {
+        receiver.on_event(BuildEvent::LevelStart {
+            node_count: current_level.len(),
+        });
+
+        let mut next_level = Vec::new();
+        let mut level_pending = VecDeque::new();
+
+        for node_index in &current_level {
+            for (_, dep) in graph.get_dependency_edges(*node_index) {
+                if dep.valid
+                    && let Some(to) = dep.to
+                    && let Some(n) = graph.get_node(to)
+                    && n.is_workspace()
+                    && *node_index == root_idx
+                {
+                    next_level.push(to);
+                }
+            }
+
+            let unresolved = collect_unresolved_edges(graph, *node_index);
+            receiver.on_event(BuildEvent::DependencyCount {
+                count: unresolved.len(),
+            });
+            for edge in unresolved {
+                level_pending.push_back((*node_index, edge));
+            }
+        }
+
+        loop {
+            pump_fetches(&mut fetches, &mut fetch_queue, &registry_url, concurrency);
+
+            while let Some((parent, edge)) = level_pending.pop_front() {
+                receiver.on_event(BuildEvent::Resolving { name: &edge.name });
+
+                if !edge.spec.is_registry_spec() {
+                    let processed = process_dependency(graph, registry, parent, &edge, config)
+                        .await
+                        .map_err(|inner| chain_err(graph, parent, &edge, inner))?;
+                    handle_processed(graph, receiver, parent, &edge, &processed, &mut next_level);
+                    continue;
+                }
+
+                if let Some(processed) = try_reuse_dependency(graph, parent, &edge) {
+                    handle_processed(graph, receiver, parent, &edge, &processed, &mut next_level);
+                    continue;
+                }
+
+                let (real_name, real_spec) = normalize_spec(&edge.name, &edge.spec);
+                if supports_semver {
+                    let key = (real_name.clone(), real_spec.clone());
+                    if let Some(error) = version_failures.get(&key) {
+                        if edge.edge_type == EdgeType::Optional {
+                            receiver.on_event(BuildEvent::Skipped {
+                                name: &edge.name,
+                                spec: &edge.spec,
+                            });
+                            continue;
+                        }
+                        return Err(chain_err(
+                            graph,
+                            parent,
+                            &edge,
+                            registry_error(format!("{}@{}: {error}", real_name, real_spec)),
+                        ));
+                    }
+
+                    if let Some(manifest) = version_cache.get(&key).cloned() {
+                        let resolved = ResolvedPackage {
+                            name: edge.name.clone(),
+                            version: manifest.version.clone(),
+                            manifest,
+                        };
+                        let processed = if graph
+                            .check_override(parent, &edge.name, Some(&resolved.version))
+                            .is_some()
+                        {
+                            process_dependency(graph, registry, parent, &edge, config)
+                                .await
+                                .map_err(|inner| chain_err(graph, parent, &edge, inner))?
+                        } else {
+                            receiver.on_event(BuildEvent::PackageResolved(
+                                (&*resolved.manifest).into(),
+                            ));
+                            schedule_transitive_prefetches(
+                                &resolved.manifest,
+                                &preload_config,
+                                supports_semver,
+                                &full_cache,
+                                &version_cache,
+                                &full_failures,
+                                &version_failures,
+                                &mut inflight_full,
+                                &mut inflight_version,
+                                &mut fetch_queue,
+                            );
+                            process_dependency_with_resolved(
+                                graph, parent, &edge, &resolved, config,
+                            )
+                        };
+                        handle_processed(
+                            graph,
+                            receiver,
+                            parent,
+                            &edge,
+                            &processed,
+                            &mut next_level,
+                        );
+                        continue;
+                    }
+
+                    let waiters = version_waiters.entry(key.clone()).or_default();
+                    waiters.push((parent, edge));
+                    if inflight_version.insert(key.clone()) {
+                        fetch_queue.push_back(FetchRequest::Version {
+                            name: key.0,
+                            spec: key.1,
+                        });
+                    }
+                } else {
+                    if let Some(error) = full_failures.get(&real_name) {
+                        if edge.edge_type == EdgeType::Optional {
+                            receiver.on_event(BuildEvent::Skipped {
+                                name: &edge.name,
+                                spec: &edge.spec,
+                            });
+                            continue;
+                        }
+                        return Err(chain_err(
+                            graph,
+                            parent,
+                            &edge,
+                            registry_error(format!("{}: {error}", real_name)),
+                        ));
+                    }
+
+                    if let Some(full) = full_cache.get(&real_name).cloned() {
+                        let Some(resolved) = resolve_from_full_manifest::<R::Error>(
+                            &edge,
+                            &full,
+                            &real_spec,
+                            &mut core_cache,
+                        )
+                        .map_err(|inner| chain_err(graph, parent, &edge, inner))?
+                        else {
+                            receiver.on_event(BuildEvent::Skipped {
+                                name: &edge.name,
+                                spec: &edge.spec,
+                            });
+                            continue;
+                        };
+
+                        let processed = if graph
+                            .check_override(parent, &edge.name, Some(&resolved.version))
+                            .is_some()
+                        {
+                            process_dependency(graph, registry, parent, &edge, config)
+                                .await
+                                .map_err(|inner| chain_err(graph, parent, &edge, inner))?
+                        } else {
+                            receiver.on_event(BuildEvent::PackageResolved(
+                                (&*resolved.manifest).into(),
+                            ));
+                            schedule_transitive_prefetches(
+                                &resolved.manifest,
+                                &preload_config,
+                                supports_semver,
+                                &full_cache,
+                                &version_cache,
+                                &full_failures,
+                                &version_failures,
+                                &mut inflight_full,
+                                &mut inflight_version,
+                                &mut fetch_queue,
+                            );
+                            process_dependency_with_resolved(
+                                graph, parent, &edge, &resolved, config,
+                            )
+                        };
+                        handle_processed(
+                            graph,
+                            receiver,
+                            parent,
+                            &edge,
+                            &processed,
+                            &mut next_level,
+                        );
+                        continue;
+                    }
+
+                    let waiters = full_waiters.entry(real_name.clone()).or_default();
+                    waiters.push((parent, edge));
+                    if inflight_full.insert(real_name.clone()) {
+                        fetch_queue.push_back(FetchRequest::Full { name: real_name });
+                    }
+                }
+
+                pump_fetches(&mut fetches, &mut fetch_queue, &registry_url, concurrency);
+            }
+
+            if full_waiters.is_empty() && version_waiters.is_empty() {
+                break;
+            }
+
+            let Some(done) = fetches.next().await else {
+                let mut fallback = Vec::new();
+                for (_, waiters) in full_waiters.drain() {
+                    fallback.extend(waiters);
+                }
+                for (_, waiters) in version_waiters.drain() {
+                    fallback.extend(waiters);
+                }
+                for (parent, edge) in fallback {
+                    let processed = process_dependency(graph, registry, parent, &edge, config)
+                        .await
+                        .map_err(|inner| chain_err(graph, parent, &edge, inner))?;
+                    handle_processed(graph, receiver, parent, &edge, &processed, &mut next_level);
+                }
+                break;
+            };
+            let done = done.map_err(|e| {
+                registry_error::<R::Error>(format!("manifest fetch task failed: {e}"))
+            })?;
+
+            apply_fetch_result(
+                done,
+                &mut full_cache,
+                &mut version_cache,
+                &mut full_waiters,
+                &mut version_waiters,
+                &mut full_failures,
+                &mut version_failures,
+                &mut inflight_full,
+                &mut inflight_version,
+                &mut fetch_queue,
+                &preload_config,
+                supports_semver,
+                &mut level_pending,
+            );
+        }
+
+        receiver.on_event(BuildEvent::LevelComplete {
+            next_level_count: next_level.len(),
+        });
+        current_level = next_level;
+    }
+
+    Ok(())
+}
+
+/// Run the preload phase to warm up the cache with manifests.
 async fn run_preload_phase<R: RegistryClient, E: EventReceiver>(
     graph: &DependencyGraph,
     registry: &R,

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -1362,7 +1362,14 @@ where
 
     let registry_url = registry.registry_url().trim_end_matches('/').to_string();
     let supports_semver = registry.supports_semver_resolution();
-    let concurrency = config.concurrency.max(1);
+    // Non-semver registries (npmjs.org) return large all-versions manifests
+    // that benefit from higher connection fan-out. Auto-raise to 256 unless
+    // the caller explicitly set a lower limit via CLI flag.
+    let concurrency = if !supports_semver {
+        config.concurrency.max(256)
+    } else {
+        config.concurrency.max(1)
+    };
     let preload_config = PreloadConfig {
         peer_deps: config.peer_deps,
         concurrency,

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -899,7 +899,19 @@ impl FetchQueues {
             return Some(request);
         }
 
-        if self.active_prefetches() >= prefetch_concurrency {
+        // Only cap prefetch when the demand queue still has pending items — those
+        // items need slots reserved so they aren't held behind a wall of prefetch.
+        // When the demand queue is empty (all known-needed fetches are already
+        // in-flight), allow prefetch to fill every remaining slot: there is nothing
+        // to reserve capacity for, and more speculative coverage means the BFS is
+        // more likely to find manifests already in cache when it needs them.
+        let cap = if self.demand.is_empty() {
+            usize::MAX
+        } else {
+            prefetch_concurrency
+        };
+
+        if self.active_prefetches() >= cap {
             return None;
         }
 

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -837,19 +837,20 @@ where
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn parse_full_manifest_inline(raw_bytes: Vec<u8>) -> anyhow::Result<Arc<FullManifest>> {
-    let mut parse_buf = raw_bytes.clone();
-    let mut manifest: FullManifest = simd_json::serde::from_slice(&mut parse_buf)
-        .map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))?;
+async fn parse_full_manifest_off_runtime(raw_bytes: Vec<u8>) -> anyhow::Result<Arc<FullManifest>> {
+    let parse_buf = raw_bytes.clone();
+    let mut manifest: FullManifest = crate::service::parse_json_off_runtime(parse_buf).await?;
     manifest.raw = Arc::from(raw_bytes);
     Ok(Arc::new(manifest))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn parse_core_manifest_inline(mut bytes: Vec<u8>) -> anyhow::Result<Arc<CoreVersionManifest>> {
-    simd_json::serde::from_slice::<CoreVersionManifest>(&mut bytes)
+async fn parse_core_manifest_off_runtime(
+    bytes: Vec<u8>,
+) -> anyhow::Result<Arc<CoreVersionManifest>> {
+    crate::service::parse_json_off_runtime::<CoreVersionManifest>(bytes)
+        .await
         .map(Arc::new)
-        .map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1205,7 +1206,7 @@ fn resolve_from_full_manifest<RE>(
 
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::too_many_arguments)]
-fn apply_fetch_result(
+async fn apply_fetch_result(
     done: FetchDone,
     full_cache: &mut HashMap<String, Arc<FullManifest>>,
     version_cache: &mut HashMap<(String, String), Arc<CoreVersionManifest>>,
@@ -1223,7 +1224,11 @@ fn apply_fetch_result(
 
     match done {
         FetchDone::Full { name, result } => {
-            match result.and_then(|(bytes, _etag)| parse_full_manifest_inline(bytes)) {
+            let parsed: anyhow::Result<Arc<FullManifest>> = match result {
+                Ok((bytes, _etag)) => parse_full_manifest_off_runtime(bytes).await,
+                Err(e) => Err(e),
+            };
+            match parsed {
                 Ok(full) => {
                     full_cache.insert(name.clone(), full);
                 }
@@ -1237,7 +1242,11 @@ fn apply_fetch_result(
         }
         FetchDone::Version { name, spec, result } => {
             let key = (name, spec);
-            match result.and_then(parse_core_manifest_inline) {
+            let parsed: anyhow::Result<Arc<CoreVersionManifest>> = match result {
+                Ok(bytes) => parse_core_manifest_off_runtime(bytes).await,
+                Err(e) => Err(e),
+            };
+            match parsed {
                 Ok(manifest) => {
                     version_cache.insert(key.clone(), Arc::clone(&manifest));
                     schedule_transitive_prefetches(
@@ -1541,7 +1550,8 @@ where
                 &preload_config,
                 supports_semver,
                 &mut level_pending,
-            );
+            )
+            .await;
         }
 
         receiver.on_event(BuildEvent::LevelComplete {

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use futures::stream::{FuturesUnordered, StreamExt};
 #[cfg(not(target_arch = "wasm32"))]
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 
 #[cfg(feature = "http-tarball")]
 use anyhow::Context as _;
@@ -772,9 +772,34 @@ pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
 type WaitingEdge = (NodeIndex, DependencyEdgeInfo);
 
 #[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FetchPriority {
+    Demand,
+    Prefetch,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum FetchKey {
+    Full(String),
+    Version(String, String),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone)]
 enum FetchRequest {
     Full { name: String },
     Version { name: String, spec: String },
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl FetchRequest {
+    fn key(&self) -> FetchKey {
+        match self {
+            Self::Full { name } => FetchKey::Full(name.clone()),
+            Self::Version { name, spec } => FetchKey::Version(name.clone(), spec.clone()),
+        }
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -788,6 +813,16 @@ enum FetchDone {
         spec: String,
         result: anyhow::Result<Vec<u8>>,
     },
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl FetchDone {
+    fn key(&self) -> FetchKey {
+        match self {
+            Self::Full { name, .. } => FetchKey::Full(name.clone()),
+            Self::Version { name, spec, .. } => FetchKey::Version(name.clone(), spec.clone()),
+        }
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -815,6 +850,88 @@ fn parse_core_manifest_inline(mut bytes: Vec<u8>) -> anyhow::Result<Arc<CoreVers
     simd_json::serde::from_slice::<CoreVersionManifest>(&mut bytes)
         .map(Arc::new)
         .map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Default)]
+struct FetchQueues {
+    demand: VecDeque<FetchRequest>,
+    prefetch: VecDeque<FetchRequest>,
+    queued: HashMap<FetchKey, FetchPriority>,
+    active: HashMap<FetchKey, FetchPriority>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl FetchQueues {
+    fn enqueue(&mut self, request: FetchRequest, priority: FetchPriority) {
+        let key = request.key();
+        if self.active.contains_key(&key) {
+            return;
+        }
+
+        if let Some(queued_priority) = self.queued.get_mut(&key) {
+            if priority == FetchPriority::Demand && *queued_priority == FetchPriority::Prefetch {
+                *queued_priority = FetchPriority::Demand;
+                self.demand.push_back(request);
+            }
+            return;
+        }
+
+        self.queued.insert(key, priority);
+        match priority {
+            FetchPriority::Demand => self.demand.push_back(request),
+            FetchPriority::Prefetch => self.prefetch.push_back(request),
+        }
+    }
+
+    fn complete(&mut self, key: &FetchKey) {
+        self.active.remove(key);
+    }
+
+    fn active_prefetches(&self) -> usize {
+        self.active
+            .values()
+            .filter(|priority| **priority == FetchPriority::Prefetch)
+            .count()
+    }
+
+    fn pop_next(&mut self, prefetch_concurrency: usize) -> Option<FetchRequest> {
+        if let Some(request) = self.pop_priority(FetchPriority::Demand) {
+            return Some(request);
+        }
+
+        if self.active_prefetches() >= prefetch_concurrency {
+            return None;
+        }
+
+        self.pop_priority(FetchPriority::Prefetch)
+    }
+
+    fn pop_priority(&mut self, priority: FetchPriority) -> Option<FetchRequest> {
+        let queue = match priority {
+            FetchPriority::Demand => &mut self.demand,
+            FetchPriority::Prefetch => &mut self.prefetch,
+        };
+
+        while let Some(request) = queue.pop_front() {
+            let key = request.key();
+            match self.queued.get(&key).copied() {
+                Some(queued_priority) if queued_priority == priority => {
+                    self.queued.remove(&key);
+                    self.active.insert(key, priority);
+                    return Some(request);
+                }
+                Some(_) | None => {}
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn prefetch_concurrency_limit(concurrency: usize) -> usize {
+    (concurrency / 4).max(1)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -859,12 +976,13 @@ fn fetch_registry_manifest(registry_url: String, request: FetchRequest) -> Fetch
 #[cfg(not(target_arch = "wasm32"))]
 fn pump_fetches(
     fetches: &mut FuturesUnordered<FetchFuture>,
-    queue: &mut VecDeque<FetchRequest>,
+    fetch_queues: &mut FetchQueues,
     registry_url: &str,
     concurrency: usize,
 ) {
+    let prefetch_concurrency = prefetch_concurrency_limit(concurrency);
     while fetches.len() < concurrency {
-        let Some(request) = queue.pop_front() else {
+        let Some(request) = fetch_queues.pop_next(prefetch_concurrency) else {
             break;
         };
         fetches.push(fetch_registry_manifest(registry_url.to_string(), request));
@@ -876,33 +994,29 @@ fn pump_fetches(
 fn schedule_registry_fetch(
     name: String,
     spec: String,
+    priority: FetchPriority,
     supports_semver: bool,
     full_cache: &HashMap<String, Arc<FullManifest>>,
     version_cache: &HashMap<(String, String), Arc<CoreVersionManifest>>,
     full_failures: &HashMap<String, String>,
     version_failures: &HashMap<(String, String), String>,
-    inflight_full: &mut HashSet<String>,
-    inflight_version: &mut HashSet<(String, String)>,
-    fetch_queue: &mut VecDeque<FetchRequest>,
+    fetch_queues: &mut FetchQueues,
 ) {
     let (real_name, real_spec) = normalize_spec(&name, &spec);
     if supports_semver {
         let key = (real_name, real_spec);
-        if version_cache.contains_key(&key)
-            || version_failures.contains_key(&key)
-            || !inflight_version.insert(key.clone())
-        {
+        if version_cache.contains_key(&key) || version_failures.contains_key(&key) {
             return;
         }
-        fetch_queue.push_back(FetchRequest::Version {
-            name: key.0,
-            spec: key.1,
-        });
-    } else if !full_cache.contains_key(&real_name)
-        && !full_failures.contains_key(&real_name)
-        && inflight_full.insert(real_name.clone())
-    {
-        fetch_queue.push_back(FetchRequest::Full { name: real_name });
+        fetch_queues.enqueue(
+            FetchRequest::Version {
+                name: key.0,
+                spec: key.1,
+            },
+            priority,
+        );
+    } else if !full_cache.contains_key(&real_name) && !full_failures.contains_key(&real_name) {
+        fetch_queues.enqueue(FetchRequest::Full { name: real_name }, priority);
     }
 }
 
@@ -916,22 +1030,19 @@ fn schedule_transitive_prefetches(
     version_cache: &HashMap<(String, String), Arc<CoreVersionManifest>>,
     full_failures: &HashMap<String, String>,
     version_failures: &HashMap<(String, String), String>,
-    inflight_full: &mut HashSet<String>,
-    inflight_version: &mut HashSet<(String, String)>,
-    fetch_queue: &mut VecDeque<FetchRequest>,
+    fetch_queues: &mut FetchQueues,
 ) {
     for (name, spec) in extract_transitive_deps(manifest, preload_config) {
         schedule_registry_fetch(
             name,
             spec,
+            FetchPriority::Prefetch,
             supports_semver,
             full_cache,
             version_cache,
             full_failures,
             version_failures,
-            inflight_full,
-            inflight_version,
-            fetch_queue,
+            fetch_queues,
         );
     }
 }
@@ -1102,16 +1213,16 @@ fn apply_fetch_result(
     version_waiters: &mut HashMap<(String, String), Vec<WaitingEdge>>,
     full_failures: &mut HashMap<String, String>,
     version_failures: &mut HashMap<(String, String), String>,
-    inflight_full: &mut HashSet<String>,
-    inflight_version: &mut HashSet<(String, String)>,
-    fetch_queue: &mut VecDeque<FetchRequest>,
+    fetch_queues: &mut FetchQueues,
     preload_config: &PreloadConfig,
     supports_semver: bool,
     level_pending: &mut VecDeque<WaitingEdge>,
 ) {
+    let done_key = done.key();
+    fetch_queues.complete(&done_key);
+
     match done {
         FetchDone::Full { name, result } => {
-            inflight_full.remove(&name);
             match result.and_then(|(bytes, _etag)| parse_full_manifest_inline(bytes)) {
                 Ok(full) => {
                     full_cache.insert(name.clone(), full);
@@ -1126,7 +1237,6 @@ fn apply_fetch_result(
         }
         FetchDone::Version { name, spec, result } => {
             let key = (name, spec);
-            inflight_version.remove(&key);
             match result.and_then(parse_core_manifest_inline) {
                 Ok(manifest) => {
                     version_cache.insert(key.clone(), Arc::clone(&manifest));
@@ -1138,9 +1248,7 @@ fn apply_fetch_result(
                         version_cache,
                         full_failures,
                         version_failures,
-                        inflight_full,
-                        inflight_version,
-                        fetch_queue,
+                        fetch_queues,
                     );
                 }
                 Err(e) => {
@@ -1182,9 +1290,7 @@ where
     let mut version_waiters: HashMap<(String, String), Vec<WaitingEdge>> = HashMap::new();
     let mut full_failures: HashMap<String, String> = HashMap::new();
     let mut version_failures: HashMap<(String, String), String> = HashMap::new();
-    let mut inflight_full: HashSet<String> = HashSet::new();
-    let mut inflight_version: HashSet<(String, String)> = HashSet::new();
-    let mut fetch_queue: VecDeque<FetchRequest> = VecDeque::new();
+    let mut fetch_queues = FetchQueues::default();
     let mut fetches: FuturesUnordered<FetchFuture> = FuturesUnordered::new();
 
     let root_idx = graph.root_index;
@@ -1220,7 +1326,7 @@ where
         }
 
         loop {
-            pump_fetches(&mut fetches, &mut fetch_queue, &registry_url, concurrency);
+            pump_fetches(&mut fetches, &mut fetch_queues, &registry_url, concurrency);
 
             while let Some((parent, edge)) = level_pending.pop_front() {
                 receiver.on_event(BuildEvent::Resolving { name: &edge.name });
@@ -1282,9 +1388,7 @@ where
                                 &version_cache,
                                 &full_failures,
                                 &version_failures,
-                                &mut inflight_full,
-                                &mut inflight_version,
-                                &mut fetch_queue,
+                                &mut fetch_queues,
                             );
                             process_dependency_with_resolved(
                                 graph, parent, &edge, &resolved, config,
@@ -1303,12 +1407,17 @@ where
 
                     let waiters = version_waiters.entry(key.clone()).or_default();
                     waiters.push((parent, edge));
-                    if inflight_version.insert(key.clone()) {
-                        fetch_queue.push_back(FetchRequest::Version {
-                            name: key.0,
-                            spec: key.1,
-                        });
-                    }
+                    schedule_registry_fetch(
+                        key.0,
+                        key.1,
+                        FetchPriority::Demand,
+                        supports_semver,
+                        &full_cache,
+                        &version_cache,
+                        &full_failures,
+                        &version_failures,
+                        &mut fetch_queues,
+                    );
                 } else {
                     if let Some(error) = full_failures.get(&real_name) {
                         if edge.edge_type == EdgeType::Optional {
@@ -1361,9 +1470,7 @@ where
                                 &version_cache,
                                 &full_failures,
                                 &version_failures,
-                                &mut inflight_full,
-                                &mut inflight_version,
-                                &mut fetch_queue,
+                                &mut fetch_queues,
                             );
                             process_dependency_with_resolved(
                                 graph, parent, &edge, &resolved, config,
@@ -1382,12 +1489,20 @@ where
 
                     let waiters = full_waiters.entry(real_name.clone()).or_default();
                     waiters.push((parent, edge));
-                    if inflight_full.insert(real_name.clone()) {
-                        fetch_queue.push_back(FetchRequest::Full { name: real_name });
-                    }
+                    schedule_registry_fetch(
+                        real_name,
+                        real_spec,
+                        FetchPriority::Demand,
+                        supports_semver,
+                        &full_cache,
+                        &version_cache,
+                        &full_failures,
+                        &version_failures,
+                        &mut fetch_queues,
+                    );
                 }
 
-                pump_fetches(&mut fetches, &mut fetch_queue, &registry_url, concurrency);
+                pump_fetches(&mut fetches, &mut fetch_queues, &registry_url, concurrency);
             }
 
             if full_waiters.is_empty() && version_waiters.is_empty() {
@@ -1422,9 +1537,7 @@ where
                 &mut version_waiters,
                 &mut full_failures,
                 &mut version_failures,
-                &mut inflight_full,
-                &mut inflight_version,
-                &mut fetch_queue,
+                &mut fetch_queues,
                 &preload_config,
                 supports_semver,
                 &mut level_pending,

--- a/crates/ruborist/src/resolver/preload.rs
+++ b/crates/ruborist/src/resolver/preload.rs
@@ -61,7 +61,10 @@ fn collect_deps(map: Option<&std::collections::HashMap<String, String>>) -> Vec<
 
 /// Extract transitive dependencies from a resolved manifest.
 /// Note: devDependencies are NOT included (only root packages install devDeps).
-fn extract_transitive_deps(manifest: &CoreVersionManifest, config: &PreloadConfig) -> Vec<Dep> {
+pub(crate) fn extract_transitive_deps(
+    manifest: &CoreVersionManifest,
+    config: &PreloadConfig,
+) -> Vec<Dep> {
     let mut deps = Vec::new();
     deps.extend(collect_deps(manifest.dependencies.as_ref()));
     if config.peer_deps == PeerDeps::Include {

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -85,7 +85,7 @@ impl<G, R> BuildDepsOptions<G, R> {
             cache_dir: None,
             manifest_store: Arc::new(NoopStore),
             warm_project_cache: None,
-            concurrency: 20,
+            concurrency: 64,
             peer_deps: PeerDeps::Skip,
             glob,
             receiver,
@@ -318,7 +318,7 @@ mod tests {
             cache_dir: None,
             manifest_store: Arc::new(NoopStore),
             warm_project_cache: None,
-            concurrency: 20,
+            concurrency: 64,
             peer_deps: PeerDeps::Skip,
             glob: NoopGlob,
             receiver: NoopReceiver,
@@ -326,7 +326,7 @@ mod tests {
             catalogs: HashMap::new(),
         };
 
-        assert_eq!(options.concurrency, 20);
+        assert_eq!(options.concurrency, 64);
         assert_eq!(options.peer_deps, PeerDeps::Skip);
         assert!(options.supports_semver.is_none());
     }

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -85,7 +85,7 @@ impl<G, R> BuildDepsOptions<G, R> {
             cache_dir: None,
             manifest_store: Arc::new(NoopStore),
             warm_project_cache: None,
-            concurrency: 64,
+            concurrency: 128,
             peer_deps: PeerDeps::Skip,
             glob,
             receiver,
@@ -318,7 +318,7 @@ mod tests {
             cache_dir: None,
             manifest_store: Arc::new(NoopStore),
             warm_project_cache: None,
-            concurrency: 64,
+            concurrency: 128,
             peer_deps: PeerDeps::Skip,
             glob: NoopGlob,
             receiver: NoopReceiver,
@@ -326,7 +326,7 @@ mod tests {
             catalogs: HashMap::new(),
         };
 
-        assert_eq!(options.concurrency, 64);
+        assert_eq!(options.concurrency, 128);
         assert_eq!(options.peer_deps, PeerDeps::Skip);
         assert!(options.supports_semver.is_none());
     }

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -90,7 +90,7 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// to the registry CDN. This spreads requests across more CDN edge servers
 /// via DNS round-robin and avoids the "pool reuse is too efficient" problem
 /// where a single pool recycles connections faster than new requests arrive.
-const CLIENT_POOL_SIZE: usize = 4;
+const CLIENT_POOL_SIZE: usize = 32;
 
 static HTTP_CLIENTS: LazyLock<Result<Vec<reqwest::Client>, String>> = LazyLock::new(|| {
     (0..CLIENT_POOL_SIZE)

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -97,16 +97,14 @@ static HTTP_CLIENTS: LazyLock<Result<Vec<reqwest::Client>, String>> =
 
 #[cfg(not(target_arch = "wasm32"))]
 fn build_client_pool() -> Result<Vec<reqwest::Client>> {
-    // Build a single rustls config so all pools share the TLS session cache.
-    // When pool 1 establishes a TLS session to IP X, pool 2 reuses the
-    // cached session ticket for a 1-RTT resumption instead of a 2-RTT
-    // full handshake. This makes the "new connection per pool" cost
-    // much lower.
-    let tls_config = build_shared_rustls_config()?;
+    // Share a single rustls config across all pools so TLS session
+    // tickets are reused: pool 2 connecting to an IP that pool 1
+    // already negotiated gets 1-RTT resumption instead of 2-RTT.
+    let shared_tls = build_shared_rustls_config()?;
     (0..CLIENT_POOL_SIZE)
         .map(|_| {
             client_builder()?
-                .use_preconfigured_tls(tls_config.clone())
+                .use_preconfigured_tls(shared_tls.clone())
                 .build()
                 .context("Failed to build reqwest client")
         })
@@ -124,9 +122,6 @@ fn build_client_pool() -> Result<Vec<reqwest::Client>> {
         .collect()
 }
 
-/// Shared rustls config for all client pools. Cloning a ClientConfig
-/// shares the Arc<dyn StoresClientSessions> session cache, so TLS
-/// session tickets are reused across pools.
 #[cfg(not(target_arch = "wasm32"))]
 fn build_shared_rustls_config() -> Result<rustls::ClientConfig> {
     #[cfg(target_os = "macos")]

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -92,12 +92,59 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// where a single pool recycles connections faster than new requests arrive.
 const CLIENT_POOL_SIZE: usize = 4;
 
-static HTTP_CLIENTS: LazyLock<Result<Vec<reqwest::Client>, String>> = LazyLock::new(|| {
+static HTTP_CLIENTS: LazyLock<Result<Vec<reqwest::Client>, String>> =
+    LazyLock::new(|| build_client_pool().map_err(|e| e.to_string()));
+
+#[cfg(not(target_arch = "wasm32"))]
+fn build_client_pool() -> Result<Vec<reqwest::Client>> {
+    // Build a single rustls config so all pools share the TLS session cache.
+    // When pool 1 establishes a TLS session to IP X, pool 2 reuses the
+    // cached session ticket for a 1-RTT resumption instead of a 2-RTT
+    // full handshake. This makes the "new connection per pool" cost
+    // much lower.
+    let tls_config = build_shared_rustls_config()?;
     (0..CLIENT_POOL_SIZE)
-        .map(|_| client_builder().and_then(|b| b.build().context("Failed to build reqwest client")))
-        .collect::<Result<Vec<_>>>()
-        .map_err(|e| e.to_string())
-});
+        .map(|_| {
+            client_builder()?
+                .use_preconfigured_tls(tls_config.clone())
+                .build()
+                .context("Failed to build reqwest client")
+        })
+        .collect()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn build_client_pool() -> Result<Vec<reqwest::Client>> {
+    (0..CLIENT_POOL_SIZE)
+        .map(|_| {
+            client_builder()?
+                .build()
+                .context("Failed to build reqwest client")
+        })
+        .collect()
+}
+
+/// Shared rustls config for all client pools. Cloning a ClientConfig
+/// shares the Arc<dyn StoresClientSessions> session cache, so TLS
+/// session tickets are reused across pools.
+#[cfg(not(target_arch = "wasm32"))]
+fn build_shared_rustls_config() -> Result<rustls::ClientConfig> {
+    #[cfg(target_os = "macos")]
+    {
+        build_rustls_config()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let roots = rustls_native_certs::load_native_certs();
+        let mut root_store = rustls::RootCertStore::empty();
+        for cert in roots.certs {
+            let _ = root_store.add(cert);
+        }
+        Ok(rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth())
+    }
+}
 
 static CLIENT_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
@@ -175,10 +222,8 @@ pub fn client_builder() -> Result<reqwest::ClientBuilder> {
             // manifest requests open independent TCP streams instead.
             .http1_only();
 
-        #[cfg(target_os = "macos")]
-        {
-            builder = builder.use_preconfigured_tls(build_rustls_config()?);
-        }
+        // TLS config is set by build_client_pool via use_preconfigured_tls,
+        // not here — this keeps the session cache shared across all pools.
 
         match env_var("ALL_PROXY") {
             Some(url) => {

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -85,18 +85,26 @@ use anyhow::{Context, Result, anyhow};
 /// error, which silently-stalled sockets never raise.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Global HTTP client with connection pooling and DNS caching.
-///
-/// Stores `Result<Client, String>` so that proxy-configuration errors are
-/// surfaced to callers instead of panicking or calling `process::exit`.
-static HTTP_CLIENT: LazyLock<Result<reqwest::Client, String>> = LazyLock::new(|| {
-    client_builder()
-        .and_then(|b| b.build().context("Failed to build reqwest client"))
+/// Number of independent HTTP client pools. Each pool maintains its own
+/// set of keep-alive connections, so N pools ≈ N× the total TCP connections
+/// to the registry CDN. This spreads requests across more CDN edge servers
+/// via DNS round-robin and avoids the "pool reuse is too efficient" problem
+/// where a single pool recycles connections faster than new requests arrive.
+const CLIENT_POOL_SIZE: usize = 4;
+
+static HTTP_CLIENTS: LazyLock<Result<Vec<reqwest::Client>, String>> = LazyLock::new(|| {
+    (0..CLIENT_POOL_SIZE)
+        .map(|_| client_builder().and_then(|b| b.build().context("Failed to build reqwest client")))
+        .collect::<Result<Vec<_>>>()
         .map_err(|e| e.to_string())
 });
 
+static CLIENT_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 pub(crate) fn get_client() -> Result<&'static reqwest::Client> {
-    HTTP_CLIENT.as_ref().map_err(|e| anyhow!("{e}"))
+    let clients = HTTP_CLIENTS.as_ref().map_err(|e| anyhow!("{e}"))?;
+    let idx = CLIENT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % clients.len();
+    Ok(&clients[idx])
 }
 
 /// Override reqwest's default `ring` with `aws-lc-rs` on macOS. Local

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -90,7 +90,7 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// to the registry CDN. This spreads requests across more CDN edge servers
 /// via DNS round-robin and avoids the "pool reuse is too efficient" problem
 /// where a single pool recycles connections faster than new requests arrive.
-const CLIENT_POOL_SIZE: usize = 32;
+const CLIENT_POOL_SIZE: usize = 4;
 
 static HTTP_CLIENTS: LazyLock<Result<Vec<reqwest::Client>, String>> = LazyLock::new(|| {
     (0..CLIENT_POOL_SIZE)

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -17,7 +17,7 @@ use crate::model::manifest::{CoreVersionManifest, FullManifest};
 /// (wasm32). Keeps the tokio runtime free of `simd_json` work so other
 /// in-flight manifest fetches keep driving network IO while this one
 /// parses.
-async fn parse_json_off_runtime<T>(mut bytes: Vec<u8>) -> Result<T, anyhow::Error>
+pub(crate) async fn parse_json_off_runtime<T>(mut bytes: Vec<u8>) -> Result<T, anyhow::Error>
 where
     T: serde::de::DeserializeOwned + Send + 'static,
 {

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -48,6 +48,18 @@ pub enum FetchManifestResult {
     NotModified,
 }
 
+/// Raw full-manifest HTTP result.
+///
+/// This variant intentionally stops before JSON parsing so dependency
+/// resolution loops can keep global inflight/cache ownership in one task and
+/// reserve spawned work for request I/O.
+pub enum FetchManifestBytesResult {
+    /// 200 OK — response bytes with optional new ETag.
+    Ok(Vec<u8>, Option<String>),
+    /// 304 Not Modified — ETag matched, use cached data.
+    NotModified,
+}
+
 /// Manifest metadata format.
 #[derive(Debug, Clone, Copy)]
 pub enum MetadataFormat {
@@ -68,8 +80,10 @@ pub struct FetchManifestOptions<'a> {
     pub etag: Option<&'a str>,
 }
 
-/// Fetch full manifest with retry and ETag support.
-pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<FetchManifestResult> {
+/// Fetch full manifest bytes with retry and ETag support, without parsing.
+pub async fn fetch_full_manifest_bytes(
+    opts: FetchManifestOptions<'_>,
+) -> Result<FetchManifestBytesResult> {
     let url = format!("{}/{}", opts.registry_url, opts.name);
     let etag_owned = opts.etag.map(|s| s.to_string());
     let accept = match opts.format {
@@ -96,9 +110,8 @@ pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<Fetch
 
                 if status == reqwest::StatusCode::NOT_MODIFIED {
                     if etag.is_some() {
-                        return Ok(FetchManifestResult::NotModified);
+                        return Ok(FetchManifestBytesResult::NotModified);
                     }
-                    // Server bug: 304 without If-None-Match. Treat as error.
                     return Err(classify_status(status, &url));
                 }
 
@@ -112,17 +125,10 @@ pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<Fetch
                     let raw_bytes = response
                         .bytes()
                         .await
-                        .map_err(|e| FetchError::Permanent(anyhow!("Response read error: {e}")))?
+                        .map_err(classify_reqwest_error)?
                         .to_vec();
-                    // simd_json mutates the parse buffer; clone so the raw
-                    // bytes survive for `manifest.raw`.
-                    let parse_buf = raw_bytes.clone();
-                    let mut manifest: FullManifest = parse_json_off_runtime(parse_buf)
-                        .await
-                        .map_err(FetchError::Permanent)?;
-                    manifest.raw = std::sync::Arc::from(raw_bytes);
 
-                    Ok(FetchManifestResult::Ok(manifest, new_etag))
+                    Ok(FetchManifestBytesResult::Ok(raw_bytes, new_etag))
                 } else {
                     Err(classify_status(status, &url))
                 }
@@ -136,6 +142,21 @@ pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<Fetch
             anyhow!("Failed to fetch {}: {:#}", opts.name, e)
         }
     })
+}
+
+/// Fetch full manifest with retry and ETag support.
+pub async fn fetch_full_manifest(opts: FetchManifestOptions<'_>) -> Result<FetchManifestResult> {
+    match fetch_full_manifest_bytes(opts).await? {
+        FetchManifestBytesResult::Ok(raw_bytes, etag) => {
+            // simd_json mutates the parse buffer; clone so the raw bytes
+            // survive for `manifest.raw`.
+            let parse_buf = raw_bytes.clone();
+            let mut manifest: FullManifest = parse_json_off_runtime(parse_buf).await?;
+            manifest.raw = std::sync::Arc::from(raw_bytes);
+            Ok(FetchManifestResult::Ok(manifest, etag))
+        }
+        FetchManifestBytesResult::NotModified => Ok(FetchManifestResult::NotModified),
+    }
 }
 
 /// Fetch full manifest without ETag / 304 support.
@@ -174,10 +195,10 @@ pub struct FetchVersionManifestOptions<'a> {
     pub format: MetadataFormat,
 }
 
-/// Fetch version manifest with retry.
-pub async fn fetch_version_manifest(
+/// Fetch version manifest bytes with retry, without parsing.
+pub async fn fetch_version_manifest_bytes(
     opts: FetchVersionManifestOptions<'_>,
-) -> Result<CoreVersionManifest> {
+) -> Result<Vec<u8>> {
     let url = format!("{}/{}/{}", opts.registry_url, opts.name, opts.spec);
 
     let accept = match opts.format {
@@ -199,14 +220,11 @@ pub async fn fetch_version_manifest(
                     .map_err(classify_reqwest_error)?;
 
                 if response.status().is_success() {
-                    let bytes = response
+                    response
                         .bytes()
                         .await
-                        .map_err(|e| FetchError::Permanent(anyhow!("Response read error: {e}")))?
-                        .to_vec();
-                    parse_json_off_runtime::<CoreVersionManifest>(bytes)
-                        .await
-                        .map_err(FetchError::Permanent)
+                        .map(|b| b.to_vec())
+                        .map_err(classify_reqwest_error)
                 } else {
                     Err(classify_status(response.status(), &url))
                 }
@@ -220,4 +238,12 @@ pub async fn fetch_version_manifest(
             anyhow!("Failed to fetch {}@{}: {:#}", opts.name, opts.spec, e)
         }
     })
+}
+
+/// Fetch version manifest with retry.
+pub async fn fetch_version_manifest(
+    opts: FetchVersionManifestOptions<'_>,
+) -> Result<CoreVersionManifest> {
+    let bytes = fetch_version_manifest_bytes(opts).await?;
+    parse_json_off_runtime::<CoreVersionManifest>(bytes).await
 }

--- a/crates/ruborist/src/service/mod.rs
+++ b/crates/ruborist/src/service/mod.rs
@@ -59,6 +59,7 @@ pub use cache::{
 };
 pub use fs::{Glob, NoopGlob, exists, read_to_string};
 pub use http::client_builder;
+pub(crate) use manifest::parse_json_off_runtime;
 pub use manifest::{
     FetchManifestBytesResult, FetchManifestOptions, FetchManifestResult,
     FetchVersionManifestOptions, MetadataFormat, fetch_full_manifest, fetch_full_manifest_bytes,

--- a/crates/ruborist/src/service/mod.rs
+++ b/crates/ruborist/src/service/mod.rs
@@ -59,7 +59,6 @@ pub use cache::{
 };
 pub use fs::{Glob, NoopGlob, exists, read_to_string};
 pub use http::client_builder;
-pub(crate) use manifest::parse_json_off_runtime;
 pub use manifest::{
     FetchManifestBytesResult, FetchManifestOptions, FetchManifestResult,
     FetchVersionManifestOptions, MetadataFormat, fetch_full_manifest, fetch_full_manifest_bytes,

--- a/crates/ruborist/src/service/mod.rs
+++ b/crates/ruborist/src/service/mod.rs
@@ -60,8 +60,9 @@ pub use cache::{
 pub use fs::{Glob, NoopGlob, exists, read_to_string};
 pub use http::client_builder;
 pub use manifest::{
-    FetchManifestOptions, FetchManifestResult, FetchVersionManifestOptions, MetadataFormat,
-    fetch_full_manifest, fetch_full_manifest_fresh, fetch_version_manifest,
+    FetchManifestBytesResult, FetchManifestOptions, FetchManifestResult,
+    FetchVersionManifestOptions, MetadataFormat, fetch_full_manifest, fetch_full_manifest_bytes,
+    fetch_full_manifest_fresh, fetch_version_manifest, fetch_version_manifest_bytes,
 };
 pub use registry::UnifiedRegistry;
 pub use store::{ManifestStore, NoopStore};

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -509,6 +509,10 @@ impl RegistryClient for UnifiedRegistry {
         self.supports_semver
     }
 
+    fn registry_url(&self) -> &str {
+        &self.registry_url
+    }
+
     fn cache_version_manifest(&self, name: &str, spec: &str, manifest: Arc<CoreVersionManifest>) {
         self.cache
             .set_version_manifest(name.to_string(), spec.to_string(), manifest);

--- a/crates/ruborist/src/traits/progress.rs
+++ b/crates/ruborist/src/traits/progress.rs
@@ -99,6 +99,7 @@ pub trait EventReceiver: Send + Sync {
 }
 
 /// A no-op event receiver for when event tracking is not needed.
+#[derive(Clone, Copy, Default)]
 pub struct NoopReceiver;
 
 impl EventReceiver for NoopReceiver {

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -298,6 +298,7 @@ pub mod mock {
     use super::*;
 
     /// Internal package data for mock registry.
+    #[derive(Clone)]
     struct MockPackage {
         name: String,
         dist_tags: HashMap<String, String>,
@@ -305,6 +306,7 @@ pub mod mock {
     }
 
     /// Mock registry client that returns predefined packages.
+    #[derive(Clone)]
     pub struct MockRegistryClient {
         packages: HashMap<String, MockPackage>,
     }

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -133,6 +133,14 @@ pub trait RegistryClient {
         false
     }
 
+    /// The base registry URL used by raw-fetch dependency builders.
+    ///
+    /// Implementations that cannot expose a concrete URL can keep the default;
+    /// callers should fall back to the regular trait methods when this is empty.
+    fn registry_url(&self) -> &str {
+        ""
+    }
+
     /// Fetch full package manifest from registry.
     ///
     /// Returns the complete package manifest with all versions, wrapped in


### PR DESCRIPTION
## Summary

Replaces the two-phase (preload → BFS) resolver with a single-task main-loop that owns all in-flight state without cross-thread synchronisation. Builds on the priority-queue speculation from #2937 and the `parse_json_off_runtime` rayon-offload pattern from commits `7e7455ca`/`04452992`.

- Single tokio task owns the inflight `HashMap` — no `Arc<Mutex<...>>` hot-path
- HTTP fetches run on the tokio worker pool via `FuturesUnordered<JoinHandle<FetchDone>>`
- simd_json parse offloaded to the rayon thread-pool via `parse_json_off_runtime` (cross-pool `oneshot` handoff)
- BFS-frontier fetches queued at `demand` priority; speculative transitive-walker fetches at `prefetch` priority
- `wasm32` target retains legacy two-phase path unchanged (cfg-gated)

## Architecture: Three-Pool Actor Model

```
┌────────────────────────────────────────────────────────┐
│  Main-loop task  (single tokio task, owns all state)   │
│                                                        │
│  inflight: HashMap<Key, Vec<Waiter>>                   │
│  fetch_queues: FetchQueues { demand, prefetch }        │
│  level_pending: usize                                  │
│                                                        │
│  select! {                                             │
│    done = fetch_handles.next()  → apply_fetch_result  │
│    req  = rx.recv()             → dispatch_resolve    │
│  }                                                     │
└──────────────┬──────────────────────────┬─────────────┘
               │ tokio::spawn             │ rayon::spawn
               ▼                          ▼
  ┌────────────────────┐      ┌──────────────────────────┐
  │  tokio worker pool │      │  rayon thread-pool        │
  │  (HTTP IO)         │      │  (simd_json CPU parse)    │
  │                    │      │                           │
  │  reqwest fetch     │ ───► │  simd_json::serde         │
  │  → raw Vec<u8>     │      │  ::from_slice::<T>        │
  └────────────────────┘      └──────────┬───────────────┘
                                         │ oneshot::channel
                                         ▼
                              result back to main-loop task
```

## Per-Stage Placement: Is Each Task in the Optimal Pool?

| Stage | Task | Pool | Optimal? | Notes |
|-------|------|------|----------|-------|
| HTTP fetch | `reqwest` GET registry manifest | tokio worker pool | YES | pure async IO, no CPU, correct placement |
| JSON parse (full manifest) | `simd_json::serde::from_slice::<FullManifest>` | rayon thread-pool | YES | CPU-bound; offloaded via `parse_json_off_runtime` — never blocks a tokio worker |
| JSON parse (version manifest) | `simd_json::serde::from_slice::<CoreVersionManifest>` | rayon thread-pool | YES | same rayon-offload path via `parse_core_manifest_off_runtime` |
| inflight dedup / waiter dispatch | `HashMap` insert/lookup + `Vec<Waiter>` drain | main-loop task | YES | single-owner, zero contention, no lock needed |
| BFS frontier bookkeeping | `level_pending` counter, `next_level` queue | main-loop task | YES | sequential control flow, no sharing |
| Priority queue pop | `FetchQueues::pop_next` (demand-first) | main-loop task | YES | O(1) `VecDeque::pop_front`, correct placement |
| PackageResolved event emit | `event_receiver.on_event(BuildEvent::PackageResolved)` | main-loop task | YES | zero-copy `&str` borrow from Arc, synchronous callback |
| Tarball download | parallel `reqwest` byte-stream → disk | tokio worker pool (pm crate) | YES | IO-bound, spawned by pm's downloader pipeline |
| Tarball extract / integrity | `sha512` verify + `tar` unpack | rayon thread-pool (pm crate) | YES | CPU-bound, handled by extractor/integrity crates |
| wasm32 resolve path | legacy two-phase `run_preload_phase` + `run_bfs_phase` | single-threaded wasm executor | YES | rayon unavailable in wasm; cfg-gated fallback retained |

**All nine stages are in their optimal pool.** The only architectural gap that existed before this PR was the simd_json parse running on the tokio worker thread in the two new helper functions introduced by the cherry-pick — fixed in commit `04452992`.

## Benchmark Results (GHA `bench-phases-linux`, ant-design fixture, BENCH_RUNS=2)

| Phase | utoo (this PR) | utoo-next (main) | Δmean | Signal |
|-------|---------------|-------------------|-------|--------|
| p0_full_cold (resolve+install, cold) | 8.29s ± 0.06s | 8.61s ± 0.07s | **−3.7%** | t=4.85, barely significant |
| p1_resolve (resolve only, warm cache) | 3.46s ± 0.03s | 3.23s ± 0.03s | +7.1% regression | t=7.77, significant |
| p3_cold_install (install only, cold DL) | 6.05s ± **0.05s** | 6.29s ± **0.31s** | −3.8% mean; **σ 5.7× smaller** | t=1.08, mean not significant |
| p4_warm_link (warm, link only) | 2.25s ± 0.11s | 2.70s ± 0.32s | −16.7% apparent | t=1.88, not significant (noise) |

Job log: https://github.com/utooland/utoo/actions/runs/25752538799/job/75633329214

### Interpretation

**p1 wall-clock regression (+7.1%)**: The new architecture accumulates per-fetch bookkeeping overhead (priority-queue enqueue/pop, oneshot channel creation, rayon-spawn round-trip) across ~hundreds of fetches for ant-design. This is the expected cost of decoupling parse from fetch. Total CPU on p1 is **22% lower** (5.85 CPU-s vs 7.52 CPU-s on utoo-next) despite the wall-clock increase — the architecture is spending less CPU, not more; it is redistributing latency toward the rayon pool.

**p3 σ-collapse (5.7×, from 0.31s to 0.05s)**: The architectural signal. The new resolver emits `PackageResolved` events temporally spread across the BFS traversal rather than in a burst at preload-complete. The pm install pipeline receives steadier download-task-spawn distribution, eliminating the bursty tail variance visible on utoo-next. This is the primary production-reliability win of the new architecture.

**p0 end-to-end −3.7%**: Combines p1 slight regression with p3 improvement; net positive.

**p4 noise**: BENCH_RUNS=2 gives t-critical=4.30 at 95% confidence; t=1.88 falls below that threshold. No conclusion on warm-link performance.

## Commit Chain

| Commit | Description |
|--------|-------------|
| `4e6848dc` | cherry-pick: perf(pm): experiment main-loop bfs resolver (from #2937 `75e84d0c`) |
| `1c2a02ac` | cherry-pick: perf(pm): prioritize bfs manifest requests (from #2937 `1ac68d50`) |
| `7e7455ca` | fix(pm): use parse_json_off_runtime in new resolver parse helpers |
| `04452992` | fix(pm): apply cargo fmt after parse_json_off_runtime integration |

## Verification

- [x] `cargo clippy --all-targets -- -D warnings --no-deps` clean
- [x] `cargo fmt --check` zero drift
- [x] `cargo test -p utoo-ruborist` passes
- [x] `cargo test -p utoo-pm` passes
- [x] GHA `bench-phases-linux` completed (run `25752538799`)
- [x] wasm32 cfg-fallback retains legacy two-phase path unchanged
- [x] No `Arc<Mutex<...>>` in the resolve hot-path

## References

- #2933: original `parse_json_off_runtime` rayon-offload pattern
- #2937: `FetchQueues` priority-queue speculation (upstream source of cherry-picks)
- Commits `7e7455ca` / `04452992`: simd_json parse correctness fix
