### PR TITLE
feat(pack): support stats.json for node target

### DIFF
--- a/crates/pack-api/src/webpack_stats.rs
+++ b/crates/pack-api/src/webpack_stats.rs
@@ -15,6 +15,7 @@ use turbopack_core::{
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
 };
 use turbopack_css::chunk::CssChunk;
+use turbopack_nodejs::{EcmascriptBuildNodeChunk, EcmascriptBuildNodeEntryChunk};
 
 #[turbo_tasks::value]
 #[derive(Serialize, Deserialize, Debug)]
@@ -134,6 +135,94 @@ pub async fn get_asset_intermediate_info(
         for item in chunk_items.iter() {
             local_chunk_items.push((*item, chunk_ident.clone()));
         }
+    }
+
+    if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBuildNodeChunk>(asset) {
+        let chunk_path_full = chunk.path().await?;
+        let chunk_ident = dist_root
+            .await?
+            .get_relative_path_to(&chunk_path_full)
+            .unwrap_or_else(|| chunk_path_full.path.clone());
+
+        local_chunks.push(WebpackStatsChunk {
+            size: asset_len,
+            files: vec![chunk_ident.clone()],
+            id: chunk_ident.clone(),
+            ..Default::default()
+        });
+
+        let chunk_items = chunk.chunk().chunk_items().await?;
+        for item in chunk_items.iter() {
+            local_chunk_items.push((*item, chunk_ident.clone()));
+        }
+    }
+
+    if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBuildNodeEntryChunk>(asset) {
+        let entry_path_full = chunk.path().await?;
+        let entry_path = dist_root
+            .await?
+            .get_relative_path_to(&entry_path_full)
+            .unwrap_or_else(|| entry_path_full.path.clone());
+
+        local_chunks.push(WebpackStatsChunk {
+            size: asset_len,
+            files: vec![entry_path.clone()],
+            id: entry_path.clone(),
+            ..Default::default()
+        });
+
+        let evaluatable_assets = chunk.evaluatable_assets().await?;
+        let items: Vec<_> = evaluatable_assets
+            .iter()
+            .map(|&evaluatable_asset| {
+                let entry_path = entry_path.clone();
+                async move {
+                    let item = evaluatable_asset
+                        .as_chunk_item(chunk.module_graph(), chunk.chunking_context());
+                    Ok::<_, anyhow::Error>((item.to_resolved().await?, entry_path))
+                }
+            })
+            .try_join()
+            .await?;
+        local_chunk_items.extend(items);
+
+        let entry_referenced_assets = chunk.chunks_data().await?;
+        let futures: Vec<_> = entry_referenced_assets
+            .iter()
+            .map(|asset| {
+                let asset = *asset;
+                async move {
+                    let chunk_data = asset.await?;
+                    let name: RcStr = chunk_data.path.as_str().into();
+                    Ok::<_, anyhow::Error>((name.clone(), WebpackStatsEntrypointAssets { name }))
+                }
+            })
+            .collect();
+
+        let results = futures::future::try_join_all(futures).await?;
+        let mut entry_chunks = Vec::with_capacity(results.len() + 1);
+        let mut entry_assets_list = Vec::with_capacity(results.len() + 1);
+
+        for (chunk_name, asset_info) in results {
+            entry_chunks.push(chunk_name);
+            entry_assets_list.push(asset_info);
+        }
+
+        entry_chunks.push(entry_path.clone());
+        entry_assets_list.push(WebpackStatsEntrypointAssets {
+            name: entry_path.clone(),
+        });
+
+        let entry_name: RcStr = remove_extension_from_str(entry_path.as_str()).into();
+
+        local_entrypoints.push((
+            entry_name.clone(),
+            WebpackStatsEntrypoint {
+                name: entry_name,
+                chunks: entry_chunks,
+                assets: entry_assets_list,
+            },
+        ));
     }
 
     if let Some(chunk_list) = ResolvedVc::try_downcast_type::<EcmascriptDevChunkList>(asset) {

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/config.json
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/config.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "target": "node",
+    "optimization": {
+      "minify": false,
+      "moduleIds": "named"
+    },
+    "stats": true
+  }
+}

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/input/index.js
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/input/index.js
@@ -1,0 +1,7 @@
+const { getBaseName } = require("./utils");
+
+function processPath(filePath) {
+  return getBaseName(filePath);
+}
+
+module.exports = { processPath };

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/input/utils.js
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/input/utils.js
@@ -1,0 +1,7 @@
+const path = require("path");
+
+function getBaseName(filePath) {
+  return path.basename(filePath);
+}
+
+module.exports = { getBaseName };

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/output/_root-of-the-server___7e972a20.js
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/output/_root-of-the-server___7e972a20.js
@@ -1,0 +1,30 @@
+module.exports = [
+"[externals]/path [external] (path, cjs)", ((__turbopack_context__, module, exports) => {
+
+var mod = __turbopack_context__.x("path", () => require("path"));
+
+module.exports = mod;
+}),
+"[project]/target_node/stats_node/input/utils.js [server] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+const path = __turbopack_context__.r("[externals]/path [external] (path, cjs)");
+function getBaseName(filePath) {
+    return path.basename(filePath);
+}
+module.exports = {
+    getBaseName
+};
+}),
+"[project]/target_node/stats_node/input/index.js [server] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+const { getBaseName } = __turbopack_context__.r("[project]/target_node/stats_node/input/utils.js [server] (ecmascript)");
+function processPath(filePath) {
+    return getBaseName(filePath);
+}
+module.exports = {
+    processPath
+};
+}),
+];
+
+//# sourceMappingURL=_root-of-the-server___7e972a20.js.map

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/output/_root-of-the-server___7e972a20.js.map
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/output/_root-of-the-server___7e972a20.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 9, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/target_node/stats_node/input/utils.js"],"sourcesContent":["const path = require(\"path\");\n\nfunction getBaseName(filePath) {\n  return path.basename(filePath);\n}\n\nmodule.exports = { getBaseName };\n"],"names":["path","getBaseName","filePath","basename","module","exports"],"mappings":"AAAA,MAAMA;AAEN,SAASC,YAAYC,QAAQ;IAC3B,OAAOF,KAAKG,QAAQ,CAACD;AACvB;AAEAE,OAAOC,OAAO,GAAG;IAAEJ;AAAY"}},
+    {"offset": {"line": 19, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/target_node/stats_node/input/index.js"],"sourcesContent":["const { getBaseName } = require(\"./utils\");\n\nfunction processPath(filePath) {\n  return getBaseName(filePath);\n}\n\nmodule.exports = { processPath };\n"],"names":["getBaseName","processPath","filePath","module","exports"],"mappings":"AAAA,MAAM,EAAEA,WAAW,EAAE;AAErB,SAASC,YAAYC,QAAQ;IAC3B,OAAOF,YAAYE;AACrB;AAEAC,OAAOC,OAAO,GAAG;IAAEH;AAAY"}}]
+}

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/output/_turbopack__runtime.js
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/output/_turbopack__runtime.js
@@ -1,0 +1,5 @@
+var RUNTIME_PUBLIC_PATH = "_turbopack__runtime.js";
+var RELATIVE_ROOT_PATH = "/ROOT";
+var ASSET_PREFIX = "/";
+var WORKER_FORWARDED_GLOBALS = [];
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/output/_turbopack__runtime.js.map
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/output/_turbopack__runtime.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/output/main.js
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/output/main.js
@@ -1,0 +1,4 @@
+var R=require("./_turbopack__runtime.js")("main.js")
+R.c("_root-of-the-server___7e972a20.js")
+R.m("[project]/target_node/stats_node/input/index.js [server] (ecmascript)")
+module.exports=R.m("[project]/target_node/stats_node/input/index.js [server] (ecmascript)").exports

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/output/stats.json
@@ -1,0 +1,146 @@
+{
+  "entrypoints": {
+    "./main": {
+      "name": "./main",
+      "chunks": [
+        "./main.js",
+        "_root-of-the-server___7e972a20.js"
+      ],
+      "assets": [
+        {
+          "name": "./main.js"
+        },
+        {
+          "name": "_root-of-the-server___7e972a20.js"
+        }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "./_root-of-the-server___7e972a20.js",
+      "size": 934,
+      "hash": "",
+      "files": [
+        "./_root-of-the-server___7e972a20.js"
+      ]
+    },
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "./main.js",
+      "size": 271,
+      "hash": "",
+      "files": [
+        "./main.js"
+      ]
+    }
+  ],
+  "assets": [
+    {
+      "type": "asset",
+      "name": "_root-of-the-server___7e972a20.js",
+      "info": {},
+      "size": 934,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "_root-of-the-server___7e972a20.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "_root-of-the-server___7e972a20.js.map",
+      "info": {},
+      "size": 1048,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "_root-of-the-server___7e972a20.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "_turbopack__runtime.js",
+      "info": {},
+      "size": 162,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "_turbopack__runtime.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "_turbopack__runtime.js.map",
+      "info": {},
+      "size": 53,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "_turbopack__runtime.js.map"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "main.js",
+      "info": {},
+      "size": 271,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "main.js"
+      ]
+    },
+    {
+      "type": "asset",
+      "name": "main.js.map",
+      "info": {},
+      "size": 53,
+      "emitted": false,
+      "comparedForEmit": false,
+      "cached": false,
+      "chunks": [
+        "main.js.map"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "name": "path",
+      "id": "path",
+      "chunks": [
+        "./_root-of-the-server___7e972a20.js"
+      ],
+      "size": null
+    },
+    {
+      "name": "target_node/stats_node/input/index.js",
+      "id": "target_node/stats_node/input/index.js",
+      "chunks": [
+        "./main.js",
+        "./_root-of-the-server___7e972a20.js"
+      ],
+      "size": 147
+    },
+    {
+      "name": "target_node/stats_node/input/utils.js",
+      "id": "target_node/stats_node/input/utils.js",
+      "chunks": [
+        "./_root-of-the-server___7e972a20.js"
+      ],
+      "size": 135
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

When building with \`target: node\` **without** a \`library\` config, Turbopack uses \`NodeJsChunkingContext\` which produces \`EcmascriptBuildNodeChunk\` and \`EcmascriptBuildNodeEntryChunk\` — distinct from the library chunk types. These two node-specific chunk types were not handled in \`get_asset_intermediate_info\`, so they were silently skipped and never appeared in the generated \`stats.json\`.

- Add \`EcmascriptBuildNodeChunk\` handling to emit chunk entries in \`stats.json\`
- Add \`EcmascriptBuildNodeEntryChunk\` handling to emit entrypoint entries in \`stats.json\`
- Add snapshot test (\`target_node/stats_node\`) with a plain node target build and \`stats: true\` to cover both new code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)