### PR TITLE
perf(pm): queue manifest store writes

### DIFF
--- a/crates/pm/src/util/json.rs
+++ b/crates/pm/src/util/json.rs
@@ -1,6 +1,9 @@
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 /// Read and parse a JSON file into the specified type.
@@ -10,6 +13,34 @@ pub async fn read_json_file<T: DeserializeOwned>(path: &Path) -> Result<T> {
         .with_context(|| format!("Failed to read file {path:?}"))?;
 
     serde_json::from_slice(&bytes).with_context(|| format!("Failed to parse JSON from {path:?}"))
+}
+
+/// Serialize `value` as compact JSON and stream it to `path` through a
+/// [`BufWriter`], skipping the intermediate `Vec<u8>` that
+/// `serde_json::to_vec` + `std::fs::write` would allocate.
+///
+/// Synchronous on purpose: the caller in [`crate::util::manifest_store`] runs
+/// it on a dedicated OS thread so manifest persistence never touches the
+/// async runtime's worker or blocking pool. Async callers should wrap this
+/// in `tokio::task::spawn_blocking` (or write the async-aware counterpart
+/// when one is needed).
+///
+/// The parent directory of `path` must already exist; this helper does *not*
+/// `mkdir -p`. The cost-benefit of "try the write first, recover on
+/// `NotFound`" is policy-level (warm-cache rewrites want to skip the extra
+/// syscall every time), so the recovery loop lives at the call site, not
+/// here. A missing parent surfaces as [`io::ErrorKind::NotFound`] for the
+/// caller to match on.
+///
+/// Serialization failures — rare for `derive(Serialize)` types, possible for
+/// hand-written impls or maps with non-string keys — are folded into
+/// [`io::Error`] via [`io::Error::other`] so the whole API speaks one error
+/// type and callers can keep matching on [`io::ErrorKind`].
+pub fn write_compact_sync<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer(&mut writer, value).map_err(io::Error::other)?;
+    writer.flush()
 }
 
 /// Load package.json from a directory path and deserialize into the caller's
@@ -133,6 +164,35 @@ mod tests {
         // Last value wins, matching JSON.parse semantics
         assert_eq!(view.scripts.get("prepublish").unwrap(), "node build.js");
         assert_eq!(view.scripts.get("test").unwrap(), "node build/test.js");
+    }
+
+    #[tokio::test]
+    async fn write_compact_sync_round_trips_through_read_json_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("out.json");
+        let value = json!({
+            "name": "test",
+            "version": "1.0.0",
+            "deps": ["a", "b", "c"],
+        });
+
+        super::write_compact_sync(&path, &value).unwrap();
+
+        let read_back: Value = read_json_file(&path).await.unwrap();
+        assert_eq!(read_back, value);
+
+        // Compact form: no inter-token whitespace.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains(": "));
+        assert!(!raw.contains(", "));
+    }
+
+    #[test]
+    fn write_compact_sync_requires_existing_parent_directory() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("missing").join("out.json");
+        let err = super::write_compact_sync(&path, &json!({})).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[tokio::test]

--- a/crates/pm/src/util/manifest_store.rs
+++ b/crates/pm/src/util/manifest_store.rs
@@ -4,13 +4,17 @@
 //! - `<cache_dir>/<name>/versions.json`              ← `VersionsInfo` (etag + version list)
 //! - `<cache_dir>/<name>/manifests/<version>.json`   ← `CoreVersionManifest`
 //!
-//! Writes are fire-and-forget: each `store_*` call spawns a detached task and
-//! returns immediately, so the resolver hot path never waits on the disk.
+//! Writes are fire-and-forget: each `store_*` call enqueues a background write
+//! and returns immediately, so the resolver hot path never waits on the disk.
 //! Errors are logged at debug level — disk cache is opportunistic; a failed
 //! write only costs a future cache miss.
+//! Serialization and file writes run on a dedicated writer thread so manifest
+//! persistence does not occupy async runtime workers or Tokio's blocking pool.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::mpsc::{self, Sender};
+use std::thread::JoinHandle;
 
 use async_trait::async_trait;
 use serde::Serialize;
