### PR TITLE
perf(pm): skip install progress off tty

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -21,7 +21,8 @@ use crate::util::downloader::download_stats;
 use crate::util::json::load_package_lock_json_from_path;
 use crate::util::linker::link;
 use crate::util::logger::{
-    PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
+    finish_progress_bar, inc_progress, log_progress, print_install_counts, set_progress_length,
+    start_progress_bar,
 };
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
 
@@ -89,7 +90,7 @@ pub async fn install_packages(
             for (path, package) in packages.iter() {
                 // Skip packages based on omit config
                 if should_omit_package(package, omit) {
-                    PROGRESS_BAR.inc(1);
+                    inc_progress(1);
                     continue;
                 }
                 let path = path.clone();
@@ -108,13 +109,13 @@ pub async fn install_packages(
                     if package.link.is_some() {
                         let link_name = extract_package_name(&path);
                         if link_name.is_empty() {
-                            PROGRESS_BAR.inc(1);
+                            inc_progress(1);
                             continue;
                         }
                         link(Path::new(&resolved), Path::new(&path))
                             .await
                             .with_context(|| format!("Link failed: {resolved} -> {path}"))?;
-                        PROGRESS_BAR.inc(1);
+                        inc_progress(1);
                         continue;
                     }
 
@@ -122,14 +123,14 @@ pub async fn install_packages(
                     if let Some(ref cpu) = package.cpu
                         && !is_cpu_compatible(cpu)
                     {
-                        PROGRESS_BAR.inc(1);
+                        inc_progress(1);
                         continue;
                     }
 
                     if let Some(ref os) = package.os
                         && !is_os_compatible(os)
                     {
-                        PROGRESS_BAR.inc(1);
+                        inc_progress(1);
                         continue;
                     }
 
@@ -153,18 +154,18 @@ pub async fn install_packages(
                                 tracing::warn!(
                                     "Optional dependency {name} failed (ignored): {e:#}"
                                 );
-                                PROGRESS_BAR.inc(1);
+                                inc_progress(1);
                                 return Ok(());
                             }
                             return Err(e);
                         }
-                        PROGRESS_BAR.inc(1);
+                        inc_progress(1);
                         log_progress(&format!("{name} resolved"));
                         update_package_binary(&target_path, &name).await
                     });
                     clone_tasks.push(task);
                 } else {
-                    PROGRESS_BAR.inc(1);
+                    inc_progress(1);
                 }
             }
         }
@@ -260,7 +261,7 @@ impl InstallService {
 
         if !package_lock.packages.is_empty() {
             start_progress_bar();
-            PROGRESS_BAR.set_length(package_lock.packages.len() as u64);
+            set_progress_length(package_lock.packages.len() as u64);
         }
 
         let link_start = Instant::now();

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -21,8 +21,8 @@ use crate::util::downloader::download_stats;
 use crate::util::json::load_package_lock_json_from_path;
 use crate::util::linker::link;
 use crate::util::logger::{
-    finish_progress_bar, inc_progress, log_progress, print_install_counts, set_progress_length,
-    start_progress_bar,
+    finish_progress_bar, inc_progress, log_progress, log_progress_lazy, print_install_counts,
+    set_progress_length, start_progress_bar,
 };
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
 
@@ -160,7 +160,7 @@ pub async fn install_packages(
                             return Err(e);
                         }
                         inc_progress(1);
-                        log_progress(&format!("{name} resolved"));
+                        log_progress_lazy(|| format!("{name} resolved"));
                         update_package_binary(&target_path, &name).await
                     });
                     clone_tasks.push(task);

--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -2,7 +2,7 @@ use crate::helper::workspace::find_workspaces;
 use crate::model::package::{LifecycleHook, LifecycleScripts, PackageInfo};
 use crate::util::cli_enum::ScriptPolicy;
 use crate::util::logger::{
-    finish_progress_bar, inc_progress, log_progress, set_progress_length, start_progress_bar,
+    finish_progress_bar, inc_progress, log_progress_lazy, set_progress_length, start_progress_bar,
 };
 use anyhow::{Context, Result};
 use futures;
