### PR TITLE
ci(pm): reduce phase bench default runs

### DIFF
--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -73,7 +73,7 @@ on:
       bench_runs:
         description: '[phases] Runs per phase'
         required: false
-        default: '3'
+        default: '2'
         type: string
 
 concurrency:
@@ -540,7 +540,7 @@ jobs:
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
-          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '2' }}
           PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
         run: |
           chmod +x bench/pm-bench-phases.sh
@@ -560,7 +560,7 @@ jobs:
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
-          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '2' }}
           PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
         run: |
           mkdir -p /tmp/pm-bench-output
@@ -629,7 +629,7 @@ jobs:
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
-          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '2' }}
           PM_LIST: 'utoo,utoo-npm,bun'
         run: |
           chmod +x bench/pm-bench-phases.sh
@@ -645,7 +645,7 @@ jobs:
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
-          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS: ${{ github.event.inputs.bench_runs || '2' }}
           PM_LIST: 'utoo,utoo-npm,bun'
         run: |
           mkdir -p /tmp/pm-bench-output


### PR DESCRIPTION
## Summary

- Lower phase-isolated PM benchmark default runs from 3 to 2.
- Apply the same default to Linux and macOS phase benchmark jobs.
- Keep explicit `bench_runs` workflow_dispatch input behavior unchanged.

## Why

This is the first split from the PM resolver/install scheduling experiment. It keeps the benchmark-label feedback loop fast enough for iterative performance work while preserving a reproducible GHA signal.

## Verification

- `git diff --check`

This PR only changes GitHub Actions benchmark defaults.