### PR TITLE
perf(pack): reduce bundle size with default packageImports

### DIFF
--- a/packages/pack/src/__test__/project.test.ts
+++ b/packages/pack/src/__test__/project.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigComplete } from "../config/types";
+import { serializeConfig } from "../core/project";
+
+const baseConfig: ConfigComplete = {
+  entry: [],
+};
+
+describe("serializeConfig", () => {
+  it("adds default package imports", async () => {
+    const serialized = JSON.parse(await serializeConfig(baseConfig, false));
+
+    expect(serialized.optimization.packageImports).toContain("lodash-es");
+    expect(serialized.optimization.packageImports).toContain("antd");
+    expect(serialized.optimization.packageImports).toContain("react-icons/fa");
+    expect(serialized.optimization.packageImports).toContain(
+      "@effect/platform-node",
+    );
+  });
+
+  it("can disable default package imports for isolated comparisons", async () => {
+    const previous = process.env.UTOO_DISABLE_DEFAULT_PACKAGE_IMPORTS;
+    process.env.UTOO_DISABLE_DEFAULT_PACKAGE_IMPORTS = "1";
+
+    try {
+      const serialized = JSON.parse(await serializeConfig(baseConfig, false));
+
+      expect(serialized.optimization.packageImports).toEqual([]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.UTOO_DISABLE_DEFAULT_PACKAGE_IMPORTS;
+      } else {
+        process.env.UTOO_DISABLE_DEFAULT_PACKAGE_IMPORTS = previous;
+      }
+    }
+  });
+
+  it("preserves user package imports before defaults without duplicates", async () => {
+    const serialized = JSON.parse(
+      await serializeConfig(
+        {
+          ...baseConfig,
+          optimization: {
+            packageImports: ["custom-package", "lodash-es", "custom-package"],
+          },
+        },
+        false,
+      ),
+    );
+
+    expect(serialized.optimization.packageImports.slice(0, 2)).toEqual([
+      "custom-package",
+      "lodash-es",
+    ]);
+    expect(
+      serialized.optimization.packageImports.filter(
+        (pkg: string) => pkg === "lodash-es",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/pack/src/core/project.ts
+++ b/packages/pack/src/core/project.ts
@@ -102,6 +102,104 @@ function normalizeStyles(
   };
 }
 
+// Align with next.js turbopack default optimizePackageImports config:
+// https://nextjs.org/docs/app/api-reference/config/next-config-js/optimizePackageImports
+const DEFAULT_OPTIMIZE_PACKAGE_IMPORTS = [
+  "lucide-react",
+  "date-fns",
+  "lodash-es",
+  "ramda",
+  "antd",
+  "react-bootstrap",
+  "ahooks",
+  "@ant-design/icons",
+  "@headlessui/react",
+  "@headlessui-float/react",
+  "@heroicons/react/20/solid",
+  "@heroicons/react/24/solid",
+  "@heroicons/react/24/outline",
+  "@visx/visx",
+  "@tremor/react",
+  "rxjs",
+  "@mui/material",
+  "@mui/icons-material",
+  "recharts",
+  "react-use",
+  "effect",
+  "@effect/schema",
+  "@effect/platform",
+  "@effect/platform-node",
+  "@effect/platform-browser",
+  "@effect/platform-bun",
+  "@effect/sql",
+  "@effect/sql-mssql",
+  "@effect/sql-mysql2",
+  "@effect/sql-pg",
+  "@effect/sql-sqlite-node",
+  "@effect/sql-sqlite-bun",
+  "@effect/sql-sqlite-wasm",
+  "@effect/sql-sqlite-react-native",
+  "@effect/rpc",
+  "@effect/rpc-http",
+  "@effect/typeclass",
+  "@effect/experimental",
+  "@effect/opentelemetry",
+  "@material-ui/core",
+  "@material-ui/icons",
+  "@tabler/icons-react",
+  "mui-core",
+  "react-icons/ai",
+  "react-icons/bi",
+  "react-icons/bs",
+  "react-icons/cg",
+  "react-icons/ci",
+  "react-icons/di",
+  "react-icons/fa",
+  "react-icons/fa6",
+  "react-icons/fc",
+  "react-icons/fi",
+  "react-icons/gi",
+  "react-icons/go",
+  "react-icons/gr",
+  "react-icons/hi",
+  "react-icons/hi2",
+  "react-icons/im",
+  "react-icons/io",
+  "react-icons/io5",
+  "react-icons/lia",
+  "react-icons/lib",
+  "react-icons/lu",
+  "react-icons/md",
+  "react-icons/pi",
+  "react-icons/ri",
+  "react-icons/rx",
+  "react-icons/si",
+  "react-icons/sl",
+  "react-icons/tb",
+  "react-icons/tfi",
+  "react-icons/ti",
+  "react-icons/vsc",
+  "react-icons/wi",
+];
+
+function mergePackageImports(packageImports: string[] | undefined): string[] {
+  const defaultPackageImports =
+    process.env.UTOO_DISABLE_DEFAULT_PACKAGE_IMPORTS === "1"
+      ? []
+      : DEFAULT_OPTIMIZE_PACKAGE_IMPORTS;
+
+  return [...new Set([...(packageImports ?? []), ...defaultPackageImports])];
+}
+
+function normalizeOptimization(
+  optimization: ConfigComplete["optimization"],
+): NonNullable<ConfigComplete["optimization"]> {
+  return {
+    ...(optimization ?? {}),
+    packageImports: mergePackageImports(optimization?.packageImports),
+  };
+}
+
 export async function serializeConfig(
   config: ConfigComplete,
   isDev: boolean,
@@ -109,6 +207,7 @@ export async function serializeConfig(
   const configSerializable = {
     ...config,
     styles: normalizeStyles(config.styles, isDev),
+    optimization: normalizeOptimization(config.optimization),
   };
 
   if (configSerializable.entry) {
@@ -118,8 +217,7 @@ export async function serializeConfig(
     });
   }
 
-  if (configSerializable.optimization) {
-    configSerializable.optimization = { ...configSerializable.optimization };
+  {
     const { modularizeImports } = configSerializable.optimization;
 
     if (modularizeImports) {


### PR DESCRIPTION


## Summary

Reduce bundle size for common barrel-export packages by enabling default packageImports aligned with Next.js.

Just refer to: https://nextjs.org/docs/app/api-reference/config/next-config-js/optimizePackageImports

This config is userful for some internal packages.


## Test Plan

Add unit test.
