### PR TITLE
perf(pm): split install cache primitives

### DIFF
--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
 use serde::de::DeserializeOwned;
+use tokio::task::spawn_blocking;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
 use utoo_ruborist::util::OnceMap;
@@ -100,7 +101,7 @@ pub async fn clone_package_once(
     CLONE_CACHE
         .get_or_init(key, || async move {
             let cache_path = resolve_cache_path(&name, &version, &tarball_url).await?;
-            tokio::task::spawn_blocking(move || {
+            spawn_blocking(move || {
                 clone_package_from_cache_sync(
                     &name,
                     &version,
@@ -275,8 +276,11 @@ fn validate_name_version_sync(dst: &Path, name: &str, version: &str) -> bool {
 
 fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
     for entry in std::fs::read_dir(src).ok()? {
-        let entry = entry.ok()?;
-        if entry.file_type().ok()?.is_dir() {
+        // Skip entries that error transiently (e.g. an entry removed by a
+        // concurrent extraction between readdir and lstat) instead of
+        // abandoning the whole search — mirrors the async `find_real_src`.
+        let Ok(entry) = entry else { continue };
+        if entry.file_type().is_ok_and(|t| t.is_dir()) {
             let path = entry.path();
             if path.file_name().is_some_and(|name| name != ".utoo_built") {
                 return Some(path);
@@ -290,54 +294,25 @@ fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
 fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
     let src_c = CString::new(real_src.as_os_str().as_bytes())?;
     let dst_c = CString::new(dst.as_os_str().as_bytes())?;
-    let mut last_error = None;
 
-    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
-        if !delay.is_zero() {
-            std::thread::sleep(delay);
-        }
-
-        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
-            0 => return Ok(()),
-            _ => {
-                let err = std::io::Error::last_os_error();
-                let _ = std::fs::remove_dir_all(dst);
-                last_error = Some(err);
-            }
-        }
+    // Single attempt: retry policy is the caller's decision, the util-layer
+    // clone primitive stays stateless.
+    match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
+        0 => Ok(()),
+        _ => Err(anyhow::anyhow!(
+            "clonefile {} -> {}: {}",
+            real_src.display(),
+            dst.display(),
+            std::io::Error::last_os_error()
+        )),
     }
-
-    Err(anyhow::anyhow!(
-        "clonefile {} -> {}: {}",
-        real_src.display(),
-        dst.display(),
-        last_error
-            .map(|e| e.to_string())
-            .unwrap_or_else(|| "unknown error".to_string())
-    ))
 }
 
 #[cfg(not(target_os = "macos"))]
 fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
-    let mut last_error = None;
-
-    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
-        if !delay.is_zero() {
-            std::thread::sleep(delay);
-        }
-
-        match hardlink_clone::clone_dir_sync(real_src, dst) {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                if dst.try_exists()? {
-                    remove_target_dir_sync(dst)?;
-                }
-                last_error = Some(e);
-            }
-        }
-    }
-
-    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("unknown hardlink clone error")))
+    // Single attempt: retry policy is the caller's decision, the util-layer
+    // clone primitive stays stateless.
+    hardlink_clone::clone_dir_sync(real_src, dst)
         .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))
 }
 

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
+use serde::de::DeserializeOwned;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
 use utoo_ruborist::util::OnceMap;
@@ -31,6 +32,24 @@ static CLONE_COUNT: AtomicUsize = AtomicUsize::new(0);
 /// Returns the number of fresh clones performed (pnpm "added" equivalent).
 pub fn clone_count() -> usize {
     CLONE_COUNT.load(Ordering::Relaxed)
+}
+
+/// Clone a package from an already-resolved cache path without touching the
+/// global clone/download single-flight maps. Schedulers that own deduplication
+/// use this sync primitive from their worker pool.
+pub fn clone_package_from_cache_sync(
+    name: &str,
+    version: &str,
+    tarball_url: &str,
+    cache_path: &Path,
+    target_path: &Path,
+) -> Result<()> {
+    let is_git = is_git_url(tarball_url);
+    let fresh = clone_package_sync(cache_path, target_path, name, version, !is_git)?;
+    if fresh {
+        CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+    Ok(())
 }
 
 /// Normalize a target path into the canonical key used by `CLONE_CACHE`.
@@ -78,15 +97,17 @@ pub async fn clone_package_once(
     let tarball_url = tarball_url.to_string();
     let target_path = target_path.to_path_buf();
 
-    // Git packages are extracted flat (no `package/` wrapper directory),
-    // so skip `find_real_src` which would incorrectly pick a subdirectory.
-    let is_git = is_git_url(&tarball_url);
-
     CLONE_CACHE
         .get_or_init(key, || async move {
             let cache_path = resolve_cache_path(&name, &version, &tarball_url).await?;
-            let fresh = clone_package(&cache_path, &target_path, &name, &version, !is_git)
-                .await
+            tokio::task::spawn_blocking(move || {
+                clone_package_from_cache_sync(
+                    &name,
+                    &version,
+                    &tarball_url,
+                    &cache_path,
+                    &target_path,
+                )
                 .inspect_err(|e| {
                     tracing::warn!(
                         "Clone failed: {}@{} to {}: {:#}",
@@ -96,12 +117,10 @@ pub async fn clone_package_once(
                         e
                     )
                 })
-                .ok()?;
-
-            if fresh {
-                CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
-            }
-            Some(())
+                .ok()
+            })
+            .await
+            .ok()?
         })
         .await
         .map(|_| ())
@@ -118,7 +137,6 @@ use libc::clonefile;
 
 #[cfg(not(target_os = "macos"))]
 mod hardlink_clone {
-    use std::collections::HashSet;
     use std::path::{Path, PathBuf};
     use std::{fs, io};
 
@@ -172,83 +190,180 @@ mod hardlink_clone {
         Ok(())
     }
 
-    /// Clone directory using spawn_blocking for sync I/O.
-    /// Uses hardlink when possible, falls back to copy.
-    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
+    /// Clone directory using sync I/O. Uses hardlink when possible, falls back
+    /// to copy.
+    pub fn clone_dir_sync(src: &Path, dst: &Path) -> Result<()> {
         let err_msg = format!("Failed to clone {} to {}", src.display(), dst.display());
+
+        if !fs::metadata(src)?.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "Source is not a directory",
+            ))
+            .with_context(|| err_msg);
+        }
+
+        let mut force_copy = has_install_script_sync(src);
+
+        let mut files = Vec::new();
+        let mut dirs = Vec::new();
+        collect_entries(src, dst, &mut files, &mut dirs)?;
+
+        for dir in &dirs {
+            fs::create_dir_all(dir).with_context(|| err_msg.clone())?;
+        }
+
+        let mut warned_per_file = false;
+        for entry in &files {
+            if force_copy {
+                copy_file_sync(&entry.src, &entry.dst)?;
+            } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
+                if e.kind() == io::ErrorKind::CrossesDevices {
+                    tracing::warn!(
+                        "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
+                        src.display(),
+                        dst.display(),
+                        e
+                    );
+                    force_copy = true;
+                } else if !warned_per_file {
+                    tracing::warn!(
+                        "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
+                        entry.src.display(),
+                        entry.dst.display(),
+                        e
+                    );
+                    warned_per_file = true;
+                }
+                copy_file_sync(&entry.src, &entry.dst)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Clone directory using spawn_blocking for callers that are still async.
+    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
         let src = src.to_path_buf();
         let dst = dst.to_path_buf();
-
-        tokio::task::spawn_blocking(move || {
-            if !fs::metadata(&src)?.is_dir() {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotADirectory,
-                    "Source is not a directory",
-                ));
-            }
-
-            let mut force_copy = has_install_script_sync(&src);
-
-            // Phase 1: Collect all files and directories
-            let mut files = Vec::new();
-            let mut dirs = Vec::new();
-            collect_entries(&src, &dst, &mut files, &mut dirs)?;
-
-            // Phase 2: Create all directories
-            let mut created_dirs = HashSet::new();
-            for dir in &dirs {
-                if created_dirs.insert(dir.clone())
-                    && let Err(e) = fs::create_dir_all(dir)
-                    && e.kind() != io::ErrorKind::AlreadyExists
-                {
-                    return Err(e);
-                }
-            }
-
-            // Phase 3: Clone files (hardlink, fall back to copy on error).
-            //
-            // EXDEV (src cache and dst on different filesystems, e.g. a
-            // global install where ~/.cache/nm lives on a different volume
-            // than /usr/local) is a property of the src/dst pair — every
-            // remaining file would fail the same way, so latch `force_copy`
-            // and skip hardlink for the rest of this clone.
-            //
-            // Any other hardlink error (EMLINK on a single inode whose link
-            // count is exhausted, EPERM on a specific file, etc.) is
-            // per-file: copy this one and keep trying hardlink on the next.
-            // We warn only on the first such failure per package to avoid
-            // spamming hundreds of identical warnings when an entire package
-            // can't be hardlinked.
-            let mut warned_per_file = false;
-            for entry in &files {
-                if force_copy {
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
-                    if e.kind() == io::ErrorKind::CrossesDevices {
-                        tracing::warn!(
-                            "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
-                            src.display(),
-                            dst.display(),
-                            e
-                        );
-                        force_copy = true;
-                    } else if !warned_per_file {
-                        tracing::warn!(
-                            "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
-                            entry.src.display(),
-                            entry.dst.display(),
-                            e
-                        );
-                        warned_per_file = true;
-                    }
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                }
-            }
-            Ok(())
-        })
-        .await?
-        .with_context(|| err_msg)
+        tokio::task::spawn_blocking(move || clone_dir_sync(&src, &dst)).await?
     }
+}
+
+fn load_package_json_sync<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let pkg_path = path.join("package.json");
+    let content = std::fs::read_to_string(&pkg_path)
+        .with_context(|| format!("Failed to read file {pkg_path:?}"))?;
+
+    match serde_json::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(original_err) => match serde_json::from_str::<serde_json::Value>(&content) {
+            Ok(value) => serde_json::from_value(value)
+                .with_context(|| format!("Failed to deserialize {pkg_path:?}")),
+            Err(_) => {
+                Err(original_err).with_context(|| format!("Failed to parse JSON from {pkg_path:?}"))
+            }
+        },
+    }
+}
+
+fn validate_name_version_sync(dst: &Path, name: &str, version: &str) -> bool {
+    let Ok(pkg) = load_package_json_sync::<IdentityView>(dst) else {
+        return false;
+    };
+    pkg.name == name && pkg.version == version
+}
+
+fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(src).ok()? {
+        let entry = entry.ok()?;
+        if entry.file_type().ok()?.is_dir() {
+            let path = entry.path();
+            if path.file_name().is_some_and(|name| name != ".utoo_built") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    let src_c = CString::new(real_src.as_os_str().as_bytes())?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
+    let mut last_error = None;
+
+    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
+
+        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
+            0 => return Ok(()),
+            _ => {
+                let err = std::io::Error::last_os_error();
+                let _ = std::fs::remove_dir_all(dst);
+                last_error = Some(err);
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "clonefile {} -> {}: {}",
+        real_src.display(),
+        dst.display(),
+        last_error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string())
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    let mut last_error = None;
+
+    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
+
+        match hardlink_clone::clone_dir_sync(real_src, dst) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                if dst.try_exists()? {
+                    remove_target_dir_sync(dst)?;
+                }
+                last_error = Some(e);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("unknown hardlink clone error")))
+        .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))
+}
+
+fn remove_target_dir_sync(dst: &Path) -> Result<()> {
+    std::fs::remove_dir_all(dst)
+        .with_context(|| format!("Failed to clean target directory {}", dst.display()))
+}
+
+fn clone_sync(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
+    let real_src = if find_real {
+        find_real_src_sync(src)
+            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?
+    } else {
+        src.to_path_buf()
+    };
+
+    if dst.try_exists()? {
+        remove_target_dir_sync(dst)?;
+    }
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    clone_dir_native_sync(&real_src, dst)?;
+    Ok(())
 }
 
 async fn validate_directory(src: &Path, dst: &Path) -> Result<bool> {
@@ -442,6 +557,24 @@ pub async fn clone_package(
         }
     }
     clone(src, dst, find_real).await?;
