### PR TITLE
perf(pm): cap tokio runtime workers

### DIFF
--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -50,6 +50,10 @@ use crate::helper::workspace::init_project_root;
 
 use crate::helper::migrate::{FromPm, migrate_from_pnpm};
 
+// Keep async network polling compact on high-core machines; CPU-heavy extract
+// and clone work still scales through rayon's pool.
+const MAX_TOKIO_WORKER_THREADS: usize = 4;
+
 fn detect_shell_from_env() -> Option<clap_complete::Shell> {
     // Most common on Unix-like systems.
     let shell_path = std::env::var("SHELL").ok()?;
@@ -344,13 +348,9 @@ enum Commands {
 fn main() {
     crate::util::sysconf::init();
 
-    let worker_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(4);
-
     let result = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .worker_threads(worker_threads)
+        .worker_threads(tokio_worker_threads())
         .build()
         .expect("failed to build tokio runtime")
         .block_on(async_main());
@@ -366,6 +366,12 @@ fn main() {
         }
         process::exit(1);
     }
+}
+
+fn tokio_worker_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().min(MAX_TOKIO_WORKER_THREADS))
+        .unwrap_or(MAX_TOKIO_WORKER_THREADS)
 }
 
 async fn async_main() -> Result<()> {


### PR DESCRIPTION
## Summary

Experimental follow-up to #2989. Cap the PM tokio runtime worker count at 4 while leaving rayon extract/clone workers based on available parallelism.

## Why

poolab p3 measurements show much higher voluntary context switches than GHA. A 4-core affinity run reduced voluntary ctx substantially without changing wall time, but it also constrained rayon and converted part of the signal into involuntary ctx. This draft isolates the async runtime side only.

## Validation

- cargo fmt --check
- cargo test -p utoo-pm test_cli_debug_assert
- cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps

## Expected Signal

GHA/npmjs should be neutral if the runner already exposes 4 or fewer effective CPUs. poolab should tell us whether high-core quota runtime polling is the main source of the p3 ctx amplification.