### PR TITLE
perf(pm): split install download and extract lanes

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -2,11 +2,14 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
+use bytes::Bytes;
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::util::cloner::clone_package_from_cache;
-use crate::util::downloader::{download_and_extract_to_cache, resolve_seeded_cache_path};
+use crate::util::downloader::{
+    download_bytes, extract_to_cache, registry_cache_lookup, resolve_seeded_cache_path,
+};
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -50,11 +53,17 @@ struct ReadyClone {
     cache_path: PathBuf,
 }
 
+#[derive(Debug)]
+struct DownloadedPackage {
+    package: PackageFetch,
+    bytes: Bytes,
+}
+
 type CloneResponder = oneshot::Sender<Result<(), String>>;
 
-const CLONE_CONCURRENCY_PER_CPU: usize = 4;
+const CLONE_CONCURRENCY_PER_CPU: usize = 2;
 const MIN_CLONE_CONCURRENCY: usize = 4;
-const MAX_CLONE_CONCURRENCY: usize = 32;
+const MAX_CLONE_CONCURRENCY: usize = 16;
 const DEFAULT_CLONE_CONCURRENCY: usize = 8;
 
 #[cfg(windows)]
@@ -80,6 +89,10 @@ enum OpDone {
         result: Result<Option<PathBuf>, String>,
     },
     Download {
+        package: PackageFetch,
+        result: Result<DownloadOutcome, String>,
+    },
+    Extract {
         key: PackageKey,
         result: Result<PathBuf, String>,
     },
@@ -87,6 +100,11 @@ enum OpDone {
         target: PathBuf,
         result: Result<(), String>,
     },
+}
+
+enum DownloadOutcome {
+    Cached(PathBuf),
+    Bytes(Bytes),
 }
 
 #[derive(Clone)]
