### PR TITLE
perf(pm): optimize version manifest hot path

### DIFF
--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -15,11 +15,13 @@ use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
 use crate::resolver::version::resolve_target_version;
 
-/// Parse JSON bytes on rayon's CPU thread pool (native) or inline
-/// (wasm32). Keeps the tokio runtime free of `simd_json` work so other
-/// in-flight manifest fetches keep driving network IO while this one
-/// parses.
-pub(crate) async fn parse_json_off_runtime<T>(bytes: Bytes) -> Result<T, anyhow::Error>
+/// Parse a JSON buffer on rayon's CPU thread pool (native) or inline
+/// (wasm32). The buffer is consumed because `simd_json` mutates it in place.
+/// Keeps the tokio runtime free of `simd_json` work so other in-flight
+/// manifest fetches keep driving network IO while this one parses.
+pub(crate) async fn parse_json_vec_off_runtime<T>(
+    mut parse_buf: Vec<u8>,
+) -> Result<T, anyhow::Error>
 where
     T: serde::de::DeserializeOwned + Send + 'static,
 {
@@ -27,7 +29,6 @@ where
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let mut parse_buf = bytes.to_vec();
             let result = simd_json::serde::from_slice::<T>(&mut parse_buf)
                 .map_err(|e| anyhow!("JSON parse error: {e}"));
             let _ = tx.send(result);
@@ -37,7 +38,6 @@ where
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut parse_buf = bytes.to_vec();
         simd_json::serde::from_slice::<T>(&mut parse_buf)
             .map_err(|e| anyhow!("JSON parse error: {e}"))
     }
@@ -250,8 +250,41 @@ pub struct FetchVersionManifestOptions<'a> {
     pub format: MetadataFormat,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+async fn read_body_vec(mut response: reqwest::Response) -> Result<Vec<u8>, FetchError> {
+    let capacity = response
+        .content_length()
+        .and_then(|len| usize::try_from(len).ok())
+        .unwrap_or(0);
+    let mut body = Vec::with_capacity(capacity);
+    while let Some(chunk) = response.chunk().await.map_err(classify_reqwest_error)? {
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn read_body_vec(response: reqwest::Response) -> Result<Vec<u8>, FetchError> {
+    response
+        .bytes()
+        .await
+        .map(|bytes| bytes.to_vec())
+        .map_err(classify_reqwest_error)
+}
+
 /// Fetch version manifest bytes with retry, without parsing.
 pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>) -> Result<Bytes> {
+    fetch_version_manifest_vec(opts).await.map(Bytes::from)
+}
+
+/// Fetch version manifest into a mutable parse buffer with retry.
+///
+/// Exact-version manifests do not need to retain raw response bytes for later
+/// extraction. Reading directly into `Vec<u8>` avoids the hot-path
+/// `Bytes -> Vec` copy before `simd_json` parses in place.
+pub(crate) async fn fetch_version_manifest_vec(
+    opts: FetchVersionManifestOptions<'_>,
+) -> Result<Vec<u8>> {
     let url = format!("{}/{}/{}", opts.registry_url, opts.name, opts.spec);
 
     let accept = match opts.format {
@@ -273,7 +306,7 @@ pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>)
                     .map_err(classify_reqwest_error)?;
 
                 if response.status().is_success() {
-                    response.bytes().await.map_err(classify_reqwest_error)
+                    read_body_vec(response).await
                 } else {
                     Err(classify_status(response.status(), &url))
                 }
@@ -293,6 +326,36 @@ pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>)
 pub async fn fetch_version_manifest(
     opts: FetchVersionManifestOptions<'_>,
 ) -> Result<CoreVersionManifest> {
-    let bytes = fetch_version_manifest_bytes(opts).await?;
-    parse_json_off_runtime::<CoreVersionManifest>(bytes).await
+    let bytes = fetch_version_manifest_vec(opts).await?;
+    parse_json_vec_off_runtime::<CoreVersionManifest>(bytes).await
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TinyManifest {
+        name: String,
+        version: String,
+    }
+
+    #[tokio::test]
+    async fn parse_json_vec_off_runtime_consumes_mutable_buffer() {
+        let parsed = parse_json_vec_off_runtime::<TinyManifest>(
+            br#"{"name":"demo","version":"1.0.0"}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            parsed,
+            TinyManifest {
+                name: "demo".to_string(),
+                version: "1.0.0".to_string(),
+            }
+        );
+    }
 }

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -40,8 +40,6 @@ fn current_timestamp_secs() -> u64 {
     (js_sys::Date::now() / 1000.0) as u64
 }
 
-use dashmap::DashSet;
-
 use super::cache::{PackageCache, Versions, VersionsInfo};
 use super::manifest;
 use super::provider::{ManifestFullData, ManifestJob, ManifestJobDone, ManifestProvider};
@@ -88,13 +86,6 @@ pub struct UnifiedRegistry {
     /// `(name, spec)`. Same gate-only pattern: the canonical `Arc<…>`
     /// lives in `PackageCache.version_manifests`; the gate stores `()`.
     inflight_version: Arc<OnceMap<(String, String), ()>>,
-    /// Dedup set for `store_version_manifest` disk writes keyed by
-    /// `(name, resolved_version)`. `inflight_version` is keyed by
-    /// `(name, spec)`, so sibling specs (e.g. `^1.0.0` and `^1.2.0`)
-    /// resolving to the same version each fire the gate independently
-    /// and would otherwise issue duplicate writes for the same path.
-    /// First insert wins; subsequent specs skip the redundant write.
-    stored_version: Arc<DashSet<(String, String)>>,
 }
 
 /// Builder for `UnifiedRegistry`.
@@ -163,7 +154,6 @@ impl UnifiedRegistryBuilder {
             supports_semver,
             inflight_full: Arc::new(OnceMap::new()),
             inflight_version: Arc::new(OnceMap::new()),
-            stored_version: Arc::new(DashSet::new()),
         }
     }
 }