@@ -283,7 +283,7 @@ impl PackageService {
                     let script = script.to_string();
                     let is_optional = *is_optional;
                     async move {
-                        log_progress(&format!("{} {}", package.name, hook));
+                        log_progress_lazy(|| format!("{} {}", package.name, hook));
                         let start = std::time::Instant::now();
                         let result =
                             ScriptService::execute_script(&package, hook, ScriptOutput::Silent)

--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -1,7 +1,9 @@
 use crate::helper::workspace::find_workspaces;
 use crate::model::package::{LifecycleHook, LifecycleScripts, PackageInfo};
 use crate::util::cli_enum::ScriptPolicy;
-use crate::util::logger::{PROGRESS_BAR, finish_progress_bar, log_progress, start_progress_bar};
+use crate::util::logger::{
+    finish_progress_bar, inc_progress, log_progress, set_progress_length, start_progress_bar,
+};
 use anyhow::{Context, Result};
 use futures;
 use std::collections::HashMap;
@@ -242,7 +244,7 @@ impl PackageService {
             let scripts_start = std::time::Instant::now();
             if total_scripts > 0 {
                 start_progress_bar();
-                PROGRESS_BAR.set_length(total_scripts as u64);
+                set_progress_length(total_scripts as u64);
             }
 
             // Execute preinstall scripts in parallel
@@ -301,7 +303,7 @@ impl PackageService {
                             package.path.display(),
                             script
                         );
-                        PROGRESS_BAR.inc(1);
+                        inc_progress(1);
                         (is_optional, result)
                     }
                 })

--- a/crates/pm/src/util/logger.rs
+++ b/crates/pm/src/util/logger.rs
@@ -172,10 +172,17 @@ pub fn inc_progress(delta: u64) {
 }
 
 pub fn log_progress(text: &str) {
+    log_progress_lazy(|| text.to_string());
+}
+
+pub fn log_progress_lazy<F>(message: F)
+where
+    F: FnOnce() -> String,
+{
     if !*IS_TTY {
         return;
     }
-    PROGRESS_BAR.set_message(text.to_string());
+    PROGRESS_BAR.set_message(message());
 }
 
 // Global timer for log_time/log_time_end
@@ -270,6 +277,7 @@ impl utoo_ruborist::progress::EventReceiver for ProgressReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
     use std::time::Duration;
 
     #[test]
@@ -296,5 +304,18 @@ mod tests {
         let d = Duration::from_millis(0); // 0.0s
         let s = format_elapsed_time(d).to_string();
         assert_eq!(s, "[0.0s]");
+    }
+
+    #[test]
+    fn test_log_progress_lazy_skips_message_when_not_tty() {
+        if *IS_TTY {
+            return;
+        }
+        let called = Cell::new(false);
+        log_progress_lazy(|| {
+            called.set(true);
+            "hidden".to_string()
+        });
+        assert!(!called.get());
     }
 }

