### PR TITLE
perf(pm): run install clone workers on rayon

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -7,7 +7,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 
-use crate::util::cloner::{clone_count, clone_package_from_cache};
+use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
 use crate::util::downloader::{
     download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
     registry_cache_lookup, resolve_seeded_cache_path,
@@ -248,11 +248,14 @@ struct SchedulerState {
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
     blocked_by_parent: HashMap<PathBuf, Vec<CloneSpec>>,
     clone_queue: VecDeque<ReadyClone>,
+    done_tx: mpsc::UnboundedSender<OpDone>,
+    done_rx: mpsc::UnboundedReceiver<OpDone>,
     ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
 }
 
 impl SchedulerState {
     fn new(rx: mpsc::UnboundedReceiver<Command>) -> Self {
+        let (done_tx, done_rx) = mpsc::unbounded_channel();
         Self {
             rx,
             shutdown: false,
@@ -270,6 +273,8 @@ impl SchedulerState {
             clone_waiters: HashMap::new(),
             blocked_by_parent: HashMap::new(),
             clone_queue: VecDeque::new(),
+            done_tx,
+            done_rx,
             ops: FuturesUnordered::new(),
         }
     }
@@ -306,6 +311,11 @@ impl SchedulerState {
                         Some(Ok(done)) => self.handle_done(done),
                         Some(Err(e)) => tracing::warn!("Install scheduler worker failed: {e}"),
                         None => {}
+                    }
+                }
+                done = self.done_rx.recv() => {
+                    if let Some(done) = done {
+                        self.handle_done(done);
                     }
                 }
             }
@@ -455,18 +465,21 @@ impl SchedulerState {
                 continue;
             }
 
-            self.ops.push(tokio::spawn(async move {
-                let result = clone_package_from_cache(
-                    &job.spec.package.name,
-                    &job.spec.package.version,
-                    &job.spec.package.tarball_url,
-                    &job.cache_path,
-                    &job.spec.target,
-                )
-                .await
-                .map_err(|e| format!("{e:#}"));
-                OpDone::Clone { target, result }
-            }));
+            let done_tx = self.done_tx.clone();
+            rayon::spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    clone_package_from_cache_sync(
+                        &job.spec.package.name,
+                        &job.spec.package.version,
+                        &job.spec.package.tarball_url,
+                        &job.cache_path,
+                        &job.spec.target,
+                    )
+                    .map_err(|e| format!("{e:#}"))
+                }))
+                .unwrap_or_else(|_| Err("install clone worker panicked".to_string()));
+                let _ = done_tx.send(OpDone::Clone { target, result });
+            });
         }
     }
 

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
 
