### PR TITLE
perf(pm): skip missing clean deps roots

### DIFF
--- a/crates/pm/src/service/clean.rs
+++ b/crates/pm/src/service/clean.rs
@@ -160,6 +160,10 @@ pub async fn clean_deps(groups: &HashMap<usize, Vec<(String, Package)>>, cwd: &P
     }
 
     for nm_dir in &nm_dirs {
+        if !crate::fs::try_exists(nm_dir).await? {
+            tracing::debug!("Skipping missing node_modules: {}", nm_dir.display());
+            continue;
+        }
         remove_stale_entries(nm_dir).await?;
         remove_unused_packages(nm_dir, cwd, &valid_packages).await?;
     }
@@ -224,5 +228,17 @@ mod tests {
         assert!(is_legacy_npminstall("_utoo-cli@1.0.0@2.0.0"));
         assert!(!is_legacy_npminstall("lodash"));
         assert!(!is_legacy_npminstall("_lodash@1.0.0"));
+    }
+
+    #[tokio::test]
+    async fn test_clean_deps_skips_missing_node_modules() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        fs::write(temp_dir.path().join("package.json"), r#"{"name":"root"}"#).await?;
+
+        let groups = HashMap::new();
+        clean_deps(&groups, temp_dir.path()).await?;
+
+        assert!(!temp_dir.path().join("node_modules").exists());
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Small AB experiment for p3/p4 install overhead.

`clean_deps` currently always enters stale-entry cleanup and unused-package globbing for the root `node_modules`, even when the directory does not exist. In phase-isolated p3/p4, the prepare step removes `node_modules` before each run, so this path should be a no-op.

This change skips each `node_modules` root when it is missing before running stale cleanup and package globbing. Existing workspace `node_modules` directories are still discovered and cleaned when present.

## Hypothesis

This should remove a small amount of cold/warm install filesystem probing and glob setup in p3/p4. Expected impact is small; keep only if same-run p3/p4 wall or ctx moves positively.

## Validation

Passed:

- `cargo fmt`
- `cargo test -p utoo-pm service::clean::tests::test_clean_deps_skips_missing_node_modules`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

Full workspace clippy is not repeated here; it is currently blocked in this worktree by the known `pack-core`/`next.js` API mismatch observed on #2969 validation.

## Benchmark Plan

Label-trigger GHA bench, compare p3/p4 against same-run `utoo-next`, `utoo-npm`, and `bun`.