### PR TITLE
fix(pack): respect output filename templates in dev

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -622,13 +622,34 @@ pub async fn get_client_chunking_context(
         builder = builder.entry_root_export(Some(entry_root_export.clone()));
     }
 
+    let output = config.output().await?;
+
+    if let Some(filename) = &output.filename {
+        builder = builder.filename(filename.clone());
+    }
+
+    if let Some(chunk_filename) = &output.chunk_filename {
+        builder = builder.chunk_filename(chunk_filename.clone());
+    }
+
+    if let Some(css_filename) = &output.css_filename {
+        builder = builder.css_filename(css_filename.clone());
+    }
+
+    if let Some(css_chunk_filename) = &output.css_chunk_filename {
+        builder = builder.css_chunk_filename(css_chunk_filename.clone());
+    }
+
+    if let Some(asset_module_filename) = &output.asset_module_filename {
+        builder = builder.asset_module_filename(asset_module_filename.clone());
+    }
+
     if mode.is_development() {
         builder = builder
             .hot_module_replacement()
             .source_map_source_type(SourceMapSourceType::AbsoluteFileUri)
             .dynamic_chunk_content_loading(true);
     } else {
-        let output = config.output().await?;
         let split_chunks = &config.optimization().await?.split_chunks;
 
         let (ecmascript_chunking_config, css_chunking_config) = (
@@ -649,26 +670,6 @@ pub async fn get_client_chunking_context(
                 Into::into,
             ),
         );
-
-        if let Some(filename) = &output.filename {
-            builder = builder.filename(filename.clone());
-        }
-
-        if let Some(chunk_filename) = &output.chunk_filename {
-            builder = builder.chunk_filename(chunk_filename.clone());
-        }
-
-        if let Some(css_filename) = &output.css_filename {
-            builder = builder.css_filename(css_filename.clone());
-        }
-
-        if let Some(css_chunk_filename) = &output.css_chunk_filename {
-            builder = builder.css_chunk_filename(css_chunk_filename.clone());
-        }
-
-        if let Some(asset_module_filename) = &output.asset_module_filename {
-            builder = builder.asset_module_filename(asset_module_filename.clone());
-        }
 
         builder = builder
             .chunking_config(

--- a/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "mode": "development",
+    "output": {
+      "assetModuleFilename": "assets/[name].[contenthash:8]"
+    },
+    "sourceMaps": false
+  }
+}

--- a/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/input/index.js
+++ b/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/input/index.js
@@ -1,0 +1,3 @@
+import logo from "./logo.jpg";
+
+globalThis.__logo = logo;

--- a/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/input/logo.jpg
+++ b/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/input/logo.jpg
@@ -1,0 +1,1 @@
+fake jpg content for dev asset filename snapshot

--- a/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/output/assets/logo.d706eea4.jpg
+++ b/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/output/assets/logo.d706eea4.jpg
@@ -1,0 +1,1 @@
+fake jpg content for dev asset filename snapshot

--- a/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/output/input_0e1f1939.js
+++ b/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/output/input_0e1f1939.js
@@ -1,0 +1,13 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/basic/asset_module_filename_dev/input/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([]);
+var __TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$asset_module_filename_dev$2f$input$2f$logo$2e$jpg__$28$static__in__ecmascript$29$__ = __turbopack_context__.i("[project]/basic/asset_module_filename_dev/input/logo.jpg (static in ecmascript)");
+;
+globalThis.__logo = __TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$asset_module_filename_dev$2f$input$2f$logo$2e$jpg__$28$static__in__ecmascript$29$__["default"];
+}),
+"[project]/basic/asset_module_filename_dev/input/logo.jpg (static in ecmascript)", ((__turbopack_context__) => {
+
+__turbopack_context__.q("/assets/logo.d706eea4.jpg");}),
+]);

--- a/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/output/input_index_83022b3b.js
+++ b/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/output/input_index_83022b3b.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK_CHUNK_LISTS"] || (globalThis["TURBOPACK_CHUNK_LISTS"] = [])).push({
+    script: typeof document === "object" ? document.currentScript : undefined,
+    chunks: ["input_0e1f1939.js"],
+    source: "entry"
+});