@@ -21,11 +25,15 @@ use crate::util::json::read_json_file;
 
 pub struct DiskManifestStore {
     cache_dir: PathBuf,
+    writer: Option<ManifestWriter>,
 }
 
 impl DiskManifestStore {
     pub fn new(cache_dir: PathBuf) -> Self {
-        Self { cache_dir }
+        Self {
+            cache_dir,
+            writer: Some(ManifestWriter::spawn()),
+        }
     }
 
     fn versions_path(&self, name: &str) -> PathBuf {
@@ -37,6 +45,12 @@ impl DiskManifestStore {
             .join(name)
             .join("manifests")
             .join(format!("{version}.json"))
+    }
+
+    fn enqueue_write(&self, job: ManifestWriteJob) {
+        if let Some(writer) = &self.writer {
+            writer.enqueue(job);
+        }
     }
 }
 
@@ -58,7 +72,7 @@ impl ManifestStore for DiskManifestStore {
 
     fn store_versions(&self, name: &str, info: Arc<VersionsInfo>) {
         let path = self.versions_path(name);
-        tokio::spawn(async move { write_json(&path, &*info).await });
+        self.enqueue_write(ManifestWriteJob::Versions { path, info });
     }
 
     fn store_version_manifest(
@@ -68,14 +82,73 @@ impl ManifestStore for DiskManifestStore {
         manifest: Arc<CoreVersionManifest>,
     ) {
         let path = self.manifest_path(name, version);
-        tokio::spawn(async move { write_json(&path, &*manifest).await });
+        self.enqueue_write(ManifestWriteJob::VersionManifest { path, manifest });
+    }
+}
+
+impl Drop for DiskManifestStore {
+    fn drop(&mut self) {
+        if let Some(writer) = self.writer.take() {
+            writer.join();
+        }
+    }
+}
+
+enum ManifestWriteJob {
+    Versions {
+        path: PathBuf,
+        info: Arc<VersionsInfo>,
+    },
+    VersionManifest {
+        path: PathBuf,
+        manifest: Arc<CoreVersionManifest>,
+    },
+}
+
+struct ManifestWriter {
+    tx: Sender<ManifestWriteJob>,
+    handle: JoinHandle<()>,
+}
+
+impl ManifestWriter {
+    fn spawn() -> Self {
+        let (tx, rx) = mpsc::channel();
+        let handle = std::thread::Builder::new()
+            .name("utoo-manifest-store".to_string())
+            .spawn(move || {
+                while let Ok(job) = rx.recv() {
+                    match job {
+                        ManifestWriteJob::Versions { path, info } => {
+                            write_json_sync(&path, &*info);
+                        }
+                        ManifestWriteJob::VersionManifest { path, manifest } => {
+                            write_json_sync(&path, &*manifest);
+                        }
+                    }
+                }
+            })
+            .expect("failed to spawn manifest store writer");
+        Self { tx, handle }
+    }
+
+    fn enqueue(&self, job: ManifestWriteJob) {
+        if self.tx.send(job).is_err() {
+            tracing::debug!("Manifest store writer stopped before accepting write");
+        }
+    }
+
+    fn join(self) {
+        drop(self.tx);
+        if self.handle.join().is_err() {
+            tracing::debug!("Manifest store writer panicked");
+        }
     }
 }
 
 /// Serialize `value` and write to `path`. On `NotFound`, create the parent
 /// directory and retry once — saves the mkdir syscall on every warm-cache
 /// rewrite. Errors are logged at debug; disk cache is opportunistic.
-async fn write_json<T: Serialize>(path: &Path, value: &T) {
+fn write_json_sync<T: Serialize>(path: &Path, value: &T) {
     let bytes = match serde_json::to_vec(value) {
         Ok(b) => b,
         Err(e) => {
@@ -83,19 +156,70 @@ async fn write_json<T: Serialize>(path: &Path, value: &T) {
             return;
         }
     };
-    match crate::fs::write(path, &bytes).await {
+    match std::fs::write(path, &bytes) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             if let Some(parent) = path.parent()
-                && let Err(e) = crate::fs::create_dir_all(parent).await
+                && let Err(e) = std::fs::create_dir_all(parent)
             {
                 tracing::debug!("Failed to create {parent:?}: {e}");
                 return;
             }
-            if let Err(e) = crate::fs::write(path, &bytes).await {
+            if let Err(e) = std::fs::write(path, &bytes) {
                 tracing::debug!("Failed to write {path:?}: {e}");
             }
         }
         Err(e) => tracing::debug!("Failed to write {path:?}: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use tempfile::tempdir;
+    use utoo_ruborist::service::Versions;
+
+    use super::*;
+
+    #[test]
+    fn drop_flushes_queued_manifest_writes() {
+        let dir = tempdir().unwrap();
+        {
+            let store = DiskManifestStore::new(dir.path().to_path_buf());
+            store.store_versions(
+                "pkg",
+                Arc::new(VersionsInfo {
+                    versions: Versions {
+                        version_list: vec!["1.0.0".to_string()],
+                        dist_tags: HashMap::from([("latest".to_string(), "1.0.0".to_string())]),
+                    },
+                    etag: Some("etag".to_string()),
+                    last_updated: 1,
+                }),
+            );
+            store.store_version_manifest(
+                "pkg",
+                "1.0.0",
+                Arc::new(CoreVersionManifest {
+                    name: "pkg".to_string(),
+                    version: "1.0.0".to_string(),
+                    ..Default::default()
+                }),
+            );
+        }
+
+        let versions: VersionsInfo =
+            serde_json::from_slice(&std::fs::read(dir.path().join("pkg/versions.json")).unwrap())
+                .unwrap();
+        assert_eq!(versions.versions.version_list, ["1.0.0"]);
+
+        let manifest: CoreVersionManifest = serde_json::from_slice(
+            &std::fs::read(dir.path().join("pkg/manifests/1.0.0.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(manifest.name, "pkg");
+        assert_eq!(manifest.version, "1.0.0");
     }
 }

--- a/crates/pm/src/util/manifest_store.rs
+++ b/crates/pm/src/util/manifest_store.rs
@@ -11,7 +11,8 @@
 //! Serialization and file writes run on a dedicated writer thread so manifest
 //! persistence does not occupy async runtime workers or Tokio's blocking pool.
 
-use std::io::{BufWriter, Write};
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::mpsc::{self, SyncSender, TrySendError};
@@ -22,7 +23,7 @@ use serde::Serialize;
 use utoo_ruborist::model::manifest::CoreVersionManifest;
 use utoo_ruborist::service::{ManifestStore, VersionsInfo};
 
-use crate::util::json::read_json_file;
+use crate::util::json::{read_json_file, write_compact_sync};
 
 /// Opportunistic writer backlog. If disk stalls beyond this, new cache writes
 /// are dropped instead of letting resolver memory grow without bound.
@@ -156,32 +157,28 @@ impl ManifestWriter {
     }
 }
 
-/// Serialize `value` and write to `path`. On `NotFound`, create the parent
-/// directory and retry once — saves the mkdir syscall on every warm-cache
-/// rewrite. Errors are logged at debug; disk cache is opportunistic.
+/// Apply the manifest-cache write policy on top of
+/// [`crate::util::json::write_compact_sync`]: on `NotFound`, create the
+/// parent directory once and retry — this is how the resolver hot path
+/// avoids the up-front `mkdir` syscall on every warm-cache rewrite. All
+/// errors are swallowed at the `debug` log level because the disk cache is
+/// opportunistic; a dropped write only costs a future cache miss.
 fn write_json_sync<T: Serialize>(path: &Path, value: &T) {
-    match write_json_file_sync(path, value) {
+    match write_compact_sync(path, value) {
         Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        Err(e) if e.kind() == ErrorKind::NotFound => {
             if let Some(parent) = path.parent()
-                && let Err(e) = std::fs::create_dir_all(parent)
+                && let Err(e) = fs::create_dir_all(parent)
             {
                 tracing::debug!("Failed to create {parent:?}: {e}");
                 return;
             }
-            if let Err(e) = write_json_file_sync(path, value) {
+            if let Err(e) = write_compact_sync(path, value) {
                 tracing::debug!("Failed to write {path:?}: {e}");
             }
         }
         Err(e) => tracing::debug!("Failed to write {path:?}: {e}"),
     }
-}
-
-fn write_json_file_sync<T: Serialize>(path: &Path, value: &T) -> std::io::Result<()> {
-    let file = std::fs::File::create(path)?;
-    let mut writer = BufWriter::new(file);
-    serde_json::to_writer(&mut writer, value).map_err(std::io::Error::other)?;
-    writer.flush()
 }
 
 #[cfg(test)]

--- a/crates/pm/src/util/manifest_store.rs
+++ b/crates/pm/src/util/manifest_store.rs
@@ -11,9 +11,10 @@
 //! Serialization and file writes run on a dedicated writer thread so manifest
 //! persistence does not occupy async runtime workers or Tokio's blocking pool.
 
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::mpsc::{self, Sender};
+use std::sync::mpsc::{self, SyncSender, TrySendError};
 use std::thread::JoinHandle;
 
 use async_trait::async_trait;
@@ -22,6 +23,10 @@ use utoo_ruborist::model::manifest::CoreVersionManifest;
 use utoo_ruborist::service::{ManifestStore, VersionsInfo};
 
 use crate::util::json::read_json_file;
+
+/// Opportunistic writer backlog. If disk stalls beyond this, new cache writes
+/// are dropped instead of letting resolver memory grow without bound.
+const MANIFEST_WRITE_QUEUE_CAPACITY: usize = 1024;
 
 pub struct DiskManifestStore {
     cache_dir: PathBuf,
@@ -106,13 +111,13 @@ enum ManifestWriteJob {
 }
 
 struct ManifestWriter {
-    tx: Sender<ManifestWriteJob>,
+    tx: SyncSender<ManifestWriteJob>,
     handle: JoinHandle<()>,
 }
 
 impl ManifestWriter {
     fn spawn() -> Self {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::sync_channel(MANIFEST_WRITE_QUEUE_CAPACITY);
         let handle = std::thread::Builder::new()
             .name("utoo-manifest-store".to_string())
             .spawn(move || {
@@ -132,8 +137,14 @@ impl ManifestWriter {
     }
 
     fn enqueue(&self, job: ManifestWriteJob) {
-        if self.tx.send(job).is_err() {
-            tracing::debug!("Manifest store writer stopped before accepting write");
+        match self.tx.try_send(job) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                tracing::debug!("Manifest store writer queue full; dropping cache write");
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                tracing::debug!("Manifest store writer stopped before accepting write");
+            }
         }
     }
 
@@ -149,14 +160,7 @@ impl ManifestWriter {
 /// directory and retry once — saves the mkdir syscall on every warm-cache
 /// rewrite. Errors are logged at debug; disk cache is opportunistic.
 fn write_json_sync<T: Serialize>(path: &Path, value: &T) {
-    let bytes = match serde_json::to_vec(value) {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::debug!("Failed to serialize {path:?}: {e}");
-            return;
-        }
-    };
-    match std::fs::write(path, &bytes) {
+    match write_json_file_sync(path, value) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             if let Some(parent) = path.parent()
@@ -165,12 +169,19 @@ fn write_json_sync<T: Serialize>(path: &Path, value: &T) {
                 tracing::debug!("Failed to create {parent:?}: {e}");
                 return;
             }
-            if let Err(e) = std::fs::write(path, &bytes) {
+            if let Err(e) = write_json_file_sync(path, value) {
                 tracing::debug!("Failed to write {path:?}: {e}");
             }
         }
         Err(e) => tracing::debug!("Failed to write {path:?}: {e}"),
     }
+}
+
+fn write_json_file_sync<T: Serialize>(path: &Path, value: &T) -> std::io::Result<()> {
+    let file = std::fs::File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer(&mut writer, value).map_err(std::io::Error::other)?;
+    writer.flush()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Queue `DiskManifestStore` writes through one dedicated background writer thread instead of spawning one Tokio task per manifest write.
- Keep resolver hot paths fire-and-forget while avoiding async runtime / blocking-pool contention from manifest persistence.
- Bound the opportunistic writer queue; if disk stalls and the queue fills, new cache writes are dropped instead of growing resolver memory without limit.
- Stream JSON serialization through `BufWriter` instead of materializing a full `Vec<u8>` before each disk write.
- Flush queued manifest writes when the store is dropped, with a unit test covering versions and per-version manifest writes.

## Why

The p1 investigation showed `versions.json` / version-manifest persistence is required for cache parity, but per-write Tokio tasks add scheduler noise on the resolve hot path. This PR keeps the same cache semantics and moves serialization + filesystem writes behind a single bounded queue. The cache is opportunistic, so dropping writes under extreme backpressure is preferable to unbounded memory growth.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm manifest_store`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

Note: full workspace `cargo clippy --all-targets -- -D warnings --no-deps` is currently blocked in this worktree by pack-core / next.js submodule API mismatch, unrelated to this PM-only change.
