### PR TITLE
perf(pm): execute resolver provider jobs

### DIFF
--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -32,6 +32,7 @@ use crate::model::node::EdgeType;
 use crate::model::package_json::PackageJson;
 use crate::resolver::preload::{PreloadConfig, preload_manifests};
 use crate::resolver::registry::{ResolveError, resolve_registry_dep};
+use crate::service::ManifestProvider;
 use crate::spec::{Catalogs, PackageSpec, Protocol};
 use crate::traits::progress::{BuildEvent, EventReceiver, NoopReceiver};
 use crate::traits::registry::{RegistryClient, ResolvedPackage};
@@ -758,11 +759,15 @@ fn handle_processed<E: EventReceiver>(
 /// // Add initial dependency edges to root...
 /// build_deps(&mut graph, &registry, PeerDeps::Include).await?;
 /// ```
-pub async fn build_deps<R: RegistryClient>(
+pub async fn build_deps<R>(
     graph: &mut DependencyGraph,
     registry: &R,
     peer_deps: PeerDeps,
-) -> Result<(), ResolveError<R::Error>> {
+) -> Result<(), ResolveError<R::Error>>
+where
+    R: ManifestProvider,
+    R::Error: Send,
+{
     let config = BuildDepsConfig::default().with_peer_deps(peer_deps);
     build_deps_with_config(graph, registry, config, &NoopReceiver).await
 }
@@ -780,12 +785,17 @@ pub async fn build_deps<R: RegistryClient>(
 /// * `registry` - Registry client for fetching packages
 /// * `peer_deps` - How to handle peer dependencies
 /// * `receiver` - Event receiver for handling build events
-pub async fn build_deps_with_receiver<R: RegistryClient, E: EventReceiver>(
+pub async fn build_deps_with_receiver<R, E>(
     graph: &mut DependencyGraph,
     registry: &R,
     peer_deps: PeerDeps,
     receiver: &E,
-) -> Result<(), ResolveError<R::Error>> {
+) -> Result<(), ResolveError<R::Error>>
+where
+    R: ManifestProvider,
+    R::Error: Send,
+    E: EventReceiver,
+{
     let config = BuildDepsConfig::default().with_peer_deps(peer_deps);
     build_deps_with_config(graph, registry, config, receiver).await
 }
@@ -810,12 +820,17 @@ pub async fn build_deps_with_receiver<R: RegistryClient, E: EventReceiver>(
 ///
 /// build_deps_with_config(&mut graph, &registry, config, &receiver).await?;
 /// ```
-pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
+pub async fn build_deps_with_config<R, E>(
     graph: &mut DependencyGraph,
     registry: &R,
     config: BuildDepsConfig,
     receiver: &E,
-) -> Result<(), ResolveError<R::Error>> {
+) -> Result<(), ResolveError<R::Error>>
+where
+    R: ManifestProvider,
+    R::Error: Send,
+    E: EventReceiver,
+{
     tracing::debug!(
         "Starting dependency tree build, peer_deps: {:?}, concurrency: {}, skip_preload: {}",
         config.peer_deps,
@@ -973,10 +988,14 @@ use std::path::Path;
 /// let pkg: PackageJson = serde_json::from_str(&pkg_content)?;
 /// let lock = resolve(&pkg, &registry).await?;
 /// ```
-pub async fn resolve<R: RegistryClient>(
+pub async fn resolve<R>(
     pkg: &PackageJson,
     registry: &R,
-) -> Result<PackageLock, ResolveError<R::Error>> {
+) -> Result<PackageLock, ResolveError<R::Error>>
+where
+    R: ManifestProvider,
+    R::Error: Send,
+{
     resolve_with_options(pkg, registry, PeerDeps::Include, &NoopReceiver).await
 }
 
@@ -987,12 +1006,17 @@ pub async fn resolve<R: RegistryClient>(
 /// * `registry` - Registry client for fetching packages
 /// * `peer_deps` - How to handle peer dependencies
 /// * `receiver` - Event receiver for progress tracking
-pub async fn resolve_with_options<R: RegistryClient, E: EventReceiver>(
+pub async fn resolve_with_options<R, E>(
     pkg: &PackageJson,
     registry: &R,
     peer_deps: PeerDeps,
     receiver: &E,
-) -> Result<PackageLock, ResolveError<R::Error>> {
+) -> Result<PackageLock, ResolveError<R::Error>>
+where
+    R: ManifestProvider,
+    R::Error: Send,
+    E: EventReceiver,
+{
     // Create graph with root node
     let mut graph = DependencyGraph::from_package_json(PathBuf::from("."), pkg.clone());
 

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -32,7 +32,7 @@ use crate::model::node::EdgeType;
 use crate::model::package_json::PackageJson;
 use crate::resolver::preload::{PreloadConfig, preload_manifests};
 use crate::resolver::registry::{ResolveError, resolve_registry_dep};
-use crate::service::ManifestProvider;
+use crate::service::{ManifestProvider, ProjectCacheData};
 use crate::spec::{Catalogs, PackageSpec, Protocol};
 use crate::traits::progress::{BuildEvent, EventReceiver, NoopReceiver};
 use crate::traits::registry::{RegistryClient, ResolvedPackage};
@@ -118,6 +118,8 @@ pub struct BuildDepsConfig {
     /// Catalog definitions for the `catalog:` dependency protocol.
     /// Key `""` = default catalog, other keys = named catalogs.
     pub catalogs: Catalogs,
+    /// Host-provided project cache used to seed resolver manifest state.
+    pub warm_project_cache: Option<ProjectCacheData>,
 }
 
 impl Default for BuildDepsConfig {
@@ -130,6 +132,7 @@ impl Default for BuildDepsConfig {
             git_clone_cache: Arc::new(GitCloneCache::new()),
             http_fetch_cache: Arc::new(HttpFetchCache::new()),
             catalogs: HashMap::new(),
+            warm_project_cache: None,
         }
     }
 }
@@ -162,6 +165,12 @@ impl BuildDepsConfig {
     /// Set catalog definitions for `catalog:` protocol resolution.
     pub fn with_catalogs(mut self, catalogs: Catalogs) -> Self {
         self.catalogs = catalogs;
+        self
+    }
+
+    /// Set the host-provided warm project cache.
+    pub fn with_warm_project_cache(mut self, warm_project_cache: Option<ProjectCacheData>) -> Self {
+        self.warm_project_cache = warm_project_cache;
         self
     }
 }

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -651,6 +651,97 @@ pub async fn process_dependency<R: RegistryClient>(
     }
 }
 
+/// Place an already-resolved registry package into the graph.
+///
+/// The demand resolver uses this after a manifest job completes; the legacy
+/// resolver path also goes through it so placement semantics stay shared.
+pub fn process_dependency_with_resolved(
+    graph: &mut DependencyGraph,
+    node_index: NodeIndex,
+    edge_info: &DependencyEdgeInfo,
+    resolved: &ResolvedPackage,
+    config: &BuildDepsConfig,
+) -> ProcessResult {
+    match graph.find_compatible_node(node_index, &edge_info.name, &edge_info.spec) {
+        FindResult::Reuse(existing_index) => {
+            graph.mark_dependency_resolved(edge_info.edge_id, existing_index);
+            update_node_type_from_edge(graph, node_index, existing_index, &edge_info.edge_type);
+            ProcessResult::Reused(existing_index)
+        }
+        FindResult::Conflict(conflict_parent) | FindResult::New(conflict_parent) => {
+            let new_node = create_package_node(&edge_info.name, resolved, conflict_parent, graph);
+            let new_index = graph.add_node(new_node);
+            graph.add_physical_edge(conflict_parent, new_index);
+            graph.mark_dependency_resolved(edge_info.edge_id, new_index);
+            update_node_type_from_edge(graph, node_index, new_index, &edge_info.edge_type);
+            add_edges_from(
+                graph,
+                new_index,
+                &*resolved.manifest,
+                &EdgeContext::new(config.peer_deps, DevDeps::Exclude),
+            );
+            ProcessResult::Created(new_index)
+        }
+    }
+}
+
+fn chain_err<E>(
+    graph: &DependencyGraph,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    inner: ResolveError<E>,
+) -> ResolveError<E> {
+    let mut chain = graph.logical_ancestry(parent);
+    chain.push((edge.name.clone(), edge.spec.clone()));
+    ResolveError::WithChain {
+        chain,
+        source: Box::new(inner),
+    }
+}
+
+fn handle_processed<E: EventReceiver>(
+    graph: &DependencyGraph,
+    receiver: &E,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    processed: &ProcessResult,
+    next_level: &mut Vec<NodeIndex>,
+) {
+    match processed {
+        ProcessResult::Created(idx) => {
+            if let Some(node) = graph.get_node(*idx) {
+                receiver.on_event(BuildEvent::Resolved {
+                    name: &edge.name,
+                    version: &node.version,
+                });
+                if let NodeManifest::Registry(ref manifest) = node.manifest {
+                    let parent_path = graph.get_node(parent).map(|p| p.path.as_path());
+                    receiver.on_event(BuildEvent::PackagePlaced {
+                        package: manifest.as_ref().into(),
+                        path: &node.path,
+                        parent_path,
+                    });
+                }
+            }
+            next_level.push(*idx);
+        }
+        ProcessResult::Reused(idx) => {
+            if let Some(node) = graph.get_node(*idx) {
+                receiver.on_event(BuildEvent::Reused {
+                    name: &edge.name,
+                    version: &node.version,
+                });
+            }
+        }
+        ProcessResult::Skipped => {
+            receiver.on_event(BuildEvent::Skipped {
+                name: &edge.name,
+                spec: &edge.spec,
+            });
+        }
+    }
+}
+
 /// Build the complete dependency tree using BFS traversal.
 ///
 /// This is the main entry point for dependency resolution. It starts from
@@ -837,56 +928,17 @@ async fn run_bfs_phase<R: RegistryClient, E: EventReceiver>(
                 receiver.on_event(BuildEvent::Resolving {
                     name: &edge_info.name,
                 });
-                let result = process_dependency(graph, registry, node_index, &edge_info, config)
+                let processed = process_dependency(graph, registry, node_index, &edge_info, config)
                     .await
-                    .map_err(|inner| {
-                        let mut chain = graph.logical_ancestry(node_index);
-                        chain.push((edge_info.name.clone(), edge_info.spec.clone()));
-                        ResolveError::WithChain {
-                            chain,
-                            source: Box::new(inner),
-                        }
-                    });
-                match result? {
-                    ProcessResult::Created(idx) => {
-                        // Extract node info for events
-                        if let Some(node) = graph.get_node(idx) {
-                            receiver.on_event(BuildEvent::Resolved {
-                                name: &edge_info.name,
-                                version: &node.version,
-                            });
-
-                            // Send PackagePlaced for pipeline cloning
-                            if let NodeManifest::Registry(ref manifest) = node.manifest {
-                                // Get parent path for dependency ordering
-                                let parent_path = graph
-                                    .get_node(node_index)
-                                    .map(|parent| parent.path.as_path());
-                                receiver.on_event(BuildEvent::PackagePlaced {
-                                    package: manifest.as_ref().into(),
-                                    path: &node.path,
-                                    parent_path,
-                                });
-                            }
-                        }
-
-                        next_level.push(idx);
-                    }
-                    ProcessResult::Reused(idx) => {
-                        if let Some(node) = graph.get_node(idx) {
-                            receiver.on_event(BuildEvent::Reused {
-                                name: &edge_info.name,
-                                version: &node.version,
-                            });
-                        }
-                    }
-                    ProcessResult::Skipped => {
-                        receiver.on_event(BuildEvent::Skipped {
-                            name: &edge_info.name,
-                            spec: &edge_info.spec,
-                        });
-                    }
-                }
+                    .map_err(|inner| chain_err(graph, node_index, &edge_info, inner))?;
+                handle_processed(
+                    graph,
+                    receiver,
+                    node_index,
+                    &edge_info,
+                    &processed,
+                    &mut next_level,
+                );
             }
         }
 

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -239,7 +239,8 @@ where
         .with_peer_deps(peer_deps)
         .with_concurrency(concurrency)
         .with_skip_preload(skip_preload)
-        .with_catalogs(catalogs);
+        .with_catalogs(catalogs)
+        .with_warm_project_cache(warm_project_cache);
     if let Some(dir) = cache_dir {
         config = config.with_cache_dir(dir);
     }

--- a/crates/ruborist/src/service/provider.rs
+++ b/crates/ruborist/src/service/provider.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 
 use super::cache::VersionsInfo;
 use super::manifest::MetadataFormat;
@@ -79,4 +80,10 @@ pub trait ManifestProvider: RegistryClient + Clone + Send + Sync + 'static {
     /// parse/extract offloading; scheduling, waiters, and inflight
     /// de-duplication stay in the BFS loop.
     async fn execute_manifest_job(&self, job: ManifestJob) -> Result<ManifestJobDone, Self::Error>;
+}
+
+/// Raw full-manifest bytes fetched by a provider before parsing.
+pub(crate) enum ProviderFullManifestBytes {
+    Fresh { bytes: Bytes, etag: Option<String> },
+    NotModified { versions: Arc<VersionsInfo> },
 }

--- a/crates/ruborist/src/service/registry.rs
+++ b/crates/ruborist/src/service/registry.rs
@@ -21,6 +21,7 @@
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use async_trait::async_trait;
 
 /// Get current timestamp in seconds since UNIX epoch.
 /// Works on both native and WASM targets.
@@ -43,6 +44,9 @@ use dashmap::DashSet;
 
 use super::cache::{PackageCache, Versions, VersionsInfo};
 use super::manifest;
+use super::provider::{
+    ManifestFullData, ManifestJob, ManifestJobDone, ManifestProvider, ProviderFullManifestBytes,
+};
 use super::store::{ManifestStore, NoopStore};
 use crate::model::manifest::{CoreVersionManifest, FullManifest, extract_core_version_off_runtime};
 use crate::resolver::semver::normalize_spec;
@@ -199,6 +203,78 @@ enum FullManifestResult {
     NotModified,
 }
 
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl ManifestProvider for UnifiedRegistry {
+    async fn execute_manifest_job(&self, job: ManifestJob) -> Result<ManifestJobDone, Self::Error> {
+        match job {
+            ManifestJob::Full { name, spec } => {
+                let data = match self.fetch_full_manifest_job(&name).await? {
+                    ProviderFullManifestBytes::Fresh { bytes, etag } => {
+                        let (manifest, speculative) =
+                            manifest::parse_full_manifest_with_core_off_runtime(bytes, spec)
+                                .await?;
+                        let manifest = Arc::new(manifest);
+                        let speculative = speculative.map(|(spec, core)| {
+                            let core = Arc::new(core);
+                            self.store_version_manifest(&name, Arc::clone(&core));
+                            (spec, core)
+                        });
+                        let versions = Arc::new(VersionsInfo {
+                            versions: Versions {
+                                version_list: manifest.versions.clone(),
+                                dist_tags: manifest.dist_tags.clone(),
+                            },
+                            etag,
+                            last_updated: current_timestamp_secs(),
+                        });
+                        self.store.store_versions(&name, versions);
+                        ManifestFullData::Full {
+                            manifest,
+                            speculative,
+                        }
+                    }
+                    ProviderFullManifestBytes::NotModified { versions } => {
+                        ManifestFullData::Versions(versions)
+                    }
+                };
+
+                Ok(ManifestJobDone::Full { name, data })
+            }
+            ManifestJob::Version {
+                name,
+                spec,
+                fetch_spec,
+                format,
+            } => {
+                let manifest = self
+                    .fetch_version_job_manifest(&name, &spec, &fetch_spec, format)
+                    .await?;
+                Ok(ManifestJobDone::Version {
+                    name,
+                    spec,
+                    manifest,
+                })
+            }
+            ManifestJob::ExtractVersion {
+                name,
+                spec,
+                version,
+                full,
+            } => {
+                let manifest = self
+                    .extract_version_job_manifest(&name, &spec, version, full)
+                    .await?;
+                Ok(ManifestJobDone::Version {
+                    name,
+                    spec,
+                    manifest,
+                })
+            }
+        }
+    }
+}
+
 impl UnifiedRegistry {
     /// Create a builder for `UnifiedRegistry`.
     pub fn builder() -> UnifiedRegistryBuilder {
@@ -218,6 +294,87 @@ impl UnifiedRegistry {
     /// Get the underlying in-memory cache.
     pub fn cache(&self) -> &PackageCache {
         &self.cache
+    }
+
+    fn store_version_manifest(&self, name: &str, manifest: Arc<CoreVersionManifest>) {
+        let version = manifest.version.clone();
+        self.store.store_version_manifest(name, &version, manifest);
+    }
+
+    async fn fetch_full_manifest_job(
+        &self,
+        name: &str,
+    ) -> Result<ProviderFullManifestBytes, RegistryError> {
+        let store_versions = self.store.load_versions(name).await.map(Arc::new);
+        let etag = store_versions.as_ref().and_then(|v| v.etag.clone());
+
+        match manifest::fetch_full_manifest_bytes(manifest::FetchManifestOptions {
+            registry_url: &self.registry_url,
+            name,
+            format: manifest::MetadataFormat::Abbreviated,
+            etag: etag.as_deref(),
+        })
+        .await
+        .map_err(RegistryError)?
+        {
+            manifest::FetchManifestBytesResult::Ok(bytes, etag) => {
+                Ok(ProviderFullManifestBytes::Fresh { bytes, etag })
+            }
+            manifest::FetchManifestBytesResult::NotModified => {
+                let versions = store_versions.ok_or_else(|| {
+                    RegistryError(anyhow!(
+                        "304 Not Modified without cached versions for {name}"
+                    ))
+                })?;
+                Ok(ProviderFullManifestBytes::NotModified { versions })
+            }
+        }
+    }
+
+    async fn extract_version_job_manifest(
+        &self,
+        name: &str,
+        _spec: &str,
+        version: String,
+        full: Arc<FullManifest>,
+    ) -> Result<Arc<CoreVersionManifest>, RegistryError> {
+        let (resolved_version, manifest) = extract_core_version_off_runtime(full, version).await;
+        let manifest = manifest.ok_or_else(|| {
+            RegistryError(anyhow!(
+                "Version {} not found in manifest for {}",
+                resolved_version,
+                name
+            ))
+        })?;
+        self.store_version_manifest(name, Arc::clone(&manifest));
+        Ok(manifest)
+    }
+
+    async fn fetch_version_job_manifest(
+        &self,
+        name: &str,
+        _spec: &str,
+        fetch_spec: &str,
+        format: manifest::MetadataFormat,
+    ) -> Result<Arc<CoreVersionManifest>, RegistryError> {
+        if deno_semver::Version::parse_from_npm(fetch_spec).is_ok()
+            && let Some(manifest) = self.store.load_version_manifest(name, fetch_spec).await
+        {
+            return Ok(Arc::new(manifest));
+        }
+
+        let manifest = Arc::new(
+            manifest::fetch_version_manifest(manifest::FetchVersionManifestOptions {
+                registry_url: &self.registry_url,
+                name,
+                spec: fetch_spec,
+                format,
+            })
+            .await
+            .map_err(RegistryError)?,
+        );
+        self.store_version_manifest(name, Arc::clone(&manifest));
+        Ok(manifest)
     }
 
     /// Resolve full manifest through memory → store → network with ETag validation.
@@ -509,6 +666,10 @@ impl RegistryClient for UnifiedRegistry {
         self.supports_semver
     }
 
+    fn registry_url(&self) -> &str {
+        &self.registry_url
+    }
+
     fn cache_version_manifest(&self, name: &str, spec: &str, manifest: Arc<CoreVersionManifest>) {
         self.cache
             .set_version_manifest(name.to_string(), spec.to_string(), manifest);
@@ -572,7 +733,44 @@ impl RegistryClient for UnifiedRegistry {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+    use crate::service::{ManifestJob, ManifestJobDone, ManifestProvider, ManifestStore};
+
+    #[derive(Default)]
+    struct RecordingStore {
+        stored_versions: Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl ManifestStore for RecordingStore {
+        async fn load_versions(&self, _name: &str) -> Option<VersionsInfo> {
+            None
+        }
+
+        async fn load_version_manifest(
+            &self,
+            _name: &str,
+            _version: &str,
+        ) -> Option<CoreVersionManifest> {
+            None
+        }
+
+        fn store_versions(&self, _name: &str, _info: Arc<VersionsInfo>) {}
+
+        fn store_version_manifest(
+            &self,
+            name: &str,
+            version: &str,
+            _manifest: Arc<CoreVersionManifest>,
+        ) {
+            self.stored_versions
+                .lock()
+                .unwrap()
+                .push((name.to_string(), version.to_string()));
+        }
+    }
 
     #[test]
     fn test_is_npm_registry() {
@@ -641,5 +839,62 @@ mod tests {
 
         // Both registries share the same cache
         assert!(Arc::ptr_eq(&registry1.cache, &registry2.cache));
+    }
+
+    #[tokio::test]
+    async fn test_unified_registry_executes_extract_manifest_provider_job() {
+        let store = Arc::new(RecordingStore::default());
+        let registry = UnifiedRegistry::builder()
+            .registry("https://registry.npmmirror.com")
+            .store(store.clone())
+            .build();
+
+        let (full, _) = manifest::parse_full_manifest_with_core_off_runtime(
+            bytes::Bytes::from_static(
+                br#"{
+                    "name":"provider-extract-demo",
+                    "dist-tags":{"latest":"1.0.0"},
+                    "versions":{
+                        "1.0.0":{
+                            "name":"provider-extract-demo",
+                            "version":"1.0.0",
+                            "dist":{"tarball":"https://registry.example/demo-1.0.0.tgz"}
+                        }
+                    }
+                }"#,
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let done = ManifestProvider::execute_manifest_job(
+            &registry,
+            ManifestJob::ExtractVersion {
+                name: "provider-extract-demo".to_string(),
+                spec: "latest".to_string(),
+                version: "1.0.0".to_string(),
+                full: Arc::new(full),
+            },
+        )
+        .await
+        .unwrap();
+
+        let ManifestJobDone::Version {
+            spec,
+            manifest: returned,
+            ..
+        } = done
+        else {
+            panic!("expected version manifest job");
+        };
+
+        assert_eq!(spec, "latest");
+        assert_eq!(returned.name, "provider-extract-demo");
+        assert_eq!(returned.version, "1.0.0");
+        assert_eq!(
+            store.stored_versions.lock().unwrap().as_slice(),
+            &[("provider-extract-demo".to_string(), "1.0.0".to_string())]
+        );
     }
 }

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -133,6 +133,13 @@ pub trait RegistryClient {
         false
     }
 
+    /// Base registry URL used by schedulers that need to classify raw work.
+    ///
+    /// Implementations without a concrete URL can keep the default.
+    fn registry_url(&self) -> &str {
+        ""
+    }
+
     /// Fetch full package manifest from registry.
     ///
     /// Returns the complete package manifest with all versions, wrapped in


### PR DESCRIPTION
## Summary
- Implement provider job execution and placement helper sharing.
- Require ManifestProvider at the builder boundary.
- Thread warm project cache into resolver config.

## Review Focus
- Job result shape and warm-cache ownership before demand mainloop lands.