### PR TITLE
perf(pm): remove registry cache hook

### DIFF
--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -670,11 +670,6 @@ impl RegistryClient for UnifiedRegistry {
         &self.registry_url
     }
 
-    fn cache_version_manifest(&self, name: &str, spec: &str, manifest: Arc<CoreVersionManifest>) {
-        self.cache
-            .set_version_manifest(name.to_string(), spec.to_string(), manifest);
-    }
-
     async fn fetch_full_manifest(&self, name: &str) -> Result<Arc<FullManifest>, Self::Error> {
         match self.resolve_full_manifest(name).await? {
             FullManifestResult::Full(manifest) => Ok(manifest),

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -282,21 +282,6 @@ pub trait RegistryClient {
             })
         }
     }
-
-    /// Cache a resolved version manifest for later use.
-    ///
-    /// This method is called by preload to cache (name, spec) -> version_manifest mappings,
-    /// allowing build phase to directly hit memory cache without traversing full_manifest.
-    ///
-    /// Default implementation is no-op (no caching).
-    fn cache_version_manifest(
-        &self,
-        _name: &str,
-        _spec: &str,
-        _manifest: Arc<CoreVersionManifest>,
-    ) {
-        // Default: no-op
-    }
 }
 
 /// A simple in-memory registry client for testing.


### PR DESCRIPTION
## Summary
- remove the old `RegistryClient::cache_version_manifest` preload hook
- drop the now-unused `UnifiedRegistry` implementation of that hook
- keep manifest provider tests intact

## Validation
- `cargo fmt`
- `cargo check -p utoo-ruborist`
- `cargo test -p utoo-ruborist mock_registry_executes_manifest_provider_jobs -- --nocapture`
- `cargo test -p utoo-ruborist test_unified_registry_executes_extract_manifest_provider_job -- --nocapture`
- `cargo clippy --all-targets -- -D warnings --no-deps`

## Split Plan
Part of the resolver stack split from source PR #3028. This removes a preload-era cache callback before the registry memory-cache cleanup.