### PR TITLE
ci(pm): stabilize pm review stack

### DIFF
--- a/.github/workflows/pm-ci.yml
+++ b/.github/workflows/pm-ci.yml
@@ -56,7 +56,12 @@ jobs:
       - name: Disable Windows Defender
         if: runner.os == 'Windows'
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       
       # Add: Configure Git longpaths on Windows
       - name: Configure Git (Windows)

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -133,6 +133,7 @@ jobs:
           targets: x86_64-unknown-linux-gnu
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-linux
           cache-bin: false
@@ -200,6 +201,7 @@ jobs:
           targets: aarch64-apple-darwin
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-mac-arm64
           cache-bin: false
@@ -232,6 +234,7 @@ jobs:
         run: rustup target add x86_64-apple-darwin
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-mac-x64
           cache-bin: false
@@ -269,6 +272,7 @@ jobs:
           targets: x86_64-pc-windows-msvc
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-windows
           cache-bin: false

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -254,7 +254,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Disable Windows Defender
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       - name: Init git submodules
         run: git submodule update --init --recursive --depth 1
       - name: Setup Rust toolchain
@@ -408,7 +413,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Disable Windows Defender
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/crates/pm/src/cmd/view.rs
+++ b/crates/pm/src/cmd/view.rs
@@ -10,6 +10,11 @@ use crate::util::user_config::get_registry;
 
 /// View package information from registry, similar to npm view
 pub async fn view(package_spec: &str) -> Result<()> {
+    let registry_url = get_registry();
+    view_with_registry(package_spec, &registry_url).await
+}
+
+async fn view_with_registry(package_spec: &str, registry_url: &str) -> Result<()> {
     tracing::debug!("Viewing package: {package_spec}");
 
     // Parse package specification
@@ -18,9 +23,8 @@ pub async fn view(package_spec: &str) -> Result<()> {
     tracing::debug!("Resolved package: {name} (spec: {version_spec})");
 
     // Fetch full manifest directly from registry (Complete format for display, no ETag)
-    let registry_url = get_registry();
     let (full_manifest, _etag) =
-        fetch_full_manifest_fresh(&registry_url, name, MetadataFormat::Complete)
+        fetch_full_manifest_fresh(registry_url, name, MetadataFormat::Complete)
             .await
             .map_err(|e| anyhow!("Failed to fetch package info for {}: {}", package_spec, e))?;
 
@@ -356,12 +360,41 @@ mod tests {
     /// because the registry service used ETag caching.
     #[tokio::test]
     async fn test_view_twice_no_304_error() {
+        use mockito::Matcher;
+
+        let mut server = mockito::Server::new_async().await;
+        let manifest = r#"{
+            "name": "is-odd",
+            "description": "mock package",
+            "dist-tags": { "latest": "1.0.0" },
+            "versions": {
+                "1.0.0": {
+                    "name": "is-odd",
+                    "version": "1.0.0",
+                    "description": "mock package",
+                    "dist": {}
+                }
+            }
+        }"#;
+        let mock = server
+            .mock("GET", "/is-odd")
+            .match_header("accept", "application/json")
+            .match_header("if-none-match", Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("etag", "\"mock-etag\"")
+            .with_body(manifest)
+            .expect(2)
+            .create_async()
+            .await;
+
         // First view - should succeed
-        let result1 = view("is-odd").await;
+        let result1 = view_with_registry("is-odd", &server.url()).await;
         assert!(result1.is_ok(), "First view failed: {:?}", result1.err());
 
         // Second view - should also succeed (not fail with 304 error)
-        let result2 = view("is-odd").await;
+        let result2 = view_with_registry("is-odd", &server.url()).await;
         assert!(result2.is_ok(), "Second view failed: {:?}", result2.err());
+        mock.assert_async().await;
     }
 }


### PR DESCRIPTION
## Summary
- Stabilize PM CI before the resolver/installer review stack.
- Make `view` registry behavior hermetic in tests.
- Make Windows Defender setup and cargo cache restore best-effort.

## Verification
- Covered by downstream stack verification on resolver and installer top branches.