### PR TITLE
perf(pm): skip fresh lock registry cache probes

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -18,13 +18,14 @@ use crate::model::package::PackageInfo;
 use crate::service::rebuild::RebuildService;
 use crate::util::cli_enum::{OmitType, PackageAction, SaveType};
 use crate::util::cloner::clone_count;
-use crate::util::downloader::download_stats;
+use crate::util::downloader::{download_stats, is_registry_tarball_url};
 use crate::util::json::load_package_lock_json_from_path;
 use crate::util::linker::link;
 use crate::util::logger::{
     PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
 };
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
+use utoo_ruborist::spec::SpecStr;
 
 use super::binary::update_package_binary;
 use super::clean::clean_deps;
@@ -61,6 +62,107 @@ fn should_omit_package(package: &Package, omit: &HashSet<OmitType>) -> bool {
     }
 
     false
+}
+
+fn is_package_platform_compatible(package: &Package) -> bool {
+    if let Some(ref cpu) = package.cpu
+        && !is_cpu_compatible(cpu)
+    {
+        return false;
+    }
+
+    if let Some(ref os) = package.os
+        && !is_os_compatible(os)
+    {
+        return false;
+    }
+
+    true
+}
+
+fn dependency_spec<'a>(package: &'a Package, name: &str) -> Option<&'a str> {
+    package
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(name))
+        .or_else(|| {
+            package
+                .optional_dependencies
+                .as_ref()
+                .and_then(|deps| deps.get(name))
+        })
+        .or_else(|| {
+            package
+                .dev_dependencies
+                .as_ref()
+                .and_then(|deps| deps.get(name))
+        })
+        .or_else(|| {
+            package
+                .peer_dependencies
+                .as_ref()
+                .and_then(|deps| deps.get(name))
+        })
+        .map(String::as_str)
+}
+
+fn lock_parent_path(path: &str) -> Option<&str> {
+    let index = path.rfind("node_modules/")?;
+    if index == 0 {
+        Some("")
+    } else {
+        path[..index].strip_suffix('/')
+    }
+}
+
+fn has_registry_incoming_spec(packages: &HashMap<String, Package>, path: &str, name: &str) -> bool {
+    let Some(parent_path) = lock_parent_path(path) else {
+        return false;
+    };
+    let Some(parent) = packages.get(parent_path) else {
+        return false;
+    };
+
+    dependency_spec(parent, name).is_some_and(|spec| spec.is_registry_spec())
+}
+
+fn collect_fresh_lock_download_prefetches(
+    packages: &HashMap<String, Package>,
+) -> Vec<(String, String, String)> {
+    let mut prefetches = Vec::new();
+
+    for (path, package) in packages {
+        if path.is_empty() || package.link.is_some() || !is_package_platform_compatible(package) {
+            continue;
+        }
+
+        let (Some(version), Some(resolved)) = (&package.version, &package.resolved) else {
+            continue;
+        };
+
+        if !is_registry_tarball_url(resolved) {
+            continue;
+        }
+
+        let name = package.get_name(path);
+        if name == "unknown" || !has_registry_incoming_spec(packages, path, &name) {
+            continue;
+        }
+
+        prefetches.push((name, version.clone(), resolved.clone()));
+    }
+
+    prefetches
+}
+
+fn prefetch_fresh_lock_downloads(
+    package_lock: &utoo_ruborist::lock::PackageLock,
+    scheduler: &super::install_scheduler::InstallScheduler,
+) {
+    for (name, version, resolved) in collect_fresh_lock_download_prefetches(&package_lock.packages)
+    {
+        scheduler.prefetch_download(name, version, resolved);
+    }
 }
 
 async fn install_packages(
@@ -118,17 +220,7 @@ async fn install_packages(
                         continue;
                     }
 
-                    // skip when cpu or os is not compatible
-                    if let Some(ref cpu) = package.cpu
-                        && !is_cpu_compatible(cpu)
-                    {
-                        PROGRESS_BAR.inc(1);
-                        continue;
-                    }
-
-                    if let Some(ref os) = package.os
-                        && !is_os_compatible(os)
-                    {
+                    if !is_package_platform_compatible(&package) {
                         PROGRESS_BAR.inc(1);
                         continue;
                     }
@@ -269,7 +361,8 @@ impl InstallService {
                     return Err(e);
                 }
             };
-            (lock, false)
+            prefetch_fresh_lock_downloads(&lock, &scheduler);
+            (lock, true)
         } else {
             start_progress_bar();
             let resolve_start = Instant::now();
@@ -477,5 +570,90 @@ mod tests {
             !is_optional,
             "Package with optional=false should not be optional"
         );
+    }
+
+    fn lock_pkg(name: &str, version: &str, resolved: &str) -> Package {
+        Package {
+            name: Some(name.to_string()),
+            version: Some(version.to_string()),
+            resolved: Some(resolved.to_string()),
+            ..Package::default()
+        }
+    }
+
+    #[test]
+    fn fresh_lock_prefetches_only_proven_registry_specs() {
+        let mut packages = HashMap::new();
+        packages.insert(
+            String::new(),
+            Package {
+                dependencies: Some(HashMap::from([
+                    ("react".to_string(), "^18.2.0".to_string()),
+                    (
+                        "remote-tarball".to_string(),
+                        "https://example.com/remote-tarball.tgz".to_string(),
+                    ),
+                    (
+                        "file-tarball".to_string(),
+                        "file:./file-tarball.tgz".to_string(),
+                    ),
+                ])),
+                ..Package::default()
+            },
+        );
+        packages.insert(
+            "node_modules/react".to_string(),
+            lock_pkg(
+                "react",
+                "18.2.0",
+                "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            ),
+        );
+        packages.insert(
+            "node_modules/remote-tarball".to_string(),
+            lock_pkg(
+                "remote-tarball",
+                "1.0.0",
+                "https://example.com/remote-tarball.tgz",
+            ),
+        );
+        packages.insert(
+            "node_modules/file-tarball".to_string(),
+            lock_pkg("file-tarball", "1.0.0", "file:./file-tarball.tgz"),
+        );
+
+        let prefetches = collect_fresh_lock_download_prefetches(&packages);
+
+        assert_eq!(prefetches.len(), 1);
+        assert_eq!(prefetches[0].0, "react");
+        assert_eq!(prefetches[0].1, "18.2.0");
+    }
+
+    #[test]
+    fn fresh_lock_prefetch_uses_physical_parent_for_nested_paths() {
+        let mut packages = HashMap::new();
+        packages.insert(String::new(), Package::default());
+        packages.insert(
+            "node_modules/@scope/parent".to_string(),
+            Package {
+                name: Some("@scope/parent".to_string()),
+                version: Some("1.0.0".to_string()),
+                dependencies: Some(HashMap::from([("child".to_string(), "~1.0.0".to_string())])),
+                ..Package::default()
+            },
+        );
+        packages.insert(
+            "node_modules/@scope/parent/node_modules/child".to_string(),
+            lock_pkg(
+                "child",
+                "1.0.1",
+                "https://registry.npmjs.org/child/-/child-1.0.1.tgz",
+            ),
+        );
+
+        let prefetches = collect_fresh_lock_download_prefetches(&packages);
+
+        assert_eq!(prefetches.len(), 1);
+        assert_eq!(prefetches[0].0, "child");
     }
 }

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -30,6 +30,13 @@ use utoo_ruborist::spec::SpecStr;
 use super::binary::update_package_binary;
 use super::clean::clean_deps;
 
