### PR TITLE
perf(pm): schedule fresh lock installs

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -66,6 +66,7 @@ pub async fn install_packages(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
     omit: &HashSet<OmitType>,
+    scheduler: Option<&super::install_scheduler::InstallScheduler>,
 ) -> Result<()> {
     use crate::util::cloner::clone_package_once;
 
@@ -144,11 +145,26 @@ pub async fn install_packages(
                     // Check if this is an optional dependency
                     let is_optional =
                         package.optional == Some(true) || package.dev_optional == Some(true);
+                    let scheduler = scheduler.cloned();
 
                     let task = tokio::spawn(async move {
-                        if let Err(e) =
-                            clone_package_once(&name, &version, &resolved, &target_path).await
-                        {
+                        let clone_result = match scheduler {
+                            Some(scheduler) => {
+                                scheduler
+                                    .ensure_clone(
+                                        name.clone(),
+                                        version,
+                                        resolved,
+                                        target_path.clone(),
+                                    )
+                                    .await
+                            }
+                            None => {
+                                clone_package_once(&name, &version, &resolved, &target_path).await
+                            }
+                        };
+
+                        if let Err(e) = clone_result {
                             if is_optional {
                                 tracing::warn!(
                                     "Optional dependency {name} failed (ignored): {e:#}"
@@ -264,9 +280,22 @@ impl InstallService {
         }
 
         let link_start = Instant::now();
-        install_packages(&groups, root_path, omit)
+        let scheduler_handle = if use_fresh_lock {
+            Some(super::install_scheduler::InstallSchedulerHandle::start())
+        } else {
+            None
+        };
+        let scheduler = scheduler_handle.as_ref().map(|handle| handle.scheduler());
+
+        let install_result = install_packages(&groups, root_path, omit, scheduler.as_ref())
             .await
-            .context("Failed to install packages")?;
+            .context("Failed to install packages");
+
+        if let Some(handle) = scheduler_handle {
+            handle.shutdown().await;
+        }
+
+        install_result?;
 
         // Wait for pipeline workers to complete (if any)
         if let Some(handles) = pipeline_handles {

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -1,0 +1,455 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow};
+use bytes::Bytes;
+use futures::stream::{FuturesUnordered, StreamExt};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::util::cloner::clone_package_from_cache_sync;
+use crate::util::downloader::{
+    download_bytes, extract_to_cache, registry_cache_lookup, resolve_seeded_cache_path,
+};
+use crate::util::user_config::get_manifests_concurrency_limit_sync;
+
+#[derive(Clone, Debug)]
+struct PackageFetch {
+    name: String,
+    version: String,
+    tarball_url: String,
+}
+
+impl PackageFetch {
+    fn key(&self) -> String {
+        format!("{}@{}", self.name, self.version)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CloneSpec {
+    package: PackageFetch,
+    target: PathBuf,
+}
+
+struct ReadyClone {
+    spec: CloneSpec,
+    cache_path: PathBuf,
+}
+
+struct DownloadedPackage {
+    package: PackageFetch,
+    bytes: Bytes,
+}
+
+type CloneResponder = oneshot::Sender<Result<(), String>>;
+
+enum Command {
+    EnsureClone(CloneSpec, CloneResponder),
+    Shutdown,
+}
+
+enum OpDone {
+    SeededCache {
+        spec: CloneSpec,
+        result: Result<Option<PathBuf>, String>,
+    },
+    Download {
+        package: PackageFetch,
+        result: Result<DownloadOutcome, String>,
+    },
+    Extract {
+        key: String,
+        result: Result<PathBuf, String>,
+    },
+    Clone {
+        target: PathBuf,
+        result: Result<(), String>,
+    },
+}
+
+enum DownloadOutcome {
+    Cached(PathBuf),
+    Bytes(Bytes),
+}
+
+#[derive(Clone)]
+pub(crate) struct InstallScheduler {
+    tx: mpsc::UnboundedSender<Command>,
+}
+
+pub(crate) struct InstallSchedulerHandle {
+    scheduler: InstallScheduler,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl InstallSchedulerHandle {
+    pub(crate) fn start() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            SchedulerState::new(rx).run().await;
+        });
+        Self {
+            scheduler: InstallScheduler { tx },
+            handle,
+        }
+    }
+
+    pub(crate) fn scheduler(&self) -> InstallScheduler {
+        self.scheduler.clone()
+    }
+
+    pub(crate) async fn shutdown(self) {
+        let _ = self.scheduler.tx.send(Command::Shutdown);
+        if let Err(e) = self.handle.await {
+            tracing::warn!("Install scheduler task failed: {e}");
+        }
+    }
+}
+
+impl InstallScheduler {
+    pub(crate) async fn ensure_clone(
+        &self,
+        name: String,
+        version: String,
+        tarball_url: String,
+        target: PathBuf,
+    ) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(Command::EnsureClone(
+                CloneSpec {
+                    package: PackageFetch {
+                        name,
+                        version,
+                        tarball_url,
+                    },
+                    target,
+                },
+                tx,
+            ))
+            .map_err(|_| anyhow!("install scheduler stopped"))?;
+        rx.await
+            .context("install scheduler stopped before clone completed")?
+            .map_err(anyhow::Error::msg)
+    }
+}
+
+struct SchedulerState {
+    rx: mpsc::UnboundedReceiver<Command>,
+    shutdown: bool,
+    download_limit: usize,
+    extract_limit: usize,
+    clone_limit: usize,
+    download_done: HashMap<String, PathBuf>,
+    download_active: HashSet<String>,
+    download_waiters: HashMap<String, Vec<CloneSpec>>,
+    download_queue: VecDeque<PackageFetch>,
+    extract_active: HashSet<String>,
+    extract_queue: VecDeque<DownloadedPackage>,
+    clone_done: HashSet<PathBuf>,
+    clone_active: HashSet<PathBuf>,
+    clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
+    clone_queue: VecDeque<ReadyClone>,
+    done_tx: mpsc::UnboundedSender<OpDone>,
+    done_rx: mpsc::UnboundedReceiver<OpDone>,
+    ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
+}
+
+impl SchedulerState {
+    fn new(rx: mpsc::UnboundedReceiver<Command>) -> Self {
+        let (done_tx, done_rx) = mpsc::unbounded_channel();
+        Self {
+            rx,
+            shutdown: false,
+            download_limit: get_manifests_concurrency_limit_sync().max(1),
+            extract_limit: extract_concurrency_limit(),
+            clone_limit: clone_concurrency_limit(),
+            download_done: HashMap::new(),
+            download_active: HashSet::new(),
+            download_waiters: HashMap::new(),
+            download_queue: VecDeque::new(),
+            extract_active: HashSet::new(),
+            extract_queue: VecDeque::new(),
+            clone_done: HashSet::new(),
+            clone_active: HashSet::new(),
+            clone_waiters: HashMap::new(),
+            clone_queue: VecDeque::new(),
+            done_tx,
+            done_rx,
+            ops: FuturesUnordered::new(),
+        }
+    }
+
+    async fn run(mut self) {
+        loop {
+            self.pump_downloads();
+            self.pump_extracts();
+            self.pump_clones();
+
+            if self.shutdown && self.is_idle() {
+                break;
+            }
+
+            tokio::select! {
+                command = self.rx.recv(), if !self.shutdown => {
+                    match command {
+                        Some(Command::EnsureClone(spec, responder)) => {
+                            self.queue_clone(spec, Some(responder));
+                        }
+                        Some(Command::Shutdown) | None => {
+                            self.shutdown = true;
+                        }
+                    }
+                }
+                done = self.ops.next(), if !self.ops.is_empty() => {
+                    match done {
+                        Some(Ok(done)) => self.handle_done(done),
+                        Some(Err(e)) => tracing::warn!("Install scheduler worker failed: {e}"),
+                        None => {}
+                    }
+                }
+                done = self.done_rx.recv() => {
+                    if let Some(done) = done {
+                        self.handle_done(done);
+                    }
+                }
+            }
+        }
+
+        self.fail_pending("install scheduler stopped before work completed");
+    }
+
+    fn is_idle(&self) -> bool {
+        self.download_queue.is_empty()
+            && self.extract_queue.is_empty()
+            && self.clone_queue.is_empty()
+            && self.download_active.is_empty()
+            && self.extract_active.is_empty()
+            && self.clone_active.is_empty()
+            && self.ops.is_empty()
+    }
+
+    fn queue_clone(&mut self, spec: CloneSpec, responder: Option<CloneResponder>) {
+        let target = spec.target.clone();
+        if self.clone_done.contains(&target) {
+            if let Some(responder) = responder {
+                let _ = responder.send(Ok(()));
+            }
+            return;
+        }
+
+        if let Some(waiters) = self.clone_waiters.get_mut(&target) {
+            if let Some(responder) = responder {
+                waiters.push(responder);
+            }
+            return;
+        }
+
+        self.clone_waiters
+            .insert(target.clone(), responder.into_iter().collect());
+
+        self.resolve_cache_for_clone(spec);
+    }
+
+    fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
+        let task_spec = spec.clone();
+        self.ops.push(tokio::spawn(async move {
+            let result = resolve_seeded_cache_path(
+                &task_spec.package.name,
+                &task_spec.package.version,
+                &task_spec.package.tarball_url,
+            )
+            .await
+            .map_err(|e| format!("{e:#}"));
+            OpDone::SeededCache { spec, result }
+        }));
+    }
+
+    fn ensure_download(&mut self, package: PackageFetch, waiter: Option<CloneSpec>) {
+        let key = package.key();
+        if let Some(cache_path) = self.download_done.get(&key).cloned() {
+            if let Some(spec) = waiter {
+                self.clone_queue.push_back(ReadyClone { spec, cache_path });
+            }
+            return;
+        }
+
+        if let Some(waiters) = self.download_waiters.get_mut(&key) {
+            if let Some(spec) = waiter {
+                waiters.push(spec);
+            }
+            return;
+        }
+
+        self.download_waiters
+            .insert(key, waiter.into_iter().collect());
+        self.download_queue.push_back(package);
+    }
+
+    fn pump_downloads(&mut self) {
+        while self.download_active.len() < self.download_limit
+            && self.extract_backlog() < self.download_limit
+        {
+            let Some(package) = self.download_queue.pop_front() else {
+                break;
+            };
+            let key = package.key();
+            if self.download_done.contains_key(&key) || !self.download_active.insert(key.clone()) {
+                continue;
+            }
+
+            self.ops.push(tokio::spawn(async move {
+                let result = match registry_cache_lookup(&package.name, &package.version).await {
+                    Ok(Some(cache_path)) => Ok(DownloadOutcome::Cached(cache_path)),
+                    Ok(None) => download_bytes(&package.tarball_url)
+                        .await
+                        .map(DownloadOutcome::Bytes)
+                        .map_err(|e| format!("{e:#}")),
+                    Err(e) => Err(format!("{e:#}")),
+                };
+                OpDone::Download { package, result }
+            }));
+        }
+    }
+
+    fn extract_backlog(&self) -> usize {
+        self.extract_queue.len() + self.extract_active.len()
+    }
+
+    fn pump_extracts(&mut self) {
+        while self.extract_active.len() < self.extract_limit {
+            let Some(downloaded) = self.extract_queue.pop_front() else {
+                break;
+            };
+            let key = downloaded.package.key();
+            if self.download_done.contains_key(&key) || !self.extract_active.insert(key.clone()) {
+                continue;
+            }
+
+            self.ops.push(tokio::spawn(async move {
+                let result = extract_to_cache(
+                    &downloaded.package.name,
+                    &downloaded.package.version,
+                    downloaded.bytes,
+                )
+                .await
+                .map_err(|e| format!("{e:#}"));
+                OpDone::Extract { key, result }
+            }));
+        }
+    }
+
+    fn pump_clones(&mut self) {
+        while self.clone_active.len() < self.clone_limit {
+            let Some(job) = self.clone_queue.pop_front() else {
+                break;
+            };
+            let target = job.spec.target.clone();
+            if self.clone_done.contains(&target) || !self.clone_active.insert(target.clone()) {
+                continue;
+            }
+
+            let done_tx = self.done_tx.clone();
+            rayon::spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    clone_package_from_cache_sync(
+                        &job.spec.package.name,
+                        &job.spec.package.version,
+                        &job.spec.package.tarball_url,
+                        &job.cache_path,
+                        &job.spec.target,
+                    )
+                    .map_err(|e| format!("{e:#}"))
+                }))
+                .unwrap_or_else(|_| Err("install clone worker panicked".to_string()));
+                let _ = done_tx.send(OpDone::Clone { target, result });
+            });
+        }
+    }
+
+    fn handle_done(&mut self, done: OpDone) {
+        match done {
+            OpDone::SeededCache { spec, result } => match result {
+                Ok(Some(cache_path)) => self.clone_queue.push_back(ReadyClone { spec, cache_path }),
+                Ok(None) => self.ensure_download(spec.package.clone(), Some(spec)),
+                Err(error) => self.complete_clone(spec.target, Err(error)),
+            },
+            OpDone::Download { package, result } => {
+                let key = package.key();
+                self.download_active.remove(&key);
+                match result {
+                    Ok(DownloadOutcome::Cached(cache_path)) => {
+                        self.complete_download(key, Ok(cache_path));
+                    }
+                    Ok(DownloadOutcome::Bytes(bytes)) => {
+                        self.extract_queue
+                            .push_back(DownloadedPackage { package, bytes });
+                    }
+                    Err(error) => {
+                        self.complete_download(key, Err(error));
+                    }
+                }
+            }
+            OpDone::Extract { key, result } => {
+                self.extract_active.remove(&key);
+                self.complete_download(key, result);
+            }
+            OpDone::Clone { target, result } => {
+                self.clone_active.remove(&target);
+                self.complete_clone(target, result);
+            }
+        }
+    }
+
+    fn complete_download(&mut self, key: String, result: Result<PathBuf, String>) {
+        let waiters = self.download_waiters.remove(&key).unwrap_or_default();
+        match result {
+            Ok(cache_path) => {
+                self.download_done.insert(key, cache_path.clone());
+                for spec in waiters {
+                    self.clone_queue.push_back(ReadyClone {
+                        spec,
+                        cache_path: cache_path.clone(),
+                    });
+                }
+            }
+            Err(error) => {
+                for spec in waiters {
+                    self.complete_clone(spec.target, Err(error.clone()));
+                }
+            }
+        }
+    }
+
+    fn complete_clone(&mut self, target: PathBuf, result: Result<(), String>) {
+        if result.is_ok() {
+            self.clone_done.insert(target.clone());
+        }
+
+        if let Some(waiters) = self.clone_waiters.remove(&target) {
+            for waiter in waiters {
+                let _ = waiter.send(result.clone());
+            }
+        }
+    }
+
+    fn fail_pending(&mut self, message: &str) {
+        for (_, waiters) in self.clone_waiters.drain() {
+            for waiter in waiters {
+                let _ = waiter.send(Err(message.to_string()));
+            }
+        }
+    }
+}
+
+fn clone_concurrency_limit() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| (n.get() * 2).clamp(4, 16))
+        .unwrap_or(8)
+}
+
+fn extract_concurrency_limit() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().clamp(2, 8))
+        .unwrap_or(4)
+}

--- a/crates/pm/src/service/mod.rs
+++ b/crates/pm/src/service/mod.rs
@@ -6,6 +6,7 @@ pub mod dependency_graph;
 pub mod execute;
 pub mod init;
 pub mod install;
+pub mod install_scheduler;
 pub mod package;
 pub mod package_management;
 pub mod pipeline;


### PR DESCRIPTION
## Summary
- add the install scheduler core for fresh-lock clone materialization
- route fresh-lock installs through scheduler-owned download/extract/clone dedupe
- keep stale-lock resolver pipeline unchanged in this step so the split stays reviewable

## Verification
- cargo fmt
- cargo check -p utoo-pm
- cargo clippy --all-targets -- -D warnings --no-deps
