### PR TITLE
perf(pm): route stale installs through scheduler

### DIFF
--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -17,7 +17,7 @@ use crate::fs;
 use crate::helper::workspace::find_workspaces;
 use crate::util::cli_enum::{PackageAction, SaveType};
 use crate::util::cloner::clone_package;
-use crate::util::downloader::{is_git_url, resolve_cache_path};
+use crate::util::downloader::{download_and_extract_to_cache, is_git_url};
 use crate::util::git_resolver::{resolve_git_spec, resolve_github_spec};
 use crate::util::json::{load_package_lock_json_from_path, read_json_file};
 
@@ -267,9 +267,9 @@ pub async fn prepare_global_package_json(npm_spec: &str, prefix: Option<&str>) -
         .ok_or_else(|| anyhow!("Failed to get tarball URL from manifest"))?;
 
     // Download and extract package to cache.
-    let cache_path = resolve_cache_path(&name, &resolved.version, tarball_url)
+    let cache_path = download_and_extract_to_cache(&name, &resolved.version, tarball_url)
         .await
-        .ok_or_else(|| anyhow!("Failed to download package {name}"))?;
+        .with_context(|| format!("Failed to download package {name}"))?;
 
     // If the package has install scripts, create a flag file
     // in linux, we can use hardlink when FICLONE is not supported

--- a/crates/pm/src/helper/ruborist_context.rs
+++ b/crates/pm/src/helper/ruborist_context.rs
@@ -6,7 +6,7 @@ use utoo_ruborist::service::{
     BuildDepsOptions, BuildDepsOutput, Glob, ManifestStore, UnifiedRegistry,
 };
 
-use crate::service::pipeline::{PipelineChannels, PipelineReceiver};
+use crate::service::install_scheduler::{InstallEventReceiver, InstallScheduler};
 use crate::util::cache::get_cache_dir;
 use crate::util::logger::ProgressReceiver;
 use crate::util::manifest_store::DiskManifestStore;
@@ -66,17 +66,13 @@ impl Context {
         }
     }
 
