### PR TITLE
perf(pm): batch install clone completions

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -496,19 +496,7 @@ impl SchedulerState {
     }
 
     fn spawn_clone_batch(&mut self) -> bool {
-        let mut batch = Vec::new();
-        while batch.len() < CLONE_BATCH_LIMIT {
-            let Some(job) = self.clone_queue.pop_front() else {
-                break;
-            };
-            let target = job.spec.target.clone();
-            if self.clone_done.contains(&target) || !self.clone_active.insert(target.clone()) {
-                continue;
-            }
-
-            batch.push((target, job));
-        }
-
+        let batch = self.take_clone_batch();
         if batch.is_empty() {
             return false;
         }
@@ -535,6 +523,43 @@ impl SchedulerState {
         });
 
         true
+    }
+
+    fn take_clone_batch(&mut self) -> Vec<(PathBuf, ReadyClone)> {
+        let mut batch = Vec::new();
+        while batch.len() < CLONE_BATCH_LIMIT {
+            let Some(job) = self.pop_next_clone_job() else {
+                break;
+            };
+            let target = job.spec.target.clone();
+            if self.clone_done.contains(&target) || !self.clone_active.insert(target.clone()) {
+                continue;
+            }
+
+            // Parent clones unblock nested dependency placement. Keep them out
+            // of multi-package batches so their children can enter the queue as
+            // soon as the parent materializes.
+            let unblocks_children = self.blocked_by_parent.contains_key(&target);
+            batch.push((target, job));
+            if unblocks_children {
+                break;
+            }
+        }
+        batch
+    }
+
+    fn pop_next_clone_job(&mut self) -> Option<ReadyClone> {
+        let unblocker_index = if self.blocked_by_parent.is_empty() {
+            None
+        } else {
+            self.clone_queue
+                .iter()
+                .position(|job| self.blocked_by_parent.contains_key(&job.spec.target))
+        };
+        match unblocker_index {
+            Some(index) => self.clone_queue.remove(index),
+            None => self.clone_queue.pop_front(),
+        }
     }
 
     fn handle_done(&mut self, done: OpDone) {
@@ -673,6 +698,13 @@ mod tests {
         RegistryCacheEntry { path, index: None }
     }
 
+    fn ready_clone(name: &str, version: &str, target: &str) -> ReadyClone {
+        ReadyClone {
+            spec: clone_spec(name, version, target),
+            cache: cache_entry(PathBuf::from(format!("/tmp/cache/{name}/{version}"))),
+        }
+    }
+
     #[test]
     fn ensure_download_dedupes_inflight_package() {
         let mut state = state();
@@ -801,5 +833,57 @@ mod tests {
         assert_eq!(clone_worker_limit(4), 4);
         assert_eq!(clone_worker_limit(8), 6);
         assert_eq!(clone_worker_limit(16), 10);
+    }
+
+    #[test]
+    fn clone_batch_prioritizes_parent_unblockers() {
+        let mut state = state();
+        let leaf = ready_clone("leaf", "1.0.0", "/tmp/project/node_modules/leaf");
+        let parent = ready_clone("parent", "1.0.0", "/tmp/project/node_modules/parent");
+        let child = clone_spec(
+            "child",
+            "1.0.0",
+            "/tmp/project/node_modules/parent/node_modules/child",
+        );
+        let parent_target = parent.spec.target.clone();
+
+        state.clone_queue.push_back(leaf);
+        state.clone_queue.push_back(parent);
+        state
+            .blocked_by_parent
+            .insert(parent_target.clone(), vec![child]);
+
+        let batch = state.take_clone_batch();
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].0, parent_target);
+        assert!(state.clone_active.contains(&parent_target));
+        assert_eq!(state.clone_queue.len(), 1);
+        assert_eq!(
+            state.clone_queue[0].spec.target,
+            PathBuf::from("/tmp/project/node_modules/leaf")
+        );
+    }
+
+    #[test]
+    fn clone_batch_keeps_batched_leaf_clones() {
+        let mut state = state();
+        state
+            .clone_queue
+            .push_back(ready_clone("a", "1.0.0", "/tmp/project/node_modules/a"));
+        state
+            .clone_queue
+            .push_back(ready_clone("b", "1.0.0", "/tmp/project/node_modules/b"));
+        state
+            .clone_queue
+            .push_back(ready_clone("c", "1.0.0", "/tmp/project/node_modules/c"));
+        state
+            .clone_queue
+            .push_back(ready_clone("d", "1.0.0", "/tmp/project/node_modules/d"));
+
+        let batch = state.take_clone_batch();
+
+        assert_eq!(batch.len(), CLONE_BATCH_LIMIT);
+        assert_eq!(state.clone_queue.len(), 1);
     }
 }

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -14,11 +14,15 @@ use crate::util::downloader::{
     RegistryCacheEntry, download_bytes, download_stats, extract_to_cache_indexed_sync,
     is_registry_tarball_url, registry_cache_lookup_sync, resolve_seeded_cache_path,
 };
