### PR TITLE
perf(pm): handle warm registry cache hits in scheduler

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -10,7 +10,7 @@ use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 use crate::util::cloner::{clone_count, clone_package_from_cache};
 use crate::util::downloader::{
     download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
-    registry_cache_lookup, resolve_seeded_cache_path,
+    registry_cache_lookup, registry_cache_lookup_sync, resolve_seeded_cache_path,
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
 
@@ -387,6 +387,14 @@ impl SchedulerState {
             return;
         }
 
+        if let Some(cache_path) = registry_cache_lookup_sync(&package.name, &package.version) {
+            self.download_done.insert(key, cache_path.clone());
+            if let Some(spec) = waiter {
+                self.clone_queue.push_back(ReadyClone { spec, cache_path });
+            }
+            return;
+        }
+
         self.download_waiters
             .insert(key, waiter.into_iter().collect());
         self.download_queue.push_back(package);
@@ -598,14 +606,21 @@ mod tests {
     #[test]
     fn ensure_download_dedupes_inflight_package() {
         let mut state = state();
-        let package = package("react", "18.2.0");
-        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
+        let package = package("utoo-scheduler-test-react", "18.2.0");
+        let waiter = clone_spec(
+            "utoo-scheduler-test-react",
+            "18.2.0",
+            "/tmp/project/node_modules/utoo-scheduler-test-react",
+        );
 
         state.ensure_download(package.clone(), Some(waiter));
         state.ensure_download(package, None);
 
         assert_eq!(state.download_queue.len(), 1);
-        assert_eq!(state.download_waiters["react@18.2.0"].len(), 1);
+        assert_eq!(
+            state.download_waiters["utoo-scheduler-test-react@18.2.0"].len(),
+            1
+        );
     }
 
     #[test]

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -177,6 +177,17 @@ pub async fn registry_cache_lookup(name: &str, version: &str) -> Result<Option<P
     }
 }
 
+/// Sync registry cache probe for scheduler-owned hot paths.
+pub fn registry_cache_lookup_sync(name: &str, version: &str) -> Option<PathBuf> {
+    let cache_path = registry_cache_path(name, version);
+    if cache_path.join("_resolved").try_exists().unwrap_or(false) {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        Some(cache_path)
+    } else {
+        None
+    }
+}
+
 /// Extract already downloaded registry tarball bytes into the package cache.
 pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
     let cache_path = registry_cache_path(name, version);


### PR DESCRIPTION
### What

AB experiment for p4 warm-link ctx: let the install scheduler handle registry cache hits synchronously in the main loop before enqueueing download work.

### Why

In p4 the lockfile and registry cache are already warm, but every registry package still enters a worker task just to check `<cache>/<name>/<version>/_resolved`. This keeps the scheduler state centralized while removing one per-package tokio worker from the all-cache-hit path.

### Notes

- Cache miss behavior is unchanged: misses still enqueue download work and use the existing async downloader.
- The sync probe is limited to the cheap `_resolved` marker check and only updates scheduler-owned state.
- Adjusted the scheduler dedupe unit test to avoid depending on whether the local machine happens to have `react@18.2.0` in cache.

### Validation

- `cargo fmt`
- `cargo test -p utoo-pm`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

### Bench plan

Trigger linux/npmjs phase bench and compare mainly:

| phase | expected signal |
| --- | --- |
| p3 cold install | should be neutral; cache misses still download through the same queue |
| p4 warm link | target phase; expect lower ctx from skipping per-package cache-hit worker tasks |
