### PR TITLE
perf(pm): parse version manifests from vec buffers

### DIFF
--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -14,11 +14,13 @@ use super::fetch::{
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
 
-/// Parse JSON bytes on rayon's CPU thread pool (native) or inline
-/// (wasm32). Keeps the tokio runtime free of `simd_json` work so other
-/// in-flight manifest fetches keep driving network IO while this one
-/// parses.
-pub(crate) async fn parse_json_off_runtime<T>(bytes: Bytes) -> Result<T, anyhow::Error>
+/// Parse a JSON buffer on rayon's CPU thread pool (native) or inline
+/// (wasm32). The buffer is consumed because `simd_json` mutates it in-place.
+/// Keeps the tokio runtime free of `simd_json` work so other in-flight
+/// manifest fetches keep driving network IO while this one parses.
+pub(crate) async fn parse_json_vec_off_runtime<T>(
+    mut parse_buf: Vec<u8>,
+) -> Result<T, anyhow::Error>
 where
     T: serde::de::DeserializeOwned + Send + 'static,
 {
@@ -26,7 +28,6 @@ where
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let mut parse_buf = bytes.to_vec();
             let result = simd_json::serde::from_slice::<T>(&mut parse_buf)
                 .map_err(|e| anyhow!("JSON parse error: {e}"));
             let _ = tx.send(result);
@@ -36,7 +37,6 @@ where
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut parse_buf = bytes.to_vec();
         simd_json::serde::from_slice::<T>(&mut parse_buf)
             .map_err(|e| anyhow!("JSON parse error: {e}"))
     }
@@ -71,7 +71,7 @@ pub(crate) async fn parse_full_manifest_off_runtime(
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut manifest: FullManifest = parse_json_off_runtime(raw_bytes.clone()).await?;
+        let mut manifest: FullManifest = parse_json_vec_off_runtime(raw_bytes.to_vec()).await?;
         manifest.raw = raw_bytes;
         Ok(manifest)
     }
@@ -220,6 +220,28 @@ pub async fn fetch_full_manifest_fresh(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+async fn read_body_vec(mut response: reqwest::Response) -> Result<Vec<u8>, FetchError> {
+    let capacity = response
+        .content_length()
+        .and_then(|len| usize::try_from(len).ok())
+        .unwrap_or(0);
+    let mut body = Vec::with_capacity(capacity);
+    while let Some(chunk) = response.chunk().await.map_err(classify_reqwest_error)? {
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn read_body_vec(response: reqwest::Response) -> Result<Vec<u8>, FetchError> {
+    response
+        .bytes()
+        .await
+        .map(|bytes| bytes.to_vec())
+        .map_err(classify_reqwest_error)
+}
+
 /// Options for fetching a version manifest.
 pub struct FetchVersionManifestOptions<'a> {
     pub registry_url: &'a str,
@@ -230,6 +252,17 @@ pub struct FetchVersionManifestOptions<'a> {
 
 /// Fetch version manifest bytes with retry, without parsing.
 pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>) -> Result<Bytes> {
+    fetch_version_manifest_vec(opts).await.map(Bytes::from)
+}
+
+/// Fetch version manifest into a mutable parse buffer with retry.
+///
+/// Unlike full manifests, exact-version manifests do not need to keep raw
+/// response bytes for later extraction. Reading directly into `Vec<u8>` avoids
+/// the hot-path `Bytes -> Vec` copy before `simd_json` parses in place.
+pub(crate) async fn fetch_version_manifest_vec(
+    opts: FetchVersionManifestOptions<'_>,
+) -> Result<Vec<u8>> {
     let url = format!("{}/{}/{}", opts.registry_url, opts.name, opts.spec);
 
     let accept = match opts.format {
@@ -251,7 +284,7 @@ pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>)
                     .map_err(classify_reqwest_error)?;
 
                 if response.status().is_success() {
-                    response.bytes().await.map_err(classify_reqwest_error)
+                    read_body_vec(response).await
                 } else {
                     Err(classify_status(response.status(), &url))
                 }
@@ -271,6 +304,36 @@ pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>)
 pub async fn fetch_version_manifest(
     opts: FetchVersionManifestOptions<'_>,
 ) -> Result<CoreVersionManifest> {
-    let bytes = fetch_version_manifest_bytes(opts).await?;
-    parse_json_off_runtime::<CoreVersionManifest>(bytes).await
+    let bytes = fetch_version_manifest_vec(opts).await?;
+    parse_json_vec_off_runtime::<CoreVersionManifest>(bytes).await
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TinyManifest {
+        name: String,
+        version: String,
+    }
+
+    #[tokio::test]
+    async fn parse_json_vec_off_runtime_consumes_mutable_buffer() {
+        let parsed = parse_json_vec_off_runtime::<TinyManifest>(
+            br#"{"name":"demo","version":"1.0.0"}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            parsed,
+            TinyManifest {
+                name: "demo".to_string(),
+                version: "1.0.0".to_string(),
+            }
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Read exact-version manifest responses directly into `Vec<u8>` so `simd_json` can parse the mutable buffer without a `Bytes -> Vec` copy.
- Keep full-manifest parsing unchanged where raw response bytes must remain available for later version extraction.
- Add a focused parse helper test for the new Vec-based off-runtime path.

## Why

Exact-version manifests are parsed once and do not need to retain raw bytes. This keeps the resolver parse path zero-copy where the wire response can be consumed directly, while preserving the full-manifest `raw` contract.

## Validation

- `cargo fmt`
- `cargo test -p utoo-ruborist manifest`
- `cargo clippy -p utoo-ruborist -p utoo-pm --all-targets -- -D warnings --no-deps`

Note: full workspace `cargo clippy --all-targets -- -D warnings --no-deps` is currently blocked in this worktree by pack-core / next.js submodule API mismatch, unrelated to this PM/Ruborist change.
