### PR TITLE
perf(pm): force http1 tarball downloads

### DIFF
--- a/crates/pm/src/util/retry.rs
+++ b/crates/pm/src/util/retry.rs
@@ -27,6 +27,10 @@ impl std::error::Error for RetryableError {}
 pub fn build_dns_cached_client() -> reqwest::Client {
     client_builder()
         .connect_timeout(std::time::Duration::from_secs(5)) // TLS + TCP handshake
+        // Match the resolver HTTP client: tarball installs issue many
+        // independent large responses, so avoiding HTTP/2 multiplexing keeps
+        // one slow body read from stalling unrelated downloads.
+        .http1_only()
         .read_timeout(std::time::Duration::from_secs(30)) // Timeout for individual read operations
         // No total timeout - large files (e.g. node binary ~100MB) need longer download time
         // No pool_max_idle_per_host - let reqwest manage connections freely


### PR DESCRIPTION
## Summary

- Force the PM tarball download client to use HTTP/1.1.
- Keep resolver and install tarball clients aligned so many large independent responses are not multiplexed over one HTTP/2 connection.

## Why

The p3 investigation showed the remaining cold install ctx was not only cache writes. The HTTP/1.1 AB reduced tarball-install ctx and wall time on GHA without affecting p4 materialization.

## Validation

- `cargo fmt`
- `cargo test -p utoo-pm retry`
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`

Note: full workspace `cargo clippy --all-targets -- -D warnings --no-deps` is currently blocked in this worktree by pack-core / next.js submodule API mismatch, unrelated to this PM-only change.
