### PR TITLE
fix(pack): surface dev build issues without exiting dev server

### DIFF
--- a/packages/pack-shared/src/__test__/utils.test.ts
+++ b/packages/pack-shared/src/__test__/utils.test.ts
@@ -1,6 +1,68 @@
 import { describe, expect, it } from "vitest";
 import { DevServerProxy, ProxyOptions, ProxyRule } from "../config";
-import { proxyFromObject } from "../utils";
+import type { Issue } from "../issue";
+import {
+  type EntryIssuesMap,
+  ModuleBuildError,
+  processIssues,
+  proxyFromObject,
+} from "../utils";
+
+function createIssue(severity: Issue["severity"]): Issue {
+  return {
+    severity,
+    stage: "build",
+    filePath: "[project]/src/index.less",
+    title: {
+      type: "text",
+      value: "Unrecognised input",
+    },
+    description: {
+      type: "text",
+      value: "Less parser failed",
+    },
+    documentationLink: "",
+    importTraces: [],
+  };
+}
+
+describe("processIssues", () => {
+  it("keeps throwing module build errors for the legacy signature", () => {
+    expect(() =>
+      processIssues({ issues: [createIssue("error")] }, true, false),
+    ).toThrow(ModuleBuildError);
+  });
+
+  it("stores entry issues without throwing for the dev-server signature", () => {
+    const currentEntryIssues: EntryIssuesMap = new Map();
+
+    processIssues(
+      currentEntryIssues,
+      "entrypoint:0:client",
+      {
+        issues: [
+          createIssue("error"),
+          createIssue("warning"),
+          createIssue("info"),
+        ],
+      },
+      false,
+      false,
+    );
+
+    expect(currentEntryIssues.get("entrypoint:0:client")?.size).toBe(2);
+
+    processIssues(
+      currentEntryIssues,
+      "entrypoint:0:client",
+      { issues: [] },
+      false,
+      false,
+    );
+
+    expect(currentEntryIssues.get("entrypoint:0:client")?.size).toBe(0);
+  });
+});
 
 describe("proxyFromObject", () => {
   it("converts string targets to ProxyRule with default changeOrigin", () => {

--- a/packages/pack-shared/src/utils.ts
+++ b/packages/pack-shared/src/utils.ts
@@ -15,11 +15,58 @@ export interface ResultWithIssues {
   issues: Issue[];
 }
 
+type IssueKey = `${Issue["severity"]}-${Issue["filePath"]}-${string}-${string}`;
+export type IssuesMap = Map<IssueKey, Issue>;
+export type EntryIssuesMap = Map<string, IssuesMap>;
+
+export function getIssueKey(issue: Issue): IssueKey {
+  return `${issue.severity}-${issue.filePath}-${JSON.stringify(
+    issue.title,
+  )}-${JSON.stringify(issue.description)}`;
+}
+
 export function processIssues(
   result: ResultWithIssues,
   throwIssue: boolean,
   logErrors: boolean,
+): void;
+export function processIssues(
+  currentEntryIssues: EntryIssuesMap,
+  key: string,
+  result: ResultWithIssues,
+  throwIssue: boolean,
+  logErrors: boolean,
+): void;
+export function processIssues(
+  resultOrCurrentEntryIssues: ResultWithIssues | EntryIssuesMap,
+  throwIssueOrKey: boolean | string,
+  logErrorsOrResult: boolean | ResultWithIssues,
+  maybeThrowIssue?: boolean,
+  maybeLogErrors?: boolean,
 ) {
+  const currentEntryIssues =
+    resultOrCurrentEntryIssues instanceof Map
+      ? resultOrCurrentEntryIssues
+      : undefined;
+  const key =
+    resultOrCurrentEntryIssues instanceof Map
+      ? (throwIssueOrKey as string)
+      : undefined;
+  const result = currentEntryIssues
+    ? (logErrorsOrResult as ResultWithIssues)
+    : (resultOrCurrentEntryIssues as ResultWithIssues);
+  const throwIssue = currentEntryIssues
+    ? maybeThrowIssue!
+    : (throwIssueOrKey as boolean);
+  const logErrors = currentEntryIssues
+    ? maybeLogErrors!
+    : (logErrorsOrResult as boolean);
+  const newIssues = currentEntryIssues ? new Map<IssueKey, Issue>() : undefined;
+
+  if (currentEntryIssues && key) {
+    currentEntryIssues.set(key, newIssues!);
+  }
+
   const relevantIssues = new Set();
 
   for (const issue of result.issues) {
@@ -29,6 +76,8 @@ export function processIssues(
       issue.severity !== "warning"
     )
       continue;
+
+    newIssues?.set(getIssueKey(issue), issue);
 
     if (issue.severity !== "warning") {
       if (throwIssue) {

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -1,6 +1,8 @@
 import {
   type CompilationError,
+  type EntryIssuesMap,
   type EntryOptions,
+  formatIssue,
   type HMR_ACTION_TYPES,
   HMR_ACTIONS_SENT_TO_BROWSER,
   type ReloadAction,
@@ -97,12 +99,57 @@ export type ClientState = {
   hmrPayloads: Map<string, HMR_ACTION_TYPES>;
   turbopackUpdates: TurbopackUpdate[];
   subscriptions: Map<string, AsyncIterator<any>>;
+  clientIssues: EntryIssuesMap;
 };
 
 export type SendHmr = (id: string, payload: HMR_ACTION_TYPES) => void;
 
 export const FAST_REFRESH_RUNTIME_RELOAD =
   "Fast Refresh had to perform a full reload due to a runtime error.";
+
+function hasBlockingIssues(issues: EntryIssuesMap) {
+  for (const issueMap of issues.values()) {
+    for (const issue of issueMap.values()) {
+      if (issue.severity !== "warning") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function hasBlockingResultIssues(result: TurbopackResult) {
+  return result.issues.some(
+    (issue) => issue.severity === "error" || issue.severity === "fatal",
+  );
+}
+
+function addIssuesToErrors(
+  errors: Map<string, CompilationError>,
+  issues: EntryIssuesMap,
+) {
+  for (const issueMap of issues.values()) {
+    for (const [key, issue] of issueMap) {
+      if (issue.severity === "warning") {
+        continue;
+      }
+
+      errors.set(key, {
+        message: formatIssue(issue, false),
+      });
+    }
+  }
+}
+
+function getCompilationErrors(issues: EntryIssuesMap) {
+  const errors = new Map<string, CompilationError>();
+  addIssuesToErrors(errors, issues);
+  return [...errors.values()];
+}
+
+function getClientIssueKey(id: string) {
+  return `client:${id}`;
+}
 
 export async function createHotReloader(
   bundleOptions: BundleOptions,
@@ -188,6 +235,7 @@ export async function createHotReloader(
 
   const clients = new Set<WSLike>();
   const clientStates = new WeakMap<WSLike, ClientState>();
+  const currentEntryIssues: EntryIssuesMap = new Map();
   const backgroundWatchSubscriptions = new Set<
     AsyncIterableIterator<TurbopackResult>
   >();
@@ -205,10 +253,18 @@ export async function createHotReloader(
   }
 
   function sendEnqueuedMessages() {
+    if (hasBlockingIssues(currentEntryIssues)) {
+      return;
+    }
+
     for (const client of clients) {
       const state = clientStates.get(client);
       if (!state) {
         continue;
+      }
+
+      if (hasBlockingIssues(state.clientIssues)) {
+        return;
       }
 
       for (const payload of state.hmrPayloads.values()) {
@@ -277,6 +333,7 @@ export async function createHotReloader(
   async function disposeBackgroundWatchSubscriptions() {
     const subscriptions = [...backgroundWatchSubscriptions];
     backgroundWatchSubscriptions.clear();
+    currentEntryIssues.clear();
     backgroundEndpointWriteTasks.clear();
     backgroundProjectWriteTask = undefined;
     await Promise.all(
@@ -353,6 +410,7 @@ export async function createHotReloader(
 
         const watchChanges = async (
           subscription: AsyncIterableIterator<TurbopackResult>,
+          issueKey: string,
         ) => {
           try {
             for await (const data of subscription) {
@@ -360,7 +418,14 @@ export async function createHotReloader(
                 return;
               }
 
-              processIssues(data, true, true);
+              processIssues(currentEntryIssues, issueKey, data, false, true);
+
+              if (hasBlockingResultIssues(data)) {
+                hmrEventHappened = true;
+                sendEnqueuedMessagesDebounce();
+                continue;
+              }
+
               scheduleOutputWrite(entrypoint, generation);
             }
           } catch (error) {
@@ -370,11 +435,19 @@ export async function createHotReloader(
             }
           } finally {
             backgroundWatchSubscriptions.delete(subscription);
+            currentEntryIssues.delete(issueKey);
           }
         };
 
-        void watchChanges(clientChanges);
-        void watchChanges(serverChanges);
+        const entrypointIndex = currentWatchedEntrypoints.indexOf(entrypoint);
+        void watchChanges(
+          clientChanges,
+          `entrypoint:${entrypointIndex}:client`,
+        );
+        void watchChanges(
+          serverChanges,
+          `entrypoint:${entrypointIndex}:server`,
+        );
       }),
     );
   }
@@ -387,6 +460,7 @@ export async function createHotReloader(
 
     const subscription = project!.hmrEvents(id);
     state.subscriptions.set(id, subscription);
+    const issueKey = getClientIssueKey(id);
 
     // The subscription will always emit once, which is the initial
     // computation. This is not a change, so swallow it.
@@ -394,7 +468,7 @@ export async function createHotReloader(
       await subscription.next();
 
       for await (const data of subscription) {
-        processIssues(data, true, true);
+        processIssues(state.clientIssues, issueKey, data, false, true);
         if (data.type !== "issues") {
           sendTurbopackMessage(data);
         }
@@ -422,6 +496,7 @@ export async function createHotReloader(
 
     const subscription = state.subscriptions.get(id);
     subscription?.return!();
+    state.clientIssues.delete(getClientIssueKey(id));
   }
 
   async function handleEntrypointsSubscription() {
@@ -470,6 +545,7 @@ export async function createHotReloader(
           hmrPayloads: new Map(),
           turbopackUpdates: [],
           subscriptions,
+          clientIssues: new Map(),
         });
 
         client.on("close", () => {
@@ -539,7 +615,7 @@ export async function createHotReloader(
         };
         sendToClient(client, turbopackConnected);
 
-        const errors: CompilationError[] = [];
+        const errors = getCompilationErrors(currentEntryIssues);
 
         (async function () {
           const sync: SyncAction = {
@@ -561,6 +637,7 @@ export async function createHotReloader(
         hmrPayloads: new Map(),
         turbopackUpdates: [],
         subscriptions,
+        clientIssues: new Map(),
       });
 
       const turbopackConnected: TurbopackConnectedAction = {
@@ -569,7 +646,7 @@ export async function createHotReloader(
       };
       sendToClient(ws, turbopackConnected);
 
-      const errors: CompilationError[] = [];
+      const errors = getCompilationErrors(currentEntryIssues);
       const sync: SyncAction = {
         action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
         errors,
@@ -699,6 +776,7 @@ export async function createHotReloader(
           sendEnqueuedMessages();
 
           const errors = new Map<string, CompilationError>();
+          addIssuesToErrors(errors, currentEntryIssues);
 
           for (const client of clients) {
             const state = clientStates.get(client);
@@ -707,6 +785,7 @@ export async function createHotReloader(
             }
 
             const clientErrors = new Map(errors);
+            addIssuesToErrors(clientErrors, state.clientIssues);
 
             sendToClient(client, {
               action: HMR_ACTIONS_SENT_TO_BROWSER.BUILT,


### PR DESCRIPTION
## Summary

Now the problem is when utoopack's devServer meet the ModuleError(Or other error), it will cause devServer panic and exit, the case like:

<img width="1946" height="1428" alt="image" src="https://github.com/user-attachments/assets/7e2eb6cd-a7d0-42d5-bd19-cdd80db9ebe5" />

This pr want to fix the case only under HMR，even the sourcecode meet moduleError or other error, we don't need to exit at devServer, keep the devServer alive:

<img width="2534" height="1766" alt="image" src="https://github.com/user-attachments/assets/3fdb8ed2-119b-4650-8d1e-00b5812ec930" />

When the user fix the code correctly, the devServer can continue work. it can help improve the user's debug experience.

## Test Plan

Add unit test
