### PR TITLE
perf(pm): prefetch lockfile clones

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -24,6 +24,8 @@ use crate::util::linker::link;
 use crate::util::logger::{
     PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
 };
+use crate::util::registry::{REGISTRY_NPMJS, REGISTRY_NPMMIRROR};
+use crate::util::user_config::get_registry;
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
 
 use super::binary::update_package_binary;
@@ -61,6 +63,57 @@ fn should_omit_package(package: &Package, omit: &HashSet<OmitType>) -> bool {
     }
 
     false
+}
+
+fn is_prefetchable_registry_tarball(resolved: &str, registry: &str) -> bool {
+    [registry, REGISTRY_NPMJS, REGISTRY_NPMMIRROR]
+        .into_iter()
+        .map(|registry| registry.trim_end_matches('/'))
+        .any(|registry| {
+            resolved.starts_with(registry) && resolved[registry.len()..].starts_with('/')
+        })
+}
+
+fn prefetch_lock_downloads(
+    groups: &HashMap<usize, Vec<(String, Package)>>,
+    omit: &HashSet<OmitType>,
+    scheduler: &super::install_scheduler::InstallScheduler,
+) {
+    let registry = get_registry();
+
+    for packages in groups.values() {
+        for (path, package) in packages {
+            if should_omit_package(package, omit) || package.link.is_some() {
+                continue;
+            }
+
+            let Some(resolved) = package.resolved.as_deref() else {
+                continue;
+            };
+            if !is_prefetchable_registry_tarball(resolved, &registry) {
+                continue;
+            }
+
+            if package
+                .cpu
+                .as_ref()
+                .is_some_and(|cpu| !is_cpu_compatible(cpu))
+                || package.os.as_ref().is_some_and(|os| !is_os_compatible(os))
+            {
+                continue;
+            }
+
+            let Some(version) = package.version.as_deref() else {
+                continue;
+            };
+            let name = package.get_name(path);
+            if name.is_empty() || name == "root" || name == "unknown" {
+                continue;
+            }
+
+            scheduler.prefetch_download(name, version.to_string(), resolved.to_string());
+        }
+    }
 }
 
 async fn install_packages(
@@ -286,6 +339,7 @@ impl InstallService {
         };
 
         let groups = group_by_depth(&package_lock.packages);
+        prefetch_lock_downloads(&groups, omit, &scheduler);
 
         if !package_lock.packages.is_empty() {
             start_progress_bar();
@@ -432,6 +486,30 @@ mod tests {
         omit_dev_optional.insert(OmitType::Dev);
         omit_dev_optional.insert(OmitType::Optional);
         assert!(should_omit_package(&dev_optional_pkg, &omit_dev_optional));
+    }
+
+    #[test]
+    fn test_is_prefetchable_registry_tarball() {
+        assert!(is_prefetchable_registry_tarball(
+            "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            REGISTRY_NPMMIRROR
+        ));
+        assert!(is_prefetchable_registry_tarball(
+            "https://registry.example.com/@scope/pkg/-/pkg-1.0.0.tgz",
+            "https://registry.example.com"
+        ));
+        assert!(!is_prefetchable_registry_tarball(
+            "https://registry.example.com.evil/pkg/-/pkg-1.0.0.tgz",
+            "https://registry.example.com"
+        ));
+        assert!(!is_prefetchable_registry_tarball(
+            "https://example.com/pkg.tgz",
+            REGISTRY_NPMMIRROR
+        ));
+        assert!(!is_prefetchable_registry_tarball(
+            "file:../pkg.tgz",
+            REGISTRY_NPMMIRROR
+        ));
     }
 
     #[test]

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -116,6 +116,66 @@ fn prefetch_lock_downloads(
     }
 }
 
+fn parent_package_path(path: &str) -> Option<&str> {
+    let index = path.rfind("/node_modules/")?;
+    Some(&path[..index])
+}
+
+fn prefetch_lock_clones(
+    groups: &HashMap<usize, Vec<(String, Package)>>,
+    cwd: &Path,
+    omit: &HashSet<OmitType>,
+    scheduler: &super::install_scheduler::InstallScheduler,
+) {
+    let registry = get_registry();
+    let mut depths: Vec<_> = groups.keys().copied().collect();
+    depths.sort_unstable();
+
+    for depth in depths {
+        let Some(packages) = groups.get(&depth) else {
+            continue;
+        };
+
+        for (path, package) in packages {
+            if should_omit_package(package, omit) || package.link.is_some() {
+                continue;
+            }
+
+            let Some(resolved) = package.resolved.as_deref() else {
+                continue;
+            };
+            if !is_prefetchable_registry_tarball(resolved, &registry) {
+                continue;
+            }
+
+            if package
+                .cpu
+                .as_ref()
+                .is_some_and(|cpu| !is_cpu_compatible(cpu))
+                || package.os.as_ref().is_some_and(|os| !is_os_compatible(os))
+            {
+                continue;
+            }
+
+            let Some(version) = package.version.as_deref() else {
+                continue;
+            };
+            let name = package.get_name(path);
+            if name.is_empty() || name == "root" || name == "unknown" {
+                continue;
+            }
+
+            scheduler.prefetch_clone(
+                name,
+                version.to_string(),
+                resolved.to_string(),
+                cwd.join(path),
+                parent_package_path(path).map(|parent| cwd.join(parent)),
+            );
+        }
+    }
+}
+
 async fn install_packages(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
@@ -126,6 +186,7 @@ async fn install_packages(
     // without a message the bar looks frozen on large trees.
     log_progress("validating node_modules");
     clean_deps(groups, cwd).await?;
+    prefetch_lock_clones(groups, cwd, omit, scheduler);
     log_progress("linking packages");
 
     // Always process level-by-level to ensure parent directories exist before
@@ -510,6 +571,24 @@ mod tests {
             "file:../pkg.tgz",
             REGISTRY_NPMMIRROR
         ));
+    }
+
+    #[test]
+    fn test_parent_package_path() {
+        assert_eq!(parent_package_path("node_modules/lodash"), None);
+        assert_eq!(parent_package_path("node_modules/@scope/pkg"), None);
+        assert_eq!(
+            parent_package_path("node_modules/parent/node_modules/child"),
+            Some("node_modules/parent")
+        );
+        assert_eq!(
+            parent_package_path("node_modules/@scope/parent/node_modules/@scope/child"),
+            Some("node_modules/@scope/parent")
+        );
+        assert_eq!(
+            parent_package_path("packages/app/node_modules/parent/node_modules/child"),
+            Some("packages/app/node_modules/parent")
+        );
     }
 
     #[test]

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -364,7 +364,17 @@ impl SchedulerState {
             return;
         }
 
+        if self.has_registry_download_state(&spec.package) {
+            self.ensure_download(spec.package.clone(), Some(spec));
+            return;
+        }
+
         self.resolve_cache_for_clone(spec);
+    }
+
+    fn has_registry_download_state(&self, package: &PackageFetch) -> bool {
+        let key = package.key();
+        self.download_done.contains_key(&key) || self.download_waiters.contains_key(&key)
     }
 
     fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
