### PR TITLE
perf(pm): experiment queued manifest store writes

### DIFF
--- a/crates/pm/src/util/manifest_store.rs
+++ b/crates/pm/src/util/manifest_store.rs
@@ -4,15 +4,17 @@
 //! - `<cache_dir>/<name>/versions.json`              ← `VersionsInfo` (etag + version list)
 //! - `<cache_dir>/<name>/manifests/<version>.json`   ← `CoreVersionManifest`
 //!
-//! Writes are fire-and-forget: each `store_*` call spawns a detached task and
-//! returns immediately, so the resolver hot path never waits on the disk.
+//! Writes are fire-and-forget: each `store_*` call enqueues a background write
+//! and returns immediately, so the resolver hot path never waits on the disk.
 //! Errors are logged at debug level — disk cache is opportunistic; a failed
 //! write only costs a future cache miss.
-//! Serialization and file writes run on Tokio's blocking pool so manifest
-//! persistence does not occupy async runtime workers that are driving network IO.
+//! Serialization and file writes run on a dedicated writer thread so manifest
+//! persistence does not occupy async runtime workers or Tokio's blocking pool.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::mpsc::{self, Sender};
+use std::thread::JoinHandle;
 
 use async_trait::async_trait;
 use serde::Serialize;
@@ -23,11 +25,15 @@ use crate::util::json::read_json_file;
 
 pub struct DiskManifestStore {
     cache_dir: PathBuf,
+    writer: Option<ManifestWriter>,
 }
 
 impl DiskManifestStore {
     pub fn new(cache_dir: PathBuf) -> Self {
-        Self { cache_dir }
+        Self {
+            cache_dir,
+            writer: Some(ManifestWriter::spawn()),
+        }
     }
 
     fn versions_path(&self, name: &str) -> PathBuf {
@@ -39,6 +45,12 @@ impl DiskManifestStore {
             .join(name)
             .join("manifests")
             .join(format!("{version}.json"))
+    }
+
+    fn enqueue_write(&self, job: ManifestWriteJob) {
+        if let Some(writer) = &self.writer {
+            writer.enqueue(job);
+        }
     }
 }
 
@@ -60,7 +72,7 @@ impl ManifestStore for DiskManifestStore {
 
     fn store_versions(&self, name: &str, info: Arc<VersionsInfo>) {
         let path = self.versions_path(name);
-        tokio::task::spawn_blocking(move || write_json_sync(&path, &*info));
+        self.enqueue_write(ManifestWriteJob::Versions { path, info });
     }
 
     fn store_version_manifest(
@@ -70,7 +82,66 @@ impl ManifestStore for DiskManifestStore {
         manifest: Arc<CoreVersionManifest>,
     ) {
         let path = self.manifest_path(name, version);
-        tokio::task::spawn_blocking(move || write_json_sync(&path, &*manifest));
+        self.enqueue_write(ManifestWriteJob::VersionManifest { path, manifest });
+    }
+}
+
+impl Drop for DiskManifestStore {
+    fn drop(&mut self) {
+        if let Some(writer) = self.writer.take() {
+            writer.join();
+        }
+    }
+}
+
+enum ManifestWriteJob {
+    Versions {
+        path: PathBuf,
+        info: Arc<VersionsInfo>,
+    },
+    VersionManifest {
+        path: PathBuf,
+        manifest: Arc<CoreVersionManifest>,
+    },
+}
+
+struct ManifestWriter {
+    tx: Sender<ManifestWriteJob>,
+    handle: JoinHandle<()>,
+}
+
+impl ManifestWriter {
+    fn spawn() -> Self {
+        let (tx, rx) = mpsc::channel();
+        let handle = std::thread::Builder::new()
+            .name("utoo-manifest-store".to_string())
+            .spawn(move || {
+                while let Ok(job) = rx.recv() {
+                    match job {
+                        ManifestWriteJob::Versions { path, info } => {
+                            write_json_sync(&path, &*info);
+                        }
+                        ManifestWriteJob::VersionManifest { path, manifest } => {
+                            write_json_sync(&path, &*manifest);
+                        }
+                    }
+                }
+            })
+            .expect("failed to spawn manifest store writer");
+        Self { tx, handle }
+    }
+
+    fn enqueue(&self, job: ManifestWriteJob) {
+        if self.tx.send(job).is_err() {
+            tracing::debug!("Manifest store writer stopped before accepting write");
+        }
+    }
+
+    fn join(self) {
+        drop(self.tx);
+        if self.handle.join().is_err() {
+            tracing::debug!("Manifest store writer panicked");
+        }
     }
 }
 
@@ -99,5 +170,56 @@ fn write_json_sync<T: Serialize>(path: &Path, value: &T) {
             }
         }
         Err(e) => tracing::debug!("Failed to write {path:?}: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use tempfile::tempdir;
+    use utoo_ruborist::service::Versions;
+
+    use super::*;
+
+    #[test]
+    fn drop_flushes_queued_manifest_writes() {
+        let dir = tempdir().unwrap();
+        {
+            let store = DiskManifestStore::new(dir.path().to_path_buf());
+            store.store_versions(
+                "pkg",
+                Arc::new(VersionsInfo {
+                    versions: Versions {
+                        version_list: vec!["1.0.0".to_string()],
+                        dist_tags: HashMap::from([("latest".to_string(), "1.0.0".to_string())]),
+                    },
+                    etag: Some("etag".to_string()),
+                    last_updated: 1,
+                }),
+            );
+            store.store_version_manifest(
+                "pkg",
+                "1.0.0",
+                Arc::new(CoreVersionManifest {
+                    name: "pkg".to_string(),
+                    version: "1.0.0".to_string(),
+                    ..Default::default()
+                }),
+            );
+        }
+
+        let versions: VersionsInfo =
+            serde_json::from_slice(&std::fs::read(dir.path().join("pkg/versions.json")).unwrap())
+                .unwrap();
+        assert_eq!(versions.versions.version_list, ["1.0.0"]);
+
+        let manifest: CoreVersionManifest = serde_json::from_slice(
+            &std::fs::read(dir.path().join("pkg/manifests/1.0.0.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(manifest.name, "pkg");
+        assert_eq!(manifest.version, "1.0.0");
     }
 }


### PR DESCRIPTION
## Summary

Experiment on top of #2948 (`c13f8c19`) to validate whether p1 resolve cost is coming from per-manifest persistence scheduling.

This changes the native PM `DiskManifestStore` write path from one detached `tokio::task::spawn_blocking` per `store_*` call to one dedicated `utoo-manifest-store` writer thread with an mpsc queue.

Expected signal:

- Lower p1 vCtx/iCtx if per-write task scheduling is material.
- Similar cache bytes and versions.json semantics; writes still flush when the store is dropped.
- p3 should be mostly unaffected because this only changes manifest persistence.

## Validation

- `cargo fmt`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
- `cargo test -p utoo-pm util::manifest_store::tests::drop_flushes_queued_manifest_writes`
- `cargo test -p utoo-pm` (`260 passed`, `3 ignored`)

## Notes

This is an AB experiment. If GHA shows no p1 ctx/wall improvement, reject it and keep the simpler current implementation.

## GHA AB Data

Baseline is #2948 at `c13f8c19`:

- Run `25928212949`: p1 `2.46s ±0.02`, ctx `23.6K / 29.7K`; p3 noisy `10.48s ±3.86`
- Run `25928980212`: p1 `2.59s ±0.05`, ctx `24.3K / 30.4K`; p3 noisy `7.99s ±3.66`

Writer queue experiment:

| run | p0 | p1 | p1 ctx | p3 | p4 | read |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `25948582503` | `7.80s ±0.01` | `2.43s ±0.06` | `15.4K / 20.5K` | `5.95s ±0.12` | `2.39s ±0.04` | strong p1 ctx drop, no p3 regression |
| `25949014826` | `7.80s ±0.80` | `2.38s ±0.03` | `17.3K / 22.7K` | `10.75s ±3.41` | `1.95s ±0.10` | p1 repeats; p3 has slow sample `7.03s ... 13.73s` |

Conclusion: queued manifest-store writes are a promising p1 optimization. Across two GHA runs, p1 ctx drops from roughly `24K / 30K` to `15K-17K / 20K-23K`, and wall improves to `2.38s`-`2.43s`. p3 is noisy in one run, but this change only affects manifest persistence; keep watching p3 before folding into the main PR.