+struct FreshLockRegistryPackage {
+    path: String,
+    name: String,
+    version: String,
+    resolved: String,
+}
+
 /// Check if a package should be omitted based on omit config
 fn should_omit_package(package: &Package, omit: &HashSet<OmitType>) -> bool {
     if omit.is_empty() {
@@ -126,9 +133,9 @@ fn has_registry_incoming_spec(packages: &HashMap<String, Package>, path: &str, n
     dependency_spec(parent, name).is_some_and(|spec| spec.is_registry_spec())
 }
 
-fn collect_fresh_lock_download_prefetches(
+fn collect_fresh_lock_registry_packages(
     packages: &HashMap<String, Package>,
-) -> Vec<(String, String, String)> {
+) -> Vec<FreshLockRegistryPackage> {
     let mut prefetches = Vec::new();
 
     for (path, package) in packages {
@@ -149,7 +156,12 @@ fn collect_fresh_lock_download_prefetches(
             continue;
         }
 
-        prefetches.push((name, version.clone(), resolved.clone()));
+        prefetches.push(FreshLockRegistryPackage {
+            path: path.clone(),
+            name,
+            version: version.clone(),
+            resolved: resolved.clone(),
+        });
     }
 
     prefetches
@@ -158,11 +170,16 @@ fn collect_fresh_lock_download_prefetches(
 fn prefetch_fresh_lock_downloads(
     package_lock: &utoo_ruborist::lock::PackageLock,
     scheduler: &super::install_scheduler::InstallScheduler,
-) {
-    for (name, version, resolved) in collect_fresh_lock_download_prefetches(&package_lock.packages)
-    {
-        scheduler.prefetch_download(name, version, resolved);
+) -> HashSet<String> {
+    let packages = collect_fresh_lock_registry_packages(&package_lock.packages);
+    let mut registry_paths = HashSet::with_capacity(packages.len());
+
+    for package in packages {
+        registry_paths.insert(package.path);
+        scheduler.prefetch_download(package.name, package.version, package.resolved);
     }
+
+    registry_paths
 }
 
 async fn install_packages(
@@ -170,6 +187,7 @@ async fn install_packages(
     cwd: &Path,
     omit: &HashSet<OmitType>,
     scheduler: &super::install_scheduler::InstallScheduler,
+    registry_clone_paths: &HashSet<String>,
 ) -> Result<()> {
     // Surface the clean step in the spinner — it doesn't move `pos`, so
     // without a message the bar looks frozen on large trees.
@@ -233,16 +251,29 @@ async fn install_packages(
                     let cwd_clone = cwd.to_path_buf();
                     let target_path = cwd_clone.join(&path);
                     let scheduler = scheduler.clone();
+                    let is_registry_clone = registry_clone_paths.contains(&path);
 
                     // Check if this is an optional dependency
                     let is_optional =
                         package.optional == Some(true) || package.dev_optional == Some(true);
 
                     clone_tasks.push(async move {
-                        if let Err(e) = scheduler
-                            .ensure_clone(name.clone(), version, resolved, target_path.clone())
-                            .await
-                        {
+                        let clone_result = if is_registry_clone {
+                            scheduler
+                                .ensure_registry_clone(
+                                    name.clone(),
+                                    version,
+                                    resolved,
+                                    target_path.clone(),
+                                )
+                                .await
+                        } else {
+                            scheduler
+                                .ensure_clone(name.clone(), version, resolved, target_path.clone())
+                                .await
+                        };
+
+                        if let Err(e) = clone_result {
                             if is_optional {
                                 tracing::warn!(
                                     "Optional dependency {name} failed (ignored): {e:#}"
@@ -353,7 +384,7 @@ impl InstallService {
         let scheduler_handle = super::install_scheduler::InstallSchedulerHandle::start();
         let scheduler = scheduler_handle.scheduler();
 
-        let (package_lock, used_scheduler_prefetch) = if use_fresh_lock {
+        let (package_lock, used_scheduler_prefetch, registry_clone_paths) = if use_fresh_lock {
             let lock = match load_package_lock_json_from_path(root_path).await {
                 Ok(lock) => lock,
                 Err(e) => {
@@ -361,8 +392,8 @@ impl InstallService {
                     return Err(e);
                 }
             };
-            prefetch_fresh_lock_downloads(&lock, &scheduler);
-            (lock, true)
+            let registry_clone_paths = prefetch_fresh_lock_downloads(&lock, &scheduler);
+            (lock, true, registry_clone_paths)
         } else {
             start_progress_bar();
             let resolve_start = Instant::now();
@@ -375,7 +406,7 @@ impl InstallService {
                 }
             };
             finish_progress_bar("package-lock.json resolved", Some(resolve_start.elapsed()));
-            (lock, true)
+            (lock, true, HashSet::new())
         };
 
         let groups = group_by_depth(&package_lock.packages);
@@ -386,9 +417,10 @@ impl InstallService {
         }
 
         let link_start = Instant::now();
-        let install_result = install_packages(&groups, root_path, omit, &scheduler)
-            .await
-            .context("Failed to install packages");
+        let install_result =
+            install_packages(&groups, root_path, omit, &scheduler, &registry_clone_paths)
+                .await
+                .context("Failed to install packages");
 
         scheduler_handle.shutdown().await;
         if used_scheduler_prefetch {
@@ -622,11 +654,12 @@ mod tests {
             lock_pkg("file-tarball", "1.0.0", "file:./file-tarball.tgz"),
         );
 
-        let prefetches = collect_fresh_lock_download_prefetches(&packages);
+        let prefetches = collect_fresh_lock_registry_packages(&packages);
 
         assert_eq!(prefetches.len(), 1);
-        assert_eq!(prefetches[0].0, "react");
-        assert_eq!(prefetches[0].1, "18.2.0");
+        assert_eq!(prefetches[0].path, "node_modules/react");
+        assert_eq!(prefetches[0].name, "react");
+        assert_eq!(prefetches[0].version, "18.2.0");
     }
 
     #[test]
@@ -651,9 +684,13 @@ mod tests {
             ),
         );
 
-        let prefetches = collect_fresh_lock_download_prefetches(&packages);
+        let prefetches = collect_fresh_lock_registry_packages(&packages);
 
         assert_eq!(prefetches.len(), 1);
-        assert_eq!(prefetches[0].0, "child");
+        assert_eq!(
+            prefetches[0].path,
+            "node_modules/@scope/parent/node_modules/child"
+        );
+        assert_eq!(prefetches[0].name, "child");
     }
 }

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -93,6 +93,33 @@ struct CloneSpec {
     package: PackageFetch,
     target: PathBuf,
     parent: Option<PathBuf>,
+    cache_mode: CloneCacheMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CloneCacheMode {
+    Seeded,
+    Registry,
+}
+
+impl CloneSpec {
+    fn new(package: PackageFetch, target: PathBuf, parent: Option<PathBuf>) -> Self {
+        Self {
+            package,
+            target,
+            parent,
+            cache_mode: CloneCacheMode::Seeded,
+        }
+    }
+
+    fn registry(package: PackageFetch, target: PathBuf) -> Self {
+        Self {
+            package,
+            target,
+            parent: None,
+            cache_mode: CloneCacheMode::Registry,
+        }
+    }
 }
 
 struct ReadyClone {
@@ -200,6 +227,7 @@ impl InstallScheduler {
             },
             target,
             parent,
+            cache_mode: CloneCacheMode::Seeded,
         }));
     }
 
@@ -213,15 +241,41 @@ impl InstallScheduler {
         let (tx, rx) = oneshot::channel();
         self.tx
             .send(Command::EnsureClone(
-                CloneSpec {
-                    package: PackageFetch {
+                CloneSpec::new(
+                    PackageFetch {
                         name,
                         version,
                         tarball_url,
                     },
                     target,
-                    parent: None,
-                },
+                    None,
+                ),
+                tx,
+            ))
+            .map_err(|_| anyhow!("install scheduler stopped"))?;
+        rx.await
+            .context("install scheduler stopped before clone completed")?
+            .map_err(anyhow::Error::msg)
+    }
+
+    pub(crate) async fn ensure_registry_clone(
+        &self,
+        name: String,
+        version: String,
+        tarball_url: String,
+        target: PathBuf,
+    ) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(Command::EnsureClone(
+                CloneSpec::registry(
+                    PackageFetch {
+                        name,
+                        version,
+                        tarball_url,
+                    },
+                    target,
+                ),
                 tx,
             ))
             .map_err(|_| anyhow!("install scheduler stopped"))?;
@@ -354,7 +408,14 @@ impl SchedulerState {
             return;
         }
 
-        self.resolve_cache_for_clone(spec);
+        self.prepare_clone(spec);
+    }
+
+    fn prepare_clone(&mut self, spec: CloneSpec) {
+        match spec.cache_mode {
+            CloneCacheMode::Seeded => self.resolve_cache_for_clone(spec),
+            CloneCacheMode::Registry => self.ensure_download(spec.package.clone(), Some(spec)),
+        }
     }
 
     fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
@@ -538,7 +599,7 @@ impl SchedulerState {
         if result.is_ok() {
             if let Some(children) = self.blocked_by_parent.remove(&target) {
                 for child in children {
-                    self.resolve_cache_for_clone(child);
+                    self.prepare_clone(child);
                 }
             }
         } else if let Some(children) = self.blocked_by_parent.remove(&target) {
@@ -583,11 +644,7 @@ mod tests {
     }
 
     fn clone_spec(name: &str, version: &str, target: &str) -> CloneSpec {
-        CloneSpec {
-            package: package(name, version),
-            target: PathBuf::from(target),
-            parent: None,
-        }
+        CloneSpec::new(package(name, version), PathBuf::from(target), None)
     }
 
     fn state() -> SchedulerState {
@@ -662,5 +719,18 @@ mod tests {
 
         assert_eq!(state.clone_waiters[&target].len(), 2);
         assert_eq!(state.ops.len(), 1);
+    }
+
+    #[test]
+    fn registry_clone_mode_skips_seeded_cache_probe() {
+        let mut state = state();
+        let target = PathBuf::from("/tmp/project/node_modules/react");
+        let spec = CloneSpec::registry(package("react", "18.2.0"), target);
+
+        state.queue_clone(spec, None);
+
+        assert!(state.ops.is_empty());
+        assert_eq!(state.download_queue.len(), 1);
+        assert_eq!(state.download_waiters["react@18.2.0"].len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

AB experiment for p3 fresh-lock install hot path.

This builds on the fresh-lock registry classifier from #2962. #2962 showed that merely starting downloads earlier does not materially improve p3. This PR goes one step lower in the hot path: when a lockfile package is proven to come from a registry spec, its clone request can directly join the registry cache/download state instead of spawning a seeded `_http_<url-hash>` cache probe first.

Changes:

- add `CloneCacheMode::Registry` to the install scheduler
- fresh-lock registry packages use `ensure_registry_clone`, which routes directly to `ensure_download`
- normal `ensure_clone`, resolver clone prefetch, git/file/generic HTTP tarballs still use the seeded-cache path
- keep parent/depth clone ordering unchanged

## Safety boundary

The registry fast path is only used for lock entries whose incoming parent dependency spec parses as a ruborist registry spec. Generic `https://...tgz`, `file:`, git, links, unknown package names, and platform-incompatible packages are excluded and continue through seeded-cache lookup.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm service::install_scheduler::tests`
- `cargo test -p utoo-pm fresh_lock`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
- `cargo test -p utoo-pm` (`263 passed`, `3 ignored`)

## Bench plan

Compare against #2962 and #2948 on linux/npmjs. Target phase is `p3_cold_install`; expected signal is lower ctx and possibly lower wall. p4 should stay neutral.