@@ -675,5 +685,37 @@ mod tests {
 
         assert_eq!(state.clone_waiters[&target].len(), 2);
         assert_eq!(state.ops.len(), 1);
+    }
+
+    #[test]
+    fn queue_clone_attaches_to_known_registry_download() {
+        let mut state = state();
+        let package = package("react", "18.2.0");
+        let target = PathBuf::from("/tmp/project/node_modules/react");
+        let spec = clone_spec("react", "18.2.0", target.to_string_lossy().as_ref());
+
+        state.ensure_download(package, None);
+        state.queue_clone(spec, None);
+
+        assert_eq!(state.download_queue.len(), 1);
+        assert_eq!(state.download_waiters["react@18.2.0"].len(), 1);
+        assert!(state.ops.is_empty());
+    }
+
+    #[test]
+    fn queue_clone_reuses_completed_registry_download() {
+        let mut state = state();
+        let target = PathBuf::from("/tmp/project/node_modules/react");
+        let spec = clone_spec("react", "18.2.0", target.to_string_lossy().as_ref());
+        let cache_path = PathBuf::from("/tmp/cache/react/18.2.0");
+
+        state
+            .download_done
+            .insert("react@18.2.0".to_string(), cache_path.clone());
+        state.queue_clone(spec, None);
+
+        assert_eq!(state.clone_queue.len(), 1);
+        assert_eq!(state.clone_queue[0].cache_path, cache_path);
+        assert!(state.ops.is_empty());
     }
 }

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -7,7 +7,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 
-use crate::util::cloner::{clone_count, clone_package_from_cache};
+use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
 use crate::util::downloader::{
     download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
     registry_cache_lookup, resolve_seeded_cache_path,
@@ -248,11 +248,14 @@ struct SchedulerState {
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
     blocked_by_parent: HashMap<PathBuf, Vec<CloneSpec>>,
     clone_queue: VecDeque<ReadyClone>,
+    done_tx: mpsc::UnboundedSender<OpDone>,
+    done_rx: mpsc::UnboundedReceiver<OpDone>,
     ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
 }
 
 impl SchedulerState {
     fn new(rx: mpsc::UnboundedReceiver<Command>) -> Self {
+        let (done_tx, done_rx) = mpsc::unbounded_channel();
         Self {
             rx,
             shutdown: false,
@@ -270,6 +273,8 @@ impl SchedulerState {
             clone_waiters: HashMap::new(),
             blocked_by_parent: HashMap::new(),
             clone_queue: VecDeque::new(),
+            done_tx,
+            done_rx,
             ops: FuturesUnordered::new(),
         }
     }
@@ -306,6 +311,11 @@ impl SchedulerState {
                         Some(Ok(done)) => self.handle_done(done),
                         Some(Err(e)) => tracing::warn!("Install scheduler worker failed: {e}"),
                         None => {}
+                    }
+                }
+                done = self.done_rx.recv() => {
+                    if let Some(done) = done {
+                        self.handle_done(done);
                     }
                 }
             }
@@ -455,18 +465,21 @@ impl SchedulerState {
                 continue;
             }
 
-            self.ops.push(tokio::spawn(async move {
-                let result = clone_package_from_cache(
-                    &job.spec.package.name,
-                    &job.spec.package.version,
-                    &job.spec.package.tarball_url,
-                    &job.cache_path,
-                    &job.spec.target,
-                )
-                .await
-                .map_err(|e| format!("{e:#}"));
-                OpDone::Clone { target, result }
-            }));
+            let done_tx = self.done_tx.clone();
+            rayon::spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    clone_package_from_cache_sync(
+                        &job.spec.package.name,
+                        &job.spec.package.version,
+                        &job.spec.package.tarball_url,
+                        &job.cache_path,
+                        &job.spec.target,
+                    )
+                    .map_err(|e| format!("{e:#}"))
+                }))
+                .unwrap_or_else(|_| Err("install clone worker panicked".to_string()));
+                let _ = done_tx.send(OpDone::Clone { target, result });
+            });
         }
     }
 

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -9,7 +9,7 @@ use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 
 use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
 use crate::util::downloader::{
-    download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
+    download_bytes, download_stats, extract_to_cache_sync, is_registry_tarball_url,
     registry_cache_lookup, resolve_seeded_cache_path,
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
@@ -233,6 +233,8 @@ impl InstallScheduler {
 
 struct SchedulerState {
     rx: mpsc::UnboundedReceiver<Command>,
+    done_tx: mpsc::UnboundedSender<OpDone>,
+    done_rx: mpsc::UnboundedReceiver<OpDone>,
     shutdown: bool,
     download_limit: usize,
     extract_limit: usize,
@@ -248,8 +250,6 @@ struct SchedulerState {
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
     blocked_by_parent: HashMap<PathBuf, Vec<CloneSpec>>,
     clone_queue: VecDeque<ReadyClone>,
-    done_tx: mpsc::UnboundedSender<OpDone>,
-    done_rx: mpsc::UnboundedReceiver<OpDone>,
     ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
 }
 
@@ -258,6 +258,8 @@ impl SchedulerState {
         let (done_tx, done_rx) = mpsc::unbounded_channel();
         Self {
             rx,
+            done_tx,
+            done_rx,
             shutdown: false,
             download_limit: get_manifests_concurrency_limit_sync().max(1),
             extract_limit: extract_concurrency_limit(),
@@ -273,8 +275,6 @@ impl SchedulerState {
             clone_waiters: HashMap::new(),
             blocked_by_parent: HashMap::new(),
             clone_queue: VecDeque::new(),
-            done_tx,
-            done_rx,
             ops: FuturesUnordered::new(),
         }
     }
@@ -452,16 +452,16 @@ impl SchedulerState {
                 continue;
             }
 
-            self.ops.push(tokio::spawn(async move {
-                let result = extract_to_cache(
+            let done_tx = self.done_tx.clone();
+            rayon::spawn(move || {
+                let result = extract_to_cache_sync(
                     &downloaded.package.name,
                     &downloaded.package.version,
                     downloaded.bytes,
                 )
-                .await
                 .map_err(|e| format!("{e:#}"));
-                OpDone::Extract { key, result }
-            }));
+                let _ = done_tx.send(OpDone::Extract { key, result });
+            });
         }
     }
 

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
 
@@ -21,8 +22,8 @@ pub fn clone_count() -> usize {
 
 /// Clone a package from an already-resolved cache path without touching the
 /// global clone/download single-flight maps. Schedulers that own deduplication
-/// should use this primitive.
-pub async fn clone_package_from_cache(
+/// use this sync primitive from their worker pool.
+pub fn clone_package_from_cache_sync(
     name: &str,
     version: &str,
     tarball_url: &str,
@@ -30,7 +31,7 @@ pub async fn clone_package_from_cache(
     target_path: &Path,
 ) -> Result<()> {
     let is_git = is_git_url(tarball_url);
-    let fresh = clone_package(cache_path, target_path, name, version, !is_git).await?;
+    let fresh = clone_package_sync(cache_path, target_path, name, version, !is_git)?;
     if fresh {
         CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
     }
@@ -101,83 +102,181 @@ mod hardlink_clone {
         Ok(())
     }
 
-    /// Clone directory using spawn_blocking for sync I/O.
-    /// Uses hardlink when possible, falls back to copy.
-    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
+    /// Clone directory using sync I/O. Uses hardlink when possible, falls back
+    /// to copy.
+    pub fn clone_dir_sync(src: &Path, dst: &Path) -> Result<()> {
         let err_msg = format!("Failed to clone {} to {}", src.display(), dst.display());
+
+        if !fs::metadata(src)?.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "Source is not a directory",
+            ))
+            .with_context(|| err_msg);
+        }
+
+        let mut force_copy = has_install_script_sync(src);
+
+        // Phase 1: Collect all files and directories
+        let mut files = Vec::new();
+        let mut dirs = Vec::new();
+        collect_entries(src, dst, &mut files, &mut dirs)?;
+
+        // Phase 2: Create all directories
+        let mut created_dirs = HashSet::new();
+        for dir in &dirs {
+            if created_dirs.insert(dir.clone())
+                && let Err(e) = fs::create_dir_all(dir)
+                && e.kind() != io::ErrorKind::AlreadyExists
+            {
+                return Err(e).with_context(|| err_msg.clone());
+            }
+        }
+
+        // Phase 3: Clone files (hardlink, fall back to copy on error).
+        //
+        // EXDEV (src cache and dst on different filesystems, e.g. a
+        // global install where ~/.cache/nm lives on a different volume
+        // than /usr/local) is a property of the src/dst pair — every
+        // remaining file would fail the same way, so latch `force_copy`
+        // and skip hardlink for the rest of this clone.
+        //
+        // Any other hardlink error (EMLINK on a single inode whose link
+        // count is exhausted, EPERM on a specific file, etc.) is
+        // per-file: copy this one and keep trying hardlink on the next.
+        // We warn only on the first such failure per package to avoid
+        // spamming hundreds of identical warnings when an entire package
+        // can't be hardlinked.
+        let mut warned_per_file = false;
+        for entry in &files {
+            if force_copy {
+                copy_file_sync(&entry.src, &entry.dst)?;
+            } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
+                if e.kind() == io::ErrorKind::CrossesDevices {
+                    tracing::warn!(
+                        "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
+                        src.display(),
+                        dst.display(),
+                        e
+                    );
+                    force_copy = true;
+                } else if !warned_per_file {
+                    tracing::warn!(
+                        "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
+                        entry.src.display(),
+                        entry.dst.display(),
+                        e
+                    );
+                    warned_per_file = true;
+                }
+                copy_file_sync(&entry.src, &entry.dst)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Clone directory using spawn_blocking for callers that are still async.
+    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
         let src = src.to_path_buf();
         let dst = dst.to_path_buf();
-
-        tokio::task::spawn_blocking(move || {
-            if !fs::metadata(&src)?.is_dir() {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotADirectory,
-                    "Source is not a directory",
-                ));
-            }
-
-            let mut force_copy = has_install_script_sync(&src);
-
-            // Phase 1: Collect all files and directories
-            let mut files = Vec::new();
-            let mut dirs = Vec::new();
-            collect_entries(&src, &dst, &mut files, &mut dirs)?;
-
-            // Phase 2: Create all directories
-            let mut created_dirs = HashSet::new();
-            for dir in &dirs {
-                if created_dirs.insert(dir.clone())
-                    && let Err(e) = fs::create_dir_all(dir)
-                    && e.kind() != io::ErrorKind::AlreadyExists
-                {
-                    return Err(e);
-                }
-            }
-
-            // Phase 3: Clone files (hardlink, fall back to copy on error).
-            //
-            // EXDEV (src cache and dst on different filesystems, e.g. a
-            // global install where ~/.cache/nm lives on a different volume
-            // than /usr/local) is a property of the src/dst pair — every
-            // remaining file would fail the same way, so latch `force_copy`
-            // and skip hardlink for the rest of this clone.
-            //
-            // Any other hardlink error (EMLINK on a single inode whose link
-            // count is exhausted, EPERM on a specific file, etc.) is
-            // per-file: copy this one and keep trying hardlink on the next.
-            // We warn only on the first such failure per package to avoid
-            // spamming hundreds of identical warnings when an entire package
-            // can't be hardlinked.
-            let mut warned_per_file = false;
-            for entry in &files {
-                if force_copy {
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
-                    if e.kind() == io::ErrorKind::CrossesDevices {
-                        tracing::warn!(
-                            "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
-                            src.display(),
-                            dst.display(),
-                            e
-                        );
-                        force_copy = true;
-                    } else if !warned_per_file {
-                        tracing::warn!(
-                            "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
-                            entry.src.display(),
-                            entry.dst.display(),
-                            e
-                        );
-                        warned_per_file = true;
-                    }
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                }
-            }
-            Ok(())
-        })
-        .await?
-        .with_context(|| err_msg)
+        tokio::task::spawn_blocking(move || clone_dir_sync(&src, &dst)).await?
     }
+}
+
+fn load_package_json_sync<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let pkg_path = path.join("package.json");
+    let content = std::fs::read_to_string(&pkg_path)
+        .with_context(|| format!("Failed to read file {pkg_path:?}"))?;
+
+    match serde_json::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(original_err) => match serde_json::from_str::<serde_json::Value>(&content) {
+            Ok(value) => serde_json::from_value(value)
+                .with_context(|| format!("Failed to deserialize {pkg_path:?}")),
+            Err(_) => {
+                Err(original_err).with_context(|| format!("Failed to parse JSON from {pkg_path:?}"))
+            }
+        },
+    }
+}
+
+fn validate_name_version_sync(dst: &Path, name: &str, version: &str) -> bool {
+    let Ok(pkg) = load_package_json_sync::<IdentityView>(dst) else {
+        return false;
+    };
+    pkg.name == name && pkg.version == version
+}
+
+fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(src).ok()? {
+        let entry = entry.ok()?;
+        if entry.file_type().ok()?.is_dir() {
+            let path = entry.path();
+            if path.file_name().is_some_and(|name| name != ".utoo_built") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    let src_c = CString::new(real_src.as_os_str().as_bytes())?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
+    let mut last_error = None;
+
+    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
+
+        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
+            0 => return Ok(()),
+            _ => {
+                let err = std::io::Error::last_os_error();
+                let _ = std::fs::remove_dir_all(dst);
+                last_error = Some(err);
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "clonefile {} -> {}: {}",
+        real_src.display(),
+        dst.display(),
+        last_error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string())
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    hardlink_clone::clone_dir_sync(real_src, dst)
+        .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))
+}
+
+fn clone_sync(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
+    let real_src = if find_real {
+        find_real_src_sync(src)
+            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?
+    } else {
+        src.to_path_buf()
+    };
+
+    if dst.try_exists()?
+        && let Err(e) = std::fs::remove_dir_all(dst)
+    {
+        tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+    }
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    clone_dir_native_sync(&real_src, dst)?;
+    Ok(())
 }
 
 async fn validate_directory(src: &Path, dst: &Path) -> Result<bool> {
@@ -371,6 +470,26 @@ pub async fn clone_package(
         }
     }
     clone(src, dst, find_real).await?;
