### PR TITLE
perf(pm): add resolver provider foundation

### DIFF
--- a/.github/workflows/pm-ci.yml
+++ b/.github/workflows/pm-ci.yml
@@ -56,7 +56,12 @@ jobs:
       - name: Disable Windows Defender
         if: runner.os == 'Windows'
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       
       # Add: Configure Git longpaths on Windows
       - name: Configure Git (Windows)

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -133,6 +133,7 @@ jobs:
           targets: x86_64-unknown-linux-gnu
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-linux
           cache-bin: false
@@ -200,6 +201,7 @@ jobs:
           targets: aarch64-apple-darwin
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-mac-arm64
           cache-bin: false
@@ -232,6 +234,7 @@ jobs:
         run: rustup target add x86_64-apple-darwin
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-mac-x64
           cache-bin: false
@@ -269,6 +272,7 @@ jobs:
           targets: x86_64-pc-windows-msvc
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-windows
           cache-bin: false

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -254,7 +254,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Disable Windows Defender
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       - name: Init git submodules
         run: git submodule update --init --recursive --depth 1
       - name: Setup Rust toolchain
@@ -408,7 +413,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Disable Windows Defender
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/crates/pm/src/cmd/view.rs
+++ b/crates/pm/src/cmd/view.rs
@@ -10,6 +10,11 @@ use crate::util::user_config::get_registry;
 
 /// View package information from registry, similar to npm view
 pub async fn view(package_spec: &str) -> Result<()> {
+    let registry_url = get_registry();
+    view_with_registry(package_spec, &registry_url).await
+}
+
+async fn view_with_registry(package_spec: &str, registry_url: &str) -> Result<()> {
     tracing::debug!("Viewing package: {package_spec}");
 
     // Parse package specification
@@ -18,9 +23,8 @@ pub async fn view(package_spec: &str) -> Result<()> {
     tracing::debug!("Resolved package: {name} (spec: {version_spec})");
 
     // Fetch full manifest directly from registry (Complete format for display, no ETag)
-    let registry_url = get_registry();
     let (full_manifest, _etag) =
-        fetch_full_manifest_fresh(&registry_url, name, MetadataFormat::Complete)
+        fetch_full_manifest_fresh(registry_url, name, MetadataFormat::Complete)
             .await
             .map_err(|e| anyhow!("Failed to fetch package info for {}: {}", package_spec, e))?;
 
@@ -356,12 +360,41 @@ mod tests {
     /// because the registry service used ETag caching.
     #[tokio::test]
     async fn test_view_twice_no_304_error() {
+        use mockito::Matcher;
+
+        let mut server = mockito::Server::new_async().await;
+        let manifest = r#"{
+            "name": "is-odd",
+            "description": "mock package",
+            "dist-tags": { "latest": "1.0.0" },
+            "versions": {
+                "1.0.0": {
+                    "name": "is-odd",
+                    "version": "1.0.0",
+                    "description": "mock package",
+                    "dist": {}
+                }
+            }
+        }"#;
+        let mock = server
+            .mock("GET", "/is-odd")
+            .match_header("accept", "application/json")
+            .match_header("if-none-match", Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("etag", "\"mock-etag\"")
+            .with_body(manifest)
+            .expect(2)
+            .create_async()
+            .await;
+
         // First view - should succeed
-        let result1 = view("is-odd").await;
+        let result1 = view_with_registry("is-odd", &server.url()).await;
         assert!(result1.is_ok(), "First view failed: {:?}", result1.err());
 
         // Second view - should also succeed (not fail with 304 error)
-        let result2 = view("is-odd").await;
+        let result2 = view_with_registry("is-odd", &server.url()).await;
         assert!(result2.is_ok(), "Second view failed: {:?}", result2.err());
+        mock.assert_async().await;
     }
 }

--- a/crates/pm/src/helper/ruborist_context.rs
+++ b/crates/pm/src/helper/ruborist_context.rs
@@ -12,7 +12,8 @@ use crate::util::logger::ProgressReceiver;
 use crate::util::manifest_store::DiskManifestStore;
 use crate::util::project_cache;
 use crate::util::user_config::{
-    get_catalogs, get_manifests_concurrency_limit, get_peer_deps, get_registry, get_supports_semver,
+    get_catalogs, get_peer_deps, get_registry, get_resolver_manifests_concurrency_limit,
+    get_supports_semver,
 };
 
 /// Tokio-based glob implementation.
@@ -57,7 +58,7 @@ impl Context {
             cache_dir: Some(get_cache_dir()),
             manifest_store: Self::manifest_store(),
             warm_project_cache,
-            concurrency: get_manifests_concurrency_limit().await,
+            concurrency: get_resolver_manifests_concurrency_limit().await,
             peer_deps: get_peer_deps().await,
             glob: TokioGlob,
             receiver,

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -92,7 +92,7 @@ struct Cli {
     #[arg(long, global = true, action = clap::ArgAction::SetTrue)]
     legacy_peer_deps: Option<bool>,
 
-    /// Maximum concurrent manifest fetches (default: 64)
+    /// Maximum concurrent manifest fetches (default: 64; npmjs/non-semver resolver: 256)
     #[arg(long, global = true)]
     manifests_concurrency_limit: Option<usize>,
 

--- a/crates/pm/src/service/pipeline/receiver.rs
+++ b/crates/pm/src/service/pipeline/receiver.rs
@@ -123,7 +123,7 @@ mod tests {
         }));
 
         // Should not forward other events
-        receiver.on_event(BuildEvent::PreloadStart { count: 10 });
+        receiver.on_event(BuildEvent::LevelStart { node_count: 10 });
 
         // Only one message should be in the download channel
         assert!(channels.download_rx.try_recv().is_ok());

--- a/crates/pm/src/util/json.rs
+++ b/crates/pm/src/util/json.rs
@@ -1,9 +1,6 @@
-use std::fs::File;
-use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 /// Read and parse a JSON file into the specified type.
@@ -13,34 +10,6 @@ pub async fn read_json_file<T: DeserializeOwned>(path: &Path) -> Result<T> {
         .with_context(|| format!("Failed to read file {path:?}"))?;
 
     serde_json::from_slice(&bytes).with_context(|| format!("Failed to parse JSON from {path:?}"))
-}
-
-/// Serialize `value` as compact JSON and stream it to `path` through a
-/// [`BufWriter`], skipping the intermediate `Vec<u8>` that
-/// `serde_json::to_vec` + `std::fs::write` would allocate.
-///
-/// Synchronous on purpose: the caller in [`crate::util::manifest_store`] runs
-/// it on a dedicated OS thread so manifest persistence never touches the
-/// async runtime's worker or blocking pool. Async callers should wrap this
-/// in `tokio::task::spawn_blocking` (or write the async-aware counterpart
-/// when one is needed).
-///
-/// The parent directory of `path` must already exist; this helper does *not*
-/// `mkdir -p`. The cost-benefit of "try the write first, recover on
-/// `NotFound`" is policy-level (warm-cache rewrites want to skip the extra
-/// syscall every time), so the recovery loop lives at the call site, not
-/// here. A missing parent surfaces as [`io::ErrorKind::NotFound`] for the
-/// caller to match on.
-///
-/// Serialization failures — rare for `derive(Serialize)` types, possible for
-/// hand-written impls or maps with non-string keys — are folded into
-/// [`io::Error`] via [`io::Error::other`] so the whole API speaks one error
-/// type and callers can keep matching on [`io::ErrorKind`].
-pub fn write_compact_sync<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
-    let file = File::create(path)?;
-    let mut writer = BufWriter::new(file);
-    serde_json::to_writer(&mut writer, value).map_err(io::Error::other)?;
-    writer.flush()
 }
 
 /// Load package.json from a directory path and deserialize into the caller's
@@ -164,35 +133,6 @@ mod tests {
         // Last value wins, matching JSON.parse semantics
         assert_eq!(view.scripts.get("prepublish").unwrap(), "node build.js");
         assert_eq!(view.scripts.get("test").unwrap(), "node build/test.js");
-    }
-
-    #[tokio::test]
-    async fn write_compact_sync_round_trips_through_read_json_file() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("out.json");
-        let value = json!({
-            "name": "test",
-            "version": "1.0.0",
-            "deps": ["a", "b", "c"],
-        });
-
-        super::write_compact_sync(&path, &value).unwrap();
-
-        let read_back: Value = read_json_file(&path).await.unwrap();
-        assert_eq!(read_back, value);
-
-        // Compact form: no inter-token whitespace.
-        let raw = std::fs::read_to_string(&path).unwrap();
-        assert!(!raw.contains(": "));
-        assert!(!raw.contains(", "));
-    }
-
-    #[test]
-    fn write_compact_sync_requires_existing_parent_directory() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("missing").join("out.json");
-        let err = super::write_compact_sync(&path, &json!({})).unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[tokio::test]

