### PR TITLE
perf(pm): spawn install download workers

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -450,13 +450,14 @@ impl SchedulerState {
             }
 
             self.download_active.insert(key.clone());
-            self.ops.push(Box::pin(async move {
+            let done_tx = self.done_tx.clone();
+            tokio::spawn(async move {
                 let result = download_bytes(&package.tarball_url)
                     .await
                     .map(DownloadOutcome::Bytes)
                     .map_err(|e| format!("{e:#}"));
-                OpDone::Download { package, result }
-            }));
+                let _ = done_tx.send(OpDone::Download { package, result });
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

- Move install tarball downloads out of the scheduler `FuturesUnordered` and into short-lived tokio workers.
- Keep scheduler ownership of dedupe, active sets, queues, extraction, and clone ordering.
- Report download completion back through the existing `OpDone::Download` path.

## Why

p3 cold install is dominated by registry tarball downloads plus extract/cache writes. Polling thousands of download futures directly inside the scheduler can wake the scheduler on network readiness even though the scheduler only needs the final downloaded bytes. This AB checks whether keeping network polling in worker tasks reduces scheduler interference and context-switch pressure.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm install_scheduler`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Benchmark

GHA Linux npmjs run `26114547814`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 12.64s | 10.94s | 13.93s | 11.29s | 104.2K / 41.9K |
| p1 resolve | 1.77s | 2.67s | 2.56s | 2.14s | 14.9K / 19.1K |
| p3 cold install | 10.40s | 8.43s | 10.85s | 7.88s | 82.2K / 29.4K |
| p4 warm link | 4.93s | 4.02s | 3.09s | 4.87s | 7.7K / 4.2K |

Windows e2e failed on npmjs `HTTP 406 Not Acceptable` while resolving `@isaacs/cliui`, matching known registry flake behavior and not specific to this install scheduler change.

## Conclusion

Do not pick this into #2989. The intended signal was lower p3 scheduler/network context pressure, but the run shows higher p3 vCtx than #2989 and no wall improvement. p4 was also globally noisy, but the experiment still does not produce the target signal.
