### PR TITLE
perf(pm): cap install worker pressure

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -660,12 +660,12 @@ fn clone_worker_limit(clone_limit: usize) -> usize {
     clone_limit
         .saturating_div(2)
         .saturating_add(2)
-        .clamp(1, clone_limit.max(1))
+        .clamp(1, clone_limit.clamp(1, 4))
 }
 
 fn extract_concurrency_limit() -> usize {
     std::thread::available_parallelism()
-        .map(|n| n.get().clamp(2, 8))
+        .map(|n| n.get().clamp(2, 4))
         .unwrap_or(4)
 }
 
@@ -831,8 +831,8 @@ mod tests {
     fn clone_worker_limit_batches_clone_completion_without_serializing_all_clones() {
         assert_eq!(clone_worker_limit(1), 1);
         assert_eq!(clone_worker_limit(4), 4);
-        assert_eq!(clone_worker_limit(8), 6);
-        assert_eq!(clone_worker_limit(16), 10);
+        assert_eq!(clone_worker_limit(8), 4);
+        assert_eq!(clone_worker_limit(16), 4);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Experiment for p3 cold install scheduling pressure.

- cap install clone workers at 4 instead of scaling to 6/10 on larger runners
- cap extract concurrency at 4 instead of 8
- keep the scheduler architecture unchanged; only tune worker pressure around clone/extract materialization

## Verification

- cargo fmt
- cargo test -p utoo-pm install_scheduler
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps

## GHA Benchmark

Conclusion: negative on GHA; do not integrate as-is.

Compared with #2989 latest Linux/npmjs run (`26102983933`), this worker-cap experiment (`26105816781`) regresses p0 and p3:

| phase | #2989 utoo | #2996 utoo | note |
| --- | ---: | ---: | --- |
| p0 full cold | 7.34s, 65.1K/45.7K ctx | 9.85s, 82.6K/52.8K ctx | regression |
| p1 resolve | 2.39s, 14.9K/19.3K ctx | 2.77s, 15.5K/19.8K ctx | run/network noise, no benefit |
| p3 cold install | 5.30s, 52.4K/33.8K ctx | 5.68s, 62.3K/40.6K ctx | regression |
| p4 warm link | 2.20s, 7.9K/4.6K ctx | 2.17s, 7.9K/4.6K ctx | neutral |

The cap can improve one high-ctx internal environment, but GHA does not support making it the default.
