### PR TITLE
perf(pm): clone first waiter after extract

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -109,6 +109,12 @@ struct ReadyClone {
 struct DownloadedPackage {
     package: PackageFetch,
     bytes: Bytes,
+    primary_clone: Option<CloneSpec>,
+}
+
+struct ExtractOutcome {
+    cache: RegistryCacheEntry,
+    primary_clone: Option<(PathBuf, Result<(), String>)>,
 }
 
 type CloneResponder = oneshot::Sender<Result<(), String>>;
@@ -132,7 +138,8 @@ enum OpDone {
     },
     Extract {
         key: String,
-        result: Result<RegistryCacheEntry, String>,
+        primary_target: Option<PathBuf>,
+        result: Result<ExtractOutcome, String>,
     },
     CloneBatch {
         results: Vec<(PathBuf, Result<(), String>)>,
@@ -476,13 +483,40 @@ impl SchedulerState {
 
             let done_tx = self.done_tx.clone();
             rayon::spawn(move || {
-                let result = extract_to_cache_indexed_sync(
-                    &downloaded.package.name,
-                    &downloaded.package.version,
-                    downloaded.bytes,
-                )
-                .map_err(|e| format!("{e:#}"));
-                let _ = done_tx.send(OpDone::Extract { key, result });
+                let primary_target = downloaded
+                    .primary_clone
+                    .as_ref()
+                    .map(|spec| spec.target.clone());
+                let result = (|| -> Result<ExtractOutcome, String> {
+                    let cache = extract_to_cache_indexed_sync(
+                        &downloaded.package.name,
+                        &downloaded.package.version,
+                        downloaded.bytes,
+                    )
+                    .map_err(|e| format!("{e:#}"))?;
+                    let primary_clone = downloaded.primary_clone.map(|spec| {
+                        let target = spec.target.clone();
+                        let result = clone_package_from_cache_indexed_sync(
+                            &spec.package.name,
+                            &spec.package.version,
+                            &spec.package.tarball_url,
+                            &cache.path,
+                            &spec.target,
+                            cache.index.as_ref(),
+                        )
+                        .map_err(|e| format!("{e:#}"));
+                        (target, result)
+                    });
+                    Ok(ExtractOutcome {
+                        cache,
+                        primary_clone,
+                    })
+                })();
+                let _ = done_tx.send(OpDone::Extract {
+                    key,
+                    primary_target,
+                    result,
+                });
             });
         }
     }
@@ -574,17 +608,38 @@ impl SchedulerState {
                 self.download_active.remove(&key);
                 match result {
                     Ok(DownloadOutcome::Bytes(bytes)) => {
-                        self.extract_queue
-                            .push_back(DownloadedPackage { package, bytes });
+                        let primary_clone = self.take_primary_extract_clone(&key);
+                        self.extract_queue.push_back(DownloadedPackage {
+                            package,
+                            bytes,
+                            primary_clone,
+                        });
                     }
                     Err(error) => {
                         self.complete_download(key, Err(error));
                     }
                 }
             }
-            OpDone::Extract { key, result } => {
+            OpDone::Extract {
+                key,
+                primary_target,
+                result,
+            } => {
                 self.extract_active.remove(&key);
-                self.complete_download(key, result);
+                match result {
+                    Ok(outcome) => {
+                        self.complete_download(key, Ok(outcome.cache));
+                        if let Some((target, result)) = outcome.primary_clone {
+                            self.complete_clone(target, result);
+                        }
+                    }
+                    Err(error) => {
+                        self.complete_download(key, Err(error.clone()));
+                        if let Some(target) = primary_target {
+                            self.complete_clone(target, Err(error));
+                        }
+                    }
+                }
             }
             OpDone::CloneBatch { results } => {
                 self.clone_workers_active = self.clone_workers_active.saturating_sub(1);
@@ -614,6 +669,18 @@ impl SchedulerState {
                 }
             }
         }
+    }
+
+    fn take_primary_extract_clone(&mut self, key: &str) -> Option<CloneSpec> {
+        let waiters = self.download_waiters.get_mut(key)?;
+        if waiters.is_empty() {
+            return None;
+        }
+        let index = waiters
+            .iter()
+            .position(|spec| self.blocked_by_parent.contains_key(&spec.target))
+            .unwrap_or(0);
+        Some(waiters.remove(index))
     }
 
     fn complete_clone(&mut self, target: PathBuf, result: Result<(), String>) {
@@ -735,8 +802,10 @@ mod tests {
 
         assert!(!state.download_active.contains(&key));
         assert!(state.download_waiters.contains_key(&key));
+        assert!(state.download_waiters[&key].is_empty());
         assert_eq!(state.extract_queue.len(), 1);
         assert_eq!(state.extract_queue[0].package.key(), key);
+        assert!(state.extract_queue[0].primary_clone.is_some());
     }
 
     #[test]
@@ -772,11 +841,45 @@ mod tests {
 
         state.handle_done(OpDone::Extract {
             key: key.clone(),
-            result: Ok(cache_entry(cache_path.clone())),
+            primary_target: None,
+            result: Ok(ExtractOutcome {
+                cache: cache_entry(cache_path.clone()),
+                primary_clone: None,
+            }),
         });
 
         assert!(!state.extract_active.contains(&key));
         assert_eq!(state.download_done[&key].path, cache_path);
+        assert_eq!(state.clone_queue.len(), 1);
+    }
+
+    #[test]
+    fn extract_completion_finishes_primary_clone_and_queues_remaining_waiters() {
+        let mut state = state();
+        let key = "react@18.2.0".to_string();
+        let primary_target = PathBuf::from("/tmp/project/node_modules/react");
+        let remaining = clone_spec(
+            "react",
+            "18.2.0",
+            "/tmp/project/node_modules/other/node_modules/react",
+        );
+        let cache_path = PathBuf::from("/tmp/cache/react/18.2.0");
+
+        state.extract_active.insert(key.clone());
+        state.download_waiters.insert(key.clone(), vec![remaining]);
+
+        state.handle_done(OpDone::Extract {
+            key: key.clone(),
+            primary_target: Some(primary_target.clone()),
+            result: Ok(ExtractOutcome {
+                cache: cache_entry(cache_path.clone()),
+                primary_clone: Some((primary_target.clone(), Ok(()))),
+            }),
+        });
+
+        assert!(!state.extract_active.contains(&key));
+        assert_eq!(state.download_done[&key].path, cache_path);
+        assert!(state.clone_done.contains(&primary_target));
         assert_eq!(state.clone_queue.len(), 1);
     }
 


### PR DESCRIPTION
## Summary

This is a p3 scheduler experiment on top of #2989.

When a tarball download completes, the scheduler already knows which clone placements are waiting for that package. Today extract completes, reports cache readiness to the scheduler, then the scheduler queues clone/materialize work onto rayon. This PR moves the first ready clone waiter into the extract worker:

- download completion removes one primary clone waiter from `download_waiters`;
- extract worker writes the cache and immediately materializes that primary target;
- extract completion still records the cache and queues remaining waiters normally;
- if extract fails, the primary and remaining waiters receive the same error;
- if primary clone fails after cache succeeds, remaining waiters can still use the cache.

## Hypothesis

- p3 may improve by removing one scheduler/rayon handoff per downloaded package with a ready waiter.
- p4 should be neutral because warm link does not use the extract path.
- ctx may move either way: fewer clone tasks, but longer extract workers.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm install_scheduler`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Bench Results

Baseline #2989 integrated head (`fd38cfff`):

- run `26094747554`: p3 `5.30s`, ctx `52.1K/35.0K`; p4 `2.07s`, ctx `7.5K/4.5K`
- full-green run `26095851789`: p3 `5.66s`, ctx `54.7K/37.6K`; p4 `2.16s`, ctx `7.8K/4.6K`

This PR #2995 (`d1acae9`, run `26100667673`):

- p0 `7.71s`, ctx `77.8K/50.2K`
- p1 `2.52s`, ctx `17.5K/22.0K`
- p3 `5.75s`, ctx `59.7K/33.9K`
- p4 `2.09s`, ctx `7.6K/4.3K`

Conclusion: do not integrate for now. p4 is neutral as expected, but p3 does not beat the #2989+#2991 baseline and vCtx increases. The extra coupling between extract and first materialize is not justified by this result.