### PR TITLE
perf(pm): poll install network ops in scheduler

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 
 use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
@@ -106,6 +108,7 @@ struct DownloadedPackage {
 }
 
 type CloneResponder = oneshot::Sender<Result<(), String>>;
+type SchedulerOp = Pin<Box<dyn Future<Output = OpDone> + Send>>;
 
 enum Command {
     PrefetchDownload(PackageFetch),
@@ -249,7 +252,7 @@ struct SchedulerState {
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
     blocked_by_parent: HashMap<PathBuf, Vec<CloneSpec>>,
     clone_queue: VecDeque<ReadyClone>,
-    ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
+    ops: FuturesUnordered<SchedulerOp>,
 }
 
 impl SchedulerState {
@@ -306,10 +309,8 @@ impl SchedulerState {
                     }
                 }
                 done = self.ops.next(), if !self.ops.is_empty() => {
-                    match done {
-                        Some(Ok(done)) => self.handle_done(done),
-                        Some(Err(e)) => tracing::warn!("Install scheduler worker failed: {e}"),
-                        None => {}
+                    if let Some(done) = done {
+                        self.handle_done(done);
                     }
                 }
                 done = self.done_rx.recv() => {
@@ -378,7 +379,7 @@ impl SchedulerState {
 
     fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
         let task_spec = spec.clone();
-        self.ops.push(tokio::spawn(async move {
+        self.ops.push(Box::pin(async move {
             let result = resolve_seeded_cache_path(
                 &task_spec.package.name,
                 &task_spec.package.version,
@@ -442,7 +443,7 @@ impl SchedulerState {
             }
 
             self.download_active.insert(key.clone());
-            self.ops.push(tokio::spawn(async move {
+            self.ops.push(Box::pin(async move {
                 let result = download_bytes(&package.tarball_url)
                     .await
                     .map(DownloadOutcome::Bytes)


### PR DESCRIPTION
## Summary

Stacked on #2986. This AB experiment removes per-download `tokio::spawn` from the install scheduler and polls network/cache futures directly from the scheduler loop.

- keep extract and clone work on rayon workers
- keep download, extract, and clone concurrency limits unchanged
- replace `FuturesUnordered<JoinHandle<OpDone>>` with `FuturesUnordered` of scheduler-owned futures for download and seeded-cache lookup

## Hypothesis

P3 still has high context-switch counts after the cache-walk removal in #2986. Download and seeded-cache lookup are async IO operations and do not need one tokio task per package. Polling these futures directly in the scheduler may reduce runtime scheduling overhead while preserving the same worker boundary for CPU and filesystem-heavy extract/clone work.

## Benchmark Notes

Public GHA npmjs label run (`pm-bench-phases`, linux, ant-design, run `26077600795`; all latest CI/e2e jobs succeeded):

- `p0_full_cold`: `utoo 6.54s`, `81.9K / 51.2K ctx` vs `utoo-npm 7.00s`, `135.0K / 101.5K ctx`, `utoo-next 7.02s`, `142.5K / 98.3K ctx`, `bun 7.41s`, `22.0K / 18.0K ctx`
- `p1_resolve`: `utoo 2.52s`, `18.0K / 21.0K ctx` vs `utoo-npm 3.22s`, `89.4K / 101.7K ctx`, `utoo-next 3.27s`, `90.2K / 97.3K ctx`, `bun 2.34s`, `12.4K / 4.6K ctx`
- `p3_cold_install`: `utoo 4.50s`, `68.2K / 39.0K ctx` vs `utoo-npm 5.94s`, `116.0K / 49.8K ctx`, `utoo-next 5.67s`, `105.0K / 47.3K ctx`, `bun 5.45s`, `10.6K / 7.9K ctx`
- `p4_warm_link`: `utoo 1.62s`, `13.8K / 9.2K ctx` vs `utoo-npm 1.71s`, `43.6K / 18.4K ctx`, `utoo-next 1.90s`, `42.0K / 19.0K ctx`, `bun 2.09s`, `314 / 12 ctx`

Compared with the current published/npm baseline, scheduler-owned download futures keep the main improvement concentrated in context switches (`p1`: ~5.0x lower vCtx and ~4.8x lower iCtx; `p3`: ~1.7x lower vCtx; `p4`: ~3.2x lower vCtx) while improving wall time in `p0`, `p3`, and `p4`. `p3` and `p4` still have a large ctx gap versus bun, so the next investigation remains materialize/extract filesystem behavior rather than network scheduling.

`npmmirror.com` is intentionally not run on label-triggered GHA jobs; use manual dispatch for public npmmirror data.

## Validation

- `cargo fmt`
- `CARGO_NET_OFFLINE=true cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
- `CARGO_NET_OFFLINE=true cargo test -p utoo-pm service::install_scheduler -- --nocapture`
