### PR TITLE
perf(pm): serialize scheduler extract writes

### DIFF
--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -39,7 +39,11 @@ pub fn extract_and_write_sync(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
         .with_context(|| format!("Failed to create destination directory: {}", dest.display()))?;
 
     let estimated_size = estimate_uncompressed_size(&gzip_bytes);
-    extract_tarball_sync(gzip_bytes, estimated_size, dest)
+    // The install scheduler already parallelizes at the package level.
+    // Keeping each tarball's file writes serial avoids nested rayon fan-out
+    // where many package extract workers all enqueue per-file write chunks at
+    // the same time.
+    extract_tarball_sync(gzip_bytes, estimated_size, dest, FileWriteMode::Serial)
 }
 
 /// Estimate uncompressed size from gzip footer (last 4 bytes store original size mod 2^32).
@@ -69,6 +73,12 @@ struct ExtractedEntry {
     mode: u32,
 }
 
+#[derive(Clone, Copy)]
+enum FileWriteMode {
+    ParallelChunks,
+    Serial,
+}
+
 /// Extract tarball using libdeflate for decompression + rayon for parallel writes.
 ///
 /// Uses rayon::spawn (not tokio blocking pool) to avoid thread storms.
@@ -80,7 +90,12 @@ async fn extract_tarball(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
     let (tx, rx) = tokio::sync::oneshot::channel();
 
     rayon::spawn(move || {
-        let result = extract_tarball_sync(gzip_bytes, estimated_size, &dest_owned);
+        let result = extract_tarball_sync(
+            gzip_bytes,
+            estimated_size,
+            &dest_owned,
+            FileWriteMode::ParallelChunks,
+        );
         let _ = tx.send(result);
     });
 
@@ -88,7 +103,12 @@ async fn extract_tarball(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
 }
 
 /// Synchronous extraction: decompress + parse + parallel write, all on rayon.
-fn extract_tarball_sync(gzip_bytes: Bytes, estimated_size: usize, dest: &Path) -> Result<()> {
+fn extract_tarball_sync(
+    gzip_bytes: Bytes,
+    estimated_size: usize,
+    dest: &Path,
+    file_write_mode: FileWriteMode,
+) -> Result<()> {
     use rayon::prelude::*;
     use std::collections::HashSet;
     use std::fs;
@@ -153,24 +173,38 @@ fn extract_tarball_sync(gzip_bytes: Bytes, estimated_size: usize, dest: &Path) -
     // 92% → 81%, with no observable wall-time loss vs par_iter (20s vs
     // 18s, within run-to-run noise).
     const WRITE_CHUNK_SIZE: usize = 64;
-    entries
-        .par_chunks(WRITE_CHUNK_SIZE)
-        .try_for_each(|chunk| -> Result<()> {
-            for entry in chunk {
-                let mut file = fs::File::create(&entry.path)
-                    .with_context(|| format!("Failed to create: {}", entry.path.display()))?;
-                file.write_all(&entry.data)
-                    .with_context(|| format!("Failed to write: {}", entry.path.display()))?;
+    let write_entry = |entry: &ExtractedEntry| -> Result<()> {
+        let mut file = fs::File::create(&entry.path)
+            .with_context(|| format!("Failed to create: {}", entry.path.display()))?;
+        file.write_all(&entry.data)
+            .with_context(|| format!("Failed to write: {}", entry.path.display()))?;
 
-                // Skip chmod for 0o644 (most files) — File::create() already produces
-                // this via umask (0o666 & ~0o022 = 0o644).
-                #[cfg(unix)]
-                if entry.mode != 0o644 {
-                    fs::set_permissions(&entry.path, fs::Permissions::from_mode(entry.mode)).ok();
-                }
+        // Skip chmod for 0o644 (most files) — File::create() already produces
+        // this via umask (0o666 & ~0o022 = 0o644).
+        #[cfg(unix)]
+        if entry.mode != 0o644 {
+            fs::set_permissions(&entry.path, fs::Permissions::from_mode(entry.mode)).ok();
+        }
+        Ok(())
+    };
+
+    match file_write_mode {
+        FileWriteMode::ParallelChunks => {
+            entries
+                .par_chunks(WRITE_CHUNK_SIZE)
+                .try_for_each(|chunk| -> Result<()> {
+                    for entry in chunk {
+                        write_entry(entry)?;
+                    }
+                    Ok(())
+                })?;
+        }
+        FileWriteMode::Serial => {
+            for entry in &entries {
+                write_entry(entry)?;
             }
-            Ok(())
-        })?;
+        }
+    }
 
     // Set directory permissions
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- keep async standalone tarball extraction on the existing parallel file-write path
- make the install scheduler's sync extraction write files serially inside each tarball
- avoid nested rayon fan-out when package-level extract workers are already running concurrently

## Hypothesis

p3 cold install already has package-level extraction concurrency from the install scheduler. Each package extract worker currently enters `extract_tarball_sync`, which then fans out per-file writes through rayon again. That nested parallelism can oversubscribe the filesystem path: many package workers all enqueue file-write chunks at once.

Serial file writes inside one tarball should reduce scheduler pressure and sys time while preserving cross-package extraction parallelism.

## Validation

- `cargo fmt`
- `CARGO_NET_OFFLINE=true cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
- `CARGO_NET_OFFLINE=true cargo test -p utoo-pm util::downloader -- --nocapture`

## GHA Benchmark

Runs:

- https://github.com/utooland/utoo/actions/runs/26042006409
- https://github.com/utooland/utoo/actions/runs/26043785334

linux/npmjs phase bench, this PR column only:

| phase | run 1 | run 2 |
| --- | ---: | ---: |
| p0 wall | 9.91s | 9.95s |
| p0 vCtx/iCtx | 90.0K / 56.8K | 90.8K / 51.1K |
| p1 wall | 2.56s | 2.82s |
| p1 vCtx/iCtx | 14.9K / 18.4K | 16.5K / 19.5K |
| p3 wall | 6.34s | 5.83s |
| p3 vCtx/iCtx | 69.1K / 46.5K | 67.6K / 42.5K |
| p4 wall | 2.14s | 2.16s |
| p4 vCtx/iCtx | 13.4K / 9.7K | 13.1K / 9.3K |

N=2 comparison points:

- p4 is neutral and stable, as expected, because warm-link does not extract tarballs.
- p3 remains healthy and beats the same-run `utoo-next` / `utoo-npm` baselines on wall and vCtx.
- The isolated contribution of serial per-tarball writes is still modest/uncertain because this PR is stacked on the install scheduler changes; compared with the previous stacked PR's historical GHA samples, p3 is in the same band rather than a clear step-change.

## Benchmark Plan

Use the normal GHA linux/npmjs phase bench. The expected signal is p3 sys/ctx improvement. p4 should be neutral because warm-link does not extract tarballs.

This PR is stacked on #2982 so it can be reviewed and benchmarked independently from the progress fast path.