+    Ok(true)
+}
+
+/// Sync clone path with the same name/version validation as [`clone_package`].
+fn clone_package_sync(
+    src: &Path,
+    dst: &Path,
+    name: &str,
+    version: &str,
+    find_real: bool,
+) -> Result<bool> {
+    if dst.try_exists()? {
+        if validate_name_version_sync(dst, name, version) {
+            return Ok(false);
+        }
+        if let Err(e) = std::fs::remove_dir_all(dst) {
+            tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+        }
+    }
+    clone_sync(src, dst, find_real)?;
     Ok(true)
 }
 

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -10,7 +10,7 @@ use utoo_ruborist::http::{file_cache_slot, http_cache_slot};
 use utoo_ruborist::spec::Protocol;
 
 use super::cache::get_cache_dir;
-use super::extractor::extract_and_write;
+use super::extractor::{extract_and_write, extract_and_write_sync};
 use super::retry::{RetryableError, build_dns_cached_client, create_retry_strategy};
 
 // Global downloader client. Concurrency and duplicate work are controlled by
@@ -197,6 +197,23 @@ pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result
     Ok(cache_path)
 }
 
+/// Synchronous form of [`extract_to_cache`] for schedulers that already run
+/// extraction on a CPU/disk worker.
+pub fn extract_to_cache_sync(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
+    let cache_path = registry_cache_path(name, version);
+
+    if cache_path.join("_resolved").try_exists().unwrap_or(false) {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        return Ok(cache_path);
+    }
+
+    extract_and_write_sync(bytes, &cache_path)
+        .with_context(|| format!("Extract {name}@{version} into {}", cache_path.display()))?;
+
+    DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
+    Ok(cache_path)
+}
+
 /// Download tarball bytes with retries (network phase only).
 pub async fn download_bytes(url: &str) -> Result<Bytes> {
     let retry_count = AtomicU32::new(0);
@@ -276,6 +293,20 @@ mod tests {
         let content = crate::fs::read_to_string(dest.join("file.txt"))
             .await
             .unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn test_extract_and_write_sync() {
+        let tar_gz = create_tar_gz();
+        let temp_dir = TempDir::new().unwrap();
+        let dest = temp_dir.path().join("pkg");
+
+        extract_and_write_sync(Bytes::from(tar_gz), &dest).unwrap();
+
+        assert!(dest.join("_resolved").exists());
+        assert!(dest.join("file.txt").exists());
+        let content = std::fs::read_to_string(dest.join("file.txt")).unwrap();
         assert_eq!(content, "hello world");
     }
 

--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -26,6 +26,22 @@ pub async fn extract_and_write(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
     extract_tarball(gzip_bytes, dest).await
 }
 
+/// Synchronous extraction entry point for callers that already execute on a
+/// worker thread.
+pub fn extract_and_write_sync(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
+    let resolved_path = dest.join("_resolved");
+    if resolved_path.try_exists()? {
+        tracing::debug!("Extract skipped, already resolved: {}", dest.display());
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(dest)
+        .with_context(|| format!("Failed to create destination directory: {}", dest.display()))?;
+
+    let estimated_size = estimate_uncompressed_size(&gzip_bytes);
+    extract_tarball_sync(gzip_bytes, estimated_size, dest)
+}
+
 /// Estimate uncompressed size from gzip footer (last 4 bytes store original size mod 2^32).
 fn estimate_uncompressed_size(gzip_data: &[u8]) -> usize {
     if gzip_data.len() < 4 {


### PR DESCRIPTION
## Summary
- prefetch registry clone work from an existing package-lock after node_modules validation finishes
- queue lockfile clones by depth and pass parent package paths for nested installs
- keep link/file/git packages on the existing ensure path; this experiment targets registry p3/p4 hot paths

## Hypothesis
p3/p4 currently prefetch registry downloads from lockfile, but clone work still expands only when each depth reaches `ensure_clone`. Queueing clone specs after `clean_deps` lets the scheduler overlap cache lookup/download/extract/clone earlier while `ensure_clone` only attaches to already-known work.

## Validation
- cargo fmt
- cargo test -p utoo-pm service::install::tests::test_parent_package_path
- cargo test -p utoo-pm service::install::tests::test_is_prefetchable_registry_tarball
- cargo test -p utoo-pm service::install_scheduler::tests
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps

## Benchmark
GHA linux/npmjs, run 26020770842:

| phase | utoo wall | utoo ctx | #2974 wall | #2974 ctx | utoo-next wall | bun wall |
|---|---:|---:|---:|---:|---:|---:|
| p0_full_cold | 7.35s ±0.12 | 85.5K / 48.6K | 7.58s ±0.13 | 84.9K / 51.9K | 7.88s ±0.22 | 9.09s ±0.24 |
| p1_resolve | 2.50s ±0.27 | 14.2K / 18.8K | 2.44s ±0.03 | 16.8K / 21.4K | 2.94s ±0.07 | 1.89s ±0.06 |
| p3_cold_install | 5.22s ±0.32 | 66.8K / 39.7K | 6.34s ±1.90 | 78.1K / 44.0K | 7.27s ±2.62 | 6.62s ±0.02 |
| p4_warm_link | 2.14s ±0.13 | 21.7K / 13.6K | 2.21s ±0.04 | 18.4K / 12.1K | 2.46s ±0.14 | 3.32s ±0.03 |

Conclusion: p3 wall is the best so far, but p4 ctx regresses compared with #2975 and #2974. Treat this as a p3-only idea; do not fold it until #2977 and #2975 N=2 show whether the p3 gain can be obtained without hurting p4.
