### PR TITLE
perf(pm): prioritize install clone pumping

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -290,8 +290,10 @@ impl SchedulerState {
     async fn run(mut self) {
         loop {
             self.pump_downloads();
-            self.pump_extracts();
+            // Keep network prefetch moving first, then give ready materialize
+            // work a chance to enter rayon before starting more cache writes.
             self.pump_clones();
+            self.pump_extracts();
 
             if self.shutdown && self.is_idle() {
                 break;


### PR DESCRIPTION
## Summary

This is an independent p3 scheduler experiment on top of #2989.

The install scheduler currently pumps ready work in this order:

1. downloads
2. extracts
3. clones/materialize

When p3 has both extracted packages and ready clone placements, new extract workers can enter the global rayon queue before materialize workers. This PR keeps network prefetch first, but gives ready clone/materialize work a chance to enter rayon before starting more cache writes.

## Hypothesis

- p3 may improve if clone/materialize critical-path work is less often queued behind extract/cache-write work.
- p4 should be neutral because warm link has no extract queue.
- If p3 regresses, it means keeping extract/cache writes fully ahead of materialize is better for this workload.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm install_scheduler`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Bench Result

GHA Linux npmjs run `26093648834`:

| phase | utoo wall | vCtx | iCtx |
|---|---:|---:|---:|
| p3 cold install | 6.22s | 56.8K | 36.5K |
| p4 warm link | 1.93s | 7.4K | 4.4K |

p4 is a no-op control for this PR because there is no extract queue in warm link, so its movement is GHA noise. p3 regressed versus #2989 latest npmjs reference (`5.29s, 53.0K/32.9K`).

Conclusion: reject for now. Pure pump-order priority does not look like the right p3 fix.