--- a/crates/pm/src/util/logger.rs
+++ b/crates/pm/src/util/logger.rs
@@ -219,21 +219,6 @@ impl utoo_ruborist::progress::EventReceiver for ProgressReceiver {
         }
         use utoo_ruborist::progress::BuildEvent;
         match event {
-            BuildEvent::PreloadStart { count } | BuildEvent::PreloadQueued { count } => {
-                PROGRESS_BAR.inc_length(count as u64);
-            }
-            BuildEvent::PreloadFetching { name } => {
-                log_progress(&format!("fetching {}", name));
-            }
-            BuildEvent::PreloadProgress { name, .. } => {
-                PROGRESS_BAR.inc(1);
-                log_progress(&format!("resolved {}", name));
-            }
-            BuildEvent::PreloadComplete { success, failed } => {
-                PROGRESS_BAR.set_position(0);
-                PROGRESS_BAR.set_length(0);
-                log_progress(&format!("preload: {} ok, {} failed", success, failed));
-            }
             BuildEvent::DependencyCount { count } => {
                 PROGRESS_BAR.inc_length(count as u64);
             }

--- a/crates/pm/src/util/manifest_store.rs
+++ b/crates/pm/src/util/manifest_store.rs
@@ -11,11 +11,9 @@
 //! Serialization and file writes run on a dedicated writer thread so manifest
 //! persistence does not occupy async runtime workers or Tokio's blocking pool.
 
-use std::fs;
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::mpsc::{self, SyncSender, TrySendError};
+use std::sync::mpsc::{self, Sender};
 use std::thread::JoinHandle;
 
 use async_trait::async_trait;
@@ -23,11 +21,7 @@ use serde::Serialize;
 use utoo_ruborist::model::manifest::CoreVersionManifest;
 use utoo_ruborist::service::{ManifestStore, VersionsInfo};
 
-use crate::util::json::{read_json_file, write_compact_sync};
-
-/// Opportunistic writer backlog. If disk stalls beyond this, new cache writes
-/// are dropped instead of letting resolver memory grow without bound.
-const MANIFEST_WRITE_QUEUE_CAPACITY: usize = 1024;
+use crate::util::json::read_json_file;
 
 pub struct DiskManifestStore {
     cache_dir: PathBuf,
@@ -112,13 +106,13 @@ enum ManifestWriteJob {
 }
 
 struct ManifestWriter {
-    tx: SyncSender<ManifestWriteJob>,
+    tx: Sender<ManifestWriteJob>,
     handle: JoinHandle<()>,
 }
 
 impl ManifestWriter {
     fn spawn() -> Self {
-        let (tx, rx) = mpsc::sync_channel(MANIFEST_WRITE_QUEUE_CAPACITY);
+        let (tx, rx) = mpsc::channel();
         let handle = std::thread::Builder::new()
             .name("utoo-manifest-store".to_string())
             .spawn(move || {
@@ -138,14 +132,8 @@ impl ManifestWriter {
     }
 
     fn enqueue(&self, job: ManifestWriteJob) {
-        match self.tx.try_send(job) {
-            Ok(()) => {}
-            Err(TrySendError::Full(_)) => {
-                tracing::debug!("Manifest store writer queue full; dropping cache write");
-            }
-            Err(TrySendError::Disconnected(_)) => {
-                tracing::debug!("Manifest store writer stopped before accepting write");
-            }
+        if self.tx.send(job).is_err() {
+            tracing::debug!("Manifest store writer stopped before accepting write");
         }
     }
 
@@ -157,23 +145,27 @@ impl ManifestWriter {
     }
 }
 
-/// Apply the manifest-cache write policy on top of
-/// [`crate::util::json::write_compact_sync`]: on `NotFound`, create the
-/// parent directory once and retry — this is how the resolver hot path
-/// avoids the up-front `mkdir` syscall on every warm-cache rewrite. All
-/// errors are swallowed at the `debug` log level because the disk cache is
-/// opportunistic; a dropped write only costs a future cache miss.
+/// Serialize `value` and write to `path`. On `NotFound`, create the parent
+/// directory and retry once — saves the mkdir syscall on every warm-cache
+/// rewrite. Errors are logged at debug; disk cache is opportunistic.
 fn write_json_sync<T: Serialize>(path: &Path, value: &T) {
-    match write_compact_sync(path, value) {
+    let bytes = match serde_json::to_vec(value) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::debug!("Failed to serialize {path:?}: {e}");
+            return;
+        }
+    };
+    match std::fs::write(path, &bytes) {
         Ok(()) => {}
-        Err(e) if e.kind() == ErrorKind::NotFound => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             if let Some(parent) = path.parent()
-                && let Err(e) = fs::create_dir_all(parent)
+                && let Err(e) = std::fs::create_dir_all(parent)
             {
                 tracing::debug!("Failed to create {parent:?}: {e}");
                 return;
             }
-            if let Err(e) = write_compact_sync(path, value) {
+            if let Err(e) = std::fs::write(path, &bytes) {
                 tracing::debug!("Failed to write {path:?}: {e}");
             }
         }

--- a/crates/pm/src/util/project_cache.rs
+++ b/crates/pm/src/util/project_cache.rs
@@ -1,7 +1,7 @@
 //! Disk persistence for ruborist's project-level manifest cache.
 //!
-//! Stored at `<root>/node_modules/.utoo-manifest.json`. Used to skip the
-//! preload phase on warm installs.
+//! Stored at `<root>/node_modules/.utoo-manifest.json`. Used to warm the
+//! demand resolver's in-memory manifest cache across installs.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/pm/src/util/retry.rs
+++ b/crates/pm/src/util/retry.rs
@@ -30,7 +30,7 @@ pub fn build_dns_cached_client() -> reqwest::Client {
         .read_timeout(std::time::Duration::from_secs(30)) // Timeout for individual read operations
         // No total timeout - large files (e.g. node binary ~100MB) need longer download time
         // No pool_max_idle_per_host - let reqwest manage connections freely
-        // Concurrency is controlled by semaphore in preload service
+        // Concurrency is controlled by each caller's semaphore.
         .build()
         .expect("Failed to build reqwest client")
 }

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -132,16 +132,56 @@ pub fn get_install_scope() -> InstallScope {
     INSTALL_SCOPE.get().copied().unwrap_or_default()
 }
 
-// Manifest fetch concurrency configuration
-static MANIFESTS_CONCURRENCY_LIMIT: LazyLock<ConfigValue<usize>> =
-    LazyLock::new(|| ConfigValue::new("manifests-concurrency-limit", 64));
+// Manifest fetch concurrency configuration.
+//
+// Keep the user-visible/default tarball download limit at 64. Registry
+// resolution can opt into a higher default for non-semver registries via
+// `get_resolver_manifests_concurrency_limit`; tarball download/extract still
+// uses `get_manifests_concurrency_limit_sync` so install IO is not inflated.
+const DEFAULT_MANIFESTS_CONCURRENCY_LIMIT: usize = 64;
+const NON_SEMVER_RESOLVER_CONCURRENCY_LIMIT: usize = 256;
+
+static MANIFESTS_CONCURRENCY_LIMIT: LazyLock<ConfigValue<usize>> = LazyLock::new(|| {
+    ConfigValue::new(
+        "manifests-concurrency-limit",
+        DEFAULT_MANIFESTS_CONCURRENCY_LIMIT,
+    )
+});
+static MANIFESTS_CONCURRENCY_CLI_SET: OnceLock<()> = OnceLock::new();
 
 pub fn set_manifests_concurrency_limit(value: Option<usize>) {
+    if value.is_some() {
+        let _ = MANIFESTS_CONCURRENCY_CLI_SET.set(());
+    }
     MANIFESTS_CONCURRENCY_LIMIT.set(value);
 }
 
 pub async fn get_manifests_concurrency_limit() -> usize {
     MANIFESTS_CONCURRENCY_LIMIT.get().await
+}
+
+fn resolver_manifest_concurrency_limit(
+    configured_limit: usize,
+    cli_set: bool,
+    supports_semver: Option<bool>,
+) -> usize {
+    if !cli_set
+        && configured_limit == DEFAULT_MANIFESTS_CONCURRENCY_LIMIT
+        && supports_semver == Some(false)
+    {
+        NON_SEMVER_RESOLVER_CONCURRENCY_LIMIT
+    } else {
+        configured_limit
+    }
+}
+
+pub async fn get_resolver_manifests_concurrency_limit() -> usize {
+    let limit = get_manifests_concurrency_limit().await;
+    resolver_manifest_concurrency_limit(
+        limit,
+        MANIFESTS_CONCURRENCY_CLI_SET.get().is_some(),
+        get_supports_semver(),
+    )
 }
 
 pub fn get_manifests_concurrency_limit_sync() -> usize {
@@ -356,6 +396,50 @@ mod tests {
         assert!(config.parse_config_value("True"));
         assert!(!config.parse_config_value("false"));
         assert!(!config.parse_config_value("anything"));
+    }
+
+    #[test]
+    fn test_resolver_manifest_concurrency_raises_npmjs_default() {
+        assert_eq!(
+            resolver_manifest_concurrency_limit(
+                DEFAULT_MANIFESTS_CONCURRENCY_LIMIT,
+                false,
+                Some(false),
+            ),
+            NON_SEMVER_RESOLVER_CONCURRENCY_LIMIT
+        );
+    }
+
+    #[test]
+    fn test_resolver_manifest_concurrency_preserves_explicit_limit() {
+        assert_eq!(
+            resolver_manifest_concurrency_limit(32, true, Some(false)),
+            32
+        );
+        assert_eq!(
+            resolver_manifest_concurrency_limit(
+                DEFAULT_MANIFESTS_CONCURRENCY_LIMIT,
+                true,
+                Some(false),
+            ),
+            DEFAULT_MANIFESTS_CONCURRENCY_LIMIT
+        );
+    }
+
+    #[test]
+    fn test_resolver_manifest_concurrency_preserves_semver_default() {
+        assert_eq!(
+            resolver_manifest_concurrency_limit(
+                DEFAULT_MANIFESTS_CONCURRENCY_LIMIT,
+                false,
+                Some(true),
+            ),
+            DEFAULT_MANIFESTS_CONCURRENCY_LIMIT
+        );
+        assert_eq!(
+            resolver_manifest_concurrency_limit(DEFAULT_MANIFESTS_CONCURRENCY_LIMIT, false, None),
+            DEFAULT_MANIFESTS_CONCURRENCY_LIMIT
+        );
     }
 
     #[tokio::test]

--- a/crates/ruborist/src/service/http.rs
+++ b/crates/ruborist/src/service/http.rs
@@ -9,7 +9,7 @@
 //!       |          |                                            |
 //!       |        true (npmmirror)                     false (npmjs.org)
 //!       |          |                                            |
-//!       |   fetch_version_manifest          resolve_full_manifest
+//!       |   fetch version job              fetch full manifest job
 //!       |   GET /{name}/{spec}              GET /{name}
 //!       |   Accept: abbreviated             Accept: abbreviated
 //!       |          |                        + If-None-Match: {etag}
@@ -29,7 +29,7 @@
 //!       v
 //!  +-----------------------------------------------------------------+
 //!  |  http.rs -- HTTP Client  (this file)                            |
-//!  |  global singleton reqwest::Client (LazyLock)                    |
+//!  |  global reqwest::Client pool (LazyLock)                         |
 //!  |  rustls TLS + no_proxy + env proxy + CachingResolver            |
 //!  +-----------------------------------------------------------------+
 //!       |
@@ -76,6 +76,8 @@
 //! WASM targets skip DNS entirely (browser handles it).
 
 use std::sync::LazyLock;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
@@ -85,16 +87,48 @@ use anyhow::{Context, Result, anyhow};
 /// error, which silently-stalled sockets never raise.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Global HTTP client with connection pooling and DNS caching.
+/// Number of independent registry HTTP client pools.
 ///
-/// Stores `Result<Client, String>` so that proxy-configuration errors are
+/// GHA npmjs pcap showed bun spreading resolve traffic across a few
+/// Cloudflare edge IPs while a single reqwest pool concentrated requests on
+/// one IP. Four pools keeps the model small but gives the resolver enough
+/// independent keep-alive pools to fan out when npmjs/full-manifest
+/// concurrency is raised.
+#[cfg(not(target_arch = "wasm32"))]
+const CLIENT_POOL_SIZE: usize = 4;
+
+/// Global HTTP clients with connection pooling and DNS caching.
+///
+/// Stores `Result<Vec<Client>, String>` so that proxy-configuration errors are
 /// surfaced to callers instead of panicking or calling `process::exit`.
+#[cfg(not(target_arch = "wasm32"))]
+static HTTP_CLIENTS: LazyLock<Result<Vec<reqwest::Client>, String>> = LazyLock::new(|| {
+    (0..CLIENT_POOL_SIZE)
+        .map(|_| client_builder().and_then(|b| b.build().context("Failed to build reqwest client")))
+        .collect::<Result<Vec<_>>>()
+        .map_err(|e| e.to_string())
+});
+
+#[cfg(not(target_arch = "wasm32"))]
+static CLIENT_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn get_client() -> Result<&'static reqwest::Client> {
+    let clients = HTTP_CLIENTS.as_ref().map_err(|e| anyhow!("{e}"))?;
+    let idx = CLIENT_COUNTER.fetch_add(1, Ordering::Relaxed) % clients.len();
+    Ok(&clients[idx])
+}
+
+/// WASM targets retain a single browser-backed client; there is no native TCP
+/// connection pool to fan out.
+#[cfg(target_arch = "wasm32")]
 static HTTP_CLIENT: LazyLock<Result<reqwest::Client, String>> = LazyLock::new(|| {
     client_builder()
         .and_then(|b| b.build().context("Failed to build reqwest client"))
         .map_err(|e| e.to_string())
 });
 
+#[cfg(target_arch = "wasm32")]
 pub(crate) fn get_client() -> Result<&'static reqwest::Client> {
     HTTP_CLIENT.as_ref().map_err(|e| anyhow!("{e}"))
 }

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -14,11 +14,13 @@ use super::fetch::{
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
 
-/// Parse JSON bytes on rayon's CPU thread pool (native) or inline
-/// (wasm32). Keeps the tokio runtime free of `simd_json` work so other
-/// in-flight manifest fetches keep driving network IO while this one
-/// parses.
-pub(crate) async fn parse_json_off_runtime<T>(bytes: Bytes) -> Result<T, anyhow::Error>
+/// Parse a JSON buffer on rayon's CPU thread pool (native) or inline
+/// (wasm32). The buffer is consumed because `simd_json` mutates it in-place.
+/// Keeps the tokio runtime free of `simd_json` work so other in-flight
+/// manifest fetches keep driving network IO while this one parses.
+pub(crate) async fn parse_json_vec_off_runtime<T>(
+    mut parse_buf: Vec<u8>,
+) -> Result<T, anyhow::Error>
 where
     T: serde::de::DeserializeOwned + Send + 'static,
 {
@@ -26,7 +28,6 @@ where
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let mut parse_buf = bytes.to_vec();
             let result = simd_json::serde::from_slice::<T>(&mut parse_buf)
                 .map_err(|e| anyhow!("JSON parse error: {e}"));
             let _ = tx.send(result);
@@ -36,7 +37,6 @@ where
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut parse_buf = bytes.to_vec();
         simd_json::serde::from_slice::<T>(&mut parse_buf)
             .map_err(|e| anyhow!("JSON parse error: {e}"))
     }
@@ -71,7 +71,8 @@ pub(crate) async fn parse_full_manifest_off_runtime(
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut manifest: FullManifest = parse_json_off_runtime(raw_bytes.clone()).await?;
+        let mut manifest: FullManifest =
+            parse_json_vec_off_runtime(raw_bytes.clone().to_vec()).await?;
         manifest.raw = raw_bytes;
         Ok(manifest)
     }
@@ -220,6 +221,28 @@ pub async fn fetch_full_manifest_fresh(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+async fn read_body_vec(mut response: reqwest::Response) -> Result<Vec<u8>, FetchError> {
+    let capacity = response
+        .content_length()
+        .and_then(|len| usize::try_from(len).ok())
+        .unwrap_or(0);
+    let mut body = Vec::with_capacity(capacity);
+    while let Some(chunk) = response.chunk().await.map_err(classify_reqwest_error)? {
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn read_body_vec(response: reqwest::Response) -> Result<Vec<u8>, FetchError> {
+    response
+        .bytes()
+        .await
+        .map(|bytes| bytes.to_vec())
+        .map_err(classify_reqwest_error)
+}
+
 /// Options for fetching a version manifest.
 pub struct FetchVersionManifestOptions<'a> {
     pub registry_url: &'a str,
@@ -230,6 +253,17 @@ pub struct FetchVersionManifestOptions<'a> {
 
 /// Fetch version manifest bytes with retry, without parsing.
 pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>) -> Result<Bytes> {
+    fetch_version_manifest_vec(opts).await.map(Bytes::from)
+}
+
+/// Fetch version manifest into a mutable parse buffer with retry.
+///
+/// Unlike full manifests, exact-version manifests do not need to keep raw
+/// response bytes for later extraction. Reading directly into `Vec<u8>` avoids
+/// the hot-path `Bytes -> Vec` copy before `simd_json` parses in place.
+pub(crate) async fn fetch_version_manifest_vec(
+    opts: FetchVersionManifestOptions<'_>,
+) -> Result<Vec<u8>> {
     let url = format!("{}/{}/{}", opts.registry_url, opts.name, opts.spec);
 
     let accept = match opts.format {
@@ -251,7 +285,7 @@ pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>)
                     .map_err(classify_reqwest_error)?;
 
                 if response.status().is_success() {
-                    response.bytes().await.map_err(classify_reqwest_error)
+                    read_body_vec(response).await
                 } else {
                     Err(classify_status(response.status(), &url))
                 }
@@ -271,6 +305,36 @@ pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>)
 pub async fn fetch_version_manifest(
     opts: FetchVersionManifestOptions<'_>,
 ) -> Result<CoreVersionManifest> {
-    let bytes = fetch_version_manifest_bytes(opts).await?;
-    parse_json_off_runtime::<CoreVersionManifest>(bytes).await
+    let bytes = fetch_version_manifest_vec(opts).await?;
+    parse_json_vec_off_runtime::<CoreVersionManifest>(bytes).await
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TinyManifest {
+        name: String,
+        version: String,
+    }
+
+    #[tokio::test]
+    async fn parse_json_vec_off_runtime_consumes_mutable_buffer() {
+        let parsed = parse_json_vec_off_runtime::<TinyManifest>(
+            br#"{"name":"demo","version":"1.0.0"}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            parsed,
+            TinyManifest {
+                name: "demo".to_string(),
+                version: "1.0.0".to_string(),
+            }
+        );
+    }
 }

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -13,6 +13,7 @@ use super::fetch::{
 };
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::resolver::version::resolve_target_version;
 
 /// Parse a JSON buffer on rayon's CPU thread pool (native) or inline
 /// (wasm32). The buffer is consumed because `simd_json` mutates it in-place.
@@ -49,21 +50,44 @@ where
 pub(crate) async fn parse_full_manifest_off_runtime(
     raw_bytes: Bytes,
 ) -> Result<FullManifest, anyhow::Error> {
+    parse_full_manifest_with_core_off_runtime(raw_bytes, None)
+        .await
+        .map(|(manifest, _)| manifest)
+}
+
+pub(crate) type FullManifestParseResult = (FullManifest, Option<(String, CoreVersionManifest)>);
+
+fn parse_full_manifest_with_core_sync(
+    raw_bytes: Bytes,
+    spec: Option<String>,
+) -> Result<FullManifestParseResult, anyhow::Error> {
+    // simd_json mutates the parse buffer; copy inside the worker so
+    // response-body bytes can stay immutable until parsing starts.
+    let mut parse_buf = raw_bytes.to_vec();
+    let mut manifest: FullManifest = simd_json::serde::from_slice::<FullManifest>(&mut parse_buf)
+        .map_err(|e| anyhow!("JSON parse error: {e}"))?;
+    manifest.raw = raw_bytes;
+
+    let speculative = spec.and_then(|spec| {
+        resolve_target_version((&manifest).into(), &spec)
+            .ok()
+            .and_then(|version| manifest.get_core_version(&version).map(|core| (spec, core)))
+    });
+
+    Ok((manifest, speculative))
+}
+
+/// Parse a full wire-fetched manifest and optionally extract the current BFS
+/// edge's version in the same off-runtime worker task.
+pub(crate) async fn parse_full_manifest_with_core_off_runtime(
+    raw_bytes: Bytes,
+    spec: Option<String>,
+) -> Result<FullManifestParseResult, anyhow::Error> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let result = (|| -> Result<FullManifest, anyhow::Error> {
-                // simd_json mutates the parse buffer; copy inside the worker so
-                // response-body bytes can stay immutable until parsing starts.
-                let mut parse_buf = raw_bytes.to_vec();
-                let mut manifest: FullManifest =
-                    simd_json::serde::from_slice::<FullManifest>(&mut parse_buf)
-                        .map_err(|e| anyhow!("JSON parse error: {e}"))?;
-                manifest.raw = raw_bytes;
-
-                Ok(manifest)
-            })();
+            let result = parse_full_manifest_with_core_sync(raw_bytes, spec);
             let _ = tx.send(result);
         });
         rx.await
@@ -71,10 +95,7 @@ pub(crate) async fn parse_full_manifest_off_runtime(
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut manifest: FullManifest =
-            parse_json_vec_off_runtime(raw_bytes.clone().to_vec()).await?;
-        manifest.raw = raw_bytes;
-        Ok(manifest)
+        parse_full_manifest_with_core_sync(raw_bytes, spec)
     }
 }
 
@@ -336,5 +357,34 @@ mod tests {
                 version: "1.0.0".to_string(),
             }
         );
+    }
+
+    #[tokio::test]
+    async fn parse_full_manifest_with_core_extracts_requested_spec() {
+        let raw = Bytes::from_static(
+            br#"{
+                "name":"demo",
+                "dist-tags":{"latest":"1.0.0"},
+                "versions":{
+                    "1.0.0":{
+                        "name":"demo",
+                        "version":"1.0.0",
+                        "dist":{"tarball":"https://registry.example/demo-1.0.0.tgz"}
+                    }
+                }
+            }"#,
+        );
+
+        let (manifest, speculative) =
+            parse_full_manifest_with_core_off_runtime(raw.clone(), Some("latest".to_string()))
+                .await
+                .unwrap();
+
+        assert_eq!(manifest.name, "demo");
+        assert_eq!(manifest.raw, raw);
+        let (spec, core) = speculative.unwrap();
+        assert_eq!(spec, "latest");
+        assert_eq!(core.name, "demo");
+        assert_eq!(core.version, "1.0.0");
     }
 }

--- a/crates/ruborist/src/service/mod.rs
+++ b/crates/ruborist/src/service/mod.rs
@@ -49,6 +49,7 @@ pub(crate) mod fetch;
 mod fs;
 pub(crate) mod http;
 pub(crate) mod manifest;
+mod provider;
 mod registry;
 mod store;
 
@@ -64,5 +65,6 @@ pub use manifest::{
     FetchVersionManifestOptions, MetadataFormat, fetch_full_manifest, fetch_full_manifest_bytes,
     fetch_full_manifest_fresh, fetch_version_manifest, fetch_version_manifest_bytes,
 };
+pub use provider::{ManifestFullData, ManifestJob, ManifestJobDone, ManifestProvider};
 pub use registry::UnifiedRegistry;
 pub use store::{ManifestStore, NoopStore};

--- a/crates/ruborist/src/service/provider.rs
+++ b/crates/ruborist/src/service/provider.rs
@@ -1,0 +1,82 @@
+//! Manifest provider boundary for resolver drivers.
+//!
+//! The demand BFS loop owns per-run cache, waiters, and inflight de-duplication.
+//! A provider only executes one manifest job and hides whether it satisfied the
+//! job from memory, persistent storage, or the network.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::cache::VersionsInfo;
+use super::manifest::MetadataFormat;
+use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::traits::registry::RegistryClient;
+
+/// Full-manifest data returned by a provider job.
+#[derive(Clone)]
+pub enum ManifestFullData {
+    /// A parsed full manifest. When the original job carried a spec, the
+    /// provider may also return the matching version manifest extracted in the
+    /// same worker task so the main loop can avoid an extra extract hop.
+    Full {
+        manifest: Arc<FullManifest>,
+        speculative: Option<(String, Arc<CoreVersionManifest>)>,
+    },
+    /// A validated versions list, usually from a 304 path. The main loop can
+    /// resolve a concrete version and schedule a version-manifest job.
+    Versions(Arc<VersionsInfo>),
+}
+
+/// Unit of work spawned by the demand BFS loop.
+#[derive(Clone)]
+pub enum ManifestJob {
+    Full {
+        name: String,
+        /// Optional range/tag from the BFS edge that caused this full-manifest
+        /// fetch. The provider can use it to speculatively extract the current
+        /// version while the full manifest bytes are already on a CPU worker.
+        spec: Option<String>,
+    },
+    Version {
+        name: String,
+        /// Cache/waiter key owned by the main loop.
+        spec: String,
+        /// Registry request spec. For npmjs 304 flows this is the resolved
+        /// exact version, while `spec` remains the original range key.
+        fetch_spec: String,
+        /// Metadata format for the version endpoint. Semver-capable registries
+        /// accept install-v1 for range/tag queries; npmjs exact-version
+        /// fallback requires the complete metadata format.
+        format: MetadataFormat,
+    },
+    ExtractVersion {
+        name: String,
+        spec: String,
+        version: String,
+        full: Arc<FullManifest>,
+    },
+}
+
+/// Result of one provider job.
+pub enum ManifestJobDone {
+    Full {
+        name: String,
+        data: ManifestFullData,
+    },
+    Version {
+        name: String,
+        spec: String,
+        manifest: Arc<CoreVersionManifest>,
+    },
+}
+
+/// Lower-level manifest provider used by the demand BFS loop.
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait ManifestProvider: RegistryClient + Clone + Send + Sync + 'static {
+    /// Execute one manifest job. The provider owns I/O, persistence, and
+    /// parse/extract offloading; scheduling, waiters, and inflight
+    /// de-duplication stay in the BFS loop.
+    async fn execute_manifest_job(&self, job: ManifestJob) -> Result<ManifestJobDone, Self::Error>;
+}

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -298,6 +298,7 @@ pub mod mock {
     use super::*;
 
     /// Internal package data for mock registry.
+    #[derive(Clone)]
     struct MockPackage {
         name: String,
         dist_tags: HashMap<String, String>,
@@ -305,6 +306,7 @@ pub mod mock {
     }
 
     /// Mock registry client that returns predefined packages.
+    #[derive(Clone)]
     pub struct MockRegistryClient {
         packages: HashMap<String, MockPackage>,
     }
@@ -392,5 +394,104 @@ pub mod mock {
                 ..Default::default()
             }))
         }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl crate::service::ManifestProvider for MockRegistryClient {
+        async fn execute_manifest_job(
+            &self,
+            job: crate::service::ManifestJob,
+        ) -> Result<crate::service::ManifestJobDone, Self::Error> {
+            use crate::service::{ManifestFullData, ManifestJob, ManifestJobDone};
+
+            match job {
+                ManifestJob::Full { name, spec } => {
+                    let full = self.fetch_full_manifest(&name).await?;
+                    let speculative = spec.and_then(|spec| {
+                        resolve_target_version((&*full).into(), &spec)
+                            .ok()
+                            .and_then(|version| {
+                                full.get_core_version(&version)
+                                    .map(|core| (spec, Arc::new(core)))
+                            })
+                    });
+                    Ok(ManifestJobDone::Full {
+                        name,
+                        data: ManifestFullData::Full {
+                            manifest: full,
+                            speculative,
+                        },
+                    })
+                }
+                ManifestJob::Version {
+                    name,
+                    spec,
+                    fetch_spec,
+                    format: _,
+                } => {
+                    let manifest = self.fetch_version_manifest(&name, &fetch_spec).await?;
+                    Ok(ManifestJobDone::Version {
+                        name,
+                        spec,
+                        manifest,
+                    })
+                }
+                ManifestJob::ExtractVersion {
+                    name,
+                    spec,
+                    version,
+                    full,
+                } => {
+                    let manifest =
+                        full.get_core_version(&version)
+                            .map(Arc::new)
+                            .ok_or_else(|| {
+                                MockError(format!(
+                                    "Version {version} not found in manifest for {name}"
+                                ))
+                            })?;
+                    Ok(ManifestJobDone::Version {
+                        name,
+                        spec,
+                        manifest,
+                    })
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_registry_executes_manifest_provider_jobs() {
+        let mut registry = MockRegistryClient::new();
+        registry.add_package(
+            "demo",
+            "1.0.0",
+            CoreVersionManifest {
+                name: "demo".to_string(),
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let done = crate::service::ManifestProvider::execute_manifest_job(
+            &registry,
+            crate::service::ManifestJob::Full {
+                name: "demo".to_string(),
+                spec: Some("latest".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let crate::service::ManifestJobDone::Full { data, .. } = done else {
+            panic!("expected full manifest job result");
+        };
+        let crate::service::ManifestFullData::Full { speculative, .. } = data else {
+            panic!("expected full manifest data");
+        };
+        let (spec, manifest) = speculative.unwrap();
+        assert_eq!(spec, "latest");
+        assert_eq!(manifest.version, "1.0.0");
     }
 }


### PR DESCRIPTION
## Summary
- Add the ManifestProvider boundary and mock provider support.
- Move version manifest parsing to Vec buffers and add speculative full-manifest core extraction.
- Add registry HTTP client fan-out and initial PM wiring.

## Review Focus
- Provider trait shape and ownership boundaries.
- No scheduler/mainloop behavior change yet.