### PR TITLE
perf(pm): skip lifecycle reads when scripts are ignored

### DIFF
--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -147,7 +147,7 @@ impl PackageService {
             }
 
             // Read lifecycle scripts from package.json only if needed
-            let lifecycle_scripts = if has_scripts || scripts == ScriptPolicy::Run {
+            let lifecycle_scripts = if scripts == ScriptPolicy::Run && has_scripts {
                 Self::read_lifecycle_scripts(&package_path)
                     .await
                     .with_context(|| format!("Failed to read scripts for package: {path}"))?
@@ -896,6 +896,14 @@ mod tests {
             assert!(
                 !package_info.bin_files.is_empty(),
                 "Package {} should have bin_files in scripts mode",
+                package_info.name
+            );
+            assert!(
+                package_info
+                    .lifecycle_scripts
+                    .get_script(LifecycleHook::Postinstall)
+                    .is_none(),
+                "ignored scripts should not be read for {}",
                 package_info.name
             );
         }


### PR DESCRIPTION
## Summary

- skip package lifecycle-script reads during rebuild when install runs with `--ignore-scripts`
- keep binary linking behavior unchanged
- add coverage that ignore mode does not populate lifecycle scripts

## Hypothesis

p3/p4 benchmark runs use `utoo install --ignore-scripts`. Rebuild currently still reads package.json for packages marked with `hasInstallScript`, even though those scripts cannot run. Avoiding those reads should reduce warm-link filesystem work and async scheduling overhead.

## Validation

- cargo fmt
- cargo test -p utoo-pm service::package::tests::test_collect_packages_from_lock_with_scripts
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps

## Benchmark Plan

- GHA label-triggered pm-bench-phases, Linux/npmjs only
- Compare p3/p4 wall and vCtx/iCtx against #2948 baseline and #2965
