### PR TITLE
perf(pm): resolve install seeded cache synchronously

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -10,7 +10,7 @@ use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 use crate::util::cloner::{clone_count, clone_package_from_cache};
 use crate::util::downloader::{
     download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
-    registry_cache_lookup, resolve_seeded_cache_path,
+    registry_cache_lookup, resolve_seeded_cache_path_sync,
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
 
@@ -358,17 +358,13 @@ impl SchedulerState {
     }
 
     fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
-        let task_spec = spec.clone();
-        self.ops.push(tokio::spawn(async move {
-            let result = resolve_seeded_cache_path(
-                &task_spec.package.name,
-                &task_spec.package.version,
-                &task_spec.package.tarball_url,
-            )
-            .await
-            .map_err(|e| format!("{e:#}"));
-            OpDone::SeededCache { spec, result }
-        }));
+        let result = resolve_seeded_cache_path_sync(
+            &spec.package.name,
+            &spec.package.version,
+            &spec.package.tarball_url,
+        )
+        .map_err(|e| format!("{e:#}"));
+        self.handle_done(OpDone::SeededCache { spec, result });
     }
 
     fn ensure_download(&mut self, package: PackageFetch, waiter: Option<CloneSpec>) {
@@ -598,22 +594,33 @@ mod tests {
     #[test]
     fn ensure_download_dedupes_inflight_package() {
         let mut state = state();
-        let package = package("react", "18.2.0");
-        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
+        let package = package("utoo-scheduler-test-react", "18.2.0");
+        let waiter = clone_spec(
+            "utoo-scheduler-test-react",
+            "18.2.0",
+            "/tmp/project/node_modules/utoo-scheduler-test-react",
+        );
 
         state.ensure_download(package.clone(), Some(waiter));
         state.ensure_download(package, None);
 
         assert_eq!(state.download_queue.len(), 1);
-        assert_eq!(state.download_waiters["react@18.2.0"].len(), 1);
+        assert_eq!(
+            state.download_waiters["utoo-scheduler-test-react@18.2.0"].len(),
+            1
+        );
     }
 
     #[test]
     fn download_completion_releases_slot_and_queues_extract() {
         let mut state = state();
-        let package = package("react", "18.2.0");
+        let package = package("utoo-scheduler-test-react", "18.2.0");
         let key = package.key();
-        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
+        let waiter = clone_spec(
+            "utoo-scheduler-test-react",
+            "18.2.0",
+            "/tmp/project/node_modules/utoo-scheduler-test-react",
+        );
 
         state.download_active.insert(key.clone());
         state.download_waiters.insert(key.clone(), vec![waiter]);
@@ -632,9 +639,13 @@ mod tests {
     #[test]
     fn extract_completion_wakes_clone_waiters() {
         let mut state = state();
-        let key = "react@18.2.0".to_string();
-        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
-        let cache_path = PathBuf::from("/tmp/cache/react/18.2.0");
+        let key = "utoo-scheduler-test-react@18.2.0".to_string();
+        let waiter = clone_spec(
+            "utoo-scheduler-test-react",
+            "18.2.0",
+            "/tmp/project/node_modules/utoo-scheduler-test-react",
+        );
+        let cache_path = PathBuf::from("/tmp/cache/utoo-scheduler-test-react/18.2.0");
 
         state.extract_active.insert(key.clone());
         state.download_waiters.insert(key.clone(), vec![waiter]);
@@ -652,8 +663,12 @@ mod tests {
     #[tokio::test]
     async fn queue_clone_dedupes_inflight_target() {
         let mut state = state();
-        let target = PathBuf::from("/tmp/project/node_modules/react");
-        let spec = clone_spec("react", "18.2.0", target.to_string_lossy().as_ref());
+        let target = PathBuf::from("/tmp/project/node_modules/utoo-scheduler-test-react");
+        let spec = clone_spec(
+            "utoo-scheduler-test-react",
+            "18.2.0",
+            target.to_string_lossy().as_ref(),
+        );
         let (first, _first_rx) = oneshot::channel();
         let (second, _second_rx) = oneshot::channel();
 
@@ -661,6 +676,7 @@ mod tests {
         state.queue_clone(spec, Some(second));
 
         assert_eq!(state.clone_waiters[&target].len(), 2);
-        assert_eq!(state.ops.len(), 1);
+        assert!(state.ops.is_empty());
+        assert_eq!(state.download_queue.len(), 1);
     }
 }

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -60,22 +60,14 @@ pub fn is_registry_tarball_url(url: &str) -> bool {
     matches!(url.parse::<Protocol>(), Ok(Protocol::Http))
 }
 
-/// Look up the cache path for a git-resolved package.
-///
-/// Git packages are cloned during BFS resolution (inside ruborist) and
-/// stored at `<cache_dir>/<name>/<commit_sha>/`.
-pub async fn git_cache_lookup(name: &str, version: &str, tarball_url: &str) -> Option<PathBuf> {
+pub fn git_cache_lookup_sync(name: &str, version: &str, tarball_url: &str) -> Option<PathBuf> {
     let commit_sha = tarball_url.split_once('#').map(|(_, frag)| frag)?;
     if commit_sha.contains("..") || commit_sha.contains('/') || commit_sha.contains('\\') {
         tracing::warn!("Suspicious commit SHA fragment in URL: {}", tarball_url);
         return None;
     }
-    let cache_dir = get_cache_dir();
-    let cache_path = cache_dir.join(name).join(commit_sha);
-    if crate::fs::try_exists(&cache_path.join("_resolved"))
-        .await
-        .unwrap_or(false)
-    {
+    let cache_path = get_cache_dir().join(name).join(commit_sha);
+    if cache_path.join("_resolved").try_exists().unwrap_or(false) {
         return Some(cache_path);
     }
     tracing::warn!(
@@ -86,17 +78,9 @@ pub async fn git_cache_lookup(name: &str, version: &str, tarball_url: &str) -> O
     None
 }
 
-/// Look up a ruborist-seeded cache slot at `<cache_dir>/<name>/<slot>/`.
-///
-/// Returns `Some(path)` only if the slot's `_resolved` marker exists —
-/// otherwise returns `None` so the caller can fall through to the next
-/// routing step (typically the registry download path).
-async fn slot_cache_lookup(name: &str, slot: String) -> Option<PathBuf> {
+fn slot_cache_lookup_sync(name: &str, slot: String) -> Option<PathBuf> {
     let cache_path = get_cache_dir().join(name).join(slot);
-    if crate::fs::try_exists(&cache_path.join("_resolved"))
-        .await
-        .unwrap_or(false)
-    {
+    if cache_path.join("_resolved").try_exists().unwrap_or(false) {
         Some(cache_path)
     } else {
         None
@@ -108,34 +92,32 @@ async fn slot_cache_lookup(name: &str, slot: String) -> Option<PathBuf> {
 /// The URL must already be absolute; call sites that read relative URLs
 /// from the lockfile are responsible for re-absolutizing against the
 /// project root before reaching the cloner.
-pub async fn file_cache_lookup(name: &str, tarball_url: &str) -> Option<PathBuf> {
+pub fn file_cache_lookup_sync(name: &str, tarball_url: &str) -> Option<PathBuf> {
     let abs_path = tarball_url.strip_prefix("file:")?;
-    slot_cache_lookup(name, file_cache_slot(std::path::Path::new(abs_path))).await
+    slot_cache_lookup_sync(name, file_cache_slot(std::path::Path::new(abs_path)))
 }
 
 /// Look up the cache path for an HTTP(S) tarball dep.
-pub async fn http_tarball_cache_lookup(name: &str, tarball_url: &str) -> Option<PathBuf> {
-    slot_cache_lookup(name, http_cache_slot(tarball_url)).await
+pub fn http_tarball_cache_lookup_sync(name: &str, tarball_url: &str) -> Option<PathBuf> {
+    slot_cache_lookup_sync(name, http_cache_slot(tarball_url))
 }
 
 /// Resolve cache slots that may have been seeded during dependency resolution
 /// without falling through to registry download. `Ok(None)` means this is a
 /// registry-style HTTP tarball that should be downloaded into `<name>/<version>`.
-pub async fn resolve_seeded_cache_path(
+pub fn resolve_seeded_cache_path_sync(
     name: &str,
     version: &str,
     tarball_url: &str,
 ) -> Result<Option<PathBuf>> {
     match tarball_url.parse::<Protocol>() {
-        Ok(Protocol::Git) => git_cache_lookup(name, version, tarball_url)
-            .await
+        Ok(Protocol::Git) => git_cache_lookup_sync(name, version, tarball_url)
             .map(Some)
             .ok_or_else(|| anyhow::anyhow!("git cache not found for {name}@{version}")),
-        Ok(Protocol::File) => file_cache_lookup(name, tarball_url)
-            .await
+        Ok(Protocol::File) => file_cache_lookup_sync(name, tarball_url)
             .map(Some)
             .ok_or_else(|| anyhow::anyhow!("file tarball cache not found for {name}@{version}")),
-        _ => Ok(http_tarball_cache_lookup(name, tarball_url).await),
+        _ => Ok(http_tarball_cache_lookup_sync(name, tarball_url)),
     }
 }
 


### PR DESCRIPTION
## Summary

- resolve ruborist-seeded install cache paths synchronously inside the install scheduler
- remove the per-package tokio task used only for cache marker probing
- keep clone/download/extract behavior unchanged for this AB

## Hypothesis

p4 warm-link still pays a per-package async cache-probe cost before falling through to the registry cache path. Moving the `_resolved` marker probe into the scheduler should reduce context switches without changing IO volume.

## Validation

- cargo fmt
- cargo test -p utoo-pm service::install_scheduler::tests
- cargo test -p utoo-pm util::downloader::tests
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps

## Benchmark Plan

- GHA label-triggered pm-bench-phases, Linux/npmjs only
- Compare p3/p4 wall and vCtx/iCtx against #2948 baseline
