### PR TITLE
perf(pm): add mock manifest provider

### DIFF
--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -298,6 +298,7 @@ pub mod mock {
     use super::*;
 
     /// Internal package data for mock registry.
+    #[derive(Clone)]
     struct MockPackage {
         name: String,
         dist_tags: HashMap<String, String>,
@@ -305,6 +306,7 @@ pub mod mock {
     }
 
     /// Mock registry client that returns predefined packages.
+    #[derive(Clone)]
     pub struct MockRegistryClient {
         packages: HashMap<String, MockPackage>,
     }
@@ -392,5 +394,104 @@ pub mod mock {
                 ..Default::default()
             }))
         }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl crate::service::ManifestProvider for MockRegistryClient {
+        async fn execute_manifest_job(
+            &self,
+            job: crate::service::ManifestJob,
+        ) -> Result<crate::service::ManifestJobDone, Self::Error> {
+            use crate::service::{ManifestFullData, ManifestJob, ManifestJobDone};
+
+            match job {
+                ManifestJob::Full { name, spec } => {
+                    let full = self.fetch_full_manifest(&name).await?;
+                    let speculative = spec.and_then(|spec| {
+                        resolve_target_version((&*full).into(), &spec)
+                            .ok()
+                            .and_then(|version| {
+                                full.get_core_version(&version)
+                                    .map(|core| (spec, Arc::new(core)))
+                            })
+                    });
+                    Ok(ManifestJobDone::Full {
+                        name,
+                        data: ManifestFullData::Full {
+                            manifest: full,
+                            speculative,
+                        },
+                    })
+                }
+                ManifestJob::Version {
+                    name,
+                    spec,
+                    fetch_spec,
+                    format: _,
+                } => {
+                    let manifest = self.fetch_version_manifest(&name, &fetch_spec).await?;
+                    Ok(ManifestJobDone::Version {
+                        name,
+                        spec,
+                        manifest,
+                    })
+                }
+                ManifestJob::ExtractVersion {
+                    name,
+                    spec,
+                    version,
+                    full,
+                } => {
+                    let manifest =
+                        full.get_core_version(&version)
+                            .map(Arc::new)
+                            .ok_or_else(|| {
+                                MockError(format!(
+                                    "Version {version} not found in manifest for {name}"
+                                ))
+                            })?;
+                    Ok(ManifestJobDone::Version {
+                        name,
+                        spec,
+                        manifest,
+                    })
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_registry_executes_manifest_provider_jobs() {
+        let mut registry = MockRegistryClient::new();
+        registry.add_package(
+            "demo",
+            "1.0.0",
+            CoreVersionManifest {
+                name: "demo".to_string(),
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let done = crate::service::ManifestProvider::execute_manifest_job(
+            &registry,
+            crate::service::ManifestJob::Full {
+                name: "demo".to_string(),
+                spec: Some("latest".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let crate::service::ManifestJobDone::Full { data, .. } = done else {
+            panic!("expected full manifest job result");
+        };
+        let crate::service::ManifestFullData::Full { speculative, .. } = data else {
+            panic!("expected full manifest data");
+        };
+        let (spec, manifest) = speculative.unwrap();
+        assert_eq!(spec, "latest");
+        assert_eq!(manifest.version, "1.0.0");
     }
 }


### PR DESCRIPTION
## Summary

Review-sized split from #3028 / #2948, stacked after #3034.

Prepares resolver main-loop tests by teaching the test mock registry to satisfy `ManifestProvider` jobs:

- derives `Clone` for the mock registry data;
- implements `ManifestProvider` for `MockRegistryClient` under `#[cfg(test)]`;
- supports full, version, and extract jobs using existing mock registry methods;
- adds a focused test for speculative full-manifest provider execution.

No production behavior changes in this PR.

## Size

- Diff against #3034: `1 file changed, 101 insertions(+)`

## Validation

- `cargo fmt`
- `cargo check -p utoo-ruborist`
- `cargo test -p utoo-ruborist traits::registry::mock::mock_registry_executes_manifest_provider_jobs`
- `cargo clippy --all-targets -- -D warnings --no-deps`

`pack-napi` still warns locally because `next.js` is a symlink in this worktree; clippy exits successfully.