--- a/crates/pm/src/util/logger.rs
+++ b/crates/pm/src/util/logger.rs
@@ -105,6 +105,9 @@ pub fn get_log_file_path() -> Option<&'static PathBuf> {
 
 /// Finish the progress bar, optionally appending a dimmed `[2.6s]` suffix.
 pub fn finish_progress_bar(msg: &str, elapsed: Option<Duration>) {
+    if !*IS_TTY {
+        return;
+    }
     if PROGRESS_BAR.length().unwrap_or(0) == 0 {
         return;
     }
@@ -152,6 +155,20 @@ pub fn start_progress_bar() {
     );
     PROGRESS_BAR.set_draw_target(indicatif::ProgressDrawTarget::stderr());
     PROGRESS_BAR.enable_steady_tick(Duration::from_millis(100));
+}
+
+pub fn set_progress_length(length: u64) {
+    if !*IS_TTY {
+        return;
+    }
+    PROGRESS_BAR.set_length(length);
+}
+
+pub fn inc_progress(delta: u64) {
+    if !*IS_TTY {
+        return;
+    }
+    PROGRESS_BAR.inc(delta);
 }
 
 pub fn log_progress(text: &str) {

--- a/crates/ruborist/src/service/fetch.rs
+++ b/crates/ruborist/src/service/fetch.rs
@@ -64,9 +64,11 @@ pub fn is_retryable(err: &FetchError) -> bool {
 /// - `is_body()`: stream read errors (e.g. connection reset mid-transfer)
 /// - `is_request()`: request-level errors — often caused by h2 connection
 ///   resets or pooled connection failures, so we retry these too
-/// - Everything else (e.g. `is_builder()`, `is_decode()`): permanent
+/// - `is_decode()`: transient response body decode failure, commonly caused
+///   by a truncated compressed response
+/// - Everything else (e.g. `is_builder()`): permanent
 pub fn classify_reqwest_error(e: reqwest::Error) -> FetchError {
-    let is_retryable = e.is_timeout() || e.is_body() || e.is_request() || {
+    let is_retryable = e.is_timeout() || e.is_body() || e.is_decode() || e.is_request() || {
         #[cfg(not(target_arch = "wasm32"))]
         {
             e.is_connect()

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -13,6 +13,7 @@ use super::fetch::{
 };
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::traits::registry::is_npm_registry;
 
 /// Parse JSON bytes on rayon's CPU thread pool (native) or inline
 /// (wasm32). Keeps the tokio runtime free of `simd_json` work so other
@@ -100,7 +101,7 @@ pub enum FetchManifestBytesResult {
 }
 
 /// Manifest metadata format.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetadataFormat {
     /// Only install-relevant fields (deps, dist, engines, bin).
     /// Uses `application/vnd.npm.install-v1+json`, 10-50x smaller than full.
@@ -232,7 +233,7 @@ pub struct FetchVersionManifestOptions<'a> {
 pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>) -> Result<Bytes> {
     let url = format!("{}/{}/{}", opts.registry_url, opts.name, opts.spec);
 
-    let accept = match opts.format {
+    let accept = match version_manifest_format(opts.registry_url, opts.format) {
         MetadataFormat::Abbreviated => "application/vnd.npm.install-v1+json",
         MetadataFormat::Complete => "application/json",
     };
@@ -273,4 +274,35 @@ pub async fn fetch_version_manifest(
 ) -> Result<CoreVersionManifest> {
     let bytes = fetch_version_manifest_bytes(opts).await?;
     parse_json_off_runtime::<CoreVersionManifest>(bytes).await
+}
+
+fn version_manifest_format(registry_url: &str, format: MetadataFormat) -> MetadataFormat {
+    if is_npm_registry(registry_url) {
+        // npmjs rejects single-version endpoints with install-v1 Accept (406).
+        // Keep abbreviated metadata for registries that explicitly support
+        // semver/range endpoints; exact npmjs fallback must use full JSON.
+        MetadataFormat::Complete
+    } else {
+        format
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MetadataFormat, version_manifest_format};
+
+    #[test]
+    fn npm_version_manifest_uses_complete_metadata() {
+        assert_eq!(
+            version_manifest_format("https://registry.npmjs.org", MetadataFormat::Abbreviated),
+            MetadataFormat::Complete
+        );
+        assert_eq!(
+            version_manifest_format(
+                "https://registry.npmmirror.com",
+                MetadataFormat::Abbreviated
+            ),
+            MetadataFormat::Abbreviated
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add progress helpers that no-op when stderr is not a TTY.
- Route install/link and lifecycle-script progress increments through those helpers instead of calling `PROGRESS_BAR` directly.
- Lazily build dynamic progress messages so non-TTY installs do not pay `format!` allocation cost.
- Treat transient response decode EOFs as retryable manifest fetch errors.
- Force npmjs single-version manifest requests to use `application/json`; npmjs rejects `application/vnd.npm.install-v1+json` on those endpoints with HTTP 406.

## Why

`ProgressReceiver` already avoids indicatif work in non-TTY environments, but install/package code still directly called `inc()` / `set_length()`. On CI this still takes the progress bar lock and mutates hidden state. This keeps local TTY UX unchanged while removing that cost from non-interactive installs.

The previous GHA run also exposed two registry edge cases unrelated to progress rendering: a truncated compressed body surfaced as `error decoding response body: unexpected end of file` and was not retried, and npmjs version endpoints reject install-v1 Accept headers. This patch hardens both paths while keeping npmmirror abbreviated version manifests unchanged.

## Validation

- `cargo fmt`
- `cargo test -p utoo-ruborist npm_version_manifest_uses_complete_metadata`
- `cargo test -p utoo-pm test_log_progress_lazy_skips_message_when_not_tty`
- `cargo test -p utoo-pm test_view_twice_no_304_error`
- `cargo clippy -p utoo-ruborist -p utoo-pm --all-targets -- -D warnings --no-deps`

Note: full workspace `cargo clippy --all-targets -- -D warnings --no-deps` is currently blocked in this worktree by pack-core / next.js submodule API mismatch, unrelated to this PM-only change.
