### PR TITLE
perf(pm): experiment balanced install lanes

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -394,7 +394,7 @@ impl SchedulerState {
 
     fn pump_downloads(&mut self) {
         while self.download_active.len() < self.download_limit
-            && self.extract_backlog() < self.download_limit
+            && self.extract_backlog() < self.extract_limit * 4
         {
             let Some(package) = self.download_queue.pop_front() else {
                 break;
@@ -560,13 +560,13 @@ impl SchedulerState {
 
 fn clone_concurrency_limit() -> usize {
     std::thread::available_parallelism()
-        .map(|n| (n.get() * 4).clamp(4, 32))
+        .map(|n| (n.get() * 2).clamp(4, 16))
         .unwrap_or(8)
 }
 
 fn extract_concurrency_limit() -> usize {
     std::thread::available_parallelism()
-        .map(|n| n.get().clamp(2, 8))
+        .map(|n| n.get().clamp(2, 16))
         .unwrap_or(4)
 }
 


### PR DESCRIPTION
Experiment D for #2948.\n\nChange:\n- Raise extract/write lane cap to 16.\n- Bound clone lane cap to 16.\n- Limit download lead to extract_limit * 4.\n\nHypothesis:\n- p3 may need the lanes balanced together: wider extract/write throughput, lower clone IO pressure, and bounded downloaded-byte backlog.\n\nValidation target:\n- GHA linux npmjs benchmark via labels.\n- Private poollab npmmirror AB stays out of public PR comments.