### PR TITLE
perf(pm): cap install tarball downloads

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -260,7 +260,7 @@ impl SchedulerState {
             done_tx,
             done_rx,
             shutdown: false,
-            download_limit: get_manifests_concurrency_limit_sync().max(1),
+            download_limit: download_concurrency_limit(),
             extract_limit: extract_concurrency_limit(),
             clone_limit: clone_concurrency_limit(),
             download_done: HashMap::new(),
@@ -594,6 +594,10 @@ fn clone_concurrency_limit() -> usize {
     std::thread::available_parallelism()
         .map(|n| (n.get() * 2).clamp(4, 16))
         .unwrap_or(8)
+}
+
+fn download_concurrency_limit() -> usize {
+    get_manifests_concurrency_limit_sync().clamp(1, 128)
 }
 
 fn extract_concurrency_limit() -> usize {


### PR DESCRIPTION
## Summary

Stacked on #2986. This AB experiment caps install tarball download concurrency independently from manifest concurrency.

- keep the resolver/manifest concurrency setting unchanged
- cap install tarball downloads at 128
- leave extract and clone worker limits unchanged

## Hypothesis

The install scheduler currently reuses manifest concurrency for tarball downloads. In p3, tarball downloads are followed by extract-to-cache and clone/materialize work, so excessive download fan-out can increase IO pressure and scheduler churn without improving end-to-end wall time. A lower tarball cap may keep the pipeline saturated while reducing contention.

## Validation

- `cargo fmt`
- `CARGO_NET_OFFLINE=true cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
- `CARGO_NET_OFFLINE=true cargo test -p utoo-pm service::install_scheduler -- --nocapture`
