### PR TITLE
perf(pm): route pipeline clones through scheduler

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -3,7 +3,7 @@ use anyhow::Context;
 use anyhow::Result;
 use futures::stream::{FuturesUnordered, StreamExt};
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Instant;
 
 use crate::cmd::deps::build_deps;
@@ -28,7 +28,7 @@ use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
 
 use super::binary::update_package_binary;
 use super::clean::clean_deps;
-use super::install_scheduler::{InstallScheduler, InstallSchedulerHandle};
+use super::install_scheduler::{InstallCloneRequest, InstallScheduler, InstallSchedulerHandle};
 
 /// Check if a package should be omitted based on omit config
 fn should_omit_package(package: &Package, omit: &HashSet<OmitType>) -> bool {
@@ -79,9 +79,9 @@ pub async fn install_packages(
     log_progress("linking packages");
 
     // Always process level-by-level to ensure parent directories exist before
-    // children. Within each level, tasks run concurrently. The pipeline's
-    // clone_worker may have already cloned some packages — clone_package_once
-    // deduplicates via CLONE_CACHE so no double work occurs.
+    // children. Within each level, tasks run concurrently. When a scheduler is
+    // supplied, pipeline prefetch and install-phase clones share its in-flight
+    // state; otherwise the legacy cloner provides process-wide deduplication.
     let mut depths: Vec<_> = groups.keys().cloned().collect();
     depths.sort_unstable();
 
@@ -144,10 +144,13 @@ pub async fn install_packages(
                     let cwd_clone = cwd.to_path_buf();
                     let target_path = cwd_clone.join(&path);
                     let clone_job = InstallCloneJob {
-                        name,
-                        version,
-                        resolved,
-                        target_path,
+                        request: InstallCloneRequest {
+                            name,
+                            version,
+                            tarball_url: resolved,
+                            target: target_path,
+                            parent: None,
+                        },
                     };
                     let clone_dispatcher = clone_dispatcher.clone();
 
@@ -160,7 +163,7 @@ pub async fn install_packages(
                             if is_optional {
                                 tracing::warn!(
                                     "Optional dependency {} failed (ignored): {e:#}",
-                                    clone_job.name
+                                    clone_job.request.name
                                 );
                                 PROGRESS_BAR.inc(1);
                                 return Ok(());
@@ -168,8 +171,9 @@ pub async fn install_packages(
                             return Err(e);
                         }
                         PROGRESS_BAR.inc(1);
-                        log_progress(&format!("{} resolved", clone_job.name));
-                        update_package_binary(&clone_job.target_path, &clone_job.name).await
+                        log_progress(&format!("{} resolved", clone_job.request.name));
+                        update_package_binary(&clone_job.request.target, &clone_job.request.name)
+                            .await
                     });
                     clone_tasks.push(task);
                 } else {
@@ -192,10 +196,7 @@ struct InstallCloneDispatcher {
 }
 
 struct InstallCloneJob {
-    name: String,
-    version: String,
-    resolved: String,
-    target_path: PathBuf,
+    request: InstallCloneRequest,
 }
 
 impl InstallCloneDispatcher {
@@ -207,22 +208,13 @@ impl InstallCloneDispatcher {
 
     async fn clone_package(&self, job: &InstallCloneJob) -> Result<()> {
         match &self.scheduler {
-            Some(scheduler) => {
-                scheduler
-                    .ensure_clone(
-                        job.name.clone(),
-                        job.version.clone(),
-                        job.resolved.clone(),
-                        job.target_path.clone(),
-                    )
-                    .await
-            }
+            Some(scheduler) => scheduler.ensure_clone(job.request.clone()).await,
             None => {
                 crate::util::cloner::clone_package_once(
-                    &job.name,
-                    &job.version,
-                    &job.resolved,
-                    &job.target_path,
+                    &job.request.name,
+                    &job.request.version,
+                    &job.request.tarball_url,
+                    &job.request.target,
                 )
                 .await
             }
@@ -298,24 +290,23 @@ impl InstallService {
         let use_fresh_lock = fs::try_exists(&lock_path).await.unwrap_or(false)
             && !is_pkg_lock_outdated(root_path).await.unwrap_or(true);
 
-        let (package_lock, pipeline_handles) = if use_fresh_lock {
+        let (package_lock, pipeline_handles, scheduler_handle) = if use_fresh_lock {
             let lock = load_package_lock_json_from_path(root_path).await?;
-            (lock, None)
+            (lock, None, InstallSchedulerHandle::start())
         } else {
             start_progress_bar();
             let resolve_start = Instant::now();
             let result = super::pipeline::resolve_with_pipeline(root_path).await?;
             finish_progress_bar("package-lock.json resolved", Some(resolve_start.elapsed()));
-            (result.package_lock, Some(result.handles))
+            (
+                result.package_lock,
+                Some(result.handles),
+                result.scheduler_handle,
+            )
         };
 
         let groups = group_by_depth(&package_lock.packages);
-        let scheduler_handle = pipeline_handles
-            .is_none()
-            .then(InstallSchedulerHandle::start);
-        let clone_scheduler = scheduler_handle
-            .as_ref()
-            .map(InstallSchedulerHandle::scheduler);
+        let clone_scheduler = scheduler_handle.scheduler();
 
         if !package_lock.packages.is_empty() {
             start_progress_bar();
@@ -323,21 +314,19 @@ impl InstallService {
         }
 
         let link_start = Instant::now();
-        let install_result = install_packages(&groups, root_path, omit, clone_scheduler.as_ref())
+        let install_result = install_packages(&groups, root_path, omit, Some(&clone_scheduler))
             .await
             .context("Failed to install packages");
-
-        if let Some(handle) = scheduler_handle {
-            handle.shutdown().await;
-        }
-
-        install_result?;
 
         // Wait for pipeline workers to complete (if any)
         if let Some(handles) = pipeline_handles {
             handles.await_completion().await;
             super::pipeline::print_pipeline_summary();
         }
+
+        scheduler_handle.shutdown().await;
+
+        install_result?;
         finish_progress_bar("node_modules cloned", Some(link_start.elapsed()));
 
         RebuildService::rebuild(&package_lock, root_path, scripts).await?;

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -26,14 +26,27 @@ impl PackageFetch {
 }
 
 #[derive(Clone, Debug)]
-struct CloneSpec {
-    package: PackageFetch,
-    target: PathBuf,
+pub(crate) struct InstallCloneRequest {
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) tarball_url: String,
+    pub(crate) target: PathBuf,
+    pub(crate) parent: Option<PathBuf>,
+}
+
+impl InstallCloneRequest {
+    fn package(&self) -> PackageFetch {
+        PackageFetch {
+            name: self.name.clone(),
+            version: self.version.clone(),
+            tarball_url: self.tarball_url.clone(),
+        }
+    }
 }
 
 #[derive(Debug)]
 struct ReadyClone {
-    spec: CloneSpec,
+    request: InstallCloneRequest,
     cache_path: PathBuf,
 }
 
@@ -44,14 +57,26 @@ const MIN_CLONE_CONCURRENCY: usize = 4;
 const MAX_CLONE_CONCURRENCY: usize = 32;
 const DEFAULT_CLONE_CONCURRENCY: usize = 8;
 
+#[cfg(windows)]
+fn clone_key(target: &Path) -> PathBuf {
+    target.components().collect()
+}
+
+#[cfg(not(windows))]
+fn clone_key(target: &Path) -> PathBuf {
+    target.to_path_buf()
+}
+
 enum Command {
-    EnsureClone(CloneSpec, CloneResponder),
+    EnsureClone(InstallCloneRequest, CloneResponder),
+    PrefetchClone(InstallCloneRequest),
+    PrefetchDownload(PackageFetch),
     Shutdown,
 }
 
 enum OpDone {
     SeededCache {
-        spec: CloneSpec,
+        request: InstallCloneRequest,
         result: Result<Option<PathBuf>, String>,
     },
     Download {
@@ -99,30 +124,35 @@ impl InstallSchedulerHandle {
 }
 
 impl InstallScheduler {
-    pub(crate) async fn ensure_clone(
-        &self,
-        name: String,
-        version: String,
-        tarball_url: String,
-        target: PathBuf,
-    ) -> Result<()> {
+    pub(crate) async fn ensure_clone(&self, request: InstallCloneRequest) -> Result<()> {
         let (tx, rx) = oneshot::channel();
         self.tx
-            .send(Command::EnsureClone(
-                CloneSpec {
-                    package: PackageFetch {
-                        name,
-                        version,
-                        tarball_url,
-                    },
-                    target,
-                },
-                tx,
-            ))
+            .send(Command::EnsureClone(request, tx))
             .map_err(|_| anyhow!("install scheduler stopped"))?;
         rx.await
             .context("install scheduler stopped before clone completed")?
             .map_err(anyhow::Error::msg)
+    }
+
+    pub(crate) fn prefetch_clone(&self, request: InstallCloneRequest) -> Result<()> {
+        self.tx
+            .send(Command::PrefetchClone(request))
+            .map_err(|_| anyhow!("install scheduler stopped"))
+    }
+
+    pub(crate) fn prefetch_download(
+        &self,
+        name: String,
+        version: String,
+        tarball_url: String,
+    ) -> Result<()> {
+        self.tx
+            .send(Command::PrefetchDownload(PackageFetch {
+                name,
+                version,
+                tarball_url,
+            }))
+            .map_err(|_| anyhow!("install scheduler stopped"))
     }
 }
 
@@ -133,11 +163,12 @@ struct SchedulerState {
     clone_limit: usize,
     download_done: HashMap<PackageKey, PathBuf>,
     download_active: HashSet<PackageKey>,
-    download_waiters: HashMap<PackageKey, Vec<CloneSpec>>,
+    download_waiters: HashMap<PackageKey, Vec<InstallCloneRequest>>,
     download_queue: VecDeque<PackageFetch>,
     clone_done: HashSet<PathBuf>,
     clone_active: HashSet<PathBuf>,
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
+    blocked_by_parent: HashMap<PathBuf, Vec<InstallCloneRequest>>,
     clone_queue: VecDeque<ReadyClone>,
     ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
 }
@@ -156,6 +187,7 @@ impl SchedulerState {
             clone_done: HashSet::new(),
             clone_active: HashSet::new(),
             clone_waiters: HashMap::new(),
+            blocked_by_parent: HashMap::new(),
             clone_queue: VecDeque::new(),
             ops: FuturesUnordered::new(),
         }
@@ -173,8 +205,14 @@ impl SchedulerState {
             tokio::select! {
                 command = self.rx.recv(), if !self.shutdown => {
                     match command {
-                        Some(Command::EnsureClone(spec, responder)) => {
-                            self.queue_clone(spec, Some(responder));
+                        Some(Command::EnsureClone(request, responder)) => {
+                            self.queue_clone(request, Some(responder));
+                        }
+                        Some(Command::PrefetchClone(request)) => {
+                            self.queue_clone(request, None);
+                        }
+                        Some(Command::PrefetchDownload(package)) => {
+                            self.ensure_download(package, None);
                         }
                         Some(Command::Shutdown) | None => {
                             self.shutdown = true;
@@ -202,8 +240,8 @@ impl SchedulerState {
             && self.ops.is_empty()
     }
 
-    fn queue_clone(&mut self, spec: CloneSpec, responder: Option<CloneResponder>) {
-        let target = spec.target.clone();
+    fn queue_clone(&mut self, request: InstallCloneRequest, responder: Option<CloneResponder>) {
+        let target = clone_key(&request.target);
         if self.clone_done.contains(&target) {
             if let Some(responder) = responder {
                 let _ = responder.send(Ok(()));
@@ -221,35 +259,49 @@ impl SchedulerState {
         self.clone_waiters
             .insert(target.clone(), responder.into_iter().collect());
 
-        self.resolve_cache_for_clone(spec);
+        if let Some(parent) = &request.parent {
+            let parent = clone_key(parent);
+            if self.clone_waiters.contains_key(&parent) && !self.clone_done.contains(&parent) {
+                self.blocked_by_parent
+                    .entry(parent)
+                    .or_default()
+                    .push(request);
+                return;
+            }
+        }
+
+        self.resolve_cache_for_clone(request);
     }
 
-    fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
-        let task_spec = spec.clone();
+    fn resolve_cache_for_clone(&mut self, request: InstallCloneRequest) {
+        let task_request = request.clone();
         self.ops.push(tokio::spawn(async move {
             let result = resolve_seeded_cache_path(
-                &task_spec.package.name,
-                &task_spec.package.version,
-                &task_spec.package.tarball_url,
+                &task_request.name,
+                &task_request.version,
+                &task_request.tarball_url,
             )
             .await
             .map_err(|e| format!("{e:#}"));
-            OpDone::SeededCache { spec, result }
+            OpDone::SeededCache { request, result }
         }));
     }
 
-    fn ensure_download(&mut self, package: PackageFetch, waiter: Option<CloneSpec>) {
+    fn ensure_download(&mut self, package: PackageFetch, waiter: Option<InstallCloneRequest>) {
         let key = package.key();
         if let Some(cache_path) = self.download_done.get(&key).cloned() {
-            if let Some(spec) = waiter {
-                self.clone_queue.push_back(ReadyClone { spec, cache_path });
+            if let Some(request) = waiter {
+                self.clone_queue.push_back(ReadyClone {
+                    request,
+                    cache_path,
+                });
             }
             return;
         }
 
         if let Some(waiters) = self.download_waiters.get_mut(&key) {
-            if let Some(spec) = waiter {
-                waiters.push(spec);
+            if let Some(request) = waiter {
+                waiters.push(request);
             }
             return;
         }
@@ -287,18 +339,18 @@ impl SchedulerState {
             let Some(job) = self.clone_queue.pop_front() else {
                 break;
             };
-            let target = job.spec.target.clone();
+            let target = clone_key(&job.request.target);
             if self.clone_done.contains(&target) || !self.clone_active.insert(target.clone()) {
                 continue;
             }
 
             self.ops.push(tokio::spawn(async move {
                 let result = clone_package_from_cache(
-                    &job.spec.package.name,
-                    &job.spec.package.version,
-                    &job.spec.package.tarball_url,
+                    &job.request.name,
+                    &job.request.version,
+                    &job.request.tarball_url,
                     &job.cache_path,
-                    &job.spec.target,
+                    &job.request.target,
                 )
                 .await
                 .map_err(|e| format!("{e:#}"));
@@ -309,10 +361,13 @@ impl SchedulerState {
 
     fn handle_done(&mut self, done: OpDone) {
         match done {
-            OpDone::SeededCache { spec, result } => match result {
-                Ok(Some(cache_path)) => self.clone_queue.push_back(ReadyClone { spec, cache_path }),
-                Ok(None) => self.ensure_download(spec.package.clone(), Some(spec)),
-                Err(error) => self.complete_clone(spec.target, Err(error)),
+            OpDone::SeededCache { request, result } => match result {
+                Ok(Some(cache_path)) => self.clone_queue.push_back(ReadyClone {
+                    request,
+                    cache_path,
+                }),
+                Ok(None) => self.ensure_download(request.package(), Some(request)),
+                Err(error) => self.complete_clone(clone_key(&request.target), Err(error)),
             },
             OpDone::Download { key, result } => {
                 self.download_active.remove(&key);
@@ -320,16 +375,16 @@ impl SchedulerState {
                 match result {
                     Ok(cache_path) => {
                         self.download_done.insert(key, cache_path.clone());
-                        for spec in waiters {
+                        for request in waiters {
                             self.clone_queue.push_back(ReadyClone {
-                                spec,
+                                request,
                                 cache_path: cache_path.clone(),
                             });
                         }
                     }
                     Err(error) => {
-                        for spec in waiters {
-                            self.complete_clone(spec.target, Err(error.clone()));
+                        for request in waiters {
+                            self.complete_clone(clone_key(&request.target), Err(error.clone()));
                         }
                     }
                 }
@@ -350,6 +405,21 @@ impl SchedulerState {
             for waiter in waiters {
                 let _ = waiter.send(result.clone());
             }
+        }
+
+        match (result.is_ok(), self.blocked_by_parent.remove(&target)) {
+            (true, Some(children)) => {
+                for child in children {
+                    self.resolve_cache_for_clone(child);
+                }
+            }
+            (false, Some(children)) => {
+                let error = format!("parent package {} failed to clone", target.display());
+                for child in children {
+                    self.complete_clone(clone_key(&child.target), Err(error.clone()));
+                }
+            }
+            (_, None) => {}
         }
     }
 
@@ -383,10 +453,13 @@ mod tests {
         }
     }
 
-    fn clone_spec(name: &str, version: &str, target: &str) -> CloneSpec {
-        CloneSpec {
-            package: package(name, version),
+    fn clone_request(name: &str, version: &str, target: &str) -> InstallCloneRequest {
+        InstallCloneRequest {
+            name: name.to_string(),
+            version: version.to_string(),
+            tarball_url: format!("https://registry.npmjs.org/{name}/-/{name}-{version}.tgz"),
             target: PathBuf::from(target),
+            parent: None,
         }
     }
 
@@ -399,7 +472,7 @@ mod tests {
     fn ensure_download_dedupes_inflight_package() {
         let mut state = state();
         let package = package("react", "18.2.0");
-        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
+        let waiter = clone_request("react", "18.2.0", "/tmp/project/node_modules/react");
 
         state.ensure_download(package.clone(), Some(waiter));
         state.ensure_download(package, None);
@@ -415,14 +488,51 @@ mod tests {
     async fn queue_clone_dedupes_inflight_target() {
         let mut state = state();
         let target = PathBuf::from("/tmp/project/node_modules/react");
-        let spec = clone_spec("react", "18.2.0", target.to_string_lossy().as_ref());
+        let request = clone_request("react", "18.2.0", target.to_string_lossy().as_ref());
         let (first, _first_rx) = oneshot::channel();
         let (second, _second_rx) = oneshot::channel();
 
-        state.queue_clone(spec.clone(), Some(first));
-        state.queue_clone(spec, Some(second));
+        state.queue_clone(request.clone(), Some(first));
+        state.queue_clone(request, Some(second));
 
-        assert_eq!(state.clone_waiters[&target].len(), 2);
+        assert_eq!(state.clone_waiters[&clone_key(&target)].len(), 2);
+        assert_eq!(state.ops.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn prefetch_clone_waits_for_pending_parent() {
+        let mut state = state();
+        let parent = PathBuf::from("/tmp/project/node_modules/parent");
+        let child = PathBuf::from("/tmp/project/node_modules/parent/node_modules/child");
+        let parent_request = clone_request("parent", "1.0.0", parent.to_string_lossy().as_ref());
+        let child_request = InstallCloneRequest {
+            parent: Some(parent.clone()),
+            ..clone_request("child", "1.0.0", child.to_string_lossy().as_ref())
+        };
+
+        state.queue_clone(parent_request, None);
+        state.queue_clone(child_request, None);
+
+        assert_eq!(state.blocked_by_parent[&clone_key(&parent)].len(), 1);
+        assert_eq!(state.ops.len(), 1);
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn queue_clone_normalizes_windows_path_separators() {
+        let mut state = state();
+        let forward = PathBuf::from("node_modules/@scope/pkg/node_modules/dep");
+        let backward = PathBuf::from("node_modules\\@scope\\pkg\\node_modules\\dep");
+        let first = clone_request("dep", "1.0.0", forward.to_string_lossy().as_ref());
+        let second = clone_request("dep", "1.0.0", backward.to_string_lossy().as_ref());
+        let key = clone_key(&forward);
+        let (first_tx, _first_rx) = oneshot::channel();
+        let (second_tx, _second_rx) = oneshot::channel();
+
+        state.queue_clone(first, Some(first_tx));
+        state.queue_clone(second, Some(second_tx));
+
+        assert_eq!(state.clone_waiters[&key].len(), 2);
         assert_eq!(state.ops.len(), 1);
     }
 }

--- a/crates/pm/src/service/pipeline/mod.rs
+++ b/crates/pm/src/service/pipeline/mod.rs
@@ -11,6 +11,7 @@ mod worker;
 pub use receiver::{PipelineChannels, PipelineReceiver};
 pub use worker::PipelineHandles;
 
+use super::install_scheduler::InstallSchedulerHandle;
 use crate::util::cloner::clone_count;
 use crate::util::downloader::download_stats;
 
@@ -27,6 +28,7 @@ pub fn print_pipeline_summary() {
 pub struct PipelineResult {
     pub package_lock: utoo_ruborist::lock::PackageLock,
     pub handles: PipelineHandles,
+    pub(crate) scheduler_handle: InstallSchedulerHandle,
 }
 
 /// Resolve dependencies with pipeline: concurrent download/clone during resolution.
@@ -39,7 +41,12 @@ pub async fn resolve_with_pipeline(root_path: &std::path::Path) -> anyhow::Resul
     use crate::helper::ruborist_context::{Context, spawn_save_project_cache};
 
     let (options, channels) = Context::pipeline_deps_options(root_path.to_path_buf()).await;
-    let handles = worker::start_workers(channels, root_path.to_path_buf());
+    let scheduler_handle = InstallSchedulerHandle::start();
+    let handles = worker::start_workers(
+        channels,
+        root_path.to_path_buf(),
+        scheduler_handle.scheduler(),
+    );
 
     let output = utoo_ruborist::service::build_deps(options).await?;
 
@@ -49,5 +56,6 @@ pub async fn resolve_with_pipeline(root_path: &std::path::Path) -> anyhow::Resul
     Ok(PipelineResult {
         package_lock: output.lock,
         handles,
+        scheduler_handle,
     })
 }

--- a/crates/pm/src/service/pipeline/worker.rs
+++ b/crates/pm/src/service/pipeline/worker.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use super::receiver::PipelineChannels;
-use crate::util::cloner::{clone_package_once, wait_clone_if_pending};
-use crate::util::downloader::{download_to_cache, is_git_url};
+use crate::service::install_scheduler::{InstallCloneRequest, InstallScheduler};
+use crate::util::downloader::is_registry_tarball_url;
 
 /// Pipeline worker handles for awaiting completion.
 pub struct PipelineHandles {
@@ -19,32 +19,30 @@ impl PipelineHandles {
 }
 
 /// Start download and clone pipeline workers, returning handles to await completion.
-pub fn start_workers(channels: PipelineChannels, cwd: PathBuf) -> PipelineHandles {
+pub fn start_workers(
+    channels: PipelineChannels,
+    cwd: PathBuf,
+    scheduler: InstallScheduler,
+) -> PipelineHandles {
+    let download_scheduler = scheduler.clone();
     let download_handle = tokio::spawn(async move {
         let mut rx = channels.download_rx;
         while let Some(info) = rx.recv().await {
             let Some(tarball_url) = info.tarball_url else {
                 continue;
             };
-            // Git packages are cloned & cached during BFS resolution (inside ruborist).
-            // Skip the download pipeline — the clone worker will pick up the
-            // pre-resolved cache path via resolve_cache_path.
-            if is_git_url(&tarball_url) {
-                tracing::debug!(
-                    "Skipping download for git package: {}@{}",
-                    info.name,
-                    info.version
-                );
+            if !is_registry_tarball_url(&tarball_url) {
                 continue;
             }
-            let name = info.name;
-            let version = info.version;
-            tokio::spawn(async move {
-                download_to_cache(&name, &version, &tarball_url).await;
-            });
+            if let Err(e) =
+                download_scheduler.prefetch_download(info.name, info.version, tarball_url)
+            {
+                tracing::debug!("Pipeline download prefetch failed: {e:#}");
+            }
         }
     });
 
+    let clone_scheduler = scheduler;
     let clone_handle = tokio::spawn(async move {
         let mut rx = channels.clone_rx;
         while let Some(msg) = rx.recv().await {
@@ -55,14 +53,16 @@ pub fn start_workers(channels: PipelineChannels, cwd: PathBuf) -> PipelineHandle
             let version = msg.info.version;
             let target = cwd.join(&msg.path);
             let parent_path = msg.parent_path.map(|p| cwd.join(&p));
-            tokio::spawn(async move {
-                if let Some(ref parent) = parent_path {
-                    wait_clone_if_pending(&parent.to_string_lossy()).await;
-                }
-                if let Err(e) = clone_package_once(&name, &version, &tarball_url, &target).await {
-                    tracing::debug!("Pipeline pre-clone failed for {name}@{version}: {e:#}");
-                }
-            });
+            let request = InstallCloneRequest {
+                name,
+                version,
+                tarball_url,
+                target,
+                parent: parent_path,
+            };
+            if let Err(e) = clone_scheduler.prefetch_clone(request) {
+                tracing::debug!("Pipeline clone prefetch failed: {e:#}");
+            }
         }
     });
 

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -44,16 +44,6 @@ fn cache_key(target_path: &Path) -> PathBuf {
     target_path.to_path_buf()
 }
 
-/// Wait for a pending clone at the given target path to complete (if any).
-///
-/// Used by the pipeline clone worker to ensure parent packages are
-/// cloned before their children.
-pub async fn wait_clone_if_pending(target_path: &str) {
-    CLONE_CACHE
-        .wait_if_pending(&cache_key(Path::new(target_path)))
-        .await;
-}
-
 /// Clone a package from an already-resolved cache path without touching the
 /// global clone/download single-flight maps.
 pub async fn clone_package_from_cache(

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -69,6 +69,11 @@ pub fn is_git_url(url: &str) -> bool {
     matches!(url.parse::<Protocol>(), Ok(Protocol::Git))
 }
 
+/// Check whether a tarball URL should be fetched by the registry downloader.
+pub fn is_registry_tarball_url(url: &str) -> bool {
+    matches!(url.parse::<Protocol>(), Ok(Protocol::Http))
+}
+
 /// Look up the cache path for a git-resolved package.
 ///
 /// Git packages are cloned during BFS resolution (inside ruborist) and


### PR DESCRIPTION
## Summary
- Route pipeline download and clone events through the install scheduler instead of spawning per-event download/clone tasks.
- Share one scheduler between pipeline prefetch and install materialization so install waiters reuse scheduler in-flight state.
- Move parent clone ordering into the scheduler and remove the obsolete util-level wait_clone_if_pending helper.

## Expected Metrics
- p3 stale-lock/pipeline install: lower ctx/iCtx by replacing per-event spawned download/clone tasks and util OnceMap waits with scheduler dispatch.
- p4 warm/fresh-lock install: expected neutral vs #3022; same scheduler path remains active.
- p0/p1 resolver: expected neutral except less pipeline-side task pressure while resolve emits placement events.

## Observed GHA Bench
- `bench-phases-linux` passed on run 26182235197.
- npmjs p1: `utoo` 2.86s, vCtx/iCtx 31.0K/36.6K; `utoo-next` 2.86s, 48.8K/71.9K.
- npmjs p3: `utoo` 6.54s, vCtx/iCtx 104.5K/54.7K; `utoo-next` 7.52s, 130.6K/49.8K.
- npmjs p4: `utoo` 2.09s, vCtx/iCtx 44.4K/22.3K; `utoo-next` 2.25s, 41.3K/19.4K.
- npmmirror: no output captured by this GHA run.

## Split Plan Position
- Builds on #3022 scheduler core.
- Next PR: remove or narrow remaining install util OnceMap fallback surface once CI/bench confirms scheduler coverage.

## Validation
- cargo fmt
- cargo check -p utoo-pm
- cargo test -p utoo-pm service::install_scheduler
- cargo test -p utoo-pm service::pipeline
- cargo test -p utoo-pm service::install::tests
- cargo clippy --all-targets -- -D warnings --no-deps
- GHA: clippy / format / builds / utoo-pm CI / linux+mac e2e / bench-phases-linux passed; Windows e2e still pending at last check