### PR TITLE
perf(pm): extract requested core from full manifest parse

### DIFF
--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -13,6 +13,7 @@ use super::fetch::{
 };
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::resolver::version::resolve_target_version;
 
 /// Parse a JSON buffer on rayon's CPU thread pool (native) or inline
 /// (wasm32). The buffer is consumed because `simd_json` mutates it in-place.
@@ -49,21 +50,44 @@ where
 pub(crate) async fn parse_full_manifest_off_runtime(
     raw_bytes: Bytes,
 ) -> Result<FullManifest, anyhow::Error> {
+    parse_full_manifest_with_core_off_runtime(raw_bytes, None)
+        .await
+        .map(|(manifest, _)| manifest)
+}
+
+pub(crate) type FullManifestParseResult = (FullManifest, Option<(String, CoreVersionManifest)>);
+
+fn parse_full_manifest_with_core_sync(
+    raw_bytes: Bytes,
+    spec: Option<String>,
+) -> Result<FullManifestParseResult, anyhow::Error> {
+    // simd_json mutates the parse buffer; copy inside the worker so
+    // response-body bytes can stay immutable until parsing starts.
+    let mut parse_buf = raw_bytes.to_vec();
+    let mut manifest: FullManifest = simd_json::serde::from_slice::<FullManifest>(&mut parse_buf)
+        .map_err(|e| anyhow!("JSON parse error: {e}"))?;
+    manifest.raw = raw_bytes;
+
+    let speculative = spec.and_then(|spec| {
+        resolve_target_version((&manifest).into(), &spec)
+            .ok()
+            .and_then(|version| manifest.get_core_version(&version).map(|core| (spec, core)))
+    });
+
+    Ok((manifest, speculative))
+}
+
+/// Parse a full wire-fetched manifest and optionally extract the current BFS
+/// edge's version in the same off-runtime worker task.
+pub(crate) async fn parse_full_manifest_with_core_off_runtime(
+    raw_bytes: Bytes,
+    spec: Option<String>,
+) -> Result<FullManifestParseResult, anyhow::Error> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let result = (|| -> Result<FullManifest, anyhow::Error> {
-                // simd_json mutates the parse buffer; copy inside the worker so
-                // response-body bytes can stay immutable until parsing starts.
-                let mut parse_buf = raw_bytes.to_vec();
-                let mut manifest: FullManifest =
-                    simd_json::serde::from_slice::<FullManifest>(&mut parse_buf)
-                        .map_err(|e| anyhow!("JSON parse error: {e}"))?;
-                manifest.raw = raw_bytes;
-
-                Ok(manifest)
-            })();
+            let result = parse_full_manifest_with_core_sync(raw_bytes, spec);
             let _ = tx.send(result);
         });
         rx.await
@@ -71,10 +95,7 @@ pub(crate) async fn parse_full_manifest_off_runtime(
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut manifest: FullManifest =
-            parse_json_vec_off_runtime(raw_bytes.clone().to_vec()).await?;
-        manifest.raw = raw_bytes;
-        Ok(manifest)
+        parse_full_manifest_with_core_sync(raw_bytes, spec)
     }
 }
 
@@ -336,5 +357,34 @@ mod tests {
                 version: "1.0.0".to_string(),
             }
         );
+    }
+
+    #[tokio::test]
+    async fn parse_full_manifest_with_core_extracts_requested_spec() {
+        let raw = Bytes::from_static(
+            br#"{
+                "name":"demo",
+                "dist-tags":{"latest":"1.0.0"},
+                "versions":{
+                    "1.0.0":{
+                        "name":"demo",
+                        "version":"1.0.0",
+                        "dist":{"tarball":"https://registry.example/demo-1.0.0.tgz"}
+                    }
+                }
+            }"#,
+        );
+
+        let (manifest, speculative) =
+            parse_full_manifest_with_core_off_runtime(raw.clone(), Some("latest".to_string()))
+                .await
+                .unwrap();
+
+        assert_eq!(manifest.name, "demo");
+        assert_eq!(manifest.raw, raw);
+        let (spec, core) = speculative.unwrap();
+        assert_eq!(spec, "latest");
+        assert_eq!(core.name, "demo");
+        assert_eq!(core.version, "1.0.0");
     }
 }


### PR DESCRIPTION
## Summary

Review-sized split from #3028 / #2948, stacked after #3031.

Adds the full-manifest parse helper used by the upcoming provider implementation:

- keeps `parse_full_manifest_off_runtime` as the compatibility wrapper;
- adds `parse_full_manifest_with_core_off_runtime` to parse the full manifest and optionally extract the current edge's core version in the same worker;
- preserves `FullManifest::raw` for later on-demand extraction;
- keeps native parsing on rayon and wasm parsing inline;
- adds a regression test for raw byte preservation and speculative `latest` extraction.

This PR does not change resolver scheduling yet; it only exposes the CPU helper consumed by the provider/job PR.

## Size

- Diff against #3031: `1 file changed, 65 insertions(+), 15 deletions(-)`

## Validation

- `cargo fmt`
- `cargo check -p utoo-ruborist`
- `cargo test -p utoo-ruborist service::manifest::tests::parse_full_manifest_with_core_extracts_requested_spec`
- `cargo clippy --all-targets -- -D warnings --no-deps`

`pack-napi` still warns locally because `next.js` is a symlink in this worktree; clippy exits successfully.