--- a/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/output/main.js
+++ b/crates/pack-tests/tests/snapshot/basic/asset_module_filename_dev/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_0e1f1939.js"],"runtimeModuleIds":["[project]/basic/asset_module_filename_dev/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/config.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "mode": "development",
+    "output": {
+      "filename": "scripts/[name].dev.js",
+      "chunkFilename": "chunks/[name].dev.js"
+    },
+    "sourceMaps": false
+  }
+}

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/input/index.js
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/input/index.js
@@ -1,0 +1,3 @@
+import("./message").then(({ message }) => {
+  globalThis.__message = message;
+});

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/input/message.js
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/input/message.js
@@ -1,0 +1,1 @@
+export const message = "hello";

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_index_83022b3b.dev.js
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_index_83022b3b.dev.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK_CHUNK_LISTS"] || (globalThis["TURBOPACK_CHUNK_LISTS"] = [])).push({
+    script: typeof document === "object" ? document.currentScript : undefined,
+    chunks: ["chunks/input_message_6ccb1ced.dev.js","chunks/input_index_c388c1fc.dev.js"],
+    source: "entry"
+});

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_index_c388c1fc.dev.js
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_index_c388c1fc.dev.js
@@ -1,0 +1,8 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/basic/js_filename_dev/input/index.js [client] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+__turbopack_context__.A("[project]/basic/js_filename_dev/input/message.js [client] (ecmascript, async loader)").then(({ message })=>{
+    globalThis.__message = message;
+});
+}),
+]);

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_message_6ccb1ced.dev.js
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_message_6ccb1ced.dev.js
@@ -1,0 +1,13 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/basic/js_filename_dev/input/message.js [client] (ecmascript, async loader)", ((__turbopack_context__) => {
+
+__turbopack_context__.v((parentImport) => {
+    return Promise.all([
+  "chunks/input_message_7d12845b.dev.js",
+  "chunks/input_message_807614c3.dev.js"
+].map((chunk) => __turbopack_context__.l(chunk))).then(() => {
+        return parentImport("[project]/basic/js_filename_dev/input/message.js [client] (ecmascript)");
+    });
+});
+}),
+]);

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_message_7d12845b.dev.js
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_message_7d12845b.dev.js
@@ -1,0 +1,11 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/basic/js_filename_dev/input/message.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "message",
+    ()=>message
+]);
+const message = "hello";
+}),
+]);

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_message_807614c3.dev.js
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/chunks/input_message_807614c3.dev.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK_CHUNK_LISTS"] || (globalThis["TURBOPACK_CHUNK_LISTS"] = [])).push({
+    script: typeof document === "object" ? document.currentScript : undefined,
+    chunks: ["chunks/input_message_7d12845b.dev.js"],
+    source: "dynamic"
+});

--- a/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/scripts/main.dev.js
+++ b/crates/pack-tests/tests/snapshot/basic/js_filename_dev/output/scripts/main.dev.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["chunks/input_message_6ccb1ced.dev.js","chunks/input_index_c388c1fc.dev.js"],"runtimeModuleIds":["[project]/basic/js_filename_dev/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/style/css_filename_dev/config.json
+++ b/crates/pack-tests/tests/snapshot/style/css_filename_dev/config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "mode": "development",
+    "output": {
+      "cssFilename": "styles/[name].dev.css"
+    },
+    "sourceMaps": false
+  }
+}

--- a/crates/pack-tests/tests/snapshot/style/css_filename_dev/input/index.js
+++ b/crates/pack-tests/tests/snapshot/style/css_filename_dev/input/index.js
@@ -1,0 +1,3 @@
+import "./style.css";
+
+export const color = "tomato";

--- a/crates/pack-tests/tests/snapshot/style/css_filename_dev/input/style.css
+++ b/crates/pack-tests/tests/snapshot/style/css_filename_dev/input/style.css
@@ -1,0 +1,3 @@
+.title {
+  color: tomato;
+}

--- a/crates/pack-tests/tests/snapshot/style/css_filename_dev/output/input_index_83022b3b.js
+++ b/crates/pack-tests/tests/snapshot/style/css_filename_dev/output/input_index_83022b3b.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK_CHUNK_LISTS"] || (globalThis["TURBOPACK_CHUNK_LISTS"] = [])).push({
+    script: typeof document === "object" ? document.currentScript : undefined,
+    chunks: ["styles/input_style_b6e2d8cb.dev.css","input_index_bdf2db6d.js"],
+    source: "entry"
+});

--- a/crates/pack-tests/tests/snapshot/style/css_filename_dev/output/input_index_bdf2db6d.js
+++ b/crates/pack-tests/tests/snapshot/style/css_filename_dev/output/input_index_bdf2db6d.js
@@ -1,0 +1,12 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/style/css_filename_dev/input/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "color",
+    ()=>color
+]);
+;
+const color = "tomato";
+}),
+]);

--- a/crates/pack-tests/tests/snapshot/style/css_filename_dev/output/main.js
+++ b/crates/pack-tests/tests/snapshot/style/css_filename_dev/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":[{"path":"styles/input_style_b6e2d8cb.dev.css","included":["[project]/style/css_filename_dev/input/style.css [client] (css)"]},"input_index_bdf2db6d.js"],"runtimeModuleIds":["[project]/style/css_filename_dev/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/style/css_filename_dev/output/styles/input_style_b6e2d8cb.dev.css
+++ b/crates/pack-tests/tests/snapshot/style/css_filename_dev/output/styles/input_style_b6e2d8cb.dev.css
@@ -1,0 +1,4 @@
+/* [project]/style/css_filename_dev/input/style.css [client] (css) */
+.title {
+  color: tomato;
+}


### PR DESCRIPTION


## Summary

Config `filename`、`chunkFilename`、`cssFilename`、`cssChunkFilename`、`assetModuleFilename` should also work for dev situation.

Align the behaviour with webpack: https://webpack.js.org/configuration/output/#outputcssfilename

## Test Plan

Update snapshot test
