### PR TITLE
ci(pack): migrate npm publishing to OIDC with provenance

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -209,6 +209,8 @@ jobs:
         run: npm install -g npm@11.6.2
       - name: NPM Publish
         run: |
+          set -euo pipefail
+
           echo "${VERSION}"
 
           TAG="latest"

--- a/packages/pack-cli/package.json
+++ b/packages/pack-cli/package.json
@@ -3,6 +3,11 @@
   "description": "Utoo pack cli",
   "version": "1.3.1",
   "author": "xusd320",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack-cli"
+  },
   "bin": {
     "up": "./bin/run.js"
   },

--- a/packages/pack-shared/package.json
+++ b/packages/pack-shared/package.json
@@ -39,5 +39,9 @@
   },
   "author": "xusd320",
   "license": "MIT",
-  "repository": "git@github.com:utooland/utoo.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack-shared"
+  }
 }

--- a/packages/pack/npm/darwin-arm64/package.json
+++ b/packages/pack/npm/darwin-arm64/package.json
@@ -12,6 +12,11 @@
     "pack.darwin-arm64.node"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack"
+  },
   "engines": {
     "node": ">= 20"
   }

--- a/packages/pack/npm/darwin-x64/package.json
+++ b/packages/pack/npm/darwin-x64/package.json
@@ -12,6 +12,11 @@
     "pack.darwin-x64.node"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack"
+  },
   "engines": {
     "node": ">= 20"
   }

--- a/packages/pack/npm/linux-arm64-gnu/package.json
+++ b/packages/pack/npm/linux-arm64-gnu/package.json
@@ -12,6 +12,11 @@
     "pack.linux-arm64-gnu.node"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack"
+  },
   "engines": {
     "node": ">= 20"
   },

--- a/packages/pack/npm/linux-arm64-musl/package.json
+++ b/packages/pack/npm/linux-arm64-musl/package.json
@@ -12,6 +12,11 @@
     "pack.linux-arm64-musl.node"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack"
+  },
   "engines": {
     "node": ">= 20"
   },

--- a/packages/pack/npm/linux-x64-gnu/package.json
+++ b/packages/pack/npm/linux-x64-gnu/package.json
@@ -12,6 +12,11 @@
     "pack.linux-x64-gnu.node"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack"
+  },
   "engines": {
     "node": ">= 20"
   },

--- a/packages/pack/npm/linux-x64-musl/package.json
+++ b/packages/pack/npm/linux-x64-musl/package.json
@@ -12,6 +12,11 @@
     "pack.linux-x64-musl.node"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack"
+  },
   "engines": {
     "node": ">= 20"
   },

--- a/packages/pack/npm/win32-x64-msvc/package.json
+++ b/packages/pack/npm/win32-x64-msvc/package.json
@@ -12,6 +12,11 @@
     "pack.win32-x64-msvc.node"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack"
+  },
   "engines": {
     "node": ">= 20"
   }

--- a/packages/pack/package.json
+++ b/packages/pack/package.json
@@ -90,5 +90,9 @@
     "version": "napi version",
     "generate-features-list": "node ./scripts/generate-feature-list.js"
   },
-  "repository": "git@github.com:utooland/utoo.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/utooland/utoo",
+    "directory": "packages/pack"
+  }
 }


### PR DESCRIPTION

## Summary

fix:

<img width="3004" height="866" alt="image" src="https://github.com/user-attachments/assets/e565a67f-ff4b-4f1d-b424-e7f77b5cad74" />


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