-use crate::util::user_config::get_manifests_concurrency_limit_sync;
+use crate::util::registry::REGISTRY_NPMMIRROR;
+use crate::util::user_config::{get_manifests_concurrency_limit_sync, get_registry};
 
 // Keep clone completions batched enough to reduce scheduler wakeups, while
 // avoiding long serial hardlink runs inside one rayon worker.
 const CLONE_BATCH_LIMIT: usize = 3;
+// npmmirror benefits from a larger install tarball window; keep npmjs on the
+// configured/global default because GHA/npmjs regressed when raised globally.
+const NPMMIRROR_INSTALL_DOWNLOAD_CONCURRENCY_LIMIT: usize = 128;
 
 /// Build event receiver that forwards install prefetch work to the scheduler.
 pub(crate) struct InstallEventReceiver<R: EventReceiver> {
@@ -268,7 +272,7 @@ impl SchedulerState {
             done_tx,
             done_rx,
             shutdown: false,
-            download_limit: get_manifests_concurrency_limit_sync().max(1),
+            download_limit: install_download_concurrency_limit(),
             extract_limit: extract_concurrency_limit(),
             clone_worker_limit: clone_worker_limit(clone_limit),
             download_done: HashMap::new(),
@@ -663,6 +667,19 @@ fn clone_worker_limit(clone_limit: usize) -> usize {
         .clamp(1, clone_limit.max(1))
 }
 
+fn install_download_concurrency_limit() -> usize {
+    let limit = get_manifests_concurrency_limit_sync().max(1);
+    if is_npmmirror_registry(&get_registry()) {
+        limit.max(NPMMIRROR_INSTALL_DOWNLOAD_CONCURRENCY_LIMIT)
+    } else {
+        limit
+    }
+}
+
+fn is_npmmirror_registry(registry: &str) -> bool {
+    registry.trim_end_matches('/') == REGISTRY_NPMMIRROR.trim_end_matches('/')
+}
+
 fn extract_concurrency_limit() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get().clamp(2, 8))
@@ -833,6 +850,13 @@ mod tests {
         assert_eq!(clone_worker_limit(4), 4);
         assert_eq!(clone_worker_limit(8), 6);
         assert_eq!(clone_worker_limit(16), 10);
+    }
+
+    #[test]
+    fn npmmirror_registry_uses_higher_install_download_floor() {
+        assert!(is_npmmirror_registry("https://registry.npmmirror.com"));
+        assert!(is_npmmirror_registry("https://registry.npmmirror.com/"));
+        assert!(!is_npmmirror_registry("https://registry.npmjs.org"));
     }
 
     #[test]

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -16,6 +16,10 @@ use crate::util::downloader::{
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
 
+// Keep clone completions batched enough to reduce scheduler wakeups, while
+// avoiding long serial hardlink runs inside one rayon worker.
+const CLONE_BATCH_LIMIT: usize = 3;
+
 /// Build event receiver that forwards install prefetch work to the scheduler.
 pub(crate) struct InstallEventReceiver<R: EventReceiver> {
     scheduler: InstallScheduler,
@@ -130,9 +134,8 @@ enum OpDone {
         key: String,
         result: Result<RegistryCacheEntry, String>,
     },
-    Clone {
-        target: PathBuf,
-        result: Result<(), String>,
+    CloneBatch {
+        results: Vec<(PathBuf, Result<(), String>)>,
     },
 }
 
@@ -240,7 +243,7 @@ struct SchedulerState {
     shutdown: bool,
     download_limit: usize,
     extract_limit: usize,
-    clone_limit: usize,
+    clone_worker_limit: usize,
     download_done: HashMap<String, RegistryCacheEntry>,
     download_active: HashSet<String>,
     download_waiters: HashMap<String, Vec<CloneSpec>>,
@@ -249,6 +252,7 @@ struct SchedulerState {
     extract_queue: VecDeque<DownloadedPackage>,
     clone_done: HashSet<PathBuf>,
     clone_active: HashSet<PathBuf>,
+    clone_workers_active: usize,
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
     blocked_by_parent: HashMap<PathBuf, Vec<CloneSpec>>,
     clone_queue: VecDeque<ReadyClone>,
@@ -258,6 +262,7 @@ struct SchedulerState {
 impl SchedulerState {
     fn new(rx: mpsc::UnboundedReceiver<Command>) -> Self {
         let (done_tx, done_rx) = mpsc::unbounded_channel();
+        let clone_limit = clone_concurrency_limit();
         Self {
             rx,
             done_tx,
@@ -265,7 +270,7 @@ impl SchedulerState {
             shutdown: false,
             download_limit: get_manifests_concurrency_limit_sync().max(1),
             extract_limit: extract_concurrency_limit(),
-            clone_limit: clone_concurrency_limit(),
+            clone_worker_limit: clone_worker_limit(clone_limit),
             download_done: HashMap::new(),
             download_active: HashSet::new(),
             download_waiters: HashMap::new(),
@@ -274,6 +279,7 @@ impl SchedulerState {
             extract_queue: VecDeque::new(),
             clone_done: HashSet::new(),
             clone_active: HashSet::new(),
+            clone_workers_active: 0,
             clone_waiters: HashMap::new(),
             blocked_by_parent: HashMap::new(),
             clone_queue: VecDeque::new(),
@@ -331,6 +337,7 @@ impl SchedulerState {
             && self.download_active.is_empty()
             && self.extract_active.is_empty()
             && self.clone_active.is_empty()
+            && self.clone_workers_active == 0
             && self.ops.is_empty()
     }
 
@@ -481,7 +488,16 @@ impl SchedulerState {
     }
 
     fn pump_clones(&mut self) {
-        while self.clone_active.len() < self.clone_limit {
+        while self.clone_workers_active < self.clone_worker_limit {
+            if !self.spawn_clone_batch() {
+                break;
+            }
+        }
+    }
+
+    fn spawn_clone_batch(&mut self) -> bool {
+        let mut batch = Vec::new();
+        while batch.len() < CLONE_BATCH_LIMIT {
             let Some(job) = self.clone_queue.pop_front() else {
                 break;
             };
@@ -490,20 +506,35 @@ impl SchedulerState {
                 continue;
             }
 
-            let done_tx = self.done_tx.clone();
-            rayon::spawn(move || {
-                let result = clone_package_from_cache_indexed_sync(
-                    &job.spec.package.name,
-                    &job.spec.package.version,
-                    &job.spec.package.tarball_url,
-                    &job.cache.path,
-                    &job.spec.target,
-                    job.cache.index.as_ref(),
-                )
-                .map_err(|e| format!("{e:#}"));
-                let _ = done_tx.send(OpDone::Clone { target, result });
-            });
+            batch.push((target, job));
         }
+
+        if batch.is_empty() {
+            return false;
+        }
+
+        self.clone_workers_active += 1;
+        let done_tx = self.done_tx.clone();
+        rayon::spawn(move || {
+            let results = batch
+                .into_iter()
+                .map(|(target, job)| {
+                    let result = clone_package_from_cache_indexed_sync(
+                        &job.spec.package.name,
+                        &job.spec.package.version,
+                        &job.spec.package.tarball_url,
+                        &job.cache.path,
+                        &job.spec.target,
+                        job.cache.index.as_ref(),
+                    )
+                    .map_err(|e| format!("{e:#}"));
+                    (target, result)
+                })
+                .collect();
+            let _ = done_tx.send(OpDone::CloneBatch { results });
+        });
+
+        true
     }
 
     fn handle_done(&mut self, done: OpDone) {
@@ -530,9 +561,12 @@ impl SchedulerState {
                 self.extract_active.remove(&key);
                 self.complete_download(key, result);
             }
-            OpDone::Clone { target, result } => {
-                self.clone_active.remove(&target);
-                self.complete_clone(target, result);
+            OpDone::CloneBatch { results } => {
+                self.clone_workers_active = self.clone_workers_active.saturating_sub(1);
+                for (target, result) in results {
+                    self.clone_active.remove(&target);
+                    self.complete_clone(target, result);
+                }
             }
         }
     }
@@ -595,6 +629,13 @@ fn clone_concurrency_limit() -> usize {
     std::thread::available_parallelism()
         .map(|n| (n.get() * 2).clamp(4, 16))
         .unwrap_or(8)
+}
+
+fn clone_worker_limit(clone_limit: usize) -> usize {
+    clone_limit
+        .saturating_div(2)
+        .saturating_add(2)
+        .clamp(1, clone_limit.max(1))
 }
 
 fn extract_concurrency_limit() -> usize {
@@ -752,5 +793,13 @@ mod tests {
         assert_eq!(state.clone_queue.len(), 1);
         assert_eq!(state.clone_queue[0].cache.path, cache_path);
         assert!(state.ops.is_empty());
+    }
+
+    #[test]
+    fn clone_worker_limit_batches_clone_completion_without_serializing_all_clones() {
+        assert_eq!(clone_worker_limit(1), 1);
+        assert_eq!(clone_worker_limit(4), 4);
+        assert_eq!(clone_worker_limit(8), 6);
+        assert_eq!(clone_worker_limit(16), 10);
     }
 }

--- a/crates/pm/src/util/retry.rs
+++ b/crates/pm/src/util/retry.rs
@@ -27,6 +27,10 @@ impl std::error::Error for RetryableError {}
 pub fn build_dns_cached_client() -> reqwest::Client {
     client_builder()
         .connect_timeout(std::time::Duration::from_secs(5)) // TLS + TCP handshake
+        // Match the resolver HTTP client: tarball installs issue many
+        // independent large responses, so avoiding HTTP/2 multiplexing keeps
+        // one slow body read from stalling unrelated downloads.
+        .http1_only()
         .read_timeout(std::time::Duration::from_secs(30)) // Timeout for individual read operations
         // No total timeout - large files (e.g. node binary ~100MB) need longer download time
         // No pool_max_idle_per_host - let reqwest manage connections freely


### PR DESCRIPTION
## Summary

- Batch install clone completions so the scheduler receives one completion message for a small group of clone jobs instead of one per package.
- Keep clone materialization on rayon workers; the scheduler only dispatches work and records completion state.
- Use a bounded clone worker count derived from the existing clone concurrency limit, with a small fixed batch size to avoid long serialized hardlink runs.
- Integrate #2991: prioritize parent clone unblockers and send them as single-job batches so nested dependency placement is not delayed behind unrelated hardlink work in the same batch.

## Why

p3/p4 are dominated by materialization pressure after the earlier install scheduler changes. Batching clone completions reduces scheduler wakeups, but parent packages are on the nested placement critical path. If a parent clone completes early inside a batch but its completion is reported only after other leaf clones finish, its children cannot enter the queue. The #2991 follow-up fixes that without disabling batching for ordinary leaf clones.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm install_scheduler`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

Note: full workspace `cargo clippy --all-targets -- -D warnings --no-deps` is currently blocked in this worktree by pack-core/next.js submodule API mismatch, unrelated to the PM scheduler change.

## Benchmark

Latest #2989 reference before #2991 integration, GHA Linux npmjs run `26089858682`:

| phase | utoo wall | utoo vCtx/iCtx |
| --- | ---: | ---: |
| p0_full_cold | 7.48s | 66.5K / 43.2K |
| p1_resolve | 2.37s | 15.2K / 18.2K |
| p3_cold_install | 5.29s | 53.0K / 32.9K |
| p4_warm_link | 2.23s | 7.8K / 4.5K |

#2991 AB before integration, GHA Linux npmjs run `26093544293`:

| phase | utoo wall | utoo vCtx/iCtx |
| --- | ---: | ---: |
| p3_cold_install | 5.21s | 48.4K / 34.3K |
| p4_warm_link | 1.86s | 7.6K / 4.4K |

Integrated #2989 head (`fd38cfff`), GHA Linux npmjs run `26094747554`:

| phase | utoo wall | utoo vCtx/iCtx |
| --- | ---: | ---: |
| p0_full_cold | 7.28s | 67.4K / 44.2K |
| p1_resolve | 2.39s | 14.5K / 19.7K |
| p3_cold_install | 5.30s | 52.1K / 35.0K |
| p4_warm_link | 2.07s | 7.5K / 4.5K |

Latest full green integrated run `26095851789`:

| phase | utoo wall | utoo vCtx/iCtx |
| --- | ---: | ---: |
| p0_full_cold | 10.51s | 89.5K / 57.4K |
| p1_resolve | 2.43s | 15.0K / 21.2K |
| p3_cold_install | 5.66s | 54.7K / 37.6K |
| p4_warm_link | 2.16s | 7.8K / 4.6K |

Conclusion: #2991 remains directionally positive for p4/warm materialize (`2.23s -> 2.07s/2.16s`, ctx stable). p3 is neutral to slightly noisy, which is acceptable because this change targets clone/materialize ordering rather than cold extract/cache population.

## Additional GHA Reruns

Label-triggered Linux npmjs rerun `26102023925`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 9.15s | 11.98s | 8.32s | 7.55s | 69.8K / 45.2K |
| p1 resolve | 2.09s | 3.12s | 3.10s | 2.41s | 14.1K / 18.5K |
| p3 cold install | 6.68s | 6.46s | 6.13s | 8.07s | 71.9K / 42.5K |
| p4 warm link | 3.38s | 2.44s | 2.35s | 2.08s | 7.6K / 4.4K |

Label-triggered Linux npmjs rerun `26102983933`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 9.30s | 8.06s | 8.32s | 7.34s | 65.1K / 45.7K |
| p1 resolve | 1.97s | 3.05s | 3.04s | 2.39s | 14.9K / 19.3K |
| p3 cold install | 6.68s | 9.25s | 6.95s | 5.30s | 52.4K / 33.8K |
| p4 warm link | 3.34s | 2.37s | 2.37s | 2.20s | 7.9K / 4.6K |

Latest label-triggered Linux npmjs rerun `26110858368`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 8.88s | 8.10s | 9.20s | 8.56s | 80.8K / 51.0K |
| p1 resolve | 1.94s | 2.94s | 3.00s | 3.04s | 14.2K / 19.7K |
| p3 cold install | 6.46s | 6.93s | 5.96s | 6.63s | 60.9K / 39.8K |
| p4 warm link | 3.35s | 2.33s | 2.30s | 2.11s | 7.5K / 4.5K |


Label-triggered Linux npmjs rerun `26112228488`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 7.38s | 7.44s | 7.22s | 6.79s | 88.2K / 53.6K |
| p1 resolve | 2.53s | 3.09s | 3.81s | 2.69s | 17.7K / 18.9K |
| p3 cold install | 5.53s | 5.63s | 5.63s | 6.17s | 76.2K / 43.3K |
| p4 warm link | 2.11s | 1.74s | 1.60s | 1.67s | 8.5K / 4.1K |
p4 remains stable across reruns (`2.07s/2.16s/2.08s/2.20s/2.11s`, ctx about `7.5K/4.5K`). p3 is noisier because it includes network download plus cache extraction writes. Use multiple runs for p3 rather than a single sample.

Label-triggered Linux npmjs rerun `26115911963` (bench job succeeded):

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 9.36s | 8.13s | 8.90s | 7.36s | 83.3K / 51.8K |
| p1 resolve | 2.19s | 3.26s | 3.07s | 2.50s | 15.6K / 19.6K |
| p3 cold install | 6.50s | 7.44s | 7.71s | 5.90s | 65.5K / 41.3K |
| p4 warm link | 3.55s | 2.17s | 2.34s | 2.17s | 7.7K / 4.5K |

GHA pcap diagnostic run `26116045424` (diagnostic-only; pcap overhead/noise makes wall time unsuitable for ranking):

| phase | wall | streams | zero-window / retransmit | p99 stream gap | max IO util | max write await |
|---|---:|---:|---:|---:|---:|---:|
| utoo install | 17.86s | 70 | 6 / 48 | 1.96ms | 97.3% | 481ms |
| utoo-next install | 12.45s | 69 | 4 / 9 | 2.41ms | 77.9% | 215ms |
| bun install | 13.58s | 259 | 10 / 605 | 41.97ms | 69.2% | 123ms |

Conclusion from pcap: p3 cold install does not show an obvious socket-drain starvation issue for utoo; utoo has fewer zero-window/retransmit events than bun in the install capture. The stronger signal is disk-write tail latency (`io_util_max=97.3%`, `w_await_max=481ms`), so the remaining p3 work should focus on cache/extract/write scheduling rather than raising generic tarball concurrency.

Label-triggered Linux npmjs rerun `26117122045` (bench job succeeded; p3 wall noisy):

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 9.47s | 9.28s | 9.29s | 11.05s | 71.7K / 48.4K |
| p1 resolve | 2.11s | 3.10s | 3.39s | 2.49s | 14.7K / 20.4K |
| p3 cold install | 6.96s | 10.11s | 6.30s | 8.32s | 66.5K / 40.8K |
| p4 warm link | 3.52s | 2.27s | 2.28s | 1.93s | 7.3K / 4.3K |


Label-triggered Linux npmjs rerun `26118716599` (bench job succeeded):

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 10.29s | 8.36s | 8.20s | 7.94s | 75.8K / 55.6K |
| p1 resolve | 2.24s | 3.28s | 3.25s | 2.46s | 16.1K / 20.9K |
| p3 cold install | 6.47s | 6.62s | 11.02s | 5.83s | 59.7K / 39.0K |
| p4 warm link | 3.47s | 2.41s | 2.31s | 2.18s | 7.6K / 4.6K |


## Rejected / Inconclusive Follow-ups

| PR | idea | result |
| --- | --- | --- |
| #2992 | Pump clones before extracts | p3 regressed (`6.22s`, `56.8K/36.5K`); reject for now. |
| #2993 | Halve extract slots while clone work exists | p3 wall improved (`4.84s`) but ctx regressed (`59.0K/39.2K`) and p4 no-op control moved heavily; inconclusive. |
| #2994 | Flush parent clone unblockers early from a worker | Does not beat #2991 clearly (`p3 5.38s`, `p4 2.12s`); extra completion state is not justified. |
| #2995 | Clone first waiter immediately after extract | p3 does not improve and vCtx rises (`5.75s`, `59.7K/33.9K`); do not integrate. |
| #2996 | Cap install worker pressure | GHA regression vs #2989 (`p3 5.68s`, `62.3K/40.6K`; p0 also regressed); do not integrate. |
| #2997 | Prioritize demand downloads over preload queue | Two GHA runs did not improve p3; rerun regressed (`8.02s`, `78.6K/46.1K`); do not integrate. |
| #2998 | Raise install tarball default concurrency to 256 | N=2 GHA/npmjs did not validate p3 (`8.03s`, `77.1K/40.2K`; rerun `6.35s`, `68.7K/39.8K`); do not use as a global/non-semver default. |
| #2999 | Spawn install download workers instead of polling download futures in scheduler | No target ctx/wall signal (`p3 7.88s`, `82.2K/29.4K`) and p4 control was noisy; do not integrate. |
| #3000 | Use bounded chunked file writes for scheduler indexed extracts | GHA p3 wall improved but ctx was neutral (`5.56s`, `64.6K/41.2K`) and p0 ctx regressed (`90.5K/56.3K`); poolab internal AB also showed higher ctx/sys. Do not integrate. |
| #3001 | Bound downloaded tarball backlog to `4 * extract_limit` | GHA p3 regressed vs #2989 (`6.12s`, `74.5K/43.4K` vs `5.83s`, `59.7K/39.0K`); poolab internal AB also showed slow-tarball tail risk. Do not integrate. |

Current pick status: #2991 is already integrated into this PR. No other follow-up experiment has enough GHA evidence to pick into #2989.













Label-triggered Linux npmjs rerun `26119947793` (bench job succeeded):

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 9.00s | 7.94s | 8.07s | 7.65s | 81.0K / 51.4K |
| p1 resolve | 2.09s | 3.11s | 3.00s | 2.30s | 15.8K / 19.7K |
| p3 cold install | 6.68s | 6.48s | 6.14s | 5.47s | 68.8K / 42.3K |
| p4 warm link | 3.54s | 2.48s | 2.38s | 2.13s | 7.6K / 4.5K |

This keeps #2989 in the same GHA/npmjs band: p3 remains noisy but competitive on wall time, while p4 stays stable around `2.1s` and `7.5K/4.5K` ctx. This run did not capture npmmirror output.


## P3 ctx Decomposition Notes

Latest public GHA/npmjs sample `26119947793` gives a useful p3/p4 split:

| PM | p3 cold install | p4 warm link | p3-p4 ctx delta |
|---|---:|---:|---:|
| bun | 6.68s · 5.3K / 7.0K | 3.54s · 0.2K / 0.0K | +5.1K / +7.0K |
| utoo | 5.47s · 68.8K / 42.3K | 2.13s · 7.6K / 4.5K | +61.2K / +37.8K |

Interpretation: the #2991 clone/materialize path still looks healthy; p4 remains low and stable. The remaining p3 ctx is mostly in the cold download + cache extract/write portion, not in warm node_modules materialization. Follow-up experiments should target cache/extract/write scheduling or measurement, not more clone queue reshuffling.


## Picked Follow-up: Tarball HTTP/1.1

#3002 validated forcing HTTP/1.1 for PM tarball downloads and has been picked into this PR as `f893cbd4`.

Public GHA/Linux npmjs validation from #3002 run `26123034198`:

| phase | #2989 latest before pick | #3002 HTTP/1.1 | delta |
|---|---:|---:|---:|
| p0 full cold | 7.34s · 74.6K / 50.5K | 7.69s · 58.2K / 42.2K | ctx down, wall neutral/noisy |
| p3 cold install | 5.39s · 53.8K / 33.8K | 5.13s · 33.9K / 24.3K | wall and ctx down |
| p4 warm link | 2.15s · 7.8K / 4.4K | 2.08s · 7.7K / 4.5K | stable |

Conclusion: p3's remaining ctx was not explained by cache disk writes alone. Matching the resolver's HTTP/1.1 client behavior for tarball downloads reduces p3 ctx and improves wall time without disturbing p4 materialization.


## Picked Follow-up: npmmirror Install Download Floor

#3006 validated scoping a higher install tarball concurrency floor to `registry.npmmirror.com` and has been picked into this PR as `0b2deaad`.

Public GHA/Linux npmjs validation from #3006 run `26130251370` stayed neutral because npmjs keeps the existing configured/default download window:

| phase | #2989 HTTP/1.1 baseline | #3006 scoped npmmirror | delta |
|---|---:|---:|---:|
| p0 full cold | 7.53s · 63.8K / 41.6K | 7.56s · 61.2K / 42.6K | neutral |
| p1 resolve | 2.40s · 15.4K / 19.3K | 2.38s · 14.7K / 19.1K | neutral |
| p3 cold install | 5.34s · 32.1K / 24.3K | 5.25s · 34.8K / 24.3K | neutral/noisy |
| p4 warm link | 2.08s · 7.5K / 4.3K | 2.15s · 7.5K / 4.4K | stable |

Conclusion: the earlier global high-concurrency experiments are still rejected for npmjs, but making the higher floor registry-specific avoids that regression surface.


Post-pick #2989 head run `26131041481` after integrating #3006:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 9.16s | 8.52s | 9.68s | 7.60s | 68.8K / 47.4K |
| p1 resolve | 2.13s | 3.12s | 3.18s | 2.54s | 16.8K / 20.1K |
| p3 cold install | 6.76s | 7.42s | 7.41s | 5.06s | 37.5K / 26.3K |
| p4 warm link | 3.41s | 2.36s | 2.17s | 2.04s | 7.7K / 4.6K |

This keeps the scoped npmmirror change neutral on public npmjs while p3/p4 remain in the improved #2989 band.
