### PR TITLE
perf(pm): experiment wider install extract lane

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -566,7 +566,7 @@ fn clone_concurrency_limit() -> usize {
 
 fn extract_concurrency_limit() -> usize {
     std::thread::available_parallelism()
-        .map(|n| n.get().clamp(2, 8))
+        .map(|n| n.get().clamp(2, 16))
         .unwrap_or(4)
 }
 


### PR DESCRIPTION
Experiment A for #2948.\n\nChange:\n- Raise install extract/write lane native cap from 8 to 16.\n\nHypothesis:\n- p3/p0 may improve when tarball bytes are no longer blocked behind an 8-task extract/write cap on high-core machines.\n\nValidation target:\n- GHA linux npmjs benchmark via labels.\n- Private poollab npmmirror AB stays out of public PR comments.