@@ -160,11 +178,14 @@ struct SchedulerState {
     rx: mpsc::UnboundedReceiver<Command>,
     shutdown: bool,
     download_limit: usize,
+    extract_limit: usize,
     clone_limit: usize,
     download_done: HashMap<PackageKey, PathBuf>,
     download_active: HashSet<PackageKey>,
     download_waiters: HashMap<PackageKey, Vec<InstallCloneRequest>>,
     download_queue: VecDeque<PackageFetch>,
+    extract_active: HashSet<PackageKey>,
+    extract_queue: VecDeque<DownloadedPackage>,
     clone_done: HashSet<PathBuf>,
     clone_active: HashSet<PathBuf>,
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
@@ -179,11 +200,14 @@ impl SchedulerState {
             rx,
             shutdown: false,
             download_limit: get_manifests_concurrency_limit_sync().max(1),
+            extract_limit: extract_concurrency_limit(),
             clone_limit: clone_concurrency_limit(),
             download_done: HashMap::new(),
             download_active: HashSet::new(),
             download_waiters: HashMap::new(),
             download_queue: VecDeque::new(),
+            extract_active: HashSet::new(),
+            extract_queue: VecDeque::new(),
             clone_done: HashSet::new(),
             clone_active: HashSet::new(),
             clone_waiters: HashMap::new(),
@@ -196,6 +220,7 @@ impl SchedulerState {
     async fn run(mut self) {
         loop {
             self.pump_downloads();
+            self.pump_extracts();
             self.pump_clones();
 
             if self.shutdown && self.is_idle() {
@@ -234,8 +259,10 @@ impl SchedulerState {
 
     fn is_idle(&self) -> bool {
         self.download_queue.is_empty()
+            && self.extract_queue.is_empty()
             && self.clone_queue.is_empty()
             && self.download_active.is_empty()
+            && self.extract_active.is_empty()
             && self.clone_active.is_empty()
             && self.ops.is_empty()
     }
@@ -312,7 +339,9 @@ impl SchedulerState {
     }
 
     fn pump_downloads(&mut self) {
-        while self.download_active.len() < self.download_limit {
+        while self.download_active.len() < self.download_limit
+            && self.extract_backlog() < self.download_limit
+        {
             let Some(package) = self.download_queue.pop_front() else {
                 break;
             };
@@ -322,14 +351,42 @@ impl SchedulerState {
             }
 
             self.ops.push(tokio::spawn(async move {
-                let result = download_and_extract_to_cache(
-                    &package.name,
-                    &package.version,
-                    &package.tarball_url,
+                let result = match registry_cache_lookup(&package.name, &package.version).await {
+                    Ok(Some(cache_path)) => Ok(DownloadOutcome::Cached(cache_path)),
+                    Ok(None) => download_bytes(&package.tarball_url)
+                        .await
+                        .map(DownloadOutcome::Bytes)
+                        .map_err(|e| format!("{e:#}")),
+                    Err(e) => Err(format!("{e:#}")),
+                };
+                OpDone::Download { package, result }
+            }));
+        }
+    }
+
+    fn extract_backlog(&self) -> usize {
+        self.extract_queue.len() + self.extract_active.len()
+    }
+
+    fn pump_extracts(&mut self) {
+        while self.extract_active.len() < self.extract_limit {
+            let Some(downloaded) = self.extract_queue.pop_front() else {
+                break;
+            };
+            let key = downloaded.package.key();
+            if self.download_done.contains_key(&key) || !self.extract_active.insert(key.clone()) {
+                continue;
+            }
+
+            self.ops.push(tokio::spawn(async move {
+                let result = extract_to_cache(
+                    &downloaded.package.name,
+                    &downloaded.package.version,
+                    downloaded.bytes,
                 )
                 .await
                 .map_err(|e| format!("{e:#}"));
-                OpDone::Download { key, result }
+                OpDone::Extract { key, result }
             }));
         }
     }
@@ -369,29 +426,49 @@ impl SchedulerState {
                 Ok(None) => self.ensure_download(request.package(), Some(request)),
                 Err(error) => self.complete_clone(clone_key(&request.target), Err(error)),
             },
-            OpDone::Download { key, result } => {
+            OpDone::Download { package, result } => {
+                let key = package.key();
                 self.download_active.remove(&key);
-                let waiters = self.download_waiters.remove(&key).unwrap_or_default();
                 match result {
-                    Ok(cache_path) => {
-                        self.download_done.insert(key, cache_path.clone());
-                        for request in waiters {
-                            self.clone_queue.push_back(ReadyClone {
-                                request,
-                                cache_path: cache_path.clone(),
-                            });
-                        }
+                    Ok(DownloadOutcome::Cached(cache_path)) => {
+                        self.complete_download(key, Ok(cache_path));
+                    }
+                    Ok(DownloadOutcome::Bytes(bytes)) => {
+                        self.extract_queue
+                            .push_back(DownloadedPackage { package, bytes });
                     }
                     Err(error) => {
-                        for request in waiters {
-                            self.complete_clone(clone_key(&request.target), Err(error.clone()));
-                        }
+                        self.complete_download(key, Err(error));
                     }
                 }
+            }
+            OpDone::Extract { key, result } => {
+                self.extract_active.remove(&key);
+                self.complete_download(key, result);
             }
             OpDone::Clone { target, result } => {
                 self.clone_active.remove(&target);
                 self.complete_clone(target, result);
+            }
+        }
+    }
+
+    fn complete_download(&mut self, key: PackageKey, result: Result<PathBuf, String>) {
+        let waiters = self.download_waiters.remove(&key).unwrap_or_default();
+        match result {
+            Ok(cache_path) => {
+                self.download_done.insert(key, cache_path.clone());
+                for request in waiters {
+                    self.clone_queue.push_back(ReadyClone {
+                        request,
+                        cache_path: cache_path.clone(),
+                    });
+                }
+            }
+            Err(error) => {
+                for request in waiters {
+                    self.complete_clone(clone_key(&request.target), Err(error.clone()));
+                }
             }
         }
     }
@@ -441,6 +518,12 @@ fn clone_concurrency_limit() -> usize {
         .unwrap_or(DEFAULT_CLONE_CONCURRENCY)
 }
 
+fn extract_concurrency_limit() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().clamp(2, 8))
+        .unwrap_or(4)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -482,6 +565,47 @@ mod tests {
             state.download_waiters[&PackageKey("react@18.2.0".into())].len(),
             1
         );
+    }
+
+    #[test]
+    fn download_completion_releases_slot_and_queues_extract() {
+        let mut state = state();
+        let package = package("react", "18.2.0");
+        let key = package.key();
+        let waiter = clone_request("react", "18.2.0", "/tmp/project/node_modules/react");
+
+        state.download_active.insert(key.clone());
+        state.download_waiters.insert(key.clone(), vec![waiter]);
+
+        state.handle_done(OpDone::Download {
+            package: package.clone(),
+            result: Ok(DownloadOutcome::Bytes(Bytes::from_static(b"tgz"))),
+        });
+
+        assert!(!state.download_active.contains(&key));
+        assert!(state.download_waiters.contains_key(&key));
+        assert_eq!(state.extract_queue.len(), 1);
+        assert_eq!(state.extract_queue[0].package.key(), key);
+    }
+
+    #[test]
+    fn extract_completion_wakes_clone_waiters() {
+        let mut state = state();
+        let key = PackageKey("react@18.2.0".to_string());
+        let waiter = clone_request("react", "18.2.0", "/tmp/project/node_modules/react");
+        let cache_path = PathBuf::from("/tmp/cache/react/18.2.0");
+
+        state.extract_active.insert(key.clone());
+        state.download_waiters.insert(key.clone(), vec![waiter]);
+
+        state.handle_done(OpDone::Extract {
+            key: key.clone(),
+            result: Ok(cache_path.clone()),
+        });
+
+        assert!(!state.extract_active.contains(&key));
+        assert_eq!(state.download_done[&key], cache_path);
+        assert_eq!(state.clone_queue.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -30,7 +30,7 @@ static DOWNLOAD_SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
 static DOWNLOAD_COUNT: AtomicUsize = AtomicUsize::new(0);
 static REUSE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
-fn registry_cache_path(name: &str, version: &str) -> PathBuf {
+pub fn registry_cache_path(name: &str, version: &str) -> PathBuf {
     get_cache_dir().join(name).join(version)
 }
 
@@ -234,7 +234,33 @@ pub async fn download_and_extract_to_cache(
     version: &str,
     tarball_url: &str,
 ) -> Result<PathBuf> {
+    if let Some(cache_path) = registry_cache_lookup(name, version).await? {
+        return Ok(cache_path);
+    }
+
+    let bytes = download_bytes(tarball_url)
+        .await
+        .with_context(|| format!("Download {name}@{version} from {tarball_url}"))?;
+
+    extract_to_cache(name, version, bytes).await
+}
+
+pub async fn registry_cache_lookup(name: &str, version: &str) -> Result<Option<PathBuf>> {
     let cache_path = registry_cache_path(name, version);
+    if crate::fs::try_exists(&cache_path.join("_resolved"))
+        .await
+        .unwrap_or(false)
+    {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        Ok(Some(cache_path))
+    } else {
+        Ok(None)
+    }
+}
+
+pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
+    let cache_path = registry_cache_path(name, version);
+
     if crate::fs::try_exists(&cache_path.join("_resolved"))
         .await
         .unwrap_or(false)
@@ -242,10 +268,6 @@ pub async fn download_and_extract_to_cache(
         REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
         return Ok(cache_path);
     }
-
-    let bytes = download_bytes(tarball_url)
-        .await
-        .with_context(|| format!("Download {name}@{version} from {tarball_url}"))?;
 
     extract_and_write(bytes, &cache_path)
         .await


### PR DESCRIPTION
## Summary

Completes the missing p3 install scheduling pieces from the original performance branch:

- split install tarball download and extract/write into separate scheduler lanes
- keep download slots focused on cache lookup + network bytes
- bound extract work independently and queue clones only after cache materialization finishes
- tighten install clone lane fanout to reduce clone/materialize contention

## Expected performance signal

This should recover the p3 shape from the original scheduler experiments by preventing download tasks from holding their slot through extraction and file writes. It is stacked after the version-manifest hot-path PR so the final stack can be compared directly with #2948.

## Validation

- `cargo fmt`
- `cargo check -p utoo-pm`
- `cargo test -p utoo-pm service::install_scheduler`
- `cargo test -p utoo-pm util::downloader`
- `cargo clippy --all-targets -- -D warnings --no-deps`
