### PR TITLE
perf(pm): experiment bounded install extract backlog

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -394,7 +394,7 @@ impl SchedulerState {
 
     fn pump_downloads(&mut self) {
         while self.download_active.len() < self.download_limit
-            && self.extract_backlog() < self.download_limit
+            && self.extract_backlog() < self.extract_limit * 4
         {
             let Some(package) = self.download_queue.pop_front() else {
                 break;


### PR DESCRIPTION
Experiment C for #2948.\n\nChange:\n- Limit download lead over extract/write to extract_limit * 4 instead of the full download_limit.\n\nHypothesis:\n- p0/p3 may reduce RSS, minor faults, and context switching by preventing too many downloaded tarball byte buffers from queueing ahead of extract/write.\n\nValidation target:\n- GHA linux npmjs benchmark via labels.\n- Private poollab npmmirror AB stays out of public PR comments.