### PR TITLE
perf(pm): chunk indexed extract writes

### DIFF
--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -51,11 +51,10 @@ pub(crate) fn extract_and_write_indexed_sync(
         .with_context(|| format!("Failed to create destination directory: {}", dest.display()))?;
 
     let estimated_size = estimate_uncompressed_size(&gzip_bytes);
-    // The install scheduler already parallelizes at the package level.
-    // Keeping each tarball's file writes serial avoids nested rayon fan-out
-    // where many package extract workers all enqueue per-file write chunks at
-    // the same time.
-    extract_tarball_sync(gzip_bytes, estimated_size, dest, FileWriteMode::Serial)
+    // The install scheduler already bounds package-level extract concurrency.
+    // Reuse the bounded chunk writer so large tarballs do not monopolize one
+    // extract worker while still avoiding per-file fan-out.
+    extract_tarball_sync(gzip_bytes, estimated_size, dest)
 }
 
 /// Estimate uncompressed size from gzip footer (last 4 bytes store original size mod 2^32).
@@ -86,12 +85,6 @@ struct ExtractedEntry {
     mode: u32,
 }
 
-#[derive(Clone, Copy)]
-enum FileWriteMode {
-    ParallelChunks,
-    Serial,
-}
-
 /// Extract tarball using libdeflate for decompression + rayon for parallel writes.
 ///
 /// Uses rayon::spawn (not tokio blocking pool) to avoid thread storms.
@@ -103,12 +96,7 @@ async fn extract_tarball(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
     let (tx, rx) = tokio::sync::oneshot::channel();
 
     rayon::spawn(move || {
-        let result = extract_tarball_sync(
-            gzip_bytes,
-            estimated_size,
-            &dest_owned,
-            FileWriteMode::ParallelChunks,
-        );
+        let result = extract_tarball_sync(gzip_bytes, estimated_size, &dest_owned);
         let _ = tx.send(result);
     });
 
@@ -122,7 +110,6 @@ fn extract_tarball_sync(
     gzip_bytes: Bytes,
     estimated_size: usize,
     dest: &Path,
-    file_write_mode: FileWriteMode,
 ) -> Result<Option<ExtractedPackageIndex>> {
     use rayon::prelude::*;
     use std::collections::HashSet;
@@ -203,23 +190,14 @@ fn extract_tarball_sync(
         Ok(())
     };
 
-    match file_write_mode {
-        FileWriteMode::ParallelChunks => {
-            entries
-                .par_chunks(WRITE_CHUNK_SIZE)
-                .try_for_each(|chunk| -> Result<()> {
-                    for entry in chunk {
-                        write_entry(entry)?;
-                    }
-                    Ok(())
-                })?;
-        }
-        FileWriteMode::Serial => {
-            for entry in &entries {
+    entries
+        .par_chunks(WRITE_CHUNK_SIZE)
+        .try_for_each(|chunk| -> Result<()> {
+            for entry in chunk {
                 write_entry(entry)?;
             }
-        }
-    }
+            Ok(())
+        })?;
 
     // Set directory permissions
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Reuse the existing bounded `par_chunks(64)` tarball writer for scheduler indexed extracts.
- Remove the now-unused serial extract write mode.

## Why

p3 cold install still shows high context-switch count and GHA pcap points at cache/extract write tail latency rather than socket-drain starvation. This is an AB experiment against #2989 to see whether large tarballs should stop monopolizing one extract worker while keeping per-file fan-out bounded.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm test_extract_and_write_sync`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Benchmark

GHA Linux npmjs run `26117858337`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 9.08s | 9.57s | 8.18s | 9.52s | 90.5K / 56.3K |
| p1 resolve | 2.27s | 3.02s | 3.15s | 2.36s | 15.2K / 20.8K |
| p3 cold install | 8.16s | 8.95s | 6.30s | 5.56s | 64.6K / 41.2K |
| p4 warm link | 3.37s | 2.21s | 2.08s | 1.93s | 7.7K / 4.7K |

Conclusion: p3 wall is good but p3 ctx is only neutral vs #2989, while p0 ctx regresses. Do not pick this into #2989 without stronger evidence.

Poolab/npmmirror internal AB also did not validate the ctx goal; numbers are kept out of the public PR per project guidance.