+    Ok(true)
+}
+
+/// Sync clone path with the same name/version validation as [`clone_package`].
+fn clone_package_sync(
+    src: &Path,
+    dst: &Path,
+    name: &str,
+    version: &str,
+    find_real: bool,
+) -> Result<bool> {
+    if dst.try_exists()? {
+        if validate_name_version_sync(dst, name, version) {
+            return Ok(false);
+        }
+        remove_target_dir_sync(dst)?;
+    }
+    clone_sync(src, dst, find_real)?;
     Ok(true)
 }
 
@@ -800,6 +933,31 @@ mod tests {
         // Should be cloned
         assert!(dst_dir.join("package.json").exists());
         let content = fs::read_to_string(dst_dir.join("package.json")).await?;
+        assert!(content.contains("lodash"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_clone_package_from_cache_sync_fresh_install() -> Result<()> {
+        let temp = TempDir::new()?;
+        let cache_dir = temp.path().join("cache/lodash/4.17.21");
+        let src_dir = cache_dir.join("package");
+        let dst_dir = temp.path().join("node_modules/lodash");
+
+        std::fs::create_dir_all(&src_dir)?;
+        let pkg_json = create_package_json("lodash", "4.17.21");
+        std::fs::write(src_dir.join("package.json"), &pkg_json)?;
+
+        clone_package_from_cache_sync(
+            "lodash",
+            "4.17.21",
+            "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            &cache_dir,
+            &dst_dir,
+        )?;
+
+        assert!(dst_dir.join("package.json").exists());
+        let content = std::fs::read_to_string(dst_dir.join("package.json"))?;
         assert!(content.contains("lodash"));
         Ok(())
     }

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -123,21 +123,40 @@ pub async fn http_tarball_cache_lookup(name: &str, tarball_url: &str) -> Option<
     slot_cache_lookup(name, http_cache_slot(tarball_url)).await
 }
 
+/// Resolve cache slots that may have been seeded during dependency resolution
+/// without falling through to registry download. `Ok(None)` means this is a
+/// registry-style HTTP tarball that should be downloaded into `<name>/<version>`.
+pub async fn resolve_seeded_cache_path(
+    name: &str,
+    version: &str,
+    tarball_url: &str,
+) -> Result<Option<PathBuf>> {
+    match tarball_url.parse::<Protocol>() {
+        Ok(Protocol::Git) => git_cache_lookup(name, version, tarball_url)
+            .await
+            .map(Some)
+            .ok_or_else(|| anyhow::anyhow!("git cache not found for {name}@{version}")),
+        Ok(Protocol::File) => file_cache_lookup(name, tarball_url)
+            .await
+            .map(Some)
+            .ok_or_else(|| anyhow::anyhow!("file tarball cache not found for {name}@{version}")),
+        _ => Ok(http_tarball_cache_lookup(name, tarball_url).await),
+    }
+}
+
 /// Resolve the local cache path for a package, downloading if necessary.
 ///
 /// The cloner calls this with a fully-qualified URL (never a relative
 /// path) — the install loop is responsible for any lockfile-format
 /// rewriting before we get here.
 pub async fn resolve_cache_path(name: &str, version: &str, tarball_url: &str) -> Option<PathBuf> {
-    match tarball_url.parse::<Protocol>() {
-        Ok(Protocol::Git) => git_cache_lookup(name, version, tarball_url).await,
-        Ok(Protocol::File) => file_cache_lookup(name, tarball_url).await,
-        // Otherwise try the URL-hashed http slot BFS may have seeded,
-        // then fall through to the registry `<name>/<version>/` path.
-        _ => match http_tarball_cache_lookup(name, tarball_url).await {
-            Some(p) => Some(p),
-            None => download_to_cache(name, version, tarball_url).await,
-        },
+    match resolve_seeded_cache_path(name, version, tarball_url).await {
+        Ok(Some(path)) => Some(path),
+        Ok(None) => download_to_cache(name, version, tarball_url).await,
+        Err(e) => {
+            tracing::warn!("{e:#}");
+            None
+        }
     }
 }
 
@@ -155,21 +174,13 @@ pub async fn download_to_cache(name: &str, version: &str, tarball_url: &str) -> 
         return Some((*cache_path).clone());
     }
 
-    let cache_dir = get_cache_dir();
     let name = name.to_string();
     let version = version.to_string();
     let tarball_url = tarball_url.to_string();
 
     DOWNLOAD_CACHE
         .get_or_init(key, || async move {
-            let cache_path = cache_dir.join(&name).join(&version);
-
-            // Fast path: already extracted in cache
-            if crate::fs::try_exists(&cache_path.join("_resolved"))
-                .await
-                .unwrap_or(false)
-            {
-                REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+            if let Ok(Some(cache_path)) = registry_cache_lookup(&name, &version).await {
                 return Some(cache_path);
             }
 
@@ -179,39 +190,81 @@ pub async fn download_to_cache(name: &str, version: &str, tarball_url: &str) -> 
             let semaphore = DOWNLOAD_SEMAPHORE
                 .get_or_init(|| Semaphore::new(get_manifests_concurrency_limit_sync()));
             let _permit = semaphore.acquire().await.ok()?;
-            let bytes = download_bytes(&tarball_url)
+            download_and_extract_to_cache(&name, &version, &tarball_url)
                 .await
                 .inspect_err(|e| {
                     tracing::warn!(
-                        "Download {}@{} from {}: {:#}",
+                        "Download/extract {}@{} from {} into {}: {:#}",
                         name,
                         version,
                         tarball_url,
+                        registry_cache_path(&name, &version).display(),
                         e
                     )
                 })
-                .ok()?;
-
-            // Extract
-            extract_and_write(bytes, &cache_path)
-                .await
-                .inspect_err(|e| {
-                    tracing::warn!(
-                        "Extract {}@{} into {}: {:#}",
-                        name,
-                        version,
-                        cache_path.display(),
-                        e
-                    )
-                })
-                .ok()?;
-
-            DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
-            Some(cache_path)
+                .ok()
         })
         .await
         .as_deref()
         .cloned()
+}
+
+/// Download and extract a registry tarball without global single-flight or
+/// semaphore state. Callers that already own scheduling/deduplication should use
+/// this primitive directly.
+pub async fn download_and_extract_to_cache(
+    name: &str,
+    version: &str,
+    tarball_url: &str,
+) -> Result<PathBuf> {
+    if let Some(cache_path) = registry_cache_lookup(name, version).await? {
+        return Ok(cache_path);
+    }
+
+    let bytes = download_bytes(tarball_url)
+        .await
+        .with_context(|| format!("Download {name}@{version} from {tarball_url}"))?;
+
+    extract_to_cache(name, version, bytes).await
+}
+
+/// Return the registry cache path for a package version.
+pub fn registry_cache_path(name: &str, version: &str) -> PathBuf {
+    get_cache_dir().join(name).join(version)
+}
+
+/// Look up an already extracted registry package cache.
+pub async fn registry_cache_lookup(name: &str, version: &str) -> Result<Option<PathBuf>> {
+    let cache_path = registry_cache_path(name, version);
+    if crate::fs::try_exists(&cache_path.join("_resolved"))
+        .await
+        .unwrap_or(false)
+    {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        Ok(Some(cache_path))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Extract already downloaded registry tarball bytes into the package cache.
+pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
+    let cache_path = registry_cache_path(name, version);
+
+    if crate::fs::try_exists(&cache_path.join("_resolved"))
+        .await
+        .unwrap_or(false)
+    {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        return Ok(cache_path);
+    }
+
+    extract_and_write(bytes, &cache_path)
+        .await
+        .with_context(|| format!("Extract {name}@{version} into {}", cache_path.display()))?;
+
+    DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
+    Ok(cache_path)
 }
 
 /// Download tarball bytes with retries (network phase only).


### PR DESCRIPTION
## Summary
- Split downloader into cache lookup, byte download, and extract primitives.
- Add sync cloner primitives for scheduler workers.

## Review Focus
- Primitive APIs are stateless and do not own global single-flight state.
- **No retry inside the sync clone primitives.** `clone_dir_native_sync` (both platforms) is a single attempt that returns the error as-is; whether/how to retry is the caller's decision, not baked into the util layer. The legacy async `clone` keeps its existing `Retry::spawn` (out of scope here); only the new sync path is affected.

## Follow-up (deferred to a standalone cleanup PR)
Conclusion from review, recorded here so the cleanup can continue later:

- **Install hot path is sync-only.** The `InstallScheduler` owns dedup/inflight/waiter and calls the sync primitives on its worker pool; `clone_package_once` + the clone/download `OnceMap` single-flight are removed downstream (see #3029).
- **The async `clone_package` / `clone` stay only for the single-package path in `helper/lock.rs`**, which already runs in an async context (resolve → download → clone, serially) and does not need the scheduler.
- **Keep two entry points, but not two implementations.** The async `clone` still duplicates the platform clonefile/hardlink logic and still wraps it in `Retry::spawn`. The async entry should later collapse into a thin `spawn_blocking` wrapper over the stateless sync core — removing the duplicate, pushing the retry decision out to the caller, and fixing `clonefile` running as a blocking syscall on the async runtime (macOS).
- **This convergence is intentionally NOT done in this PR**, so the split stack composes back to #3029 exactly. It belongs in a cleanup PR after the scheduler stack lands and the hot path is stable.
