### PR TITLE
perf(pm): thread warm project cache into resolver config

### DIFF
--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -32,7 +32,7 @@ use crate::model::node::EdgeType;
 use crate::model::package_json::PackageJson;
 use crate::resolver::preload::{PreloadConfig, preload_manifests};
 use crate::resolver::registry::{ResolveError, resolve_registry_dep};
-use crate::service::ManifestProvider;
+use crate::service::{ManifestProvider, ProjectCacheData};
 use crate::spec::{Catalogs, PackageSpec, Protocol};
 use crate::traits::progress::{BuildEvent, EventReceiver, NoopReceiver};
 use crate::traits::registry::{RegistryClient, ResolvedPackage};
@@ -118,6 +118,8 @@ pub struct BuildDepsConfig {
     /// Catalog definitions for the `catalog:` dependency protocol.
     /// Key `""` = default catalog, other keys = named catalogs.
     pub catalogs: Catalogs,
+    /// Host-provided project cache used to seed resolver manifest state.
+    pub warm_project_cache: Option<ProjectCacheData>,
 }
 
 impl Default for BuildDepsConfig {
@@ -130,6 +132,7 @@ impl Default for BuildDepsConfig {
             git_clone_cache: Arc::new(GitCloneCache::new()),
             http_fetch_cache: Arc::new(HttpFetchCache::new()),
             catalogs: HashMap::new(),
+            warm_project_cache: None,
         }
     }
 }
@@ -162,6 +165,12 @@ impl BuildDepsConfig {
     /// Set catalog definitions for `catalog:` protocol resolution.
     pub fn with_catalogs(mut self, catalogs: Catalogs) -> Self {
         self.catalogs = catalogs;
+        self
+    }
+
+    /// Set the host-provided warm project cache.
+    pub fn with_warm_project_cache(mut self, warm_project_cache: Option<ProjectCacheData>) -> Self {
+        self.warm_project_cache = warm_project_cache;
         self
     }
 }

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -239,7 +239,8 @@ where
         .with_peer_deps(peer_deps)
         .with_concurrency(concurrency)
         .with_skip_preload(skip_preload)
-        .with_catalogs(catalogs);
+        .with_catalogs(catalogs)
+        .with_warm_project_cache(warm_project_cache);
     if let Some(dir) = cache_dir {
         config = config.with_cache_dir(dir);
     }


### PR DESCRIPTION
## Summary
- add `warm_project_cache` to `BuildDepsConfig`
- pass host-provided project cache through the service API into resolver config
- keep the existing memory-cache prepopulation behavior unchanged until the demand mainloop consumes the config directly

## Validation
- `cargo fmt`
- `cargo check -p utoo-ruborist`
- `cargo test -p utoo-ruborist resolver::builder::tests::test_build -- --nocapture`
- `cargo test -p utoo-ruborist service::api::tests::test_build_deps_options_creation -- --nocapture`
- `cargo clippy --all-targets -- -D warnings --no-deps`

## Split Plan
Part of the resolver stack split from source PR #3028. This prepares the warm-cache data flow before the mainloop starts owning resolver-local manifest state.