### PR TITLE
fix(ci): harden utoo release publishing

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -107,11 +107,32 @@ jobs:
           UTOO_VERSION: ${{ steps.meta.outputs.version }}
           RUB_VERSION: ${{ steps.rub.outputs.version }}
         run: |
-          set -e
-          sed -i.bak "0,/^version *=.*/s|^version *=.*|version     = \"${RUB_VERSION}\"|" crates/ruborist/Cargo.toml
-          sed -i.bak "0,/^version *=.*/s|^version *=.*|version     = \"${UTOO_VERSION}\"|" crates/pm/Cargo.toml
-          sed -i.bak "s|^utoo-ruborist *=.*|utoo-ruborist      = { path = \"../ruborist\", version = \"${RUB_VERSION}\", features = [\"http-tarball\", \"native-git\"] }|" crates/pm/Cargo.toml
+          set -euo pipefail
+          sed -E -i.bak "s|^version[[:space:]]*=.*|version     = \"${RUB_VERSION}\"|" crates/ruborist/Cargo.toml
+          sed -E -i.bak "s|^version[[:space:]]*=.*|version     = \"${UTOO_VERSION}\"|" crates/pm/Cargo.toml
+          sed -E -i.bak "s|^utoo-ruborist[[:space:]]*=.*|utoo-ruborist      = { path = \"../ruborist\", version = \"${RUB_VERSION}\", features = [\"http-tarball\", \"native-git\"] }|" crates/pm/Cargo.toml
           rm -f crates/pm/Cargo.toml.bak crates/ruborist/Cargo.toml.bak
+
+          check_version() {
+            local file=$1
+            local expected=$2
+            local actual
+
+            actual=$(awk -F\" '/^version[[:space:]]*=/ { print $2; exit }' "$file")
+            if [ "$actual" != "$expected" ]; then
+              echo "Failed to update $file to version $expected; found $actual" >&2
+              head -12 "$file" >&2
+              exit 1
+            fi
+          }
+
+          check_version crates/ruborist/Cargo.toml "$RUB_VERSION"
+          check_version crates/pm/Cargo.toml "$UTOO_VERSION"
+          if ! grep -Fq "version = \"${RUB_VERSION}\"" crates/pm/Cargo.toml; then
+            echo "Failed to update utoo-ruborist dependency to version $RUB_VERSION" >&2
+            grep '^utoo-ruborist' crates/pm/Cargo.toml >&2 || true
+            exit 1
+          fi
 
           echo "----- crates/ruborist/Cargo.toml -----"
           head -12 crates/ruborist/Cargo.toml

--- a/.github/workflows/pm-release.yml
+++ b/.github/workflows/pm-release.yml
@@ -111,10 +111,19 @@ jobs:
           fi
 
       - name: Update Cargo.toml version
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
-          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" crates/pm/Cargo.toml
+          set -euo pipefail
+          sed -E -i.bak "s|^version[[:space:]]*=.*|version     = \"${VERSION}\"|" crates/pm/Cargo.toml
           rm crates/pm/Cargo.toml.bak
+
+          ACTUAL=$(awk -F\" '/^version[[:space:]]*=/ { print $2; exit }' crates/pm/Cargo.toml)
+          if [ "$ACTUAL" != "$VERSION" ]; then
+            echo "Failed to update crates/pm/Cargo.toml to version $VERSION; found $ACTUAL" >&2
+            head -12 crates/pm/Cargo.toml >&2
+            exit 1
+          fi
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -6,7 +6,7 @@ description = "Rust arborist - dependency resolution core for utoo package manag
 homepage    = "https://github.com/utooland/utoo"
 repository  = "https://github.com/utooland/utoo"
 license     = "MIT"
-keywords    = ["arborist", "dependency-resolution", "npm", "package-manager"]
+keywords    = ["arborist", "npm", "package-manager", "resolver"]
 categories  = ["development-tools"]
 
 # tombi: format.rules.table-keys-order.disabled = true


### PR DESCRIPTION
## Summary
- make PM release version injection match aligned TOML keys like `version     = ...` and fail if the injected version is not present
- add the same post-bump validation to the crates.io publish workflow
- replace the invalid `utoo-ruborist` crates.io keyword that blocked publishing

## Verification
- simulated both workflow version bump snippets against temp Cargo.toml copies
- ran `tombi format --check crates/ruborist/Cargo.toml`
- ran `git diff --check`
- attempted `cargo publish -p utoo-ruborist --dry-run --allow-dirty`, but local verification is blocked because the `next.js` submodule is not initialized in this worktree

Refs #2946