-    /// Create BuildDepsOptions with PipelineReceiver for concurrent download/clone.
-    /// Returns (options, channels) where channels are used to start pipeline workers.
-    pub async fn pipeline_deps_options(
+    /// Create BuildDepsOptions that forwards package events to the install scheduler.
+    pub async fn install_deps_options(
         cwd: PathBuf,
-    ) -> (
-        BuildDepsOptions<GlobImpl, PipelineReceiver<ProgressReceiver>>,
-        PipelineChannels,
-    ) {
-        let (receiver, channels) = PipelineReceiver::new(ProgressReceiver);
-        let options = Self::deps_options(cwd, receiver).await;
-        (options, channels)
+        scheduler: InstallScheduler,
+    ) -> BuildDepsOptions<GlobImpl, InstallEventReceiver<ProgressReceiver>> {
+        let receiver = InstallEventReceiver::new(ProgressReceiver, scheduler, cwd.clone());
+        Self::deps_options(cwd, receiver).await
     }
 
     /// Resolve dependency tree with plain ProgressReceiver. Returns

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -1,6 +1,6 @@
 use crate::util::cli_enum::ScriptPolicy;
-use anyhow::Context;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::Instant;
@@ -10,8 +10,9 @@ use crate::fs;
 use crate::helper::global_bin::get_global_bin_dir;
 use crate::helper::lock::{
     Package, UpdatePackageJsonOptions, extract_package_name, group_by_depth, is_pkg_lock_outdated,
-    prepare_global_package_json, update_package_json,
+    prepare_global_package_json, save_package_lock, update_package_json,
 };
+use crate::helper::ruborist_context::{Context, spawn_save_project_cache};
 use crate::helper::workspace::init_project_root;
 use crate::model::package::PackageInfo;
 use crate::service::rebuild::RebuildService;
@@ -62,14 +63,12 @@ fn should_omit_package(package: &Package, omit: &HashSet<OmitType>) -> bool {
     false
 }
 
-pub async fn install_packages(
+async fn install_packages(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
     omit: &HashSet<OmitType>,
-    scheduler: Option<&super::install_scheduler::InstallScheduler>,
+    scheduler: &super::install_scheduler::InstallScheduler,
 ) -> Result<()> {
-    use crate::util::cloner::clone_package_once;
-
     // Surface the clean step in the spinner — it doesn't move `pos`, so
     // without a message the bar looks frozen on large trees.
     log_progress("validating node_modules");
@@ -77,14 +76,14 @@ pub async fn install_packages(
     log_progress("linking packages");
 
     // Always process level-by-level to ensure parent directories exist before
-    // children. Within each level, tasks run concurrently. The pipeline's
-    // clone_worker may have already cloned some packages — clone_package_once
-    // deduplicates via CLONE_CACHE so no double work occurs.
+    // children. Within each level, tasks run concurrently. The install
+    // scheduler owns clone/download dedupe, so package tasks only request the
+    // concrete target they need.
     let mut depths: Vec<_> = groups.keys().cloned().collect();
     depths.sort_unstable();
 
     for depth in depths.iter() {
-        let mut clone_tasks: Vec<tokio::task::JoinHandle<Result<()>>> = Vec::new();
+        let mut clone_tasks = FuturesUnordered::new();
 
         if let Some(packages) = groups.get(depth) {
             for (path, package) in packages.iter() {
@@ -141,30 +140,17 @@ pub async fn install_packages(
                         .ok_or_else(|| anyhow::anyhow!("package {name} missing version"))?;
                     let cwd_clone = cwd.to_path_buf();
                     let target_path = cwd_clone.join(&path);
+                    let scheduler = scheduler.clone();
 
                     // Check if this is an optional dependency
                     let is_optional =
                         package.optional == Some(true) || package.dev_optional == Some(true);
-                    let scheduler = scheduler.cloned();
 
-                    let task = tokio::spawn(async move {
-                        let clone_result = match scheduler {
-                            Some(scheduler) => {
-                                scheduler
-                                    .ensure_clone(
-                                        name.clone(),
-                                        version,
-                                        resolved,
-                                        target_path.clone(),
-                                    )
-                                    .await
-                            }
-                            None => {
-                                clone_package_once(&name, &version, &resolved, &target_path).await
-                            }
-                        };
-
-                        if let Err(e) = clone_result {
+                    clone_tasks.push(async move {
+                        if let Err(e) = scheduler
+                            .ensure_clone(name.clone(), version, resolved, target_path.clone())
+                            .await
+                        {
                             if is_optional {
                                 tracing::warn!(
                                     "Optional dependency {name} failed (ignored): {e:#}"
@@ -178,19 +164,31 @@ pub async fn install_packages(
                         log_progress(&format!("{name} resolved"));
                         update_package_binary(&target_path, &name).await
                     });
-                    clone_tasks.push(task);
                 } else {
                     PROGRESS_BAR.inc(1);
                 }
             }
         }
 
-        for task in clone_tasks {
-            task.await??;
+        while let Some(result) = clone_tasks.next().await {
+            result?;
         }
     }
 
     Ok(())
+}
+
+async fn resolve_package_lock_with_scheduler(
+    root_path: &Path,
+    scheduler: super::install_scheduler::InstallScheduler,
+) -> Result<utoo_ruborist::lock::PackageLock> {
+    let options = Context::install_deps_options(root_path.to_path_buf(), scheduler).await;
+    let output = utoo_ruborist::service::build_deps(options).await?;
+
+    save_package_lock(root_path, &output.lock).await?;
+    spawn_save_project_cache(root_path.to_path_buf(), output.project_cache);
+
+    Ok(output.lock)
 }
 
 pub struct InstallService;
@@ -260,16 +258,31 @@ impl InstallService {
         // itself emits a `tracing::warn` with the specific mismatch reason.
         let use_fresh_lock = fs::try_exists(&lock_path).await.unwrap_or(false)
             && !is_pkg_lock_outdated(root_path).await.unwrap_or(true);
+        let scheduler_handle = super::install_scheduler::InstallSchedulerHandle::start();
+        let scheduler = scheduler_handle.scheduler();
 
-        let (package_lock, pipeline_handles) = if use_fresh_lock {
-            let lock = load_package_lock_json_from_path(root_path).await?;
-            (lock, None)
+        let (package_lock, used_scheduler_prefetch) = if use_fresh_lock {
+            let lock = match load_package_lock_json_from_path(root_path).await {
+                Ok(lock) => lock,
+                Err(e) => {
+                    scheduler_handle.shutdown().await;
+                    return Err(e);
+                }
+            };
+            (lock, false)
         } else {
             start_progress_bar();
             let resolve_start = Instant::now();
-            let result = super::pipeline::resolve_with_pipeline(root_path).await?;
+            let lock = match resolve_package_lock_with_scheduler(root_path, scheduler.clone()).await
+            {
+                Ok(lock) => lock,
+                Err(e) => {
+                    scheduler_handle.shutdown().await;
+                    return Err(e);
+                }
+            };
             finish_progress_bar("package-lock.json resolved", Some(resolve_start.elapsed()));
-            (result.package_lock, Some(result.handles))
+            (lock, true)
         };
 
         let groups = group_by_depth(&package_lock.packages);
@@ -280,28 +293,15 @@ impl InstallService {
         }
 
         let link_start = Instant::now();
-        let scheduler_handle = if use_fresh_lock {
-            Some(super::install_scheduler::InstallSchedulerHandle::start())
-        } else {
-            None
-        };
-        let scheduler = scheduler_handle.as_ref().map(|handle| handle.scheduler());
-
-        let install_result = install_packages(&groups, root_path, omit, scheduler.as_ref())
+        let install_result = install_packages(&groups, root_path, omit, &scheduler)
             .await
             .context("Failed to install packages");
 
-        if let Some(handle) = scheduler_handle {
-            handle.shutdown().await;
+        scheduler_handle.shutdown().await;
+        if used_scheduler_prefetch {
+            super::install_scheduler::print_summary();
         }
-
         install_result?;
-
-        // Wait for pipeline workers to complete (if any)
-        if let Some(handles) = pipeline_handles {
-            handles.await_completion().await;
-            super::pipeline::print_pipeline_summary();
-        }
         finish_progress_bar("node_modules cloned", Some(link_start.elapsed()));
 
         RebuildService::rebuild(&package_lock, root_path, scripts).await?;

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -5,12 +5,75 @@ use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot};
+use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 
-use crate::util::cloner::clone_package_from_cache_sync;
+use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
 use crate::util::downloader::{
-    download_bytes, extract_to_cache, registry_cache_lookup, resolve_seeded_cache_path,
+    download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
+    registry_cache_lookup, resolve_seeded_cache_path,
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
+
+/// Build event receiver that forwards install prefetch work to the scheduler.
+pub(crate) struct InstallEventReceiver<R: EventReceiver> {
+    scheduler: InstallScheduler,
+    cwd: PathBuf,
+    inner: R,
+}
+
+impl<R: EventReceiver> InstallEventReceiver<R> {
+    pub(crate) fn new(inner: R, scheduler: InstallScheduler, cwd: PathBuf) -> Self {
+        Self {
+            scheduler,
+            cwd,
+            inner,
+        }
+    }
+}
+
+impl<R: EventReceiver> EventReceiver for InstallEventReceiver<R> {
+    fn on_event(&self, event: BuildEvent<'_>) {
+        self.inner.on_event(event);
+
+        match event {
+            BuildEvent::PackageResolved(info) if info.is_platform_compatible() => {
+                let Some(tarball_url) = info.tarball_url else {
+                    return;
+                };
+                self.scheduler.prefetch_download(
+                    info.name.to_string(),
+                    info.version.to_string(),
+                    tarball_url.to_string(),
+                );
+            }
+            BuildEvent::PackagePlaced {
+                package,
+                path,
+                parent_path,
+            } if package.is_platform_compatible() => {
+                let Some(tarball_url) = package.tarball_url else {
+                    return;
+                };
+                self.scheduler.prefetch_clone(
+                    package.name.to_string(),
+                    package.version.to_string(),
+                    tarball_url.to_string(),
+                    self.cwd.join(path),
+                    parent_path.map(|p| self.cwd.join(p)),
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(crate) fn print_summary() {
+    tracing::debug!(
+        "Install scheduler stats: downloaded={}, cloned={}",
+        download_stats().downloaded,
+        clone_count(),
+    );
+}
 
 #[derive(Clone, Debug)]
 struct PackageFetch {
@@ -29,6 +92,7 @@ impl PackageFetch {
 struct CloneSpec {
     package: PackageFetch,
     target: PathBuf,
+    parent: Option<PathBuf>,
 }
 
 struct ReadyClone {
@@ -44,6 +108,8 @@ struct DownloadedPackage {
 type CloneResponder = oneshot::Sender<Result<(), String>>;
 
 enum Command {
+    PrefetchDownload(PackageFetch),
+    PrefetchClone(CloneSpec),
     EnsureClone(CloneSpec, CloneResponder),
     Shutdown,
 }
@@ -107,6 +173,36 @@ impl InstallSchedulerHandle {
 }
 
 impl InstallScheduler {
+    pub(crate) fn prefetch_download(&self, name: String, version: String, tarball_url: String) {
+        if !is_registry_tarball_url(&tarball_url) {
+            return;
+        }
+        let _ = self.tx.send(Command::PrefetchDownload(PackageFetch {
+            name,
+            version,
+            tarball_url,
+        }));
+    }
+
+    pub(crate) fn prefetch_clone(
+        &self,
+        name: String,
+        version: String,
+        tarball_url: String,
+        target: PathBuf,
+        parent: Option<PathBuf>,
+    ) {
+        let _ = self.tx.send(Command::PrefetchClone(CloneSpec {
+            package: PackageFetch {
+                name,
+                version,
+                tarball_url,
+            },
+            target,
+            parent,
+        }));
+    }
+
     pub(crate) async fn ensure_clone(
         &self,
         name: String,
@@ -124,6 +220,7 @@ impl InstallScheduler {
                         tarball_url,
                     },
                     target,
+                    parent: None,
                 },
                 tx,
             ))
@@ -149,6 +246,7 @@ struct SchedulerState {
     clone_done: HashSet<PathBuf>,
     clone_active: HashSet<PathBuf>,
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
+    blocked_by_parent: HashMap<PathBuf, Vec<CloneSpec>>,
     clone_queue: VecDeque<ReadyClone>,
     done_tx: mpsc::UnboundedSender<OpDone>,
     done_rx: mpsc::UnboundedReceiver<OpDone>,
@@ -173,6 +271,7 @@ impl SchedulerState {
             clone_done: HashSet::new(),
             clone_active: HashSet::new(),
             clone_waiters: HashMap::new(),
+            blocked_by_parent: HashMap::new(),
             clone_queue: VecDeque::new(),
             done_tx,
             done_rx,
@@ -193,6 +292,12 @@ impl SchedulerState {
             tokio::select! {
                 command = self.rx.recv(), if !self.shutdown => {
                     match command {
+                        Some(Command::PrefetchDownload(package)) => {
+                            self.ensure_download(package, None);
+                        }
+                        Some(Command::PrefetchClone(spec)) => {
+                            self.queue_clone(spec, None);
+                        }
                         Some(Command::EnsureClone(spec, responder)) => {
                             self.queue_clone(spec, Some(responder));
                         }
@@ -247,6 +352,17 @@ impl SchedulerState {
 
         self.clone_waiters
             .insert(target.clone(), responder.into_iter().collect());
+
+        if let Some(parent) = &spec.parent
+            && self.clone_waiters.contains_key(parent)
+            && !self.clone_done.contains(parent)
+        {
+            self.blocked_by_parent
+                .entry(parent.clone())
+                .or_default()
+                .push(spec);
+            return;
+        }
 
         self.resolve_cache_for_clone(spec);
     }
@@ -431,6 +547,19 @@ impl SchedulerState {
                 let _ = waiter.send(result.clone());
             }
         }
+
+        if result.is_ok() {
+            if let Some(children) = self.blocked_by_parent.remove(&target) {
+                for child in children {
+                    self.resolve_cache_for_clone(child);
+                }
+            }
+        } else if let Some(children) = self.blocked_by_parent.remove(&target) {
+            let error = format!("parent package {} failed to clone", target.display());
+            for child in children {
+                self.complete_clone(child.target, Err(error.clone()));
+            }
+        }
     }
 
     fn fail_pending(&mut self, message: &str) {
@@ -470,6 +599,7 @@ mod tests {
         CloneSpec {
             package: package(name, version),
             target: PathBuf::from(target),
+            parent: None,
         }
     }
 

--- a/crates/pm/src/service/mod.rs
+++ b/crates/pm/src/service/mod.rs
@@ -9,7 +9,6 @@ pub mod install;
 pub mod install_scheduler;
 pub mod package;
 pub mod package_management;
-pub mod pipeline;
 pub mod pm_pack;
 pub mod publish;
 pub mod rebuild;

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -2,28 +2,14 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
-use once_cell::sync::Lazy;
 use serde::de::DeserializeOwned;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
-use utoo_ruborist::util::OnceMap;
 
-use super::downloader::{is_git_url, resolve_cache_path};
+use super::downloader::is_git_url;
 use super::json::load_package_json;
 use super::retry::create_retry_strategy;
 use crate::fs;
-
-/// Global clone cache shared between pipeline and install phases.
-///
-/// Key: normalized target path. Install (`cwd.join("node_modules/foo")` →
-/// forward slashes) and pipeline (`Path::join` injects backslashes on
-/// Windows) produce the same logical target with different separators;
-/// without normalization OnceMap sees them as distinct keys, dedup fails,
-/// and concurrent tasks race on the same destination — manifesting as
-/// `ERROR_SHARING_VIOLATION` (os error 32) on Windows. `PathBuf` from
-/// `Path::components().collect()` parses both separators uniformly and
-/// rebuilds with the OS-preferred one, giving a stable key.
-static CLONE_CACHE: Lazy<OnceMap<PathBuf, ()>> = Lazy::new(OnceMap::new);
 
 /// Number of `node_modules/` directories freshly materialized this run.
 /// Mirrors pnpm's "added" semantic.
@@ -50,81 +36,6 @@ pub fn clone_package_from_cache_sync(
         CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
     }
     Ok(())
-}
-
-/// Normalize a target path into the canonical key used by `CLONE_CACHE`.
-#[cfg(windows)]
-fn cache_key(target_path: &Path) -> PathBuf {
-    target_path.components().collect()
-}
-
-#[cfg(not(windows))]
-fn cache_key(target_path: &Path) -> PathBuf {
-    target_path.to_path_buf()
-}
-
-/// Wait for a pending clone at the given target path to complete (if any).
-///
-/// Used by the pipeline clone worker to ensure parent packages are
-/// cloned before their children.
-pub async fn wait_clone_if_pending(target_path: &str) {
-    CLONE_CACHE
-        .wait_if_pending(&cache_key(Path::new(target_path)))
-        .await;
-}
-
-/// Clone a package to target path, downloading to cache first if needed.
-///
-/// Uses global `OnceMap` for deduplication: the same target path is only cloned once,
-/// even when called concurrently from pipeline workers and the install phase.
-pub async fn clone_package_once(
-    name: &str,
-    version: &str,
-    tarball_url: &str,
-    target_path: &Path,
-) -> Result<()> {
-    let key = cache_key(target_path);
-
-    // Skip the param clones + future construction when the pipeline
-    // (or a sibling task) already cloned this target.
-    if CLONE_CACHE.is_done(&key) {
-        return Ok(());
-    }
-
-    let err_label = format!("{name}@{version}");
-    let name = name.to_string();
-    let version = version.to_string();
-    let tarball_url = tarball_url.to_string();
-    let target_path = target_path.to_path_buf();
-
-    CLONE_CACHE
-        .get_or_init(key, || async move {
-            let cache_path = resolve_cache_path(&name, &version, &tarball_url).await?;
-            tokio::task::spawn_blocking(move || {
-                clone_package_from_cache_sync(
-                    &name,
-                    &version,
-                    &tarball_url,
-                    &cache_path,
-                    &target_path,
-                )
-                .inspect_err(|e| {
-                    tracing::warn!(
-                        "Clone failed: {}@{} to {}: {:#}",
-                        name,
-                        version,
-                        target_path.display(),
-                        e
-                    )
-                })
-                .ok()
-            })
-            .await
-            .ok()?
-        })
-        .await
-        .map(|_| ())
-        .ok_or_else(|| anyhow::anyhow!("clone {err_label} failed (see warning log for details)"))
 }
 
 #[cfg(target_os = "macos")]
@@ -572,20 +483,6 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     use super::*;
-
-    #[cfg(windows)]
-    #[test]
-    fn cache_key_normalizes_path_separators() {
-        // install.rs joins lockfile-derived strings (forward slashes) while
-        // pipeline workers go through `Path::join` (backslashes). Both must
-        // produce the same OnceMap key — otherwise concurrent clones race
-        // and Windows raises ERROR_SHARING_VIOLATION.
-        let forward = cache_key(Path::new("node_modules/@scope/pkg/node_modules/dep"));
-        let backward = cache_key(Path::new("node_modules\\@scope\\pkg\\node_modules\\dep"));
-        let mixed = cache_key(Path::new("node_modules/@scope/pkg\\node_modules\\dep"));
-        assert_eq!(forward, backward);
-        assert_eq!(forward, mixed);
-    }
 
     async fn create_test_file(dir: &Path, name: &str, content: &[u8]) -> Result<PathBuf> {
         let path = dir.join(name);

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -1,39 +1,29 @@
 use std::path::PathBuf;
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use once_cell::sync::Lazy;
 use reqwest::{Client, StatusCode};
-use tokio::sync::Semaphore;
 use tokio_retry::RetryIf;
 use utoo_ruborist::http::{file_cache_slot, http_cache_slot};
 use utoo_ruborist::spec::Protocol;
-use utoo_ruborist::util::OnceMap;
 
 use super::cache::get_cache_dir;
 use super::extractor::extract_and_write;
 use super::retry::{RetryableError, build_dns_cached_client, create_retry_strategy};
-use super::user_config::get_manifests_concurrency_limit_sync;
 
-// Global downloader client - no pool limit, concurrency controlled by OnceMap
+// Global downloader client. Concurrency and duplicate work are controlled by
+// the caller's scheduler.
 static DOWNLOADER_CLIENT: Lazy<Client> = Lazy::new(build_dns_cached_client);
-
-/// Global download cache shared between pipeline and install phases.
-/// Key: "name@version", Value: cache path.
-static DOWNLOAD_CACHE: Lazy<OnceMap<String, PathBuf>> = Lazy::new(OnceMap::new);
-
-/// Semaphore controlling concurrent download count.
-static DOWNLOAD_SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
 
 static DOWNLOAD_COUNT: AtomicUsize = AtomicUsize::new(0);
 static REUSE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Process-global counters for tarball outcomes, matching pnpm's
-/// vocabulary. Each unique `(name, version)` pair lands in exactly one
-/// bucket thanks to `DOWNLOAD_CACHE`'s `OnceMap` dedup; git/file/link
-/// packages bypass this path and are not counted in either bucket.
+/// vocabulary. Scheduler-level dedupe keeps each unique `(name, version)` pair
+/// in exactly one bucket; git/file/link packages bypass this path and are not
+/// counted in either bucket.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct DownloadStats {
     /// Tarballs fetched from the registry this run.
@@ -63,6 +53,11 @@ pub fn download_stats() -> DownloadStats {
 /// Check whether a tarball URL refers to a git-resolved package.
 pub fn is_git_url(url: &str) -> bool {
     matches!(url.parse::<Protocol>(), Ok(Protocol::Git))
+}
+
+/// Check whether a tarball URL should be fetched by the registry downloader.
+pub fn is_registry_tarball_url(url: &str) -> bool {
+    matches!(url.parse::<Protocol>(), Ok(Protocol::Http))
 }
 
 /// Look up the cache path for a git-resolved package.
@@ -142,71 +137,6 @@ pub async fn resolve_seeded_cache_path(
             .ok_or_else(|| anyhow::anyhow!("file tarball cache not found for {name}@{version}")),
         _ => Ok(http_tarball_cache_lookup(name, tarball_url).await),
     }
-}
-
-/// Resolve the local cache path for a package, downloading if necessary.
-///
-/// The cloner calls this with a fully-qualified URL (never a relative
-/// path) — the install loop is responsible for any lockfile-format
-/// rewriting before we get here.
-pub async fn resolve_cache_path(name: &str, version: &str, tarball_url: &str) -> Option<PathBuf> {
-    match resolve_seeded_cache_path(name, version, tarball_url).await {
-        Ok(Some(path)) => Some(path),
-        Ok(None) => download_to_cache(name, version, tarball_url).await,
-        Err(e) => {
-            tracing::warn!("{e:#}");
-            None
-        }
-    }
-}
-
-/// Download a registry tarball to the global cache directory, returning the cache path.
-///
-/// Uses `OnceMap` to deduplicate: the same `name@version` is only downloaded once,
-/// even when called concurrently from multiple tasks (pipeline workers, install phase, etc.).
-///
-/// For git-resolved packages, use [`resolve_cache_path`] instead.
-pub async fn download_to_cache(name: &str, version: &str, tarball_url: &str) -> Option<PathBuf> {
-    let key = format!("{}@{}", name, version);
-
-    // Skip the param clones + future construction on cache hit.
-    if let Some(cache_path) = DOWNLOAD_CACHE.get(&key) {
-        return Some((*cache_path).clone());
-    }
-
-    let name = name.to_string();
-    let version = version.to_string();
-    let tarball_url = tarball_url.to_string();
-
-    DOWNLOAD_CACHE
-        .get_or_init(key, || async move {
-            if let Ok(Some(cache_path)) = registry_cache_lookup(&name, &version).await {
-                return Some(cache_path);
-            }
-
-            // Download (semaphore controlled). Permit held through extract
-            // — A/B-revert experiment to test if early permit release is
-            // the source of utoo p0 σ being ~2× baseline.
-            let semaphore = DOWNLOAD_SEMAPHORE
-                .get_or_init(|| Semaphore::new(get_manifests_concurrency_limit_sync()));
-            let _permit = semaphore.acquire().await.ok()?;
-            download_and_extract_to_cache(&name, &version, &tarball_url)
-                .await
-                .inspect_err(|e| {
-                    tracing::warn!(
-                        "Download/extract {}@{} from {} into {}: {:#}",
-                        name,
-                        version,
-                        tarball_url,
-                        registry_cache_path(&name, &version).display(),
-                        e
-                    )
-                })
-                .ok()
-        })
-        .await
-        .as_deref()
-        .cloned()
 }
 
 /// Download and extract a registry tarball without global single-flight or

--- a/crates/ruborist/src/resolver/http.rs
+++ b/crates/ruborist/src/resolver/http.rs
@@ -5,11 +5,11 @@
 //! A naive "just parse the manifest in BFS, let pm re-download at install
 //! time" design looks simpler but has two problems:
 //!
-//! 1. **Cache-slot collision**. pm's `download_to_cache` keys on
-//!    `<name>/<version>/`. A URL-supplied tarball can self-declare any
-//!    `name@version`, so an attacker-controlled URL can poison the same
-//!    slot the npm registry uses for `lodash@4.17.21`. There is no
-//!    `dist.integrity` to verify against on cache hit.
+//! 1. **Cache-slot collision**. Registry tarballs use `<name>/<version>/`.
+//!    A URL-supplied tarball can self-declare any `name@version`, so an
+//!    attacker-controlled URL can poison the same slot the npm registry uses
+//!    for `lodash@4.17.21`. There is no `dist.integrity` to verify against on
+//!    cache hit.
 //!
 //! 2. **Double download**. BFS downloads the tarball to read its manifest,
 //!    then throws the bytes away; install downloads the same URL again to
@@ -19,9 +19,9 @@
 //! `<cache>/<name>/_http_<sha256(url)[:16]>/`. URL is the natural content
 //! address (there is no etag/integrity to rely on, but the URL is what the
 //! user committed to in package.json), so it plays the same role `<sha>`
-//! plays for git. Install's `resolve_cache_path` checks this slot *before*
-//! falling through to the registry cache path, so registry tarballs stay
-//! unchanged while HTTP tarballs never re-download.
+//! plays for git. Install's scheduler checks this slot *before* falling
+//! through to the registry cache path, so registry tarballs stay unchanged
+//! while HTTP tarballs never re-download.
 //!
 //! Same-URL content changes **are not detected** — npm-land convention is
 //! that tarball URLs are immutable. Users who break that rotate the URL or
@@ -54,11 +54,11 @@
 //!  │  ResolvedPackage { dist.tarball = url, … }    ── bytes dropped here      │
 //!  └───────│──────────────────────────────────────────────────────────────────┘
 //!          ▼  (lockfile)
-//!  ┌── Install phase (pm/util/downloader.rs) ─────────────────────────────────┐
-//!  │  resolve_cache_path(name, version, url)                                  │
+//!  ┌── Install phase (pm/service/install_scheduler.rs) ───────────────────────┐
+//!  │  resolve_seeded_cache_path(name, version, url)                           │
 //!  │       ├─ is_git_url?           → git_cache_lookup                        │
 //!  │       ├─ http_tarball_cache_lookup  → <name>/_http_<hash>/_resolved → ✓ │
-//!  │       └─ (fall through)        → download_to_cache  (registry path)     │
+//!  │       └─ (fall through)        → scheduler registry download/extract    │
 //!  │                                                                          │
 //!  │  cloner:  clonefile (mac) / hardlink (linux)                             │
 //!  │       ~/.cache/nm/<name>/_http_<hash>/package/  →  node_modules/<name>/  │
@@ -82,8 +82,6 @@
 //!      (FetchError, classify_reqwest_error, classify_status, retry_strategy)
 //! ```
 //!
-//! [`download_to_cache`]: https://github.com/utooland/utoo/blob/main/crates/pm/src/util/downloader.rs
-
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Summary
- route stale-lock dependency resolution events into the install scheduler
- remove the old compiled downloader/cloner OnceMap fallback now that scheduler owns inflight dedupe
- update HTTP tarball install docs to reference scheduler-owned cache resolution

## Verification
- cargo fmt
- cargo check -p utoo-pm
- cargo test -p utoo-pm service::install_scheduler -- --nocapture
- cargo clippy --all-targets -- -D warnings --no-deps
