### PR TITLE
fix(pack): restore dev stats.json generation

### DIFF
--- a/packages/pack/src/__test__/proxyHono.test.ts
+++ b/packages/pack/src/__test__/proxyHono.test.ts
@@ -11,7 +11,7 @@ import {
   doesContextMatchUrl,
   prepareProxyRequest,
   ruleMatchesUrl,
-} from "../core/proxy-hono";
+} from "../core/proxyHono";
 
 describe("doesContextMatchUrl", () => {
   it("matches path prefix", () => {

--- a/packages/pack/src/__test__/serveStats.test.ts
+++ b/packages/pack/src/__test__/serveStats.test.ts
@@ -1,0 +1,119 @@
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(testDir, "../..");
+const repoRoot = path.resolve(packageRoot, "../..");
+const childScript = path.join(testDir, "serveStatsChild.ts");
+const viteNode = path.join(repoRoot, "node_modules/vite-node/vite-node.mjs");
+
+function runServeStatsFixture() {
+  return new Promise<unknown>((resolve, reject) => {
+    const projectPath = fs.mkdtempSync(
+      path.join(repoRoot, "target/serve-stats-"),
+    );
+    const port = 43_200 + Math.floor(Math.random() * 1000);
+    const child = spawn(
+      process.execPath,
+      [viteNode, childScript, projectPath, `${port}`],
+      {
+        cwd: packageRoot,
+        env: {
+          ...process.env,
+          NODE_PATH: [
+            path.join(packageRoot, "node_modules"),
+            path.join(repoRoot, "node_modules"),
+            process.env.NODE_PATH,
+          ]
+            .filter(Boolean)
+            .join(path.delimiter),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `serve stats fixture failed with code ${code}, signal ${signal}\n${stderr}\n${stdout}`,
+          ),
+        );
+        return;
+      }
+
+      const line = stdout
+        .split(/\r?\n/)
+        .find((item) => item.startsWith("__STATS_SNAPSHOT__"));
+      if (!line) {
+        reject(
+          new Error(
+            `serve stats fixture did not print stats\n${stderr}\n${stdout}`,
+          ),
+        );
+        return;
+      }
+
+      resolve(JSON.parse(line.slice("__STATS_SNAPSHOT__".length)));
+    });
+  });
+}
+
+describe("serve stats", () => {
+  it("writes webpack stats.json in dev mode for top-level html config", async () => {
+    await expect(runServeStatsFixture()).resolves.toMatchInlineSnapshot(`
+      {
+        "assets": [
+          {
+            "name": "_root-of-the-server___<hash>.js",
+            "type": "asset",
+          },
+          {
+            "name": "_root-of-the-server___<hash>.js.map",
+            "type": "asset",
+          },
+          {
+            "name": "main.js",
+            "type": "asset",
+          },
+          {
+            "name": "main.js.map",
+            "type": "asset",
+          },
+          {
+            "name": "src_index_<hash>.js",
+            "type": "asset",
+          },
+        ],
+        "entrypoints": {
+          "main": {
+            "assets": [
+              "_root-of-the-server___<hash>.js",
+              "main.js",
+              "src_index_<hash>.js",
+            ],
+            "chunks": [
+              "_root-of-the-server___<hash>.js",
+              "main.js",
+              "src_index_<hash>.js",
+            ],
+          },
+        },
+        "htmlGenerated": true,
+      }
+    `);
+  }, 30_000);
+});

--- a/packages/pack/src/__test__/serveStatsChild.ts
+++ b/packages/pack/src/__test__/serveStatsChild.ts
@@ -1,0 +1,99 @@
+import fs from "fs";
+import path from "path";
+import { serve } from "../commands/dev";
+
+const [, , projectPath, portArg] = process.argv;
+
+if (!projectPath || !portArg) {
+  throw new Error("Usage: serveStatsChild <projectPath> <port>");
+}
+
+const port = Number(portArg);
+const srcDir = path.join(projectPath, "src");
+const statsPath = path.join(projectPath, "dist", "stats.json");
+const htmlPath = path.join(projectPath, "dist", "index.html");
+
+function normalizeFileName(name: string): string {
+  return name.replace(/_[0-9a-f]{8}(?=\.)/g, "_<hash>");
+}
+
+function normalizeStats(stats: any) {
+  return {
+    assets: (stats.assets ?? [])
+      .map((asset: any) => ({
+        name: normalizeFileName(asset.name ?? ""),
+        type: asset.type,
+      }))
+      .sort((a: { name: string }, b: { name: string }) =>
+        a.name.localeCompare(b.name),
+      ),
+    entrypoints: Object.fromEntries(
+      Object.entries<any>(stats.entrypoints ?? {}).map(([name, entrypoint]) => [
+        name,
+        {
+          assets: (entrypoint.assets ?? []).map((asset: any) =>
+            normalizeFileName(
+              typeof asset === "string" ? asset : (asset.name ?? ""),
+            ),
+          ),
+          chunks: (entrypoint.chunks ?? []).map((chunk: any) =>
+            normalizeFileName(String(chunk)),
+          ),
+        },
+      ]),
+    ),
+    htmlGenerated: fs.existsSync(htmlPath),
+  };
+}
+
+async function waitForStats() {
+  const deadline = Date.now() + 20_000;
+
+  while (!fs.existsSync(statsPath)) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${statsPath}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  const stats = JSON.parse(fs.readFileSync(statsPath, "utf8"));
+  if (!stats.entrypoints?.main) {
+    throw new Error("stats.json is missing the main entrypoint");
+  }
+
+  console.log(`__STATS_SNAPSHOT__${JSON.stringify(normalizeStats(stats))}`);
+}
+
+async function main() {
+  fs.rmSync(projectPath, { recursive: true, force: true });
+  fs.mkdirSync(srcDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(srcDir, "index.js"),
+    'console.log("serve stats snapshot");\n',
+  );
+
+  await serve(
+    {
+      config: {
+        entry: [{ import: "./src/index.js", name: "main" }],
+        html: { title: "Serve Stats Snapshot" },
+        output: { path: "./dist", clean: true },
+      },
+    },
+    projectPath,
+    projectPath,
+    {
+      hostname: "127.0.0.1",
+      logServerInfo: false,
+      port,
+    },
+  );
+
+  await waitForStats();
+  process.kill(process.pid, "SIGTERM");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -123,6 +123,21 @@ export async function createHotReloader(
     persistentCaching,
   );
 
+  const htmlConfigs = [
+    ...(Array.isArray((bundleOptions.config as any).html)
+      ? (bundleOptions.config as any).html
+      : (bundleOptions.config as any).html
+        ? [(bundleOptions.config as any).html]
+        : []),
+    ...bundleOptions.config.entry
+      .filter((e: EntryOptions) => !!e.html)
+      .map((e: EntryOptions) => e.html!),
+  ];
+  const shouldCreateWebpackStats =
+    Boolean(process.env.ANALYZE) ||
+    bundleOptions.config.stats ||
+    htmlConfigs.length > 0;
+
   let project: Project;
   try {
     project = await createProject(
@@ -137,10 +152,7 @@ export async function createHotReloader(
         config: {
           ...bundleOptions.config,
           mode: "development",
-          stats:
-            Boolean(process.env.ANALYZE) ||
-            bundleOptions.config.stats ||
-            bundleOptions.config.entry.some((e: EntryOptions) => !!e.html),
+          stats: shouldCreateWebpackStats,
           optimization: {
             ...bundleOptions.config.optimization,
             minify: false,
@@ -179,20 +191,6 @@ export async function createHotReloader(
   const backgroundWatchSubscriptions = new Set<
     AsyncIterableIterator<TurbopackResult>
   >();
-  const htmlConfigs = [
-    ...(Array.isArray((bundleOptions.config as any).html)
-      ? (bundleOptions.config as any).html
-      : (bundleOptions.config as any).html
-        ? [(bundleOptions.config as any).html]
-        : []),
-    ...bundleOptions.config.entry
-      .filter((e: EntryOptions) => !!e.html)
-      .map((e: EntryOptions) => e.html!),
-  ];
-  const shouldWriteProjectOutputs =
-    Boolean(process.env.ANALYZE) ||
-    bundleOptions.config.stats ||
-    htmlConfigs.length > 0;
 
   let currentWatchedEntrypoints: Endpoint[] = [];
   let backgroundWatchersStarted = false;
@@ -269,7 +267,7 @@ export async function createHotReloader(
   }
 
   async function writeOutputToDisk(entrypoint: Endpoint) {
-    if (shouldWriteProjectOutputs) {
+    if (shouldCreateWebpackStats) {
       await writeAllEntrypointsToDisk();
     } else {
       await writeEntrypointToDisk(entrypoint);
@@ -295,7 +293,7 @@ export async function createHotReloader(
       return;
     }
 
-    const previousTask = shouldWriteProjectOutputs
+    const previousTask = shouldCreateWebpackStats
       ? (backgroundProjectWriteTask ?? Promise.resolve())
       : (backgroundEndpointWriteTasks.get(entrypoint) ?? Promise.resolve());
     const task = previousTask
@@ -310,7 +308,7 @@ export async function createHotReloader(
         hmrEventHappened = true;
       })
       .finally(() => {
-        if (shouldWriteProjectOutputs) {
+        if (shouldCreateWebpackStats) {
           if (backgroundProjectWriteTask === task) {
             backgroundProjectWriteTask = undefined;
           }
@@ -319,7 +317,7 @@ export async function createHotReloader(
         }
       });
 
-    if (shouldWriteProjectOutputs) {
+    if (shouldCreateWebpackStats) {
       backgroundProjectWriteTask = task;
     } else {
       backgroundEndpointWriteTasks.set(entrypoint, task);
@@ -439,7 +437,7 @@ export async function createHotReloader(
         ...(entrypoints.apps ?? []),
         ...(entrypoints.libraries ?? []),
       ];
-      if (shouldWriteProjectOutputs) {
+      if (shouldCreateWebpackStats) {
         await writeAllEntrypointsToDisk();
       } else {
         await Promise.all(

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -189,11 +189,16 @@ export async function createHotReloader(
       .filter((e: EntryOptions) => !!e.html)
       .map((e: EntryOptions) => e.html!),
   ];
+  const shouldWriteProjectOutputs =
+    Boolean(process.env.ANALYZE) ||
+    bundleOptions.config.stats ||
+    htmlConfigs.length > 0;
 
   let currentWatchedEntrypoints: Endpoint[] = [];
   let backgroundWatchersStarted = false;
   let backgroundWatchGeneration = 0;
-  const backgroundWriteTasks = new Map<Endpoint, Promise<void>>();
+  const backgroundEndpointWriteTasks = new Map<Endpoint, Promise<void>>();
+  let backgroundProjectWriteTask: Promise<void> | undefined;
   let closed = false;
   let closePromise: Promise<void> | undefined;
 
@@ -251,28 +256,37 @@ export async function createHotReloader(
     }
   }
 
+  async function writeAllEntrypointsToDisk() {
+    const result = await project.writeAllEntrypointsToDisk();
+    processIssues(result, true, true);
+    await regenerateHtml();
+  }
+
   async function writeEntrypointToDisk(entrypoint: Endpoint) {
     const result = await entrypoint.writeToDisk();
     processIssues(result, true, true);
     await regenerateHtml();
   }
 
-  async function writeEntrypointsToDisk(entrypoints: Endpoint[]) {
-    await Promise.all(
-      entrypoints.map((entrypoint) => writeEntrypointToDisk(entrypoint)),
-    );
+  async function writeOutputToDisk(entrypoint: Endpoint) {
+    if (shouldWriteProjectOutputs) {
+      await writeAllEntrypointsToDisk();
+    } else {
+      await writeEntrypointToDisk(entrypoint);
+    }
   }
 
   async function disposeBackgroundWatchSubscriptions() {
     const subscriptions = [...backgroundWatchSubscriptions];
     backgroundWatchSubscriptions.clear();
-    backgroundWriteTasks.clear();
+    backgroundEndpointWriteTasks.clear();
+    backgroundProjectWriteTask = undefined;
     await Promise.all(
       subscriptions.map((subscription) => subscription.return?.()),
     );
   }
 
-  function scheduleEntrypointWrite(entrypoint: Endpoint, generation: number) {
+  function scheduleOutputWrite(entrypoint: Endpoint, generation: number) {
     if (
       !backgroundWatchersStarted ||
       closed ||
@@ -281,8 +295,9 @@ export async function createHotReloader(
       return;
     }
 
-    const previousTask =
-      backgroundWriteTasks.get(entrypoint) ?? Promise.resolve();
+    const previousTask = shouldWriteProjectOutputs
+      ? (backgroundProjectWriteTask ?? Promise.resolve())
+      : (backgroundEndpointWriteTasks.get(entrypoint) ?? Promise.resolve());
     const task = previousTask
       .catch(() => {})
       .then(async () => {
@@ -291,16 +306,24 @@ export async function createHotReloader(
           return;
         }
 
-        await writeEntrypointToDisk(entrypoint);
+        await writeOutputToDisk(entrypoint);
         hmrEventHappened = true;
       })
       .finally(() => {
-        if (backgroundWriteTasks.get(entrypoint) === task) {
-          backgroundWriteTasks.delete(entrypoint);
+        if (shouldWriteProjectOutputs) {
+          if (backgroundProjectWriteTask === task) {
+            backgroundProjectWriteTask = undefined;
+          }
+        } else if (backgroundEndpointWriteTasks.get(entrypoint) === task) {
+          backgroundEndpointWriteTasks.delete(entrypoint);
         }
       });
 
-    backgroundWriteTasks.set(entrypoint, task);
+    if (shouldWriteProjectOutputs) {
+      backgroundProjectWriteTask = task;
+    } else {
+      backgroundEndpointWriteTasks.set(entrypoint, task);
+    }
   }
 
   async function refreshBackgroundWatchers() {
@@ -340,7 +363,7 @@ export async function createHotReloader(
               }
 
               processIssues(data, true, true);
-              scheduleEntrypointWrite(entrypoint, generation);
+              scheduleOutputWrite(entrypoint, generation);
             }
           } catch (error) {
             if (!closed && generation === backgroundWatchGeneration) {
@@ -416,7 +439,15 @@ export async function createHotReloader(
         ...(entrypoints.apps ?? []),
         ...(entrypoints.libraries ?? []),
       ];
-      await writeEntrypointsToDisk(currentWatchedEntrypoints);
+      if (shouldWriteProjectOutputs) {
+        await writeAllEntrypointsToDisk();
+      } else {
+        await Promise.all(
+          currentWatchedEntrypoints.map((entrypoint) =>
+            writeEntrypointToDisk(entrypoint),
+          ),
+        );
+      }
 
       if (backgroundWatchersStarted) {
         await refreshBackgroundWatchers();

--- a/packages/pack/src/core/types.ts
+++ b/packages/pack/src/core/types.ts
@@ -63,6 +63,8 @@ export interface ProjectOptions extends BundleOptions {
 export interface Project {
   update(options: Partial<ProjectOptions>): Promise<void>;
 
+  writeAllEntrypointsToDisk(): Promise<TurbopackResult<RawEntrypoints>>;
+
   entrypointsSubscribe(): AsyncIterableIterator<
     TurbopackResult<RawEntrypoints>
   >;


### PR DESCRIPTION


## Summary

dev stats without `stats.json` generate after: https://github.com/utooland/utoo/pull/2934

<img width="2222" height="296" alt="image" src="https://github.com/user-attachments/assets/9376140a-187e-484d-a2fe-d2e7374606b0" />


## Test Plan


