### PR TITLE
perf(pm): remove clone oncemap fallback

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -68,10 +68,8 @@ pub async fn install_packages(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
     omit: &HashSet<OmitType>,
-    clone_scheduler: Option<&InstallScheduler>,
+    clone_scheduler: &InstallScheduler,
 ) -> Result<()> {
-    let clone_dispatcher = InstallCloneDispatcher::new(clone_scheduler);
-
     // Surface the clean step in the spinner — it doesn't move `pos`, so
     // without a message the bar looks frozen on large trees.
     log_progress("validating node_modules");
@@ -79,9 +77,8 @@ pub async fn install_packages(
     log_progress("linking packages");
 
     // Always process level-by-level to ensure parent directories exist before
-    // children. Within each level, tasks run concurrently. When a scheduler is
-    // supplied, pipeline prefetch and install-phase clones share its in-flight
-    // state; otherwise the legacy cloner provides process-wide deduplication.
+    // children. Within each level, tasks run concurrently. Pipeline prefetch
+    // and install-phase clones share scheduler in-flight state.
     let mut depths: Vec<_> = groups.keys().cloned().collect();
     depths.sort_unstable();
 
@@ -143,27 +140,25 @@ pub async fn install_packages(
                         .ok_or_else(|| anyhow::anyhow!("package {name} missing version"))?;
                     let cwd_clone = cwd.to_path_buf();
                     let target_path = cwd_clone.join(&path);
-                    let clone_job = InstallCloneJob {
-                        request: InstallCloneRequest {
-                            name,
-                            version,
-                            tarball_url: resolved,
-                            target: target_path,
-                            parent: None,
-                        },
+                    let clone_request = InstallCloneRequest {
+                        name,
+                        version,
+                        tarball_url: resolved,
+                        target: target_path,
+                        parent: None,
                     };
-                    let clone_dispatcher = clone_dispatcher.clone();
+                    let clone_scheduler = clone_scheduler.clone();
 
                     // Check if this is an optional dependency
                     let is_optional =
                         package.optional == Some(true) || package.dev_optional == Some(true);
 
                     let task = tokio::spawn(async move {
-                        if let Err(e) = clone_dispatcher.clone_package(&clone_job).await {
+                        if let Err(e) = clone_scheduler.ensure_clone(clone_request.clone()).await {
                             if is_optional {
                                 tracing::warn!(
                                     "Optional dependency {} failed (ignored): {e:#}",
-                                    clone_job.request.name
+                                    clone_request.name
                                 );
                                 PROGRESS_BAR.inc(1);
                                 return Ok(());
@@ -171,9 +166,8 @@ pub async fn install_packages(
                             return Err(e);
                         }
                         PROGRESS_BAR.inc(1);
-                        log_progress(&format!("{} resolved", clone_job.request.name));
-                        update_package_binary(&clone_job.request.target, &clone_job.request.name)
-                            .await
+                        log_progress(&format!("{} resolved", clone_request.name));
+                        update_package_binary(&clone_request.target, &clone_request.name).await
                     });
                     clone_tasks.push(task);
                 } else {
@@ -188,38 +182,6 @@ pub async fn install_packages(
     }
 
     Ok(())
-}
-
-#[derive(Clone)]
-struct InstallCloneDispatcher {
-    scheduler: Option<InstallScheduler>,
-}
-
-struct InstallCloneJob {
-    request: InstallCloneRequest,
-}
-
-impl InstallCloneDispatcher {
-    fn new(scheduler: Option<&InstallScheduler>) -> Self {
-        Self {
-            scheduler: scheduler.cloned(),
-        }
-    }
-
-    async fn clone_package(&self, job: &InstallCloneJob) -> Result<()> {
-        match &self.scheduler {
-            Some(scheduler) => scheduler.ensure_clone(job.request.clone()).await,
-            None => {
-                crate::util::cloner::clone_package_once(
-                    &job.request.name,
-                    &job.request.version,
-                    &job.request.tarball_url,
-                    &job.request.target,
-                )
-                .await
-            }
-        }
-    }
 }
 
 pub struct InstallService;
@@ -314,7 +276,7 @@ impl InstallService {
         }
 
         let link_start = Instant::now();
-        let install_result = install_packages(&groups, root_path, omit, Some(&clone_scheduler))
+        let install_result = install_packages(&groups, root_path, omit, &clone_scheduler)
             .await
             .context("Failed to install packages");
 

--- a/crates/pm/src/service/pipeline/mod.rs
+++ b/crates/pm/src/service/pipeline/mod.rs
@@ -3,7 +3,7 @@
 //! This module implements a pipeline architecture similar to bun's approach:
 //! - Manifest fetching and tarball downloading happen concurrently
 //! - When a package is resolved, its tarball download starts immediately
-//! - Uses global OnceMap to deduplicate requests and share results across phases
+//! - Uses the install scheduler to deduplicate requests and share in-flight work
 
 mod receiver;
 mod worker;

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -2,27 +2,13 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
-use once_cell::sync::Lazy;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
-use utoo_ruborist::util::OnceMap;
 
-use super::downloader::{is_git_url, resolve_cache_path};
+use super::downloader::is_git_url;
 use super::json::load_package_json;
 use super::retry::create_retry_strategy;
 use crate::fs;
-
-/// Global clone cache shared between pipeline and install phases.
-///
-/// Key: normalized target path. Install (`cwd.join("node_modules/foo")` →
-/// forward slashes) and pipeline (`Path::join` injects backslashes on
-/// Windows) produce the same logical target with different separators;
-/// without normalization OnceMap sees them as distinct keys, dedup fails,
-/// and concurrent tasks race on the same destination — manifesting as
-/// `ERROR_SHARING_VIOLATION` (os error 32) on Windows. `PathBuf` from
-/// `Path::components().collect()` parses both separators uniformly and
-/// rebuilds with the OS-preferred one, giving a stable key.
-static CLONE_CACHE: Lazy<OnceMap<PathBuf, ()>> = Lazy::new(OnceMap::new);
 
 /// Number of `node_modules/` directories freshly materialized this run.
 /// Mirrors pnpm's "added" semantic.
@@ -31,17 +17,6 @@ static CLONE_COUNT: AtomicUsize = AtomicUsize::new(0);
 /// Returns the number of fresh clones performed (pnpm "added" equivalent).
 pub fn clone_count() -> usize {
     CLONE_COUNT.load(Ordering::Relaxed)
-}
-
-/// Normalize a target path into the canonical key used by `CLONE_CACHE`.
-#[cfg(windows)]
-fn cache_key(target_path: &Path) -> PathBuf {
-    target_path.components().collect()
-}
-
-#[cfg(not(windows))]
-fn cache_key(target_path: &Path) -> PathBuf {
-    target_path.to_path_buf()
 }
 
 /// Clone a package from an already-resolved cache path without touching the
@@ -61,52 +36,6 @@ pub async fn clone_package_from_cache(
         CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
     }
     Ok(())
-}
-
-/// Clone a package to target path, downloading to cache first if needed.
-///
-/// Uses global `OnceMap` for deduplication: the same target path is only cloned once,
-/// even when called concurrently from pipeline workers and the install phase.
-pub async fn clone_package_once(
-    name: &str,
-    version: &str,
-    tarball_url: &str,
-    target_path: &Path,
-) -> Result<()> {
-    let key = cache_key(target_path);
-
-    // Skip the param clones + future construction when the pipeline
-    // (or a sibling task) already cloned this target.
-    if CLONE_CACHE.is_done(&key) {
-        return Ok(());
-    }
-
-    let err_label = format!("{name}@{version}");
-    let name = name.to_string();
-    let version = version.to_string();
-    let tarball_url = tarball_url.to_string();
-    let target_path = target_path.to_path_buf();
-
-    CLONE_CACHE
-        .get_or_init(key, || async move {
-            let cache_path = resolve_cache_path(&name, &version, &tarball_url).await?;
-            clone_package_from_cache(&name, &version, &tarball_url, &cache_path, &target_path)
-                .await
-                .inspect_err(|e| {
-                    tracing::warn!(
-                        "Clone failed: {}@{} to {}: {:#}",
-                        name,
-                        version,
-                        target_path.display(),
-                        e
-                    )
-                })
-                .ok()?;
-            Some(())
-        })
-        .await
-        .map(|_| ())
-        .ok_or_else(|| anyhow::anyhow!("clone {err_label} failed (see warning log for details)"))
 }
 
 #[cfg(target_os = "macos")]
@@ -452,20 +381,6 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     use super::*;
-
-    #[cfg(windows)]
-    #[test]
-    fn cache_key_normalizes_path_separators() {
-        // install.rs joins lockfile-derived strings (forward slashes) while
-        // pipeline workers go through `Path::join` (backslashes). Both must
-        // produce the same OnceMap key — otherwise concurrent clones race
-        // and Windows raises ERROR_SHARING_VIOLATION.
-        let forward = cache_key(Path::new("node_modules/@scope/pkg/node_modules/dep"));
-        let backward = cache_key(Path::new("node_modules\\@scope\\pkg\\node_modules\\dep"));
-        let mixed = cache_key(Path::new("node_modules/@scope/pkg\\node_modules\\dep"));
-        assert_eq!(forward, backward);
-        assert_eq!(forward, mixed);
-    }
 
     async fn create_test_file(dir: &Path, name: &str, content: &[u8]) -> Result<PathBuf> {
         let path = dir.join(name);


### PR DESCRIPTION
## Summary
- Make install materialization always use the install scheduler.
- Remove the obsolete clone_package_once / CLONE_CACHE OnceMap fallback from cloner.
- Keep downloader cache and git resolver caches unchanged; those still serve non-install helper paths.

## Expected Metrics
- p3/p4 install materialization: lower lock/context overhead from removing the remaining clone OnceMap fallback surface.
- p0/p1 resolver: expected neutral.
- Overall: should be mostly code simplification; performance should not regress relative to #3023.

## Split Plan Position
- Builds on #3023 after pipeline events route through scheduler.
- This is the cleanup PR that removes the old clone single-flight path once scheduler coverage is complete.

## Validation
- cargo fmt
- cargo check -p utoo-pm
- cargo test -p utoo-pm service::install_scheduler
- cargo test -p utoo-pm service::pipeline
- cargo test -p utoo-pm service::install::tests
- cargo test -p utoo-pm util::cloner
- cargo clippy --all-targets -- -D warnings --no-deps