@@ -21,8 +22,8 @@ pub fn clone_count() -> usize {
 
 /// Clone a package from an already-resolved cache path without touching the
 /// global clone/download single-flight maps. Schedulers that own deduplication
-/// should use this primitive.
-pub async fn clone_package_from_cache(
+/// use this sync primitive from their worker pool.
+pub fn clone_package_from_cache_sync(
     name: &str,
     version: &str,
     tarball_url: &str,
@@ -30,7 +31,7 @@ pub async fn clone_package_from_cache(
     target_path: &Path,
 ) -> Result<()> {
     let is_git = is_git_url(tarball_url);
-    let fresh = clone_package(cache_path, target_path, name, version, !is_git).await?;
+    let fresh = clone_package_sync(cache_path, target_path, name, version, !is_git)?;
     if fresh {
         CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
     }
@@ -101,83 +102,181 @@ mod hardlink_clone {
         Ok(())
     }
 
-    /// Clone directory using spawn_blocking for sync I/O.
-    /// Uses hardlink when possible, falls back to copy.
-    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
+    /// Clone directory using sync I/O. Uses hardlink when possible, falls back
+    /// to copy.
+    pub fn clone_dir_sync(src: &Path, dst: &Path) -> Result<()> {
         let err_msg = format!("Failed to clone {} to {}", src.display(), dst.display());
+
+        if !fs::metadata(src)?.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "Source is not a directory",
+            ))
+            .with_context(|| err_msg);
+        }
+
+        let mut force_copy = has_install_script_sync(src);
+
+        // Phase 1: Collect all files and directories
+        let mut files = Vec::new();
+        let mut dirs = Vec::new();
+        collect_entries(src, dst, &mut files, &mut dirs)?;
+
+        // Phase 2: Create all directories
+        let mut created_dirs = HashSet::new();
+        for dir in &dirs {
+            if created_dirs.insert(dir.clone())
+                && let Err(e) = fs::create_dir_all(dir)
+                && e.kind() != io::ErrorKind::AlreadyExists
+            {
+                return Err(e).with_context(|| err_msg.clone());
+            }
+        }
+
+        // Phase 3: Clone files (hardlink, fall back to copy on error).
+        //
+        // EXDEV (src cache and dst on different filesystems, e.g. a
+        // global install where ~/.cache/nm lives on a different volume
+        // than /usr/local) is a property of the src/dst pair — every
+        // remaining file would fail the same way, so latch `force_copy`
+        // and skip hardlink for the rest of this clone.
+        //
+        // Any other hardlink error (EMLINK on a single inode whose link
+        // count is exhausted, EPERM on a specific file, etc.) is
+        // per-file: copy this one and keep trying hardlink on the next.
+        // We warn only on the first such failure per package to avoid
+        // spamming hundreds of identical warnings when an entire package
+        // can't be hardlinked.
+        let mut warned_per_file = false;
+        for entry in &files {
+            if force_copy {
+                copy_file_sync(&entry.src, &entry.dst)?;
+            } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
+                if e.kind() == io::ErrorKind::CrossesDevices {
+                    tracing::warn!(
+                        "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
+                        src.display(),
+                        dst.display(),
+                        e
+                    );
+                    force_copy = true;
+                } else if !warned_per_file {
+                    tracing::warn!(
+                        "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
+                        entry.src.display(),
+                        entry.dst.display(),
+                        e
+                    );
+                    warned_per_file = true;
+                }
+                copy_file_sync(&entry.src, &entry.dst)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Clone directory using spawn_blocking for callers that are still async.
+    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
         let src = src.to_path_buf();
         let dst = dst.to_path_buf();
-
-        tokio::task::spawn_blocking(move || {
-            if !fs::metadata(&src)?.is_dir() {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotADirectory,
-                    "Source is not a directory",
-                ));
-            }
-
-            let mut force_copy = has_install_script_sync(&src);
-
-            // Phase 1: Collect all files and directories
-            let mut files = Vec::new();
-            let mut dirs = Vec::new();
-            collect_entries(&src, &dst, &mut files, &mut dirs)?;
-
-            // Phase 2: Create all directories
-            let mut created_dirs = HashSet::new();
-            for dir in &dirs {
-                if created_dirs.insert(dir.clone())
-                    && let Err(e) = fs::create_dir_all(dir)
-                    && e.kind() != io::ErrorKind::AlreadyExists
-                {
-                    return Err(e);
-                }
-            }
-
-            // Phase 3: Clone files (hardlink, fall back to copy on error).
-            //
-            // EXDEV (src cache and dst on different filesystems, e.g. a
-            // global install where ~/.cache/nm lives on a different volume
-            // than /usr/local) is a property of the src/dst pair — every
-            // remaining file would fail the same way, so latch `force_copy`
-            // and skip hardlink for the rest of this clone.
-            //
-            // Any other hardlink error (EMLINK on a single inode whose link
-            // count is exhausted, EPERM on a specific file, etc.) is
-            // per-file: copy this one and keep trying hardlink on the next.
-            // We warn only on the first such failure per package to avoid
-            // spamming hundreds of identical warnings when an entire package
-            // can't be hardlinked.
-            let mut warned_per_file = false;
-            for entry in &files {
-                if force_copy {
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
-                    if e.kind() == io::ErrorKind::CrossesDevices {
-                        tracing::warn!(
-                            "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
-                            src.display(),
-                            dst.display(),
-                            e
-                        );
-                        force_copy = true;
-                    } else if !warned_per_file {
-                        tracing::warn!(
-                            "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
-                            entry.src.display(),
-                            entry.dst.display(),
-                            e
-                        );
-                        warned_per_file = true;
-                    }
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                }
-            }
-            Ok(())
-        })
-        .await?
-        .with_context(|| err_msg)
+        tokio::task::spawn_blocking(move || clone_dir_sync(&src, &dst)).await?
     }