@@ -183,7 +173,6 @@ impl Clone for UnifiedRegistry {
             supports_semver: self.supports_semver,
             inflight_full: Arc::clone(&self.inflight_full),
             inflight_version: Arc::clone(&self.inflight_version),
-            stored_version: Arc::clone(&self.stored_version),
         }
     }
 }
@@ -396,13 +385,8 @@ impl UnifiedRegistry {
     }
 
     fn store_version_manifest(&self, name: &str, manifest: Arc<CoreVersionManifest>) {
-        let version = manifest.version.clone();
-        if self
-            .stored_version
-            .insert((name.to_string(), version.clone()))
-        {
-            self.store.store_version_manifest(name, &version, manifest);
-        }
+        self.store
+            .store_version_manifest(name, &manifest.version, Arc::clone(&manifest));
     }
 
     async fn fetch_provider_full_manifest_bytes(


### PR DESCRIPTION
## Summary

Completes the missing p1 hot-path pieces from the original resolver performance branch:

- read exact-version manifest responses directly into a mutable `Vec<u8>` buffer
- parse version manifests from that buffer with `simd_json` off the async runtime
- remove the provider-level `DashSet` write-dedupe set so cache writes stay in the host `ManifestStore` writer queue instead of adding resolver hot-path shared state

## Expected performance signal

This is intended to recover the original main-PR p1 ctx shape. #2948 reported p1 around `1.79s` with `15.7K/19.6K` v/iCtx; #3024 was still around `2.72s` with `27.9K/36.6K`, so this PR should primarily move p1 ctx down.

## Validation

- `cargo fmt`
- `cargo check -p utoo-ruborist`
- `cargo test -p utoo-ruborist service::manifest`
- `cargo test -p utoo-ruborist service::registry`
- `cargo clippy --all-targets -- -D warnings --no-deps`
