### PR TITLE
perf(pm): clone from extracted file index

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -7,10 +7,10 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 
-use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
+use crate::util::cloner::{clone_count, clone_package_from_cache_indexed_sync};
 use crate::util::downloader::{
-    download_bytes, download_stats, extract_to_cache_sync, is_registry_tarball_url,
-    registry_cache_lookup_sync, resolve_seeded_cache_path,
+    RegistryCacheEntry, download_bytes, download_stats, extract_to_cache_indexed_sync,
+    is_registry_tarball_url, registry_cache_lookup_sync, resolve_seeded_cache_path,
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
 
@@ -97,7 +97,7 @@ struct CloneSpec {
 
 struct ReadyClone {
     spec: CloneSpec,
-    cache_path: PathBuf,
+    cache: RegistryCacheEntry,
 }
 
 struct DownloadedPackage {
@@ -117,7 +117,7 @@ enum Command {
 enum OpDone {
     SeededCache {
         spec: CloneSpec,
-        result: Result<Option<PathBuf>, String>,
+        result: Result<Option<RegistryCacheEntry>, String>,
     },
     Download {
         package: PackageFetch,
@@ -125,7 +125,7 @@ enum OpDone {
     },
     Extract {
         key: String,
-        result: Result<PathBuf, String>,
+        result: Result<RegistryCacheEntry, String>,
     },
     Clone {
         target: PathBuf,
@@ -238,7 +238,7 @@ struct SchedulerState {
     download_limit: usize,
     extract_limit: usize,
     clone_limit: usize,
-    download_done: HashMap<String, PathBuf>,
+    download_done: HashMap<String, RegistryCacheEntry>,
     download_active: HashSet<String>,
     download_waiters: HashMap<String, Vec<CloneSpec>>,
     download_queue: VecDeque<PackageFetch>,
@@ -385,6 +385,7 @@ impl SchedulerState {
                 &task_spec.package.tarball_url,
             )
             .await
+            .map(|maybe_path| maybe_path.map(|path| RegistryCacheEntry { path, index: None }))
             .map_err(|e| format!("{e:#}"));
             OpDone::SeededCache { spec, result }
         }));
@@ -392,9 +393,9 @@ impl SchedulerState {
 
     fn ensure_download(&mut self, package: PackageFetch, waiter: Option<CloneSpec>) {
         let key = package.key();
-        if let Some(cache_path) = self.download_done.get(&key).cloned() {
+        if let Some(cache) = self.download_done.get(&key).cloned() {
             if let Some(spec) = waiter {
-                self.clone_queue.push_back(ReadyClone { spec, cache_path });
+                self.clone_queue.push_back(ReadyClone { spec, cache });
             }
             return;
         }
@@ -430,7 +431,13 @@ impl SchedulerState {
             }
 
             if let Some(cache_path) = cache_lookup(&package) {
-                self.complete_download(key, Ok(cache_path));
+                self.complete_download(
+                    key,
+                    Ok(RegistryCacheEntry {
+                        path: cache_path,
+                        index: None,
+                    }),
+                );
                 continue;
             }
 
@@ -461,7 +468,7 @@ impl SchedulerState {
 
             let done_tx = self.done_tx.clone();
             rayon::spawn(move || {
-                let result = extract_to_cache_sync(
+                let result = extract_to_cache_indexed_sync(
                     &downloaded.package.name,
                     &downloaded.package.version,
                     downloaded.bytes,
@@ -484,12 +491,13 @@ impl SchedulerState {
 
             let done_tx = self.done_tx.clone();
             rayon::spawn(move || {
-                let result = clone_package_from_cache_sync(
+                let result = clone_package_from_cache_indexed_sync(
                     &job.spec.package.name,
                     &job.spec.package.version,
                     &job.spec.package.tarball_url,
-                    &job.cache_path,
+                    &job.cache.path,
                     &job.spec.target,
+                    job.cache.index.as_ref(),
                 )
                 .map_err(|e| format!("{e:#}"));
                 let _ = done_tx.send(OpDone::Clone { target, result });
@@ -500,7 +508,7 @@ impl SchedulerState {
     fn handle_done(&mut self, done: OpDone) {
         match done {
             OpDone::SeededCache { spec, result } => match result {
-                Ok(Some(cache_path)) => self.clone_queue.push_back(ReadyClone { spec, cache_path }),
+                Ok(Some(cache)) => self.clone_queue.push_back(ReadyClone { spec, cache }),
                 Ok(None) => self.ensure_download(spec.package.clone(), Some(spec)),
                 Err(error) => self.complete_clone(spec.target, Err(error)),
             },
@@ -528,15 +536,15 @@ impl SchedulerState {
         }
     }
 
-    fn complete_download(&mut self, key: String, result: Result<PathBuf, String>) {
+    fn complete_download(&mut self, key: String, result: Result<RegistryCacheEntry, String>) {
         let waiters = self.download_waiters.remove(&key).unwrap_or_default();
         match result {
-            Ok(cache_path) => {
-                self.download_done.insert(key, cache_path.clone());
+            Ok(cache) => {
+                self.download_done.insert(key, cache.clone());
                 for spec in waiters {
                     self.clone_queue.push_back(ReadyClone {
                         spec,
-                        cache_path: cache_path.clone(),
+                        cache: cache.clone(),
                     });
                 }
             }
@@ -619,6 +627,10 @@ mod tests {
         SchedulerState::new(rx)
     }
 
+    fn cache_entry(path: PathBuf) -> RegistryCacheEntry {
+        RegistryCacheEntry { path, index: None }
+    }
+
     #[test]
     fn ensure_download_dedupes_inflight_package() {
         let mut state = state();
@@ -670,7 +682,7 @@ mod tests {
         assert!(state.download_queue.is_empty());
         assert!(state.download_active.is_empty());
         assert!(state.ops.is_empty());
-        assert_eq!(state.download_done[&key], cache_path);
+        assert_eq!(state.download_done[&key].path, cache_path);
         assert_eq!(state.clone_queue.len(), 1);
     }
 
@@ -686,11 +698,11 @@ mod tests {
 
         state.handle_done(OpDone::Extract {
             key: key.clone(),
-            result: Ok(cache_path.clone()),
+            result: Ok(cache_entry(cache_path.clone())),
         });
 
         assert!(!state.extract_active.contains(&key));
-        assert_eq!(state.download_done[&key], cache_path);
+        assert_eq!(state.download_done[&key].path, cache_path);
         assert_eq!(state.clone_queue.len(), 1);
     }
 
@@ -733,11 +745,11 @@ mod tests {
 
         state
             .download_done
-            .insert("react@18.2.0".to_string(), cache_path.clone());
+            .insert("react@18.2.0".to_string(), cache_entry(cache_path.clone()));
         state.queue_clone(spec, None);
 
         assert_eq!(state.clone_queue.len(), 1);
-        assert_eq!(state.clone_queue[0].cache_path, cache_path);
+        assert_eq!(state.clone_queue[0].cache.path, cache_path);
         assert!(state.ops.is_empty());
     }
 }

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -7,6 +7,7 @@ use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
 
 use super::downloader::is_git_url;
+use super::extractor::ExtractedPackageIndex;
 use super::json::load_package_json;
 use super::retry::create_retry_strategy;
 use crate::fs;
@@ -20,18 +21,20 @@ pub fn clone_count() -> usize {
     CLONE_COUNT.load(Ordering::Relaxed)
 }
 
-/// Clone a package from an already-resolved cache path without touching the
-/// global clone/download single-flight maps. Schedulers that own deduplication
-/// use this sync primitive from their worker pool.
-pub fn clone_package_from_cache_sync(
+pub(crate) fn clone_package_from_cache_indexed_sync(
     name: &str,
     version: &str,
     tarball_url: &str,
     cache_path: &Path,
     target_path: &Path,
+    index: Option<&ExtractedPackageIndex>,
 ) -> Result<()> {
     let is_git = is_git_url(tarball_url);
-    let fresh = clone_package_sync(cache_path, target_path, name, version, !is_git)?;
+    let fresh = if let Some(index) = index.filter(|_| !is_git) {
+        clone_package_indexed_sync(cache_path, target_path, name, version, index)?
+    } else {
+        clone_package_sync(cache_path, target_path, name, version, !is_git)?
+    };
     if fresh {
         CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
     }
@@ -53,6 +56,8 @@ mod hardlink_clone {
     use std::{fs, io};
 
     use anyhow::{Context, Result};
+
+    use super::ExtractedPackageIndex;
 
     struct CloneEntry {
         src: PathBuf,
@@ -173,6 +178,71 @@ mod hardlink_clone {
             }
         }
         Ok(())
+    }
+
+    pub(super) fn clone_dir_from_index_sync(
+        real_src: &Path,
+        dst: &Path,
+        index: &ExtractedPackageIndex,
+    ) -> Result<()> {
+        let err_msg = format!(
+            "Failed to clone {} to {}",
+            real_src.display(),
+            dst.display()
+        );
+        (|| -> Result<()> {
+            let mut force_copy = has_install_script_sync(real_src);
+
+            fs::create_dir(dst).or_else(|e| {
+                if e.kind() == io::ErrorKind::AlreadyExists {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            })?;
+
+            for dir in index.dirs.iter() {
+                let target = dst.join(dir);
+                fs::create_dir(&target).or_else(|e| {
+                    if e.kind() == io::ErrorKind::AlreadyExists {
+                        Ok(())
+                    } else {
+                        Err(e)
+                    }
+                })?;
+            }
+
+            let mut warned_per_file = false;
+            for rel in index.files.iter() {
+                let src = real_src.join(rel);
+                let dst = dst.join(rel);
+                if force_copy {
+                    copy_file_sync(&src, &dst)?;
+                } else if let Err(e) = fs::hard_link(&src, &dst) {
+                    if e.kind() == io::ErrorKind::CrossesDevices {
+                        tracing::warn!(
+                            "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
+                            real_src.display(),
+                            dst.display(),
+                            e
+                        );
+                        force_copy = true;
+                    } else if !warned_per_file {
+                        tracing::warn!(
+                            "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
+                            src.display(),
+                            dst.display(),
+                            e
+                        );
+                        warned_per_file = true;
+                    }
+                    copy_file_sync(&src, &dst)?;
+                }
+            }
+
+            Ok(())
+        })()
+        .with_context(|| err_msg)
     }
 
     /// Clone directory using spawn_blocking for callers that are still async.
@@ -491,6 +561,58 @@ fn clone_package_sync(
     }
     clone_sync(src, dst, find_real)?;
     Ok(true)
+}
+
+fn clone_package_indexed_sync(
+    cache_path: &Path,
+    dst: &Path,
+    name: &str,
+    version: &str,
+    index: &ExtractedPackageIndex,
+) -> Result<bool> {
+    #[cfg(target_os = "macos")]
+    {
+        if dst.try_exists()? {
+            if validate_name_version_sync(dst, name, version) {
+                return Ok(false);
+            }
+            if let Err(e) = std::fs::remove_dir_all(dst) {
+                tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+            }
+        }
+
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // clonefile only needs the root directory. Keep the full index in the
+        // shared type so Linux can use it for per-file hardlinks.
+        let _ = (&index.dirs, &index.files);
+        let real_src = cache_path.join(&index.root);
+        clone_sync(&real_src, dst, false)?;
+        Ok(true)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        if dst.try_exists()? {
+            if validate_name_version_sync(dst, name, version) {
+                return Ok(false);
+            }
+            if let Err(e) = std::fs::remove_dir_all(dst) {
+                tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+            }
+        }
+
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let real_src = cache_path.join(&index.root);
+        hardlink_clone::clone_dir_from_index_sync(&real_src, dst, index)
+            .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))?;
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -1190,6 +1312,51 @@ mod tests {
             assert_ne!(
                 src_ino, dst_ino,
                 "install-script packages must be copied, not hardlinked"
+            );
+            Ok(())
+        }
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        #[test]
+        fn test_clone_package_from_cache_indexed_hardlinks_files() -> Result<()> {
+            use std::os::unix::fs::MetadataExt;
+            use std::sync::Arc;
+
+            use crate::util::extractor::ExtractedPackageIndex;
+
+            let temp = TempDir::new()?;
+            let cache_version = temp.path().join("pkg/1.0.0");
+            let real_src = cache_version.join("package");
+            let dst_dir = temp.path().join("node_modules/pkg");
+
+            std::fs::create_dir_all(real_src.join("dist"))?;
+            std::fs::write(
+                real_src.join("package.json"),
+                br#"{"name":"pkg","version":"1.0.0"}"#,
+            )?;
+            std::fs::write(real_src.join("dist/index.js"), b"module.exports = 1")?;
+
+            let index = ExtractedPackageIndex {
+                root: PathBuf::from("package"),
+                dirs: Arc::from([PathBuf::from("dist")]),
+                files: Arc::from([
+                    PathBuf::from("package.json"),
+                    PathBuf::from("dist/index.js"),
+                ]),
+            };
+
+            clone_package_from_cache_indexed_sync(
+                "pkg",
+                "1.0.0",
+                "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
+                &cache_version,
+                &dst_dir,
+                Some(&index),
+            )?;
+
+            assert_eq!(
+                std::fs::metadata(real_src.join("dist/index.js"))?.ino(),
+                std::fs::metadata(dst_dir.join("dist/index.js"))?.ino()
             );
             Ok(())
         }

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -10,7 +10,7 @@ use utoo_ruborist::http::{file_cache_slot, http_cache_slot};
 use utoo_ruborist::spec::Protocol;
 
 use super::cache::get_cache_dir;
-use super::extractor::{extract_and_write, extract_and_write_sync};
+use super::extractor::{ExtractedPackageIndex, extract_and_write, extract_and_write_indexed_sync};
 use super::retry::{RetryableError, build_dns_cached_client, create_retry_strategy};
 
 // Global downloader client. Concurrency and duplicate work are controlled by
@@ -19,6 +19,12 @@ static DOWNLOADER_CLIENT: Lazy<Client> = Lazy::new(build_dns_cached_client);
 
 static DOWNLOAD_COUNT: AtomicUsize = AtomicUsize::new(0);
 static REUSE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone, Debug)]
+pub(crate) struct RegistryCacheEntry {
+    pub(crate) path: PathBuf,
+    pub(crate) index: Option<ExtractedPackageIndex>,
+}
 
 /// Process-global counters for tarball outcomes, matching pnpm's
 /// vocabulary. Scheduler-level dedupe keeps each unique `(name, version)` pair
@@ -209,21 +215,31 @@ pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result
     Ok(cache_path)
 }
 
-/// Synchronous form of [`extract_to_cache`] for schedulers that already run
-/// extraction on a CPU/disk worker.
-pub fn extract_to_cache_sync(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
+/// Synchronous form of [`extract_to_cache`] that also returns the file index
+/// for freshly extracted registry tarballs.
+pub(crate) fn extract_to_cache_indexed_sync(
+    name: &str,
+    version: &str,
+    bytes: Bytes,
+) -> Result<RegistryCacheEntry> {
     let cache_path = registry_cache_path(name, version);
 
     if cache_path.join("_resolved").try_exists().unwrap_or(false) {
         REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
-        return Ok(cache_path);
+        return Ok(RegistryCacheEntry {
+            path: cache_path,
+            index: None,
+        });
     }
 
-    extract_and_write_sync(bytes, &cache_path)
+    let index = extract_and_write_indexed_sync(bytes, &cache_path)
         .with_context(|| format!("Extract {name}@{version} into {}", cache_path.display()))?;
 
     DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
-    Ok(cache_path)
+    Ok(RegistryCacheEntry {
+        path: cache_path,
+        index,
+    })
 }
 
 /// Download tarball bytes with retries (network phase only).
@@ -314,7 +330,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let dest = temp_dir.path().join("pkg");
 
-        extract_and_write_sync(Bytes::from(tar_gz), &dest).unwrap();
+        extract_and_write_indexed_sync(Bytes::from(tar_gz), &dest).unwrap();
 
         assert!(dest.join("_resolved").exists());
         assert!(dest.join("file.txt").exists());

--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -3,10 +3,18 @@ use bytes::Bytes;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 const MIN_ESTIMATED_SIZE: usize = 16;
 const MAX_ESTIMATED_SIZE: usize = 512 * 1024 * 1024; // 512MB
 const DECOMPRESSION_RETRY_FACTOR: usize = 4;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ExtractedPackageIndex {
+    pub(crate) root: PathBuf,
+    pub(crate) dirs: Arc<[PathBuf]>,
+    pub(crate) files: Arc<[PathBuf]>,
+}
 
 /// Extract gzip tarball and write to destination.
 ///
@@ -26,13 +34,17 @@ pub async fn extract_and_write(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
     extract_tarball(gzip_bytes, dest).await
 }
 
-/// Synchronous extraction entry point for callers that already execute on a
-/// worker thread.
-pub fn extract_and_write_sync(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
+/// Synchronous extraction that also returns the file index observed while
+/// parsing the tarball. Cold-install schedulers can reuse this index to
+/// materialize immediately after extraction without walking the cache again.
+pub(crate) fn extract_and_write_indexed_sync(
+    gzip_bytes: Bytes,
+    dest: &Path,
+) -> Result<Option<ExtractedPackageIndex>> {
     let resolved_path = dest.join("_resolved");
     if resolved_path.try_exists()? {
         tracing::debug!("Extract skipped, already resolved: {}", dest.display());
-        return Ok(());
+        return Ok(None);
     }
 
     std::fs::create_dir_all(dest)
@@ -69,6 +81,7 @@ fn estimate_uncompressed_size(gzip_data: &[u8]) -> usize {
 /// write call site.
 struct ExtractedEntry {
     path: PathBuf,
+    relative_path: PathBuf,
     data: Bytes,
     mode: u32,
 }
@@ -99,7 +112,9 @@ async fn extract_tarball(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
         let _ = tx.send(result);
     });
 
-    rx.await.with_context(|| "Extract task panicked")?
+    rx.await
+        .with_context(|| "Extract task panicked")?
+        .map(|_| ())
 }
 
 /// Synchronous extraction: decompress + parse + parallel write, all on rayon.
@@ -108,7 +123,7 @@ fn extract_tarball_sync(
     estimated_size: usize,
     dest: &Path,
     file_write_mode: FileWriteMode,
-) -> Result<()> {
+) -> Result<Option<ExtractedPackageIndex>> {
     use rayon::prelude::*;
     use std::collections::HashSet;
     use std::fs;
@@ -217,7 +232,64 @@ fn extract_tarball_sync(
     fs::File::create(dest.join("_resolved"))
         .with_context(|| format!("Failed to create resolution marker in: {}", dest.display()))?;
 
-    Ok(())
+    Ok(build_package_index(&entries))
+}
+
+fn build_package_index(entries: &[ExtractedEntry]) -> Option<ExtractedPackageIndex> {
+    use std::collections::HashSet;
+    use std::path::Component;
+
+    let mut root = None::<PathBuf>;
+    let mut dirs = HashSet::<PathBuf>::new();
+    let mut seen_files = HashSet::<PathBuf>::new();
+    let mut files = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        let entry_root = match entry.relative_path.components().next()? {
+            Component::Normal(name) => PathBuf::from(name),
+            _ => return None,
+        };
+
+        if let Some(root) = &root {
+            if root != &entry_root {
+                return None;
+            }
+        } else {
+            root = Some(entry_root.clone());
+        }
+
+        let rel = entry
+            .relative_path
+            .strip_prefix(&entry_root)
+            .ok()?
+            .to_path_buf();
+        if rel.as_os_str().is_empty() {
+            return None;
+        }
+
+        if let Some(parent) = rel.parent() {
+            let mut dir = PathBuf::new();
+            for component in parent.components() {
+                let Component::Normal(name) = component else {
+                    return None;
+                };
+                dir.push(name);
+                dirs.insert(dir.clone());
+            }
+        }
+        if seen_files.insert(rel.clone()) {
+            files.push(rel);
+        }
+    }
+
+    let mut dirs: Vec<_> = dirs.into_iter().collect();
+    dirs.sort_unstable_by_key(|p| p.as_os_str().len());
+
+    Some(ExtractedPackageIndex {
+        root: root?,
+        dirs: dirs.into(),
+        files: files.into(),
+    })
 }
 
 /// Walk the tar stream and collect file entries as `(path, offset, len, mode)`
@@ -282,10 +354,73 @@ fn parse_tar_entries(buf: &Bytes, dest: &Path) -> Result<Vec<ExtractedEntry>> {
         let mode = if raw_mode & 0o111 != 0 { 0o755 } else { 0o644 };
         entries.push(ExtractedEntry {
             path: full_path,
+            relative_path: path,
             data: buf.slice(data_offset..data_offset + data_len),
             mode,
         });
     }
 
     Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &str) -> ExtractedEntry {
+        ExtractedEntry {
+            path: PathBuf::from("/cache").join(path),
+            relative_path: PathBuf::from(path),
+            data: Bytes::new(),
+            mode: 0o644,
+        }
+    }
+
+    #[test]
+    fn package_index_records_paths_under_tarball_root() {
+        let index = build_package_index(&[
+            entry("package/package.json"),
+            entry("package/dist/index.js"),
+            entry("package/dist/nested/value.js"),
+        ])
+        .expect("index");
+
+        assert_eq!(index.root, PathBuf::from("package"));
+        assert_eq!(
+            index.dirs.as_ref(),
+            &[PathBuf::from("dist"), PathBuf::from("dist/nested")]
+        );
+        assert_eq!(
+            index.files.as_ref(),
+            &[
+                PathBuf::from("package.json"),
+                PathBuf::from("dist/index.js"),
+                PathBuf::from("dist/nested/value.js"),
+            ]
+        );
+    }
+
+    #[test]
+    fn package_index_rejects_multiple_tarball_roots() {
+        let index = build_package_index(&[entry("package/a.js"), entry("other/b.js")]);
+        assert!(index.is_none());
+    }
+
+    #[test]
+    fn package_index_deduplicates_files_preserving_first_seen_order() {
+        let index = build_package_index(&[
+            entry("package/dist/index.js"),
+            entry("package/package.json"),
+            entry("package/dist/index.js"),
+        ])
+        .expect("index");
+
+        assert_eq!(
+            index.files.as_ref(),
+            &[
+                PathBuf::from("dist/index.js"),
+                PathBuf::from("package.json")
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Stacked on #2984. This tests the p3 hypothesis that cold install pays avoidable cache-walk cost immediately after extracting a tarball.

- return an optional file index from sync registry extraction
- deduplicate duplicate tar entries in the extracted file index while preserving first-seen order
- store that index in the install scheduler cache entry for freshly extracted tarballs
- materialize clones from the extracted index when available, avoiding a second `read_dir` walk of the package cache
- keep warm-cache and seeded-cache paths on the existing clone implementation (`index: None`)

## Expected Impact

`p3_cold_install` currently does download -> extract-to-cache -> clone-from-cache. For freshly extracted registry tarballs, extract already parsed every file path, but clone walks the cache again to rediscover those paths. Reusing the extracted file index should reduce p3 filesystem syscalls and context switches without changing cache layout or p4 behavior.

This is an AB experiment after #2985 showed demand download priority was not a p3 win.

## Benchmark Notes

Public GHA npmjs run (`pm-bench-phases`, linux, ant-design):

- `p3_cold_install`: `utoo 5.87s`, `69.0K / 46.1K ctx` vs `utoo-npm 7.03s`, `111.2K / 52.2K ctx` and `utoo-next 9.39s`, `135.1K / 48.7K ctx`
- `p4_warm_link`: `utoo 2.04s`, `13.4K / 9.7K ctx` vs `utoo-npm 2.27s`, `41.1K / 19.1K ctx`
- `p1_resolve`: stays positive from the scheduler stack, `utoo 2.39s`, `15.2K / 20.2K ctx` vs `utoo-npm 3.34s`, `77.7K / 94.2K ctx`

`npmmirror.com` did not emit output in this GHA run.

## Validation

- `cargo fmt`
- `CARGO_NET_OFFLINE=true cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
- `CARGO_NET_OFFLINE=true cargo test -p utoo-pm service::install_scheduler -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test -p utoo-pm util::extractor -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test -p utoo-pm util::downloader -- --nocapture`
- `CARGO_NET_OFFLINE=true cargo test -p utoo-pm util::cloner::hardlink_clone_tests -- --nocapture` (0 tests on mac; Linux-only indexed hardlink test is covered by GHA)
