### PR TITLE
perf(pm): update resolver cache ownership docs

### DIFF
--- a/crates/ruborist/src/model/manifest.rs
+++ b/crates/ruborist/src/model/manifest.rs
@@ -128,9 +128,8 @@ impl FullManifest {
     /// subtree is visited in place — no intermediate `serde_json::Value`
     /// allocation.
     ///
-    /// `OnceMap` single-flight in `UnifiedRegistry` reduces the per-key
-    /// invocation count to one, so the per-call full-tree parse cost is
-    /// bounded.
+    /// The BFS resolver de-duplicates in-flight extract jobs per key, so the
+    /// per-call full-tree parse cost is bounded.
     fn extract_version<T: for<'de> Deserialize<'de>>(&self, version: &str) -> Option<T> {
         use simd_json::prelude::ValueObjectAccess;
         let mut buf = self.raw.to_vec();

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -133,9 +133,10 @@ pub trait RegistryClient {
         false
     }
 
-    /// Base registry URL used by schedulers that need to classify raw work.
+    /// The base registry URL used by raw-fetch dependency builders.
     ///
-    /// Implementations without a concrete URL can keep the default.
+    /// Implementations that cannot expose a concrete URL can keep the default;
+    /// callers should fall back to the regular trait methods when this is empty.
     fn registry_url(&self) -> &str {
         ""
     }


### PR DESCRIPTION
## Summary
- update full-manifest extraction docs to point at resolver-owned inflight extract jobs
- clarify `RegistryClient::registry_url` fallback behavior for raw-fetch callers

## Validation
- `cargo fmt`
- `cargo check -p utoo-ruborist`
- `cargo clippy --all-targets -- -D warnings --no-deps`

## Split Plan
Part of the resolver stack split from source PR #3028. This is the final documentation cleanup after cache ownership moved out of `UnifiedRegistry`.