### PR TITLE
perf(pm): stream install clone completions

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -1,6 +1,7 @@
 use crate::util::cli_enum::ScriptPolicy;
 use anyhow::Context;
 use anyhow::Result;
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::Instant;
@@ -83,7 +84,7 @@ pub async fn install_packages(
     depths.sort_unstable();
 
     for depth in depths.iter() {
-        let mut clone_tasks: Vec<tokio::task::JoinHandle<Result<()>>> = Vec::new();
+        let mut clone_tasks = FuturesUnordered::new();
 
         if let Some(packages) = groups.get(depth) {
             for (path, package) in packages.iter() {
@@ -169,8 +170,8 @@ pub async fn install_packages(
             }
         }
 
-        for task in clone_tasks {
-            task.await??;
+        while let Some(joined) = clone_tasks.next().await {
+            joined??;
         }
     }
 


### PR DESCRIPTION
## Summary
- drain per-depth install clone tasks with `FuturesUnordered` instead of awaiting join handles in spawn order
- keep clone execution on the existing tokio tasks; this PR only changes completion polling order

## Expected Metrics
| Phase | Expected impact | Rationale |
| --- | --- | --- |
| p3 cold install | small wall-time improvement or neutral | later completed clone tasks no longer wait behind an earlier slow join handle before the depth can finish |
| p4 warm/materialize | small wall-time improvement or neutral | same completion-order drain helps deep node_modules layers with uneven package clone times |
| ctx / iCtx | neutral | this PR does not reduce task count yet; it only removes spawn-order head-of-line waiting |
| p0 / p1 resolve | neutral | resolver flow and manifest scheduling are untouched |

## Validation
- `cargo fmt`
- `cargo check -p utoo-pm`
- `cargo test -p utoo-pm service::install::tests`
- `cargo clippy --all-targets -- -D warnings --no-deps`

## Split Plan Position
This is the first install-side micro split after the resolver stack. Follow-up PRs should move install inflight ownership into the scheduler, then split download/extract/clone lanes separately.