### PR TITLE
perf(pm): flush clone unblockers early

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -106,6 +106,12 @@ struct ReadyClone {
     cache: RegistryCacheEntry,
 }
 
+struct CloneBatchJob {
+    target: PathBuf,
+    ready: ReadyClone,
+    flush_on_complete: bool,
+}
+
 struct DownloadedPackage {
     package: PackageFetch,
     bytes: Bytes,
@@ -133,6 +139,10 @@ enum OpDone {
     Extract {
         key: String,
         result: Result<RegistryCacheEntry, String>,
+    },
+    CloneProgress {
+        target: PathBuf,
+        result: Result<(), String>,
     },
     CloneBatch {
         results: Vec<(PathBuf, Result<(), String>)>,
@@ -506,17 +516,25 @@ impl SchedulerState {
         rayon::spawn(move || {
             let results = batch
                 .into_iter()
-                .map(|(target, job)| {
+                .filter_map(|batch_job| {
                     let result = clone_package_from_cache_indexed_sync(
-                        &job.spec.package.name,
-                        &job.spec.package.version,
-                        &job.spec.package.tarball_url,
-                        &job.cache.path,
-                        &job.spec.target,
-                        job.cache.index.as_ref(),
+                        &batch_job.ready.spec.package.name,
+                        &batch_job.ready.spec.package.version,
+                        &batch_job.ready.spec.package.tarball_url,
+                        &batch_job.ready.cache.path,
+                        &batch_job.ready.spec.target,
+                        batch_job.ready.cache.index.as_ref(),
                     )
                     .map_err(|e| format!("{e:#}"));
-                    (target, result)
+                    if batch_job.flush_on_complete {
+                        let _ = done_tx.send(OpDone::CloneProgress {
+                            target: batch_job.target,
+                            result,
+                        });
+                        None
+                    } else {
+                        Some((batch_job.target, result))
+                    }
                 })
                 .collect();
             let _ = done_tx.send(OpDone::CloneBatch { results });
@@ -525,7 +543,7 @@ impl SchedulerState {
         true
     }
 
-    fn take_clone_batch(&mut self) -> Vec<(PathBuf, ReadyClone)> {
+    fn take_clone_batch(&mut self) -> Vec<CloneBatchJob> {
         let mut batch = Vec::new();
         while batch.len() < CLONE_BATCH_LIMIT {
             let Some(job) = self.pop_next_clone_job() else {
@@ -536,14 +554,15 @@ impl SchedulerState {
                 continue;
             }
 
-            // Parent clones unblock nested dependency placement. Keep them out
-            // of multi-package batches so their children can enter the queue as
-            // soon as the parent materializes.
-            let unblocks_children = self.blocked_by_parent.contains_key(&target);
-            batch.push((target, job));
-            if unblocks_children {
-                break;
-            }
+            // Parent clones unblock nested dependency placement. Flush their
+            // completion immediately from the worker, while keeping leaf clones
+            // batched to preserve the lower scheduler wakeup count.
+            let flush_on_complete = self.blocked_by_parent.contains_key(&target);
+            batch.push(CloneBatchJob {
+                target,
+                ready: job,
+                flush_on_complete,
+            });
         }
         batch
     }
@@ -585,6 +604,10 @@ impl SchedulerState {
             OpDone::Extract { key, result } => {
                 self.extract_active.remove(&key);
                 self.complete_download(key, result);
+            }
+            OpDone::CloneProgress { target, result } => {
+                self.clone_active.remove(&target);
+                self.complete_clone(target, result);
             }
             OpDone::CloneBatch { results } => {
                 self.clone_workers_active = self.clone_workers_active.saturating_sub(1);
@@ -836,7 +859,7 @@ mod tests {
     }
 
     #[test]
-    fn clone_batch_prioritizes_parent_unblockers() {
+    fn clone_batch_prioritizes_and_flushes_parent_unblockers() {
         let mut state = state();
         let leaf = ready_clone("leaf", "1.0.0", "/tmp/project/node_modules/leaf");
         let parent = ready_clone("parent", "1.0.0", "/tmp/project/node_modules/parent");
@@ -855,14 +878,16 @@ mod tests {
 
         let batch = state.take_clone_batch();
 
-        assert_eq!(batch.len(), 1);
-        assert_eq!(batch[0].0, parent_target);
-        assert!(state.clone_active.contains(&parent_target));
-        assert_eq!(state.clone_queue.len(), 1);
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].target, parent_target);
+        assert!(batch[0].flush_on_complete);
         assert_eq!(
-            state.clone_queue[0].spec.target,
+            batch[1].target,
             PathBuf::from("/tmp/project/node_modules/leaf")
         );
+        assert!(!batch[1].flush_on_complete);
+        assert!(state.clone_active.contains(&parent_target));
+        assert!(state.clone_queue.is_empty());
     }
 
     #[test]
@@ -885,5 +910,22 @@ mod tests {
 
         assert_eq!(batch.len(), CLONE_BATCH_LIMIT);
         assert_eq!(state.clone_queue.len(), 1);
+    }
+
+    #[test]
+    fn clone_progress_completion_keeps_worker_slot_active() {
+        let mut state = state();
+        let target = PathBuf::from("/tmp/project/node_modules/parent");
+        state.clone_workers_active = 1;
+        state.clone_active.insert(target.clone());
+
+        state.handle_done(OpDone::CloneProgress {
+            target: target.clone(),
+            result: Ok(()),
+        });
+
+        assert_eq!(state.clone_workers_active, 1);
+        assert!(!state.clone_active.contains(&target));
+        assert!(state.clone_done.contains(&target));
     }
 }


### PR DESCRIPTION
## Summary

This is a p3/p4 scheduler experiment on top of #2989 after #2991 integration.

#2991 proved that parent clone completions are on the nested placement critical path. It handles that by prioritizing parent unblockers and putting them in a single-job batch. This PR keeps that early parent signal but avoids dedicating a whole worker batch to it:

- parent unblockers are still selected first;
- clone workers send `CloneProgress` immediately after a parent unblocker finishes;
- `CloneProgress` completes that target and wakes nested children, but does not release the worker slot;
- remaining leaf clones continue in the same worker and are reported by the final `CloneBatch`.

## Hypothesis

- p4 may improve over #2989/#2991 if parent children can be queued early while leaf clones remain batched.
- ctx may rise slightly because parent progress adds a message, but worker utilization should be better than single-job parent batches.
- p3 should be neutral to slightly positive; cold extract/cache work is still the larger p3 cost.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm install_scheduler`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Bench Result

GHA Linux npmjs run `26097117399`:

| phase | utoo wall | utoo vCtx/iCtx |
| --- | ---: | ---: |
| p0_full_cold | 7.40s | 71.2K / 46.7K |
| p1_resolve | 3.37s | 15.8K / 20.2K |
| p3_cold_install | 5.38s | 54.4K / 35.0K |
| p4_warm_link | 2.12s | 7.4K / 4.4K |

Reference #2989 integrated head (`fd38cfff`):

| run | p3 | p4 |
| --- | ---: | ---: |
| `26094747554` | 5.30s, 52.1K / 35.0K | 2.07s, 7.5K / 4.5K |
| `26095851789` | 5.66s, 54.7K / 37.6K | 2.16s, 7.8K / 4.6K |

Conclusion: inconclusive / do not integrate for now. The early-flush implementation is logically reasonable, but it does not beat #2991 clearly enough to justify the extra completion state and worker-slot semantics.
