### PR TITLE
ci(pack): use trusted publish by oidc

### DIFF
--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: 20
+          node-version: 22.14.0
       - name: Install
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}

--- a/.github/workflows/pack-integration.yml
+++ b/.github/workflows/pack-integration.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.14.0
 
       - name: Setup Utoo
         uses: utooland/setup-utoo@v1

--- a/.github/workflows/pack-perf.yml
+++ b/.github/workflows/pack-perf.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.14.0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -81,7 +81,7 @@ jobs:
               git config --system core.longpaths true &&
               npm run build:binding --workspace=@utoo/pack -- --target x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
-    name: utoopack-release-${{ matrix.settings.target }} - node@20
+    name: utoopack-release-${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -105,7 +105,7 @@ jobs:
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: 20
+          node-version: 22.14.0
       - name: Install
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.14.0
           registry-url: "https://registry.npmjs.org"
       - name: Setup Utoo
         uses: utooland/setup-utoo@v1
@@ -205,6 +205,8 @@ jobs:
           TAG_NAME="${{ github.event.release.tag_name }}"
           VERSION=${TAG_NAME#utoopack-v}
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: NPM Publish
         run: |
           echo "${VERSION}"

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -166,6 +166,10 @@ jobs:
     if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'utoopack-v')
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
     needs:
       - build
     steps:
@@ -174,6 +178,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: "https://registry.npmjs.org"
       - name: Setup Utoo
         uses: utooland/setup-utoo@v1
 
@@ -202,9 +207,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: NPM Publish
         run: |
-          # npm config set provenance true
-          echo "${VERSION}" &&
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc &&
+          echo "${VERSION}"
 
           TAG="latest"
           if [[ "$VERSION" == *"-"* ]]; then
@@ -223,4 +226,3 @@ jobs:
           npm publish --workspace=@utoo/pack-cli --access public --tag "${TAG}"
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   ],
   "repository": "https://github.com/utooland/utoo",
   "engines": {
-    "install-node": "20"
+    "install-node": "22"
   }
 }

--- a/packages/utoo-web/package.json
+++ b/packages/utoo-web/package.json
@@ -41,7 +41,7 @@
     "node-stdlib-browser": "^1.3.1",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
-    "webpack": "^5.0.0",
+    "webpack": "5.106.0",
     "webpack-merge": "^6.0.1",
     "yargs": "^18.0.0"
   },


### PR DESCRIPTION


## Summary

use npm trusted publish for pack-release:

<img width="2544" height="1210" alt="image" src="https://github.com/user-attachments/assets/be3f1a39-c78f-497c-9de5-2337c7e5b6b7" />


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
