### PR TITLE
perf(pm): raise install tarball concurrency

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -14,7 +14,7 @@ use crate::util::downloader::{
     RegistryCacheEntry, download_bytes, download_stats, extract_to_cache_indexed_sync,
     is_registry_tarball_url, registry_cache_lookup_sync, resolve_seeded_cache_path,
 };
-use crate::util::user_config::get_manifests_concurrency_limit_sync;
+use crate::util::user_config::get_install_tarball_concurrency_limit_sync;
 
 // Keep clone completions batched enough to reduce scheduler wakeups, while
 // avoiding long serial hardlink runs inside one rayon worker.
@@ -268,7 +268,7 @@ impl SchedulerState {
             done_tx,
             done_rx,
             shutdown: false,
-            download_limit: get_manifests_concurrency_limit_sync().max(1),
+            download_limit: get_install_tarball_concurrency_limit_sync().max(1),
             extract_limit: extract_concurrency_limit(),
             clone_worker_limit: clone_worker_limit(clone_limit),
             download_done: HashMap::new(),

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -134,10 +134,9 @@ pub fn get_install_scope() -> InstallScope {
 
 // Manifest fetch concurrency configuration.
 //
-// Keep the user-visible/default tarball download limit at 64. Registry
-// resolution can opt into a higher default for non-semver registries via
-// `get_resolver_manifests_concurrency_limit`; tarball download/extract still
-// uses `get_manifests_concurrency_limit_sync` so install IO is not inflated.
+// Keep the user-visible default at 64. Non-semver registries use a higher
+// internal default for dependency resolution and tarball downloads unless the
+// user explicitly sets a limit.
 const DEFAULT_MANIFESTS_CONCURRENCY_LIMIT: usize = 64;
 const NON_SEMVER_RESOLVER_CONCURRENCY_LIMIT: usize = 256;
 
@@ -175,9 +174,26 @@ fn resolver_manifest_concurrency_limit(
     }
 }
 
+fn install_tarball_concurrency_limit(
+    configured_limit: usize,
+    cli_set: bool,
+    supports_semver: Option<bool>,
+) -> usize {
+    resolver_manifest_concurrency_limit(configured_limit, cli_set, supports_semver)
+}
+
 pub async fn get_resolver_manifests_concurrency_limit() -> usize {
     let limit = get_manifests_concurrency_limit().await;
     resolver_manifest_concurrency_limit(
+        limit,
+        MANIFESTS_CONCURRENCY_CLI_SET.get().is_some(),
+        get_supports_semver(),
+    )
+}
+
+pub fn get_install_tarball_concurrency_limit_sync() -> usize {
+    let limit = get_manifests_concurrency_limit_sync();
+    install_tarball_concurrency_limit(
         limit,
         MANIFESTS_CONCURRENCY_CLI_SET.get().is_some(),
         get_supports_semver(),
@@ -439,6 +455,18 @@ mod tests {
         assert_eq!(
             resolver_manifest_concurrency_limit(DEFAULT_MANIFESTS_CONCURRENCY_LIMIT, false, None),
             DEFAULT_MANIFESTS_CONCURRENCY_LIMIT
+        );
+    }
+
+    #[test]
+    fn test_install_tarball_concurrency_raises_non_semver_default() {
+        assert_eq!(
+            install_tarball_concurrency_limit(
+                DEFAULT_MANIFESTS_CONCURRENCY_LIMIT,
+                false,
+                Some(false),
+            ),
+            NON_SEMVER_RESOLVER_CONCURRENCY_LIMIT
         );
     }
 


### PR DESCRIPTION
## Summary

- Use the same non-semver concurrency policy for install tarball downloads that resolver manifest fetches already use.
- Keep the user-visible default at 64 and preserve explicit `--manifests-concurrency-limit` overrides.
- Leave semver-capable registries on the configured/default limit.

## Why

p3 cold install with an existing lockfile is still network-bound on tarball fetches before extract/clone can fully saturate. The scheduler already applies backpressure from extract backlog; this change only raises the network ceiling for registries known not to support semver lookups.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm install_scheduler`
- `cargo test -p utoo-pm test_install_tarball_concurrency_raises_non_semver_default`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Benchmark

GHA Linux npmjs run `26113607691`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 11.62s | 10.41s | 9.44s | 9.76s | 89.7K / 51.8K |
| p1 resolve | 3.79s | 6.28s | 6.40s | 3.36s | 18.1K / 19.0K |
| p3 cold install | 6.67s | 10.45s | 11.96s | 8.03s | 77.1K / 40.2K |
| p4 warm link | 3.38s | 2.26s | 2.20s | 2.09s | 7.4K / 4.3K |

GHA Linux npmjs N=2 run `26114612129`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 8.96s | 9.63s | 8.64s | 7.29s | 70.1K / 44.3K |
| p1 resolve | 2.34s | 3.08s | 3.07s | 3.44s | 16.9K / 20.4K |
| p3 cold install | 6.58s | 6.42s | 6.15s | 6.35s | 68.7K / 39.8K |
| p4 warm link | 3.37s | 2.30s | 2.20s | 2.04s | 7.8K / 4.7K |

## Conclusion

Do not pick this into #2989. Raising install tarball concurrency to 256 was positive in the poolab/npmmirror AB, but GHA/npmjs does not validate it: p3 regresses or stays noisy versus #2989's stable `5.3-5.9s` range, while ctx rises. The likely direction is to keep npmjs tarball downloads at 64 and only consider registry-specific tuning for npmmirror after a separate, explicit design.
