### PR TITLE
perf(pm): reserve install clone capacity

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -464,8 +464,19 @@ impl SchedulerState {
         self.extract_queue.len() + self.extract_active.len()
     }
 
+    fn effective_extract_limit(&self) -> usize {
+        if self.clone_queue.is_empty() && self.clone_workers_active == 0 {
+            self.extract_limit
+        } else {
+            // Extract and clone both run blocking filesystem work on rayon.
+            // Once materialize has ready work, keep new cache writes from
+            // filling every extract slot and delaying clone progress.
+            self.extract_limit.saturating_div(2).max(1)
+        }
+    }
+
     fn pump_extracts(&mut self) {
-        while self.extract_active.len() < self.extract_limit {
+        while self.extract_active.len() < self.effective_extract_limit() {
             let Some(downloaded) = self.extract_queue.pop_front() else {
                 break;
             };
@@ -673,6 +684,13 @@ mod tests {
         RegistryCacheEntry { path, index: None }
     }
 
+    fn ready_clone(name: &str, version: &str, target: &str) -> ReadyClone {
+        ReadyClone {
+            spec: clone_spec(name, version, target),
+            cache: cache_entry(PathBuf::from(format!("/tmp/cache/{name}/{version}"))),
+        }
+    }
+
     #[test]
     fn ensure_download_dedupes_inflight_package() {
         let mut state = state();
@@ -801,5 +819,31 @@ mod tests {
         assert_eq!(clone_worker_limit(4), 4);
         assert_eq!(clone_worker_limit(8), 6);
         assert_eq!(clone_worker_limit(16), 10);
+    }
+
+    #[test]
+    fn extract_limit_uses_full_capacity_without_clone_work() {
+        let mut state = state();
+        state.extract_limit = 8;
+
+        assert_eq!(state.effective_extract_limit(), 8);
+    }
+
+    #[test]
+    fn extract_limit_reserves_capacity_when_clone_work_is_ready_or_active() {
+        let mut state = state();
+        state.extract_limit = 8;
+        state.clone_queue.push_back(ready_clone(
+            "react",
+            "18.2.0",
+            "/tmp/project/node_modules/react",
+        ));
+
+        assert_eq!(state.effective_extract_limit(), 4);
+
+        state.clone_queue.clear();
+        state.clone_workers_active = 1;
+
+        assert_eq!(state.effective_extract_limit(), 4);
     }
 }


### PR DESCRIPTION
## Summary

This is an independent p3 scheduler experiment on top of #2989.

Extract/cache population and clone/materialize both run blocking filesystem work on the global rayon pool. On a 2-core runner the current limits can queue extract workers and clone workers at the same time, so clone/materialize may still compete with cache writes even after completion batching.

This PR keeps full extract concurrency when there is no clone work, but halves the effective extract limit while clone work is queued or active.

## Hypothesis

- p3 may improve if clone/materialize is currently delayed by extract/cache-write rayon work.
- p4 should be neutral because warm link has no extract queue.
- If p3 regresses, extract/cache population is the critical path and this reservation is too conservative.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm install_scheduler`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Bench Result

GHA Linux npmjs run `26093744012`:

| phase | utoo wall | vCtx | iCtx |
|---|---:|---:|---:|
| p3 cold install | 4.84s | 59.0K | 39.2K |
| p4 warm link | 1.54s | 8.5K | 4.4K |

The p3 wall is faster than #2989 latest npmjs reference (`5.29s`), but ctx is worse (`53.0K/32.9K` -> `59.0K/39.2K`). Also, p4 should be a no-op control for this PR and moved a lot, which means this run had substantial GHA variance.

Conclusion: inconclusive. This needs a rerun or poollab confirmation before keeping; the wall signal is interesting, but p4 control noise prevents attributing it to the extract-slot reservation.
