### PR TITLE
fix(pack): correct server conditional exports resolution

### DIFF
--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -133,7 +133,7 @@ pub async fn get_server_module_options_context(
         .await?;
 
     let mut loader_conditions = BTreeSet::new();
-    loader_conditions.insert(WebpackLoaderBuiltinCondition::Browser);
+    loader_conditions.insert(WebpackLoaderBuiltinCondition::Node);
     loader_conditions.extend(mode.await?.webpack_loader_conditions());
 
     // A separate webpack rules will be applied to codes matching foreign_code_context_condition.

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/config.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/client.ts",
+        "name": "main"
+      }
+    ],
+    "output": {
+      "path": "output/client"
+    },
+    "server": {
+      "entry": "input/server.ts",
+      "output": {
+        "path": "output/server",
+        "filename": "index.js"
+      }
+    },
+    "optimization": {
+      "minify": false,
+      "moduleIds": "named"
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/input/client.ts
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/input/client.ts
@@ -1,0 +1,3 @@
+import { target } from "conditional-env/is-server";
+
+console.log(`client:${target}`);

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/input/server.ts
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/input/server.ts
@@ -1,0 +1,3 @@
+import { target } from "conditional-env/is-server";
+
+console.log(`server:${target}`);

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/browser.js
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/browser.js
@@ -1,0 +1,1 @@
+export const target = "browser";

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/development.js
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/development.js
@@ -1,0 +1,1 @@
+export const target = "development";

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/fallback.js
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/fallback.js
@@ -1,0 +1,1 @@
+export const target = "fallback";

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/node.js
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/node.js
@@ -1,0 +1,1 @@
+export const target = "node";

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/package.json
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/node_modules/conditional-env/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "conditional-env",
+  "type": "module",
+  "exports": {
+    "./is-server": {
+      "development": "./development.js",
+      "workerd": "./node.js",
+      "worker": "./node.js",
+      "browser": "./browser.js",
+      "deno": "./node.js",
+      "node": "./node.js",
+      "bun": "./node.js",
+      "import": "./fallback.js",
+      "default": "./fallback.js"
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/client/_project__basic_conditional_exports_server_20383dc0.js
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/client/_project__basic_conditional_exports_server_20383dc0.js
@@ -1,0 +1,22 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/basic/conditional_exports_server/node_modules/conditional-env/browser.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const target = "browser";
+__turbopack_context__.s([
+    "target",
+    0,
+    target
+]);
+}),
+"[project]/basic/conditional_exports_server/input/client.ts [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$conditional_exports_server$2f$node_modules$2f$conditional$2d$env$2f$browser$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/basic/conditional_exports_server/node_modules/conditional-env/browser.js [client] (ecmascript)");
+;
+console.log(`client:${__TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$conditional_exports_server$2f$node_modules$2f$conditional$2d$env$2f$browser$2e$js__$5b$client$5d$__$28$ecmascript$29$__["target"]}`);
+__turbopack_context__.s([]);
+}),
+]);
+
+//# sourceMappingURL=_project__basic_conditional_exports_server_20383dc0.js.map

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/client/_project__basic_conditional_exports_server_20383dc0.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/client/_project__basic_conditional_exports_server_20383dc0.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/conditional_exports_server/node_modules/conditional-env/browser.js"],"sourcesContent":["export const target = \"browser\";\n"],"names":["target"],"mappings":"AAAO,MAAMA,SAAS","ignoreList":[0]}},
+    {"offset": {"line": 14, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/conditional_exports_server/input/client.ts"],"sourcesContent":["import { target } from \"conditional-env/is-server\";\n\nconsole.log(`client:${target}`);\n"],"names":["console","log"],"mappings":"AAAA;;AAEAA,QAAQC,GAAG,CAAC,CAAC,OAAO,EAAE,0LAAM,EAAE"}}]
+}

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/client/main.js
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/client/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["_project__basic_conditional_exports_server_20383dc0.js"],"runtimeModuleIds":["[project]/basic/conditional_exports_server/input/client.ts [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/client/main.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/client/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/server/index.js
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/server/index.js
@@ -1,0 +1,28 @@
+((__UTOOPACK__) => {
+// Dummy runtime
+})([
+["index.js",
+
+"[project]/basic/conditional_exports_server/node_modules/conditional-env/node.js [server] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "target",
+    ()=>target
+]);
+const target = "node";
+}),
+"[project]/basic/conditional_exports_server/input/server.ts [server] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([]);
+var __TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$conditional_exports_server$2f$node_modules$2f$conditional$2d$env$2f$node$2e$js__$5b$server$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/basic/conditional_exports_server/node_modules/conditional-env/node.js [server] (ecmascript)");
+;
+console.log(`server:${__TURBOPACK__imported__module__$5b$project$5d2f$basic$2f$conditional_exports_server$2f$node_modules$2f$conditional$2d$env$2f$node$2e$js__$5b$server$5d$__$28$ecmascript$29$__["target"]}`);
+}),
+],
+["index.js", {"otherChunks":[],"runtimeModuleIds":["[project]/basic/conditional_exports_server/input/server.ts [server] (ecmascript)"]}],
+]);
+
+
+//# sourceMappingURL=index.js.map

--- a/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/server/index.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/conditional_exports_server/output/server/index.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 8, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/conditional_exports_server/node_modules/conditional-env/node.js"],"sourcesContent":["export const target = \"node\";\n"],"names":["target"],"mappings":";;;;AAAO,MAAMA,SAAS","ignoreList":[0]}},
+    {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/conditional_exports_server/input/server.ts"],"sourcesContent":["import { target } from \"conditional-env/is-server\";\n\nconsole.log(`server:${target}`);\n"],"names":["console","log"],"mappings":";AAAA;;AAEAA,QAAQC,GAAG,CAAC,CAAC,OAAO,EAAE,uLAAM,EAAE"}}]
+}


### PR DESCRIPTION
## Summary

- Switch server webpack loader builtin conditions from `browser` to `node` so server transforms use Node runtime semantics.
- Add a snapshot fixture that mirrors conditional exports and verifies client builds resolve `browser` while server builds resolve `node`.

## Root Cause

Server resolver conditions already include `node`, but the server module options still exposed the `browser` builtin condition to webpack loader rules. This kept server/runtime condition handling inconsistent and made regressions around mixed client/server conditional exports harder to catch.

## Validation

- `cargo fmt --check`
- `cargo test -p pack-tests test_tests__snapshot__basic__conditional_exports_server --test snapshot -- --nocapture`
- `cargo test -p pack-tests test_tests__snapshot__basic__server_function --test snapshot -- --nocapture`

Note: a full `cargo test -p pack-tests --test snapshot` was also attempted before isolating this PR branch; unrelated runtime public-path snapshots failed due existing auto public path output differences.