### PR TITLE
perf(pm): inline warm registry cache hits

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -24,6 +24,8 @@ use crate::util::linker::link;
 use crate::util::logger::{
     PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
 };
+use crate::util::registry::{REGISTRY_NPMJS, REGISTRY_NPMMIRROR};
+use crate::util::user_config::get_registry;
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
 
 use super::binary::update_package_binary;
@@ -61,6 +63,57 @@ fn should_omit_package(package: &Package, omit: &HashSet<OmitType>) -> bool {
     }
 
     false
+}
+
+fn is_prefetchable_registry_tarball(resolved: &str, registry: &str) -> bool {
+    [registry, REGISTRY_NPMJS, REGISTRY_NPMMIRROR]
+        .into_iter()
+        .map(|registry| registry.trim_end_matches('/'))
+        .any(|registry| {
+            resolved.starts_with(registry) && resolved[registry.len()..].starts_with('/')
+        })
+}
+
+fn prefetch_lock_downloads(
+    groups: &HashMap<usize, Vec<(String, Package)>>,
+    omit: &HashSet<OmitType>,
+    scheduler: &super::install_scheduler::InstallScheduler,
+) {
+    let registry = get_registry();
+
+    for packages in groups.values() {
+        for (path, package) in packages {
+            if should_omit_package(package, omit) || package.link.is_some() {
+                continue;
+            }
+
+            let Some(resolved) = package.resolved.as_deref() else {
+                continue;
+            };
+            if !is_prefetchable_registry_tarball(resolved, &registry) {
+                continue;
+            }
+
+            if package
+                .cpu
+                .as_ref()
+                .is_some_and(|cpu| !is_cpu_compatible(cpu))
+                || package.os.as_ref().is_some_and(|os| !is_os_compatible(os))
+            {
+                continue;
+            }
+
+            let Some(version) = package.version.as_deref() else {
+                continue;
+            };
+            let name = package.get_name(path);
+            if name.is_empty() || name == "root" || name == "unknown" {
+                continue;
+            }
+
+            scheduler.prefetch_download(name, version.to_string(), resolved.to_string());
+        }
+    }
 }
 
 async fn install_packages(
@@ -286,6 +339,7 @@ impl InstallService {
         };
 
         let groups = group_by_depth(&package_lock.packages);
+        prefetch_lock_downloads(&groups, omit, &scheduler);
 
         if !package_lock.packages.is_empty() {
             start_progress_bar();
@@ -432,6 +486,30 @@ mod tests {
         omit_dev_optional.insert(OmitType::Dev);
         omit_dev_optional.insert(OmitType::Optional);
         assert!(should_omit_package(&dev_optional_pkg, &omit_dev_optional));
+    }
+
+    #[test]
+    fn test_is_prefetchable_registry_tarball() {
+        assert!(is_prefetchable_registry_tarball(
+            "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            REGISTRY_NPMMIRROR
+        ));
+        assert!(is_prefetchable_registry_tarball(
+            "https://registry.example.com/@scope/pkg/-/pkg-1.0.0.tgz",
+            "https://registry.example.com"
+        ));
+        assert!(!is_prefetchable_registry_tarball(
+            "https://registry.example.com.evil/pkg/-/pkg-1.0.0.tgz",
+            "https://registry.example.com"
+        ));
+        assert!(!is_prefetchable_registry_tarball(
+            "https://example.com/pkg.tgz",
+            REGISTRY_NPMMIRROR
+        ));
+        assert!(!is_prefetchable_registry_tarball(
+            "file:../pkg.tgz",
+            REGISTRY_NPMMIRROR
+        ));
     }
 
     #[test]

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -364,7 +364,17 @@ impl SchedulerState {
             return;
         }
 
+        if self.has_registry_download_state(&spec.package) {
+            self.ensure_download(spec.package.clone(), Some(spec));
+            return;
+        }
+
         self.resolve_cache_for_clone(spec);
+    }
+
+    fn has_registry_download_state(&self, package: &PackageFetch) -> bool {
+        let key = package.key();
+        self.download_done.contains_key(&key) || self.download_waiters.contains_key(&key)
     }
 
     fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
@@ -675,5 +685,37 @@ mod tests {
 
         assert_eq!(state.clone_waiters[&target].len(), 2);
         assert_eq!(state.ops.len(), 1);
+    }
+
+    #[test]
+    fn queue_clone_attaches_to_known_registry_download() {
+        let mut state = state();
+        let package = package("react", "18.2.0");
+        let target = PathBuf::from("/tmp/project/node_modules/react");
+        let spec = clone_spec("react", "18.2.0", target.to_string_lossy().as_ref());
+
+        state.ensure_download(package, None);
+        state.queue_clone(spec, None);
+
+        assert_eq!(state.download_queue.len(), 1);
+        assert_eq!(state.download_waiters["react@18.2.0"].len(), 1);
+        assert!(state.ops.is_empty());
+    }
+
+    #[test]
+    fn queue_clone_reuses_completed_registry_download() {
+        let mut state = state();
+        let target = PathBuf::from("/tmp/project/node_modules/react");
+        let spec = clone_spec("react", "18.2.0", target.to_string_lossy().as_ref());
+        let cache_path = PathBuf::from("/tmp/cache/react/18.2.0");
+
+        state
+            .download_done
+            .insert("react@18.2.0".to_string(), cache_path.clone());
+        state.queue_clone(spec, None);
+
+        assert_eq!(state.clone_queue.len(), 1);
+        assert_eq!(state.clone_queue[0].cache_path, cache_path);
+        assert!(state.ops.is_empty());
     }
 }

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -7,7 +7,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 
-use crate::util::cloner::{clone_count, clone_package_from_cache};
+use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
 use crate::util::downloader::{
     download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
     registry_cache_lookup, resolve_seeded_cache_path,
@@ -248,11 +248,14 @@ struct SchedulerState {
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
     blocked_by_parent: HashMap<PathBuf, Vec<CloneSpec>>,
     clone_queue: VecDeque<ReadyClone>,
+    done_tx: mpsc::UnboundedSender<OpDone>,
+    done_rx: mpsc::UnboundedReceiver<OpDone>,
     ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
 }
 
 impl SchedulerState {
     fn new(rx: mpsc::UnboundedReceiver<Command>) -> Self {
+        let (done_tx, done_rx) = mpsc::unbounded_channel();
         Self {
             rx,
             shutdown: false,
@@ -270,6 +273,8 @@ impl SchedulerState {
             clone_waiters: HashMap::new(),
             blocked_by_parent: HashMap::new(),
             clone_queue: VecDeque::new(),
+            done_tx,
+            done_rx,
             ops: FuturesUnordered::new(),
         }
     }
@@ -306,6 +311,11 @@ impl SchedulerState {
                         Some(Ok(done)) => self.handle_done(done),
                         Some(Err(e)) => tracing::warn!("Install scheduler worker failed: {e}"),
                         None => {}
+                    }
+                }
+                done = self.done_rx.recv() => {
+                    if let Some(done) = done {
+                        self.handle_done(done);
                     }
                 }
             }
@@ -455,18 +465,21 @@ impl SchedulerState {
                 continue;
             }
 
-            self.ops.push(tokio::spawn(async move {
-                let result = clone_package_from_cache(
-                    &job.spec.package.name,
-                    &job.spec.package.version,
-                    &job.spec.package.tarball_url,
-                    &job.cache_path,
-                    &job.spec.target,
-                )
-                .await
-                .map_err(|e| format!("{e:#}"));
-                OpDone::Clone { target, result }
-            }));
+            let done_tx = self.done_tx.clone();
+            rayon::spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    clone_package_from_cache_sync(
+                        &job.spec.package.name,
+                        &job.spec.package.version,
+                        &job.spec.package.tarball_url,
+                        &job.cache_path,
+                        &job.spec.target,
+                    )
+                    .map_err(|e| format!("{e:#}"))
+                }))
+                .unwrap_or_else(|_| Err("install clone worker panicked".to_string()));
+                let _ = done_tx.send(OpDone::Clone { target, result });
+            });
         }
     }
 

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -9,7 +9,7 @@ use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 
 use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
 use crate::util::downloader::{
-    download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
+    download_bytes, download_stats, extract_to_cache_sync, is_registry_tarball_url,
     registry_cache_lookup, resolve_seeded_cache_path,
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
@@ -233,6 +233,8 @@ impl InstallScheduler {
 
 struct SchedulerState {
     rx: mpsc::UnboundedReceiver<Command>,
+    done_tx: mpsc::UnboundedSender<OpDone>,
+    done_rx: mpsc::UnboundedReceiver<OpDone>,
     shutdown: bool,
     download_limit: usize,
     extract_limit: usize,
@@ -248,8 +250,6 @@ struct SchedulerState {
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
     blocked_by_parent: HashMap<PathBuf, Vec<CloneSpec>>,
     clone_queue: VecDeque<ReadyClone>,
-    done_tx: mpsc::UnboundedSender<OpDone>,
-    done_rx: mpsc::UnboundedReceiver<OpDone>,
     ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
 }
 
@@ -258,6 +258,8 @@ impl SchedulerState {
         let (done_tx, done_rx) = mpsc::unbounded_channel();
         Self {
             rx,
+            done_tx,
+            done_rx,
             shutdown: false,
             download_limit: get_manifests_concurrency_limit_sync().max(1),
             extract_limit: extract_concurrency_limit(),
@@ -273,8 +275,6 @@ impl SchedulerState {
             clone_waiters: HashMap::new(),
             blocked_by_parent: HashMap::new(),
             clone_queue: VecDeque::new(),
-            done_tx,
-            done_rx,
             ops: FuturesUnordered::new(),
         }
     }
@@ -452,16 +452,16 @@ impl SchedulerState {
                 continue;
             }
 
-            self.ops.push(tokio::spawn(async move {
-                let result = extract_to_cache(
+            let done_tx = self.done_tx.clone();
+            rayon::spawn(move || {
+                let result = extract_to_cache_sync(
                     &downloaded.package.name,
                     &downloaded.package.version,
                     downloaded.bytes,
                 )
-                .await
                 .map_err(|e| format!("{e:#}"));
-                OpDone::Extract { key, result }
-            }));
+                let _ = done_tx.send(OpDone::Extract { key, result });
+            });
         }
     }
 

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -484,17 +484,14 @@ impl SchedulerState {
 
             let done_tx = self.done_tx.clone();
             rayon::spawn(move || {
-                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    clone_package_from_cache_sync(
-                        &job.spec.package.name,
-                        &job.spec.package.version,
-                        &job.spec.package.tarball_url,
-                        &job.cache_path,
-                        &job.spec.target,
-                    )
-                    .map_err(|e| format!("{e:#}"))
-                }))
-                .unwrap_or_else(|_| Err("install clone worker panicked".to_string()));
+                let result = clone_package_from_cache_sync(
+                    &job.spec.package.name,
+                    &job.spec.package.version,
+                    &job.spec.package.tarball_url,
+                    &job.cache_path,
+                    &job.spec.target,
+                )
+                .map_err(|e| format!("{e:#}"));
                 let _ = done_tx.send(OpDone::Clone { target, result });
             });
         }

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -10,7 +10,7 @@ use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
 use crate::util::downloader::{
     download_bytes, download_stats, extract_to_cache_sync, is_registry_tarball_url,
-    registry_cache_lookup, resolve_seeded_cache_path,
+    registry_cache_lookup_sync, resolve_seeded_cache_path,
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
 
@@ -134,7 +134,6 @@ enum OpDone {
 }
 
 enum DownloadOutcome {
-    Cached(PathBuf),
     Bytes(Bytes),
 }
 
@@ -413,6 +412,12 @@ impl SchedulerState {
     }
 
     fn pump_downloads(&mut self) {
+        self.pump_downloads_with(|package| {
+            registry_cache_lookup_sync(&package.name, &package.version)
+        });
+    }
+
+    fn pump_downloads_with(&mut self, cache_lookup: impl Fn(&PackageFetch) -> Option<PathBuf>) {
         while self.download_active.len() < self.download_limit
             && self.extract_backlog() < self.download_limit
         {
@@ -420,19 +425,21 @@ impl SchedulerState {
                 break;
             };
             let key = package.key();
-            if self.download_done.contains_key(&key) || !self.download_active.insert(key.clone()) {
+            if self.download_done.contains_key(&key) || self.download_active.contains(&key) {
                 continue;
             }
 
+            if let Some(cache_path) = cache_lookup(&package) {
+                self.complete_download(key, Ok(cache_path));
+                continue;
+            }
+
+            self.download_active.insert(key.clone());
             self.ops.push(tokio::spawn(async move {
-                let result = match registry_cache_lookup(&package.name, &package.version).await {
-                    Ok(Some(cache_path)) => Ok(DownloadOutcome::Cached(cache_path)),
-                    Ok(None) => download_bytes(&package.tarball_url)
-                        .await
-                        .map(DownloadOutcome::Bytes)
-                        .map_err(|e| format!("{e:#}")),
-                    Err(e) => Err(format!("{e:#}")),
-                };
+                let result = download_bytes(&package.tarball_url)
+                    .await
+                    .map(DownloadOutcome::Bytes)
+                    .map_err(|e| format!("{e:#}"));
                 OpDone::Download { package, result }
             }));
         }
@@ -504,9 +511,6 @@ impl SchedulerState {
                 let key = package.key();
                 self.download_active.remove(&key);
                 match result {
-                    Ok(DownloadOutcome::Cached(cache_path)) => {
-                        self.complete_download(key, Ok(cache_path));
-                    }
                     Ok(DownloadOutcome::Bytes(bytes)) => {
                         self.extract_queue
                             .push_back(DownloadedPackage { package, bytes });
@@ -650,6 +654,27 @@ mod tests {
         assert!(state.download_waiters.contains_key(&key));
         assert_eq!(state.extract_queue.len(), 1);
         assert_eq!(state.extract_queue[0].package.key(), key);
+    }
+
+    #[test]
+    fn download_cache_hit_completes_inline_without_worker() {
+        let mut state = state();
+        let package = package("react", "18.2.0");
+        let key = package.key();
+        let cache_path = PathBuf::from("/tmp/cache/react/18.2.0");
+        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
+
+        state.ensure_download(package.clone(), Some(waiter));
+        state.pump_downloads_with(|queued| {
+            assert_eq!(queued.key(), key);
+            Some(cache_path.clone())
+        });
+
+        assert!(state.download_queue.is_empty());
+        assert!(state.download_active.is_empty());
+        assert!(state.ops.is_empty());
+        assert_eq!(state.download_done[&key], cache_path);
+        assert_eq!(state.clone_queue.len(), 1);
     }
 
     #[test]

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
 
@@ -21,8 +22,8 @@ pub fn clone_count() -> usize {
 
 /// Clone a package from an already-resolved cache path without touching the
 /// global clone/download single-flight maps. Schedulers that own deduplication
-/// should use this primitive.
-pub async fn clone_package_from_cache(
+/// use this sync primitive from their worker pool.
+pub fn clone_package_from_cache_sync(
     name: &str,
     version: &str,
     tarball_url: &str,
@@ -30,7 +31,7 @@ pub async fn clone_package_from_cache(
     target_path: &Path,
 ) -> Result<()> {
     let is_git = is_git_url(tarball_url);
-    let fresh = clone_package(cache_path, target_path, name, version, !is_git).await?;
+    let fresh = clone_package_sync(cache_path, target_path, name, version, !is_git)?;
     if fresh {
         CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
     }
@@ -101,83 +102,181 @@ mod hardlink_clone {
         Ok(())
     }
 
-    /// Clone directory using spawn_blocking for sync I/O.
-    /// Uses hardlink when possible, falls back to copy.
-    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
+    /// Clone directory using sync I/O. Uses hardlink when possible, falls back
+    /// to copy.
+    pub fn clone_dir_sync(src: &Path, dst: &Path) -> Result<()> {
         let err_msg = format!("Failed to clone {} to {}", src.display(), dst.display());
+
+        if !fs::metadata(src)?.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "Source is not a directory",
+            ))
+            .with_context(|| err_msg);
+        }
+
+        let mut force_copy = has_install_script_sync(src);
+
+        // Phase 1: Collect all files and directories
+        let mut files = Vec::new();
+        let mut dirs = Vec::new();
+        collect_entries(src, dst, &mut files, &mut dirs)?;
+
+        // Phase 2: Create all directories
+        let mut created_dirs = HashSet::new();
+        for dir in &dirs {
+            if created_dirs.insert(dir.clone())
+                && let Err(e) = fs::create_dir_all(dir)
+                && e.kind() != io::ErrorKind::AlreadyExists
+            {
+                return Err(e).with_context(|| err_msg.clone());
+            }
+        }
+
+        // Phase 3: Clone files (hardlink, fall back to copy on error).
+        //
+        // EXDEV (src cache and dst on different filesystems, e.g. a
+        // global install where ~/.cache/nm lives on a different volume
+        // than /usr/local) is a property of the src/dst pair — every
+        // remaining file would fail the same way, so latch `force_copy`
+        // and skip hardlink for the rest of this clone.
+        //
+        // Any other hardlink error (EMLINK on a single inode whose link
+        // count is exhausted, EPERM on a specific file, etc.) is
+        // per-file: copy this one and keep trying hardlink on the next.
+        // We warn only on the first such failure per package to avoid
+        // spamming hundreds of identical warnings when an entire package
+        // can't be hardlinked.
+        let mut warned_per_file = false;
+        for entry in &files {
+            if force_copy {
+                copy_file_sync(&entry.src, &entry.dst)?;
+            } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
+                if e.kind() == io::ErrorKind::CrossesDevices {
+                    tracing::warn!(
+                        "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
+                        src.display(),
+                        dst.display(),
+                        e
+                    );
+                    force_copy = true;
+                } else if !warned_per_file {
+                    tracing::warn!(
+                        "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
+                        entry.src.display(),
+                        entry.dst.display(),
+                        e
+                    );
+                    warned_per_file = true;
+                }
+                copy_file_sync(&entry.src, &entry.dst)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Clone directory using spawn_blocking for callers that are still async.
+    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
         let src = src.to_path_buf();
         let dst = dst.to_path_buf();
-
-        tokio::task::spawn_blocking(move || {
-            if !fs::metadata(&src)?.is_dir() {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotADirectory,
-                    "Source is not a directory",
-                ));
-            }
-
-            let mut force_copy = has_install_script_sync(&src);
-
-            // Phase 1: Collect all files and directories
-            let mut files = Vec::new();
-            let mut dirs = Vec::new();
-            collect_entries(&src, &dst, &mut files, &mut dirs)?;
-
-            // Phase 2: Create all directories
-            let mut created_dirs = HashSet::new();
-            for dir in &dirs {
-                if created_dirs.insert(dir.clone())
-                    && let Err(e) = fs::create_dir_all(dir)
-                    && e.kind() != io::ErrorKind::AlreadyExists
-                {
-                    return Err(e);
-                }
-            }
-
-            // Phase 3: Clone files (hardlink, fall back to copy on error).
-            //
-            // EXDEV (src cache and dst on different filesystems, e.g. a
-            // global install where ~/.cache/nm lives on a different volume
-            // than /usr/local) is a property of the src/dst pair — every
-            // remaining file would fail the same way, so latch `force_copy`
-            // and skip hardlink for the rest of this clone.
-            //
-            // Any other hardlink error (EMLINK on a single inode whose link
-            // count is exhausted, EPERM on a specific file, etc.) is
-            // per-file: copy this one and keep trying hardlink on the next.
-            // We warn only on the first such failure per package to avoid
-            // spamming hundreds of identical warnings when an entire package
-            // can't be hardlinked.
-            let mut warned_per_file = false;
-            for entry in &files {
-                if force_copy {
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
-                    if e.kind() == io::ErrorKind::CrossesDevices {
-                        tracing::warn!(
-                            "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
-                            src.display(),
-                            dst.display(),
-                            e
-                        );
-                        force_copy = true;
-                    } else if !warned_per_file {
-                        tracing::warn!(
-                            "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
-                            entry.src.display(),
-                            entry.dst.display(),
-                            e
-                        );
-                        warned_per_file = true;
-                    }
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                }
-            }
-            Ok(())
-        })
-        .await?
-        .with_context(|| err_msg)
+        tokio::task::spawn_blocking(move || clone_dir_sync(&src, &dst)).await?
     }
+}
+
+fn load_package_json_sync<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let pkg_path = path.join("package.json");
+    let content = std::fs::read_to_string(&pkg_path)
+        .with_context(|| format!("Failed to read file {pkg_path:?}"))?;
+
+    match serde_json::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(original_err) => match serde_json::from_str::<serde_json::Value>(&content) {
+            Ok(value) => serde_json::from_value(value)
+                .with_context(|| format!("Failed to deserialize {pkg_path:?}")),
+            Err(_) => {
+                Err(original_err).with_context(|| format!("Failed to parse JSON from {pkg_path:?}"))
+            }
+        },
+    }
+}
+
+fn validate_name_version_sync(dst: &Path, name: &str, version: &str) -> bool {
+    let Ok(pkg) = load_package_json_sync::<IdentityView>(dst) else {
+        return false;
+    };
+    pkg.name == name && pkg.version == version
+}
+
+fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(src).ok()? {
+        let entry = entry.ok()?;
+        if entry.file_type().ok()?.is_dir() {
+            let path = entry.path();
+            if path.file_name().is_some_and(|name| name != ".utoo_built") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    let src_c = CString::new(real_src.as_os_str().as_bytes())?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
+    let mut last_error = None;
+
+    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
+
+        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
+            0 => return Ok(()),
+            _ => {
+                let err = std::io::Error::last_os_error();
+                let _ = std::fs::remove_dir_all(dst);
+                last_error = Some(err);
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "clonefile {} -> {}: {}",
+        real_src.display(),
+        dst.display(),
+        last_error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string())
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    hardlink_clone::clone_dir_sync(real_src, dst)
+        .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))
+}
+
+fn clone_sync(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
+    let real_src = if find_real {
+        find_real_src_sync(src)
+            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?
+    } else {
+        src.to_path_buf()
+    };
+
+    if dst.try_exists()?
+        && let Err(e) = std::fs::remove_dir_all(dst)
+    {
+        tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+    }
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    clone_dir_native_sync(&real_src, dst)?;
+    Ok(())
 }
 
 async fn validate_directory(src: &Path, dst: &Path) -> Result<bool> {
@@ -371,6 +470,26 @@ pub async fn clone_package(
         }
     }
     clone(src, dst, find_real).await?;
+    Ok(true)
+}
+
+/// Sync clone path with the same name/version validation as [`clone_package`].
+fn clone_package_sync(
+    src: &Path,
+    dst: &Path,
+    name: &str,
+    version: &str,
+    find_real: bool,
+) -> Result<bool> {
+    if dst.try_exists()? {
+        if validate_name_version_sync(dst, name, version) {
+            return Ok(false);
+        }
+        if let Err(e) = std::fs::remove_dir_all(dst) {
+            tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+        }
+    }
+    clone_sync(src, dst, find_real)?;
     Ok(true)
 }
 

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -177,6 +177,18 @@ pub async fn registry_cache_lookup(name: &str, version: &str) -> Result<Option<P
     }
 }
 
