### PR TITLE
perf(pm): force http1 tarball downloads

### DIFF
--- a/crates/pm/src/util/retry.rs
+++ b/crates/pm/src/util/retry.rs
@@ -27,6 +27,10 @@ impl std::error::Error for RetryableError {}
 pub fn build_dns_cached_client() -> reqwest::Client {
     client_builder()
         .connect_timeout(std::time::Duration::from_secs(5)) // TLS + TCP handshake
+        // Match the resolver HTTP client: tarball installs issue many
+        // independent large responses, so avoiding HTTP/2 multiplexing keeps
+        // one slow body read from stalling unrelated downloads.
+        .http1_only()
         .read_timeout(std::time::Duration::from_secs(30)) // Timeout for individual read operations
         // No total timeout - large files (e.g. node binary ~100MB) need longer download time
         // No pool_max_idle_per_host - let reqwest manage connections freely


### PR DESCRIPTION
## Summary

- Force the PM tarball downloader reqwest client to use HTTP/1.1.
- Keep the change scoped to tarball downloads; resolver manifest HTTP clients already use the same protocol choice.

## Why

p3 cold install is now mostly cold tarball download plus cache extract/write. The resolver HTTP client already avoids HTTP/2 multiplexing because one slow response can stall unrelated manifest requests on the same connection. Tarball installs have the same shape with larger bodies, so this experiment applies the same protocol choice to the PM downloader.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm retry`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

## Benchmark

Draft experiment. Add `benchmark` label and use the sticky `pm-bench-phases` result for GHA/Linux npmjs validation.
