### PR TITLE
perf(pm): use sync bin linking checks

### DIFF
--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -377,7 +377,7 @@ impl PackageService {
                 }
 
                 let target_path = package.path.join(relative_path);
-                if !crate::fs::try_exists(&target_path).await? {
+                if !target_path.try_exists()? {
                     tracing::debug!(
                         "Binary file {} does not exist, skipping",
                         target_path.display()
@@ -385,15 +385,13 @@ impl PackageService {
                     continue;
                 }
 
-                ScriptService::ensure_executable(&target_path)
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "Failed to ensure binary is executable for {} (path: {})",
-                            package.name,
-                            target_path.display()
-                        )
-                    })?;
+                ScriptService::ensure_executable_sync(&target_path).with_context(|| {
+                    format!(
+                        "Failed to ensure binary is executable for {} (path: {})",
+                        package.name,
+                        target_path.display()
+                    )
+                })?;
 
                 crate::util::linker::link_bin(&target_path, &link_path).with_context(|| {
                     format!(

--- a/crates/pm/src/service/script.rs
+++ b/crates/pm/src/service/script.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::fmt::Write as _;
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -283,6 +284,60 @@ impl ScriptService {
         Ok(())
     }
 
+    pub fn ensure_executable_sync(target_path: &Path) -> Result<()> {
+        let metadata = std::fs::metadata(target_path)
+            .with_context(|| format!("Failed to access file {}", target_path.display()))?;
+
+        if !metadata.is_file() {
+            anyhow::bail!("Path is not a file: {}", target_path.display());
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let permissions = metadata.permissions();
+            let mode = permissions.mode() & 0o777;
+            let is_executable = mode & 0o111 != 0;
+
+            if !is_executable {
+                match Self::check_and_add_shebang_sync(target_path) {
+                    Ok(added) => {
+                        if added {
+                            tracing::debug!("Added shebang to {}", target_path.display());
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!("Skipping shebang for {}: {}", target_path.display(), e);
+                    }
+                }
+            }
+
+            if mode != 0o755 {
+                let mut perms = permissions;
+                perms.set_mode(0o755);
+                std::fs::set_permissions(target_path, perms)
+                    .context("Failed to set executable permissions")?;
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            match Self::check_and_add_shebang_sync(target_path) {
+                Ok(added) => {
+                    if added {
+                        tracing::debug!("Added shebang to {}", target_path.display());
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("Skipping shebang for {}: {}", target_path.display(), e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Check if file needs shebang and add it if needed
     /// Returns Ok(true) if shebang was added, Ok(false) if not needed, Err if binary/non-UTF8
     async fn check_and_add_shebang(target_path: &Path) -> Result<bool> {
@@ -318,6 +373,32 @@ impl ScriptService {
             file.write_all(new_content.as_bytes()).await?;
             file.flush().await?;
         }
+
+        Ok(true)
+    }
+
+    fn check_and_add_shebang_sync(target_path: &Path) -> Result<bool> {
+        let header = {
+            let mut file = std::fs::File::open(target_path)?;
+            let mut buffer = vec![0u8; 512];
+            let n = file.read(&mut buffer)?;
+            buffer.truncate(n);
+
+            std::str::from_utf8(&buffer)
+                .map_err(|_| anyhow::anyhow!("File is not valid UTF-8, likely a binary file"))?
+                .to_string()
+        };
+
+        if header.starts_with("#!") {
+            return Ok(false);
+        }
+
+        let content = std::fs::read_to_string(target_path)?;
+        let new_content = format!("#!/usr/bin/env node\n{}", content);
+
+        let mut file = std::fs::File::create(target_path)?;
+        file.write_all(new_content.as_bytes())?;
+        file.flush()?;
 
         Ok(true)
     }
@@ -751,6 +832,23 @@ mod tests {
 
         // Test ensure_executable
         let result = ScriptService::ensure_executable(&test_file).await;
+        assert!(result.is_ok(), "Failed to ensure file is executable");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let permissions = fs::metadata(&test_file).unwrap().permissions();
+            assert!(permissions.mode() & 0o111 != 0, "File not made executable");
+        }
+    }
+
+    #[test]
+    fn test_ensure_executable_sync() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("test.sh");
+        fs::write(&test_file, "#!/bin/sh\necho test").unwrap();
+
+        let result = ScriptService::ensure_executable_sync(&test_file);
         assert!(result.is_ok(), "Failed to ensure file is executable");
 
         #[cfg(unix)]


### PR DESCRIPTION
## Summary

AB experiment for p3/p4 install performance.

This keeps package cloning and scheduler behavior unchanged. The only hot path moved is the bin-link rebuild path used by `utoo install --ignore-scripts`:

- replace per-bin async `try_exists().await` with `Path::try_exists()`
- add `ScriptService::ensure_executable_sync()` for bin linking
- keep existing behavior: skip missing bin targets, add shebang for text bins without one, preserve binary files, and ensure Unix executable permissions

## Hypothesis

p4 warm link has no network and uses a warm package cache, so remaining ctx should mostly come from small filesystem syscalls and per-bin async dispatch. Running these tiny bin checks synchronously should reduce scheduler/context-switch overhead without changing clone/download behavior.

## Validation

Passed:

- `cargo fmt`
- `cargo test -p utoo-pm test_ensure_executable_sync`
- `cargo test -p utoo-pm test_execute_queues_skips_missing_bin_file`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

Attempted:

- `cargo clippy --all-targets -- -D warnings --no-deps`

The full workspace clippy fails before this change is evaluated in `pack-core` because the local `next.js` symlinked checkout does not match the pack-core API usage (`CrossOrigin`, `ExternalType::Promise`, and Issue trait receiver/signature errors). PM-targeted clippy is clean.

## Benchmark Plan

Label-trigger GHA bench, compare p3/p4 against same-run `utoo-next`, `utoo-npm`, and `bun`. Keep only if p4 wall/ctx moves positively without p3 regression.