### PR TITLE
perf(pm): speculatively extract full manifest versions

### DIFF
--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -460,7 +460,7 @@ enum FetchKey {
 impl ManifestJob {
     fn key(&self) -> FetchKey {
         match self {
-            Self::Full { name } => FetchKey::Full(name.clone()),
+            Self::Full { name, .. } => FetchKey::Full(name.clone()),
             Self::Version { name, spec, .. } | Self::ExtractVersion { name, spec, .. } => {
                 FetchKey::Version(name.clone(), spec.clone())
             }
@@ -656,8 +656,13 @@ impl ManifestState {
         {
             return;
         }
-        self.fetch_queues
-            .enqueue(ManifestJob::Full { name: real_name }, priority);
+        self.fetch_queues.enqueue(
+            ManifestJob::Full {
+                name: real_name,
+                spec: Some(real_spec),
+            },
+            priority,
+        );
     }
 
     fn enqueue_version_extract(&mut self, name: String, version: String, full: Arc<FullManifest>) {
@@ -708,7 +713,22 @@ impl ManifestState {
         match done {
             FetchDone::Full { name, result } => {
                 match result {
-                    Ok(ManifestFullData::Full(full)) => {
+                    Ok(ManifestFullData::Full {
+                        manifest: full,
+                        speculative,
+                    }) => {
+                        if let Some((spec, manifest)) = speculative {
+                            self.version_cache
+                                .insert((name.clone(), spec), Arc::clone(&manifest));
+                            self.version_cache
+                                .entry((name.clone(), manifest.version.clone()))
+                                .or_insert_with(|| Arc::clone(&manifest));
+                            self.schedule_transitive_prefetches(
+                                &manifest,
+                                peer_deps,
+                                supports_semver,
+                            );
+                        }
                         self.full_cache.insert(name.clone(), full);
                     }
                     Ok(ManifestFullData::Versions(versions)) => {
@@ -1977,6 +1997,7 @@ mod tests {
         queues.enqueue(
             ManifestJob::Full {
                 name: "prefetch".to_string(),
+                spec: None,
             },
             FetchPriority::Prefetch,
         );
@@ -1996,6 +2017,45 @@ mod tests {
                 .expect("demand job")
                 .key(),
             FetchKey::Version("demand".to_string(), "^1.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_full_fetch_result_stores_speculative_manifest() {
+        let mut state = ManifestState::default();
+        let full = Arc::new(FullManifest {
+            name: "pkg".to_string(),
+            versions: vec!["1.2.3".to_string()],
+            ..Default::default()
+        });
+        let manifest = Arc::new(create_version_manifest_with_deps(
+            "pkg",
+            "1.2.3",
+            vec![("dep", "^1.0.0")],
+        ));
+
+        state.apply_fetch_result(
+            FetchDone::Full {
+                name: "pkg".to_string(),
+                result: Ok(ManifestFullData::Full {
+                    manifest: full,
+                    speculative: Some(("^1.0.0".to_string(), manifest)),
+                }),
+            },
+            false,
+            PeerDeps::Skip,
+            &mut VecDeque::new(),
+        );
+
+        let requested_key = ("pkg".to_string(), "^1.0.0".to_string());
+        assert!(state.version_cache.contains_key(&requested_key));
+        let exact_key = ("pkg".to_string(), "1.2.3".to_string());
+        assert!(state.version_cache.contains_key(&exact_key));
+        assert!(
+            state
+                .fetch_queues
+                .queued
+                .contains_key(&FetchKey::Full("dep".to_string()))
         );
     }
 

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -13,6 +13,7 @@ use super::fetch::{
 };
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::resolver::version::resolve_target_version;
 
 /// Parse JSON bytes on rayon's CPU thread pool (native) or inline
 /// (wasm32). Keeps the tokio runtime free of `simd_json` work so other
@@ -49,21 +50,44 @@ where
 pub(crate) async fn parse_full_manifest_off_runtime(
     raw_bytes: Bytes,
 ) -> Result<FullManifest, anyhow::Error> {
+    parse_full_manifest_with_core_off_runtime(raw_bytes, None)
+        .await
+        .map(|(manifest, _)| manifest)
+}
+
+pub(crate) type FullManifestParseResult = (FullManifest, Option<(String, CoreVersionManifest)>);
+
+fn parse_full_manifest_with_core_sync(
+    raw_bytes: Bytes,
+    spec: Option<String>,
+) -> Result<FullManifestParseResult, anyhow::Error> {
+    // simd_json mutates the parse buffer; copy inside the worker so
+    // response-body bytes can stay immutable until parsing starts.
+    let mut parse_buf = raw_bytes.to_vec();
+    let mut manifest: FullManifest = simd_json::serde::from_slice::<FullManifest>(&mut parse_buf)
+        .map_err(|e| anyhow!("JSON parse error: {e}"))?;
+    manifest.raw = raw_bytes;
+
+    let speculative = spec.and_then(|spec| {
+        resolve_target_version((&manifest).into(), &spec)
+            .ok()
+            .and_then(|version| manifest.get_core_version(&version).map(|core| (spec, core)))
+    });
+
+    Ok((manifest, speculative))
+}
+
+/// Parse a full wire-fetched manifest and optionally extract the current BFS
+/// edge's version in the same off-runtime worker task.
+pub(crate) async fn parse_full_manifest_with_core_off_runtime(
+    raw_bytes: Bytes,
+    spec: Option<String>,
+) -> Result<FullManifestParseResult, anyhow::Error> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let result = (|| -> Result<FullManifest, anyhow::Error> {
-                // simd_json mutates the parse buffer; copy inside the worker so
-                // response-body bytes can stay immutable until parsing starts.
-                let mut parse_buf = raw_bytes.to_vec();
-                let mut manifest: FullManifest =
-                    simd_json::serde::from_slice::<FullManifest>(&mut parse_buf)
-                        .map_err(|e| anyhow!("JSON parse error: {e}"))?;
-                manifest.raw = raw_bytes;
-
-                Ok(manifest)
-            })();
+            let result = parse_full_manifest_with_core_sync(raw_bytes, spec);
             let _ = tx.send(result);
         });
         rx.await
@@ -71,9 +95,7 @@ pub(crate) async fn parse_full_manifest_off_runtime(
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut manifest: FullManifest = parse_json_off_runtime(raw_bytes.clone()).await?;
-        manifest.raw = raw_bytes;
-        Ok(manifest)
+        parse_full_manifest_with_core_sync(raw_bytes, spec)
     }
 }
 

--- a/crates/ruborist/src/service/provider.rs
+++ b/crates/ruborist/src/service/provider.rs
@@ -22,8 +22,13 @@ use crate::traits::registry::RegistryClient;
 /// Full-manifest data returned by a provider job.
 #[derive(Clone)]
 pub enum ManifestFullData {
-    /// Fresh full manifest bytes were fetched and parsed.
-    Full(Arc<FullManifest>),
+    /// Fresh full manifest bytes were fetched and parsed. When the full job
+    /// carried the triggering spec, the provider may also return the matching
+    /// version manifest extracted in the same parse worker.
+    Full {
+        manifest: Arc<FullManifest>,
+        speculative: Option<(String, Arc<CoreVersionManifest>)>,
+    },
     /// The registry returned 304 and the persisted version list is valid.
     Versions(Arc<VersionsInfo>),
 }
@@ -32,7 +37,13 @@ pub enum ManifestFullData {
 #[derive(Clone)]
 pub enum ManifestJob {
     /// Fetch or validate a package full manifest.
-    Full { name: String },
+    Full {
+        name: String,
+        /// Optional range/tag from the BFS edge that caused this full-manifest
+        /// fetch. Providers can use it to speculatively extract the current
+        /// version while full-manifest bytes are already on a CPU worker.
+        spec: Option<String>,
+    },
     /// Fetch a version manifest.
     Version {
         name: String,

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -203,7 +203,7 @@ enum ProviderFullManifestBytes {
 impl ManifestProvider for UnifiedRegistry {
     async fn execute_manifest_job(&self, job: ManifestJob) -> Result<ManifestJobDone, Self::Error> {
         match job {
-            ManifestJob::Full { name } => self.execute_provider_full_job(name).await,
+            ManifestJob::Full { name, spec } => self.execute_provider_full_job(name, spec).await,
             ManifestJob::Version {
                 name,
                 spec,
@@ -263,8 +263,9 @@ impl UnifiedRegistry {
     async fn execute_provider_full_job(
         &self,
         name: String,
+        spec: Option<String>,
     ) -> Result<ManifestJobDone, RegistryError> {
-        let data = self.fetch_provider_full_manifest_data(&name).await?;
+        let data = self.fetch_provider_full_manifest_data(&name, spec).await?;
         Ok(ManifestJobDone::Full { name, data })
     }
 
@@ -305,10 +306,12 @@ impl UnifiedRegistry {
     async fn fetch_provider_full_manifest_data(
         &self,
         name: &str,
+        spec: Option<String>,
     ) -> Result<ManifestFullData, RegistryError> {
         match self.fetch_provider_full_manifest_bytes(name).await? {
             ProviderFullManifestBytes::Fresh { bytes, etag } => {
-                self.parse_provider_full_manifest(name, bytes, etag).await
+                self.parse_provider_full_manifest(name, bytes, etag, spec)
+                    .await
             }
             ProviderFullManifestBytes::NotModified { versions } => {
                 Ok(ManifestFullData::Versions(versions))
@@ -321,12 +324,18 @@ impl UnifiedRegistry {
         name: &str,
         bytes: bytes::Bytes,
         etag: Option<String>,
+        spec: Option<String>,
     ) -> Result<ManifestFullData, RegistryError> {
-        let manifest = Arc::new(
-            manifest::parse_full_manifest_off_runtime(bytes)
+        let (manifest, speculative) =
+            manifest::parse_full_manifest_with_core_off_runtime(bytes, spec)
                 .await
-                .map_err(RegistryError)?,
-        );
+                .map_err(RegistryError)?;
+        let manifest = Arc::new(manifest);
+        let speculative = speculative.map(|(spec, manifest)| {
+            let manifest = Arc::new(manifest);
+            self.store_version_manifest(name, Arc::clone(&manifest));
+            (spec, manifest)
+        });
         let versions = Arc::new(VersionsInfo {
             versions: Versions {
                 version_list: manifest.versions.clone(),
@@ -336,7 +345,10 @@ impl UnifiedRegistry {
             last_updated: current_timestamp_secs(),
         });
         self.store.store_versions(name, versions);
-        Ok(ManifestFullData::Full(manifest))
+        Ok(ManifestFullData::Full {
+            manifest,
+            speculative,
+        })
     }
 
     async fn fetch_provider_version_manifest(

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -403,11 +403,14 @@ pub mod mock {
             job: crate::service::ManifestJob,
         ) -> Result<crate::service::ManifestJobDone, Self::Error> {
             match job {
-                crate::service::ManifestJob::Full { name } => {
+                crate::service::ManifestJob::Full { name, spec: _ } => {
                     let manifest = self.fetch_full_manifest(&name).await?;
                     Ok(crate::service::ManifestJobDone::Full {
                         name,
-                        data: crate::service::ManifestFullData::Full(manifest),
+                        data: crate::service::ManifestFullData::Full {
+                            manifest,
+                            speculative: None,
+                        },
                     })
                 }
                 crate::service::ManifestJob::Version {


### PR DESCRIPTION
## Summary

Follow-up to the demand/prefetch resolver queue. This PR lets a full-manifest provider job carry the spec that triggered it, then parse the full manifest and optionally extract the matching version manifest in the same off-runtime worker.

- `ManifestJob::Full` now carries `spec: Option<String>`
- `ManifestFullData::Full` can include `speculative: Option<(spec, CoreVersionManifest)>`
- full-manifest parse uses `parse_full_manifest_with_core_off_runtime` so the current version can be extracted without scheduling a second `ExtractVersion` job
- main loop stores the speculative manifest under both the original spec and exact version keys, then schedules transitive prefetches from it

## Expected metrics

| Phase | Expected result |
| --- | --- |
| p1 deps, npmjs | Small but measurable wall/ctx improvement on cold full-manifest paths by avoiding one extra extract job for the edge that triggered the full fetch. |
| p1 deps, npmmirror | Mostly neutral; semver registries already use version jobs directly. |
| ctx/ictx | Should stay flat or decrease slightly. The work is moved into an existing parse worker, not a new spawned job. |
| p0/p3/p4 install | Expected neutral; install/extract/clone scheduling remains unchanged. |

## Validation

- `cargo fmt`
- `cargo check -p utoo-ruborist`
- `cargo test -p utoo-ruborist test_full_fetch_result_stores_speculative_manifest --lib`
- `cargo test -p utoo-ruborist --lib` (171 passed)
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `./e2e/utoo-pm.sh` (local full e2e passed)

## Stack plan

1. Provider boundary (#3012)
2. Graph placement helpers (#3014)
3. Shared resolved placement (#3015)
4. Demand BFS main loop (#3016)
5. Priority/preload fanout (#3017)
6. Speculative full-manifest extract (this PR)
7. Install scheduler providerization
8. Extract/clone/materialize worker lane split
9. Cleanup old scheduler/cache ownership paths