+}
+
+fn load_package_json_sync<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let pkg_path = path.join("package.json");
+    let content = std::fs::read_to_string(&pkg_path)
+        .with_context(|| format!("Failed to read file {pkg_path:?}"))?;
+
+    match serde_json::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(original_err) => match serde_json::from_str::<serde_json::Value>(&content) {
+            Ok(value) => serde_json::from_value(value)
+                .with_context(|| format!("Failed to deserialize {pkg_path:?}")),
+            Err(_) => {
+                Err(original_err).with_context(|| format!("Failed to parse JSON from {pkg_path:?}"))
+            }
+        },
+    }
+}
+
+fn validate_name_version_sync(dst: &Path, name: &str, version: &str) -> bool {
+    let Ok(pkg) = load_package_json_sync::<IdentityView>(dst) else {
+        return false;
+    };
+    pkg.name == name && pkg.version == version
+}
+
+fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(src).ok()? {
+        let entry = entry.ok()?;
+        if entry.file_type().ok()?.is_dir() {
+            let path = entry.path();
+            if path.file_name().is_some_and(|name| name != ".utoo_built") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    let src_c = CString::new(real_src.as_os_str().as_bytes())?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
+    let mut last_error = None;
+
+    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
+
+        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
+            0 => return Ok(()),
+            _ => {
+                let err = std::io::Error::last_os_error();
+                let _ = std::fs::remove_dir_all(dst);
+                last_error = Some(err);
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "clonefile {} -> {}: {}",
+        real_src.display(),
+        dst.display(),
+        last_error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string())
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    hardlink_clone::clone_dir_sync(real_src, dst)
+        .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))
+}
+
+fn clone_sync(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
+    let real_src = if find_real {
+        find_real_src_sync(src)
+            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?
+    } else {
+        src.to_path_buf()
+    };
+
+    if dst.try_exists()?
+        && let Err(e) = std::fs::remove_dir_all(dst)
+    {
+        tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+    }
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    clone_dir_native_sync(&real_src, dst)?;
+    Ok(())
 }
 
 async fn validate_directory(src: &Path, dst: &Path) -> Result<bool> {
@@ -371,6 +470,26 @@ pub async fn clone_package(
         }
     }
     clone(src, dst, find_real).await?;
+    Ok(true)
+}
+
+/// Sync clone path with the same name/version validation as [`clone_package`].
+fn clone_package_sync(
+    src: &Path,
+    dst: &Path,
+    name: &str,
+    version: &str,
+    find_real: bool,
+) -> Result<bool> {
+    if dst.try_exists()? {
+        if validate_name_version_sync(dst, name, version) {
+            return Ok(false);
+        }
+        if let Err(e) = std::fs::remove_dir_all(dst) {
+            tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+        }
+    }
+    clone_sync(src, dst, find_real)?;
     Ok(true)
 }
 


### PR DESCRIPTION
### What

AB experiment for p3/p4 install/link ctx: move scheduler-owned clone workers from the nested `tokio::spawn -> spawn_blocking` path to a single rayon worker that reports completion back to the install scheduler main loop.

### Why

Current p4 is mostly warm-cache clone/link work. Each package clone currently enters a tokio task and then hops again into the blocking pool for sync hardlink/copy. This tests whether removing that extra async/blocking-pool hop reduces context switches without changing scheduler ownership, clone ordering, cache lookup, or package semantics.

### Notes

- Scheduler state remains in the main loop.
- Clone workers still only perform atomic filesystem work and send an `OpDone::Clone` result back.
- Existing async `clone_package` remains for non-scheduler call sites.
- This is an AB PR; fold only if p3/p4 GHA data improves.

### Validation

- `cargo fmt`
- `cargo test -p utoo-pm`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

### Bench plan

Trigger linux/npmjs phase bench and compare mainly:

| phase | baseline #2948 | target |
| --- | ---: | --- |
| p3 cold install | `7.62s`, ctx `142.2K/68.3K` | wall neutral/better, ctx lower |
| p4 warm link | noisy `4.83s`, ctx `54.6K/23.5K`; recent ABs around `2.2s`, ctx `~52K/~24K` | ctx lower without wall regression |
