### PR TITLE
perf(pm): experiment bounded install clone lane

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -560,7 +560,7 @@ impl SchedulerState {
 
 fn clone_concurrency_limit() -> usize {
     std::thread::available_parallelism()
-        .map(|n| (n.get() * 4).clamp(4, 32))
+        .map(|n| (n.get() * 2).clamp(4, 16))
         .unwrap_or(8)
 }
 


### PR DESCRIPTION
Experiment B for #2948.\n\nChange:\n- Bound install clone lane from available_parallelism * 4 capped at 32 to available_parallelism * 2 capped at 16.\n\nHypothesis:\n- p3 may improve if clone/hardlink work stops contending with extract/write for disk scheduler time.\n\nValidation target:\n- GHA linux npmjs benchmark via labels.\n- Private poollab npmmirror AB stays out of public PR comments.