### PR TITLE
perf(pm): raise install tarball concurrency

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -14,7 +14,7 @@ use crate::util::downloader::{
     RegistryCacheEntry, download_bytes, download_stats, extract_to_cache_indexed_sync,
     is_registry_tarball_url, registry_cache_lookup_sync, resolve_seeded_cache_path,
 };
-use crate::util::user_config::get_manifests_concurrency_limit_sync;
+use crate::util::user_config::get_install_tarball_concurrency_limit_sync;
 
 // Keep clone completions batched enough to reduce scheduler wakeups, while
 // avoiding long serial hardlink runs inside one rayon worker.
@@ -268,7 +268,7 @@ impl SchedulerState {
             done_tx,
             done_rx,
             shutdown: false,
-            download_limit: get_manifests_concurrency_limit_sync().max(1),
+            download_limit: get_install_tarball_concurrency_limit_sync().max(1),
             extract_limit: extract_concurrency_limit(),
             clone_worker_limit: clone_worker_limit(clone_limit),
             download_done: HashMap::new(),

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -134,10 +134,9 @@ pub fn get_install_scope() -> InstallScope {
 
 // Manifest fetch concurrency configuration.
 //
-// Keep the user-visible/default tarball download limit at 64. Registry
-// resolution can opt into a higher default for non-semver registries via
-// `get_resolver_manifests_concurrency_limit`; tarball download/extract still
-// uses `get_manifests_concurrency_limit_sync` so install IO is not inflated.
+// Keep the user-visible default at 64. Non-semver registries use a higher
+// internal default for dependency resolution and tarball downloads unless the
+// user explicitly sets a limit.
 const DEFAULT_MANIFESTS_CONCURRENCY_LIMIT: usize = 64;
 const NON_SEMVER_RESOLVER_CONCURRENCY_LIMIT: usize = 256;
 
@@ -175,9 +174,26 @@ fn resolver_manifest_concurrency_limit(
     }
 }
 
+fn install_tarball_concurrency_limit(
+    configured_limit: usize,
+    cli_set: bool,
+    supports_semver: Option<bool>,
+) -> usize {
+    resolver_manifest_concurrency_limit(configured_limit, cli_set, supports_semver)
+}
+
 pub async fn get_resolver_manifests_concurrency_limit() -> usize {
     let limit = get_manifests_concurrency_limit().await;
     resolver_manifest_concurrency_limit(
+        limit,
+        MANIFESTS_CONCURRENCY_CLI_SET.get().is_some(),
+        get_supports_semver(),
+    )
+}
+
+pub fn get_install_tarball_concurrency_limit_sync() -> usize {
+    let limit = get_manifests_concurrency_limit_sync();
+    install_tarball_concurrency_limit(
         limit,
         MANIFESTS_CONCURRENCY_CLI_SET.get().is_some(),
         get_supports_semver(),
@@ -439,6 +455,18 @@ mod tests {
         assert_eq!(
             resolver_manifest_concurrency_limit(DEFAULT_MANIFESTS_CONCURRENCY_LIMIT, false, None),
             DEFAULT_MANIFESTS_CONCURRENCY_LIMIT
+        );
+    }
+
+    #[test]
+    fn test_install_tarball_concurrency_raises_non_semver_default() {
+        assert_eq!(
+            install_tarball_concurrency_limit(
+                DEFAULT_MANIFESTS_CONCURRENCY_LIMIT,
+                false,
+                Some(false),
+            ),
+            NON_SEMVER_RESOLVER_CONCURRENCY_LIMIT
         );
     }
 


### PR DESCRIPTION
## Summary

- raise the install tarball download default to the non-semver resolver default when the registry does not support semver and the user did not pass an explicit `--manifests-concurrency-limit`
- keep explicit CLI limits as the override path
- leave semver-capable registries on the existing default

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm user_config`
- `cargo test -p utoo-pm install_scheduler`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

Note: full workspace `cargo clippy --all-targets` is blocked in this worktree because `next.js` is not initialized; a temporary symlink to another worktree does not match this branch's pack-core API.