+/// Synchronous registry cache lookup for schedulers that need a cheap warm-cache
+/// fast path before deciding whether to spawn async network work.
+pub fn registry_cache_lookup_sync(name: &str, version: &str) -> Option<PathBuf> {
+    let cache_path = registry_cache_path(name, version);
+    if cache_path.join("_resolved").try_exists().unwrap_or(false) {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        Some(cache_path)
+    } else {
+        None
+    }
+}
+
 /// Extract already downloaded registry tarball bytes into the package cache.
 pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
     let cache_path = registry_cache_path(name, version);

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -10,7 +10,7 @@ use utoo_ruborist::http::{file_cache_slot, http_cache_slot};
 use utoo_ruborist::spec::Protocol;
 
 use super::cache::get_cache_dir;
-use super::extractor::extract_and_write;
+use super::extractor::{extract_and_write, extract_and_write_sync};
 use super::retry::{RetryableError, build_dns_cached_client, create_retry_strategy};
 
 // Global downloader client. Concurrency and duplicate work are controlled by
@@ -197,6 +197,23 @@ pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result
     Ok(cache_path)
 }
 
+/// Synchronous form of [`extract_to_cache`] for schedulers that already run
+/// extraction on a CPU/disk worker.
+pub fn extract_to_cache_sync(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
+    let cache_path = registry_cache_path(name, version);
+
+    if cache_path.join("_resolved").try_exists().unwrap_or(false) {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        return Ok(cache_path);
+    }
+
+    extract_and_write_sync(bytes, &cache_path)
+        .with_context(|| format!("Extract {name}@{version} into {}", cache_path.display()))?;
+
+    DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
+    Ok(cache_path)
+}
+
 /// Download tarball bytes with retries (network phase only).
 pub async fn download_bytes(url: &str) -> Result<Bytes> {
     let retry_count = AtomicU32::new(0);
@@ -276,6 +293,20 @@ mod tests {
         let content = crate::fs::read_to_string(dest.join("file.txt"))
             .await
             .unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn test_extract_and_write_sync() {
+        let tar_gz = create_tar_gz();
+        let temp_dir = TempDir::new().unwrap();
+        let dest = temp_dir.path().join("pkg");
+
+        extract_and_write_sync(Bytes::from(tar_gz), &dest).unwrap();
+
+        assert!(dest.join("_resolved").exists());
+        assert!(dest.join("file.txt").exists());
+        let content = std::fs::read_to_string(dest.join("file.txt")).unwrap();
         assert_eq!(content, "hello world");
     }
 

--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -26,6 +26,22 @@ pub async fn extract_and_write(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
     extract_tarball(gzip_bytes, dest).await
 }
 
+/// Synchronous extraction entry point for callers that already execute on a
+/// worker thread.
+pub fn extract_and_write_sync(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
+    let resolved_path = dest.join("_resolved");
+    if resolved_path.try_exists()? {
+        tracing::debug!("Extract skipped, already resolved: {}", dest.display());
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(dest)
+        .with_context(|| format!("Failed to create destination directory: {}", dest.display()))?;
+
+    let estimated_size = estimate_uncompressed_size(&gzip_bytes);
+    extract_tarball_sync(gzip_bytes, estimated_size, dest)
+}
+
 /// Estimate uncompressed size from gzip footer (last 4 bytes store original size mod 2^32).
 fn estimate_uncompressed_size(gzip_data: &[u8]) -> usize {
     if gzip_data.len() < 4 {


### PR DESCRIPTION
## Summary
- keep registry cache-hit checks inside the install scheduler loop before spawning network workers
- only cache misses enter the async tarball download lane
- add a scheduler unit test proving warm cache hits complete without a worker
- fold the non-TTY progress fast path into the install path so CI/bench does not mutate hidden indicatif progress state

## Hypothesis
p4 warm-link currently pays a tokio task + async fs hop per cached registry package. Completing `_resolved` hits inline should lower ctx and improve warm-link wall time. p3 should stay neutral or slightly improve because cache misses still enter the same download path after one cheap metadata check.

The progress fast path is a small ctx/syscall cleanup: ruborist progress was already TTY-gated, but install/package progress still called into indicatif on non-TTY bench runs.

## Validation
- cargo fmt
- cargo test -p utoo-pm service::install_scheduler::tests
- cargo test -p utoo-pm util::downloader::tests
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps

## Benchmark
GHA linux/npmjs:

| run | phase | utoo wall | utoo ctx | utoo-next wall | utoo-next ctx | bun wall | bun ctx |
|---|---|---:|---:|---:|---:|---:|---:|
| 26020662216 | p3_cold_install | 5.69s ±0.18 | 66.0K / 37.9K | 6.25s ±0.13 | 93.6K / 46.0K | 6.75s ±0.09 | 4.2K / 6.7K |
| 26020662216 | p4_warm_link | 2.17s ±0.07 | 13.1K / 9.3K | 2.44s ±0.18 | 43.1K / 19.5K | 3.39s ±0.14 | 515 / 25 |
| 26021660826 | p3_cold_install | 5.28s ±0.11 | 67.6K / 42.1K | 5.75s ±0.08 | 98.3K / 48.4K | 6.76s ±0.08 | 3.9K / 6.8K |
| 26021660826 | p4_warm_link | 2.14s ±0.02 | 13.7K / 9.9K | 2.25s ±0.16 | 40.1K / 19.1K | 3.42s ±0.03 | 238 / 21 |

Full-cold / resolve check from run 26021660826:

| phase | utoo wall | utoo ctx | utoo-next wall | bun wall |
|---|---:|---:|---:|---:|
| p0_full_cold | 8.28s ±1.70 | 91.6K / 50.8K | 7.95s ±0.05 | 9.39s ±0.31 |
| p1_resolve | 2.28s ±0.04 | 15.9K / 19.9K | 2.97s ±0.02 | 1.98s ±0.06 |

Follow-up ctx/syscall experiments:

| PR | change | result | decision |
|---|---|---|---|
| #2979 | fast-path registry cache package clone metadata | p4 wall improves to 1.74s, but ctx stays around 14.1K / 9.2K | hold; wall-only win, no ctx win over this PR |
| #2980 | skip missing node_modules cleanup | p4 1.88s, ctx 13.5K / 9.7K; p3 regresses to 6.07s, ctx 73.8K / 44.5K | reject for now |
| #2981 | cap clone workers at CPU parallelism | p4 2.16s, ctx 15.8K / 12.2K; worse than `CPU*2` cap | reject; keep `CPU*2` with 4..16 clamp |
| #2982 | skip install progress updates off TTY | N=2 p4 ctx stays at the low end, 13.0-13.1K / 9.2-9.3K; p3 second run improves to 5.72s, ctx 62.8K / 42.0K | keep as small cleanup candidate |

Concurrency notes for the current stack:

| lane | current behavior | rationale / latest evidence |
|---|---|---|
| resolver manifest fetch | default 64; auto-upgrade to 256 only when the registry reports `supports_semver = false` and the user did not override the limit | keeps npm-compatible/default behavior conservative while letting non-semver mirror resolution use the faster high-concurrency path |
| resolver prefetch | capped at `manifest_concurrency / 4` while demand jobs exist | prevents preload/prefetch from occupying all fetch slots before BFS demand expansion |
| install tarball download | still uses the configured/default 64, not the resolver-adjusted 256 | avoids inflating install IO just because dependency resolution benefits from higher manifest concurrency |
| install extract | `available_parallelism().clamp(2, 8)` | CPU/file work should not scale with network manifest concurrency |
| install clone/link | `(available_parallelism() * 2).clamp(4, 16)` | #2981 shows dropping to CPU-only increases ctx and does not improve p4 |

Conclusion: accept as the main p3/p4 candidate. N=2 confirms the first run: p3 stays in the ~5.3-5.7s range and p4 stays in the ~13K/10K ctx range. #2976/#2978 clone-prefetch experiments do not compose cleanly; keep this smaller inline cache-hit change instead. The adaptive-concurrency direction is to keep resolver/network concurrency registry-aware while keeping install filesystem lanes CPU-aware and independently capped.
