### PR TITLE
perf(pm): bound install extract backlog

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -243,6 +243,7 @@ struct SchedulerState {
     shutdown: bool,
     download_limit: usize,
     extract_limit: usize,
+    extract_backlog_limit: usize,
     clone_worker_limit: usize,
     download_done: HashMap<String, RegistryCacheEntry>,
     download_active: HashSet<String>,
@@ -263,13 +264,15 @@ impl SchedulerState {
     fn new(rx: mpsc::UnboundedReceiver<Command>) -> Self {
         let (done_tx, done_rx) = mpsc::unbounded_channel();
         let clone_limit = clone_concurrency_limit();
+        let extract_limit = extract_concurrency_limit();
         Self {
             rx,
             done_tx,
             done_rx,
             shutdown: false,
             download_limit: get_manifests_concurrency_limit_sync().max(1),
-            extract_limit: extract_concurrency_limit(),
+            extract_limit,
+            extract_backlog_limit: extract_backlog_limit(extract_limit),
             clone_worker_limit: clone_worker_limit(clone_limit),
             download_done: HashMap::new(),
             download_active: HashSet::new(),
@@ -428,7 +431,7 @@ impl SchedulerState {
 
     fn pump_downloads_with(&mut self, cache_lookup: impl Fn(&PackageFetch) -> Option<PathBuf>) {
         while self.download_active.len() < self.download_limit
-            && self.extract_backlog() < self.download_limit
+            && self.extract_backlog() < self.extract_backlog_limit
         {
             let Some(package) = self.download_queue.pop_front() else {
                 break;
@@ -669,6 +672,10 @@ fn extract_concurrency_limit() -> usize {
         .unwrap_or(4)
 }
 
+fn extract_backlog_limit(extract_limit: usize) -> usize {
+    extract_limit.saturating_mul(4).max(1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -833,6 +840,13 @@ mod tests {
         assert_eq!(clone_worker_limit(4), 4);
         assert_eq!(clone_worker_limit(8), 6);
         assert_eq!(clone_worker_limit(16), 10);
+    }
+
+    #[test]
+    fn extract_backlog_limit_keeps_downloaded_bytes_bounded() {
+        assert_eq!(extract_backlog_limit(0), 1);
+        assert_eq!(extract_backlog_limit(2), 8);
+        assert_eq!(extract_backlog_limit(8), 32);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bound the downloaded tarball backlog separately from the network concurrency limit.
- Keep install tarball download concurrency at the existing configured/default value.
- Use `4 * extract_limit` as the backlog cap, so GHA-sized runners keep about 8 downloaded tarballs queued for extraction while larger poollab runners keep about 32.

## Why

p3 cold install pcap points at cache/extract write tail latency rather than socket-drain starvation. The current scheduler lets downloaded tarball bytes backlog up to the full download limit (`64` by default), even when extract workers are the gating stage. This experiment checks whether tighter backpressure between download and extract reduces p3 context-switch/IO pressure without changing the public download concurrency default.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm install_scheduler`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Benchmark

GHA Linux npmjs run `26118968168`:

| phase | bun | utoo-next | utoo-npm | utoo | utoo ctx |
|---|---:|---:|---:|---:|---:|
| p0 full cold | 9.08s | 10.30s | 8.15s | 8.26s | 77.6K / 53.3K |
| p1 resolve | 2.09s | 3.16s | 3.13s | 3.38s | 15.1K / 20.5K |
| p3 cold install | 6.86s | 6.42s | 7.92s | 6.12s | 74.5K / 43.4K |
| p4 warm link | 3.30s | 2.45s | 2.25s | 2.23s | 7.6K / 4.4K |

Conclusion: negative. Compared with #2989 run `26118716599` (`p3 5.83s`, `59.7K/39.0K`), the bounded backlog regresses both p3 wall and ctx. Do not pick into #2989.

Poolab/npmmirror internal AB also showed this can amplify slow-tarball tail latency; numbers are kept out of the public PR per project guidance.
