### PR TITLE
perf(pm): prioritize demand install downloads

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -411,6 +411,7 @@ impl SchedulerState {
         if let Some(waiters) = self.download_waiters.get_mut(&key) {
             if let Some(spec) = waiter {
                 waiters.push(spec);
+                self.prioritize_download(&key);
             }
             return;
         }
@@ -420,13 +421,31 @@ impl SchedulerState {
         self.download_queue.push_back(package);
     }
 
+    fn prioritize_download(&mut self, key: &str) {
+        // A preloaded tarball may become the current BFS frontier's blocker
+        // later. Promote only pending work; active downloads keep running.
+        let Some(index) = self
+            .download_queue
+            .iter()
+            .position(|package| package.key() == key)
+        else {
+            return;
+        };
+        if let Some(package) = self.download_queue.remove(index) {
+            self.download_queue.push_front(package);
+        }
+    }
+
     fn pump_downloads(&mut self) {
         self.pump_downloads_with(|package| {
             registry_cache_lookup_sync(&package.name, &package.version)
         });
     }
 
-    fn pump_downloads_with(&mut self, cache_lookup: impl Fn(&PackageFetch) -> Option<PathBuf>) {
+    fn pump_downloads_with(
+        &mut self,
+        mut cache_lookup: impl FnMut(&PackageFetch) -> Option<PathBuf>,
+    ) {
         while self.download_active.len() < self.download_limit
             && self.extract_backlog() < self.download_limit
         {
@@ -716,6 +735,25 @@ mod tests {
 
         assert_eq!(state.download_queue.len(), 1);
         assert_eq!(state.download_waiters["react@18.2.0"].len(), 1);
+    }
+
+    #[test]
+    fn demand_waiter_prioritizes_pending_preload_download() {
+        let mut state = state();
+        let preload = package("preload", "1.0.0");
+        let demand = package("demand", "1.0.0");
+        let waiter = clone_spec("demand", "1.0.0", "/tmp/project/node_modules/demand");
+        let mut seen = Vec::new();
+
+        state.ensure_download(preload, None);
+        state.ensure_download(demand.clone(), None);
+        state.ensure_download(demand, Some(waiter));
+        state.pump_downloads_with(|queued| {
+            seen.push(queued.key());
+            Some(PathBuf::from(format!("/tmp/cache/{}", queued.name)))
+        });
+
+        assert_eq!(seen.first().map(String::as_str), Some("demand@1.0.0"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Experiment for p3 cold install download priority.

- keep full lockfile tarball prefetch enabled
- when BFS `ensure_clone` needs a package that is still only pending from preload, move that download to the front of the pending queue
- do not interrupt active downloads and do not reduce global download/extract/clone concurrency

## Rationale

`prefetch_lock_downloads` can enqueue the whole lockfile before depth-by-depth install starts. A later BFS demand currently attaches a waiter but keeps the tarball at its original preload position. This experiment keeps preload throughput while letting the current BFS frontier unblock earlier.

## Verification

- cargo fmt
- cargo test -p utoo-pm install_scheduler
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps

## GHA Benchmark

Conclusion: negative / not worth integrating. Two GHA runs did not improve p3; the rerun regressed p3 clearly.

Baseline is #2989 latest Linux/npmjs (`26102983933`).

| phase | #2989 utoo | #2997 run 1 (`26107409974`) | #2997 run 2 (`26108512218`) | conclusion |
| --- | ---: | ---: | ---: | --- |
| p0 full cold | 7.34s, 65.1K/45.7K ctx | 7.46s, 71.9K/49.1K ctx | 7.71s, 65.9K/46.9K ctx | no win |
| p3 cold install | 5.30s, 52.4K/33.8K ctx | 5.43s, 57.3K/43.7K ctx | 8.02s, 78.6K/46.1K ctx | regression |
| p4 warm link | 2.20s, 7.9K/4.6K ctx | 2.06s, 7.6K/4.4K ctx | 2.00s, 7.5K/4.4K ctx | p4-only win, not enough |

The hypothesis was plausible, but GHA data says pending download reprioritization adds instability without improving the p3 cold path.
