### PR TITLE
perf(pm): add install scheduler state

### DIFF
--- a/.github/workflows/pm-ci.yml
+++ b/.github/workflows/pm-ci.yml
@@ -56,7 +56,12 @@ jobs:
       - name: Disable Windows Defender
         if: runner.os == 'Windows'
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       
       # Add: Configure Git longpaths on Windows
       - name: Configure Git (Windows)

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -133,6 +133,7 @@ jobs:
           targets: x86_64-unknown-linux-gnu
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-linux
           cache-bin: false
@@ -200,6 +201,7 @@ jobs:
           targets: aarch64-apple-darwin
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-mac-arm64
           cache-bin: false
@@ -232,6 +234,7 @@ jobs:
         run: rustup target add x86_64-apple-darwin
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-mac-x64
           cache-bin: false
@@ -269,6 +272,7 @@ jobs:
           targets: x86_64-pc-windows-msvc
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           shared-key: pm-build-windows
           cache-bin: false

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -254,7 +254,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Disable Windows Defender
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       - name: Init git submodules
         run: git submodule update --init --recursive --depth 1
       - name: Setup Rust toolchain
@@ -408,7 +413,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Disable Windows Defender
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Unable to disable Windows Defender real-time monitoring: $_"
+          }
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/crates/pm/src/cmd/view.rs
+++ b/crates/pm/src/cmd/view.rs
@@ -10,6 +10,11 @@ use crate::util::user_config::get_registry;
 
 /// View package information from registry, similar to npm view
 pub async fn view(package_spec: &str) -> Result<()> {
+    let registry_url = get_registry();
+    view_with_registry(package_spec, &registry_url).await
+}
+
+async fn view_with_registry(package_spec: &str, registry_url: &str) -> Result<()> {
     tracing::debug!("Viewing package: {package_spec}");
 
     // Parse package specification
@@ -18,9 +23,8 @@ pub async fn view(package_spec: &str) -> Result<()> {
     tracing::debug!("Resolved package: {name} (spec: {version_spec})");
 
     // Fetch full manifest directly from registry (Complete format for display, no ETag)
-    let registry_url = get_registry();
     let (full_manifest, _etag) =
-        fetch_full_manifest_fresh(&registry_url, name, MetadataFormat::Complete)
+        fetch_full_manifest_fresh(registry_url, name, MetadataFormat::Complete)
             .await
             .map_err(|e| anyhow!("Failed to fetch package info for {}: {}", package_spec, e))?;
 
@@ -356,12 +360,41 @@ mod tests {
     /// because the registry service used ETag caching.
     #[tokio::test]
     async fn test_view_twice_no_304_error() {
+        use mockito::Matcher;
+
+        let mut server = mockito::Server::new_async().await;
+        let manifest = r#"{
+            "name": "is-odd",
+            "description": "mock package",
+            "dist-tags": { "latest": "1.0.0" },
+            "versions": {
+                "1.0.0": {
+                    "name": "is-odd",
+                    "version": "1.0.0",
+                    "description": "mock package",
+                    "dist": {}
+                }
+            }
+        }"#;
+        let mock = server
+            .mock("GET", "/is-odd")
+            .match_header("accept", "application/json")
+            .match_header("if-none-match", Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("etag", "\"mock-etag\"")
+            .with_body(manifest)
+            .expect(2)
+            .create_async()
+            .await;
+
         // First view - should succeed
-        let result1 = view("is-odd").await;
+        let result1 = view_with_registry("is-odd", &server.url()).await;
         assert!(result1.is_ok(), "First view failed: {:?}", result1.err());
 
         // Second view - should also succeed (not fail with 304 error)
-        let result2 = view("is-odd").await;
+        let result2 = view_with_registry("is-odd", &server.url()).await;
         assert!(result2.is_ok(), "Second view failed: {:?}", result2.err());
+        mock.assert_async().await;
     }
 }

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -66,6 +66,7 @@ pub async fn install_packages(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
     omit: &HashSet<OmitType>,
+    scheduler: Option<&super::install_scheduler::InstallScheduler>,
 ) -> Result<()> {
     use crate::util::cloner::clone_package_once;
 
@@ -144,11 +145,26 @@ pub async fn install_packages(
                     // Check if this is an optional dependency
                     let is_optional =
                         package.optional == Some(true) || package.dev_optional == Some(true);
+                    let scheduler = scheduler.cloned();
 
                     let task = tokio::spawn(async move {
-                        if let Err(e) =
-                            clone_package_once(&name, &version, &resolved, &target_path).await
-                        {
+                        let clone_result = match scheduler {
+                            Some(scheduler) => {
+                                scheduler
+                                    .ensure_clone(
+                                        name.clone(),
+                                        version,
+                                        resolved,
+                                        target_path.clone(),
+                                    )
+                                    .await
+                            }
+                            None => {
+                                clone_package_once(&name, &version, &resolved, &target_path).await
+                            }
+                        };
+
+                        if let Err(e) = clone_result {
                             if is_optional {
                                 tracing::warn!(
                                     "Optional dependency {name} failed (ignored): {e:#}"
@@ -264,9 +280,22 @@ impl InstallService {
         }
 
         let link_start = Instant::now();
-        install_packages(&groups, root_path, omit)
+        let scheduler_handle = if use_fresh_lock {
+            Some(super::install_scheduler::InstallSchedulerHandle::start())
+        } else {
+            None
+        };
+        let scheduler = scheduler_handle.as_ref().map(|handle| handle.scheduler());
+
+        let install_result = install_packages(&groups, root_path, omit, scheduler.as_ref())
             .await
-            .context("Failed to install packages")?;
+            .context("Failed to install packages");
+
+        if let Some(handle) = scheduler_handle {
+            handle.shutdown().await;
+        }
+
+        install_result?;
 
         // Wait for pipeline workers to complete (if any)
         if let Some(handles) = pipeline_handles {

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -1,0 +1,455 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow};
+use bytes::Bytes;
+use futures::stream::{FuturesUnordered, StreamExt};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::util::cloner::clone_package_from_cache_sync;
+use crate::util::downloader::{
+    download_bytes, extract_to_cache, registry_cache_lookup, resolve_seeded_cache_path,
+};
+use crate::util::user_config::get_manifests_concurrency_limit_sync;
+
+#[derive(Clone, Debug)]
+struct PackageFetch {
+    name: String,
+    version: String,
+    tarball_url: String,
+}
+
+impl PackageFetch {
+    fn key(&self) -> String {
+        format!("{}@{}", self.name, self.version)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CloneSpec {
+    package: PackageFetch,
+    target: PathBuf,
+}
+
+struct ReadyClone {
+    spec: CloneSpec,
+    cache_path: PathBuf,
+}
+
+struct DownloadedPackage {
+    package: PackageFetch,
+    bytes: Bytes,
+}
+
+type CloneResponder = oneshot::Sender<Result<(), String>>;
+
+enum Command {
+    EnsureClone(CloneSpec, CloneResponder),
+    Shutdown,
+}
+
+enum OpDone {
+    SeededCache {
+        spec: CloneSpec,
+        result: Result<Option<PathBuf>, String>,
+    },
+    Download {
+        package: PackageFetch,
+        result: Result<DownloadOutcome, String>,
+    },
+    Extract {
+        key: String,
+        result: Result<PathBuf, String>,
+    },
+    Clone {
+        target: PathBuf,
+        result: Result<(), String>,
+    },
+}
+
+enum DownloadOutcome {
+    Cached(PathBuf),
+    Bytes(Bytes),
+}
+
+#[derive(Clone)]
+pub(crate) struct InstallScheduler {
+    tx: mpsc::UnboundedSender<Command>,
+}
+
+pub(crate) struct InstallSchedulerHandle {
+    scheduler: InstallScheduler,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl InstallSchedulerHandle {
+    pub(crate) fn start() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            SchedulerState::new(rx).run().await;
+        });
+        Self {
+            scheduler: InstallScheduler { tx },
+            handle,
+        }
+    }
+
+    pub(crate) fn scheduler(&self) -> InstallScheduler {
+        self.scheduler.clone()
+    }
+
+    pub(crate) async fn shutdown(self) {
+        let _ = self.scheduler.tx.send(Command::Shutdown);
+        if let Err(e) = self.handle.await {
+            tracing::warn!("Install scheduler task failed: {e}");
+        }
+    }
+}
+
+impl InstallScheduler {
+    pub(crate) async fn ensure_clone(
+        &self,
+        name: String,
+        version: String,
+        tarball_url: String,
+        target: PathBuf,
+    ) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(Command::EnsureClone(
+                CloneSpec {
+                    package: PackageFetch {
+                        name,
+                        version,
+                        tarball_url,
+                    },
+                    target,
+                },
+                tx,
+            ))
+            .map_err(|_| anyhow!("install scheduler stopped"))?;
+        rx.await
+            .context("install scheduler stopped before clone completed")?
+            .map_err(anyhow::Error::msg)
+    }
+}
+
+struct SchedulerState {
+    rx: mpsc::UnboundedReceiver<Command>,
+    shutdown: bool,
+    download_limit: usize,
+    extract_limit: usize,
+    clone_limit: usize,
+    download_done: HashMap<String, PathBuf>,
+    download_active: HashSet<String>,
+    download_waiters: HashMap<String, Vec<CloneSpec>>,
+    download_queue: VecDeque<PackageFetch>,
+    extract_active: HashSet<String>,
+    extract_queue: VecDeque<DownloadedPackage>,
+    clone_done: HashSet<PathBuf>,
+    clone_active: HashSet<PathBuf>,
+    clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
+    clone_queue: VecDeque<ReadyClone>,
+    done_tx: mpsc::UnboundedSender<OpDone>,
+    done_rx: mpsc::UnboundedReceiver<OpDone>,
+    ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
+}
+
+impl SchedulerState {
+    fn new(rx: mpsc::UnboundedReceiver<Command>) -> Self {
+        let (done_tx, done_rx) = mpsc::unbounded_channel();
+        Self {
+            rx,
+            shutdown: false,
+            download_limit: get_manifests_concurrency_limit_sync().max(1),
+            extract_limit: extract_concurrency_limit(),
+            clone_limit: clone_concurrency_limit(),
+            download_done: HashMap::new(),
+            download_active: HashSet::new(),
+            download_waiters: HashMap::new(),
+            download_queue: VecDeque::new(),
+            extract_active: HashSet::new(),
+            extract_queue: VecDeque::new(),
+            clone_done: HashSet::new(),
+            clone_active: HashSet::new(),
+            clone_waiters: HashMap::new(),
+            clone_queue: VecDeque::new(),
+            done_tx,
+            done_rx,
+            ops: FuturesUnordered::new(),
+        }
+    }
+
+    async fn run(mut self) {
+        loop {
+            self.pump_downloads();
+            self.pump_extracts();
+            self.pump_clones();
+
+            if self.shutdown && self.is_idle() {
+                break;
+            }
+
+            tokio::select! {
+                command = self.rx.recv(), if !self.shutdown => {
+                    match command {
+                        Some(Command::EnsureClone(spec, responder)) => {
+                            self.queue_clone(spec, Some(responder));
+                        }
+                        Some(Command::Shutdown) | None => {
+                            self.shutdown = true;
+                        }
+                    }
+                }
+                done = self.ops.next(), if !self.ops.is_empty() => {
+                    match done {
+                        Some(Ok(done)) => self.handle_done(done),
+                        Some(Err(e)) => tracing::warn!("Install scheduler worker failed: {e}"),
+                        None => {}
+                    }
+                }
+                done = self.done_rx.recv() => {
+                    if let Some(done) = done {
+                        self.handle_done(done);
+                    }
+                }
+            }
+        }
+
+        self.fail_pending("install scheduler stopped before work completed");
+    }
+
+    fn is_idle(&self) -> bool {
+        self.download_queue.is_empty()
+            && self.extract_queue.is_empty()
+            && self.clone_queue.is_empty()
+            && self.download_active.is_empty()
+            && self.extract_active.is_empty()
+            && self.clone_active.is_empty()
+            && self.ops.is_empty()
+    }
+
+    fn queue_clone(&mut self, spec: CloneSpec, responder: Option<CloneResponder>) {
+        let target = spec.target.clone();
+        if self.clone_done.contains(&target) {
+            if let Some(responder) = responder {
+                let _ = responder.send(Ok(()));
+            }
+            return;
+        }
+
+        if let Some(waiters) = self.clone_waiters.get_mut(&target) {
+            if let Some(responder) = responder {
+                waiters.push(responder);
+            }
+            return;
+        }
+
+        self.clone_waiters
+            .insert(target.clone(), responder.into_iter().collect());
+
+        self.resolve_cache_for_clone(spec);
+    }
+
+    fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
+        let task_spec = spec.clone();
+        self.ops.push(tokio::spawn(async move {
+            let result = resolve_seeded_cache_path(
+                &task_spec.package.name,
+                &task_spec.package.version,
+                &task_spec.package.tarball_url,
+            )
+            .await
+            .map_err(|e| format!("{e:#}"));
+            OpDone::SeededCache { spec, result }
+        }));
+    }
+
+    fn ensure_download(&mut self, package: PackageFetch, waiter: Option<CloneSpec>) {
+        let key = package.key();
+        if let Some(cache_path) = self.download_done.get(&key).cloned() {
+            if let Some(spec) = waiter {
+                self.clone_queue.push_back(ReadyClone { spec, cache_path });
+            }
+            return;
+        }
+
+        if let Some(waiters) = self.download_waiters.get_mut(&key) {
+            if let Some(spec) = waiter {
+                waiters.push(spec);
+            }
+            return;
+        }
+
+        self.download_waiters
+            .insert(key, waiter.into_iter().collect());
+        self.download_queue.push_back(package);
+    }
+
+    fn pump_downloads(&mut self) {
+        while self.download_active.len() < self.download_limit
+            && self.extract_backlog() < self.download_limit
+        {
+            let Some(package) = self.download_queue.pop_front() else {
+                break;
+            };
+            let key = package.key();
+            if self.download_done.contains_key(&key) || !self.download_active.insert(key.clone()) {
+                continue;
+            }
+
+            self.ops.push(tokio::spawn(async move {
+                let result = match registry_cache_lookup(&package.name, &package.version).await {
+                    Ok(Some(cache_path)) => Ok(DownloadOutcome::Cached(cache_path)),
+                    Ok(None) => download_bytes(&package.tarball_url)
+                        .await
+                        .map(DownloadOutcome::Bytes)
+                        .map_err(|e| format!("{e:#}")),
+                    Err(e) => Err(format!("{e:#}")),
+                };
+                OpDone::Download { package, result }
+            }));
+        }
+    }
+
+    fn extract_backlog(&self) -> usize {
+        self.extract_queue.len() + self.extract_active.len()
+    }
+
+    fn pump_extracts(&mut self) {
+        while self.extract_active.len() < self.extract_limit {
+            let Some(downloaded) = self.extract_queue.pop_front() else {
+                break;
+            };
+            let key = downloaded.package.key();
+            if self.download_done.contains_key(&key) || !self.extract_active.insert(key.clone()) {
+                continue;
+            }
+
+            self.ops.push(tokio::spawn(async move {
+                let result = extract_to_cache(
+                    &downloaded.package.name,
+                    &downloaded.package.version,
+                    downloaded.bytes,
+                )
+                .await
+                .map_err(|e| format!("{e:#}"));
+                OpDone::Extract { key, result }
+            }));
+        }
+    }
+
+    fn pump_clones(&mut self) {
+        while self.clone_active.len() < self.clone_limit {
+            let Some(job) = self.clone_queue.pop_front() else {
+                break;
+            };
+            let target = job.spec.target.clone();
+            if self.clone_done.contains(&target) || !self.clone_active.insert(target.clone()) {
+                continue;
+            }
+
+            let done_tx = self.done_tx.clone();
+            rayon::spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    clone_package_from_cache_sync(
+                        &job.spec.package.name,
+                        &job.spec.package.version,
+                        &job.spec.package.tarball_url,
+                        &job.cache_path,
+                        &job.spec.target,
+                    )
+                    .map_err(|e| format!("{e:#}"))
+                }))
+                .unwrap_or_else(|_| Err("install clone worker panicked".to_string()));
+                let _ = done_tx.send(OpDone::Clone { target, result });
+            });
+        }
+    }
+
+    fn handle_done(&mut self, done: OpDone) {
+        match done {
+            OpDone::SeededCache { spec, result } => match result {
+                Ok(Some(cache_path)) => self.clone_queue.push_back(ReadyClone { spec, cache_path }),
+                Ok(None) => self.ensure_download(spec.package.clone(), Some(spec)),
+                Err(error) => self.complete_clone(spec.target, Err(error)),
+            },
+            OpDone::Download { package, result } => {
+                let key = package.key();
+                self.download_active.remove(&key);
+                match result {
+                    Ok(DownloadOutcome::Cached(cache_path)) => {
+                        self.complete_download(key, Ok(cache_path));
+                    }
+                    Ok(DownloadOutcome::Bytes(bytes)) => {
+                        self.extract_queue
+                            .push_back(DownloadedPackage { package, bytes });
+                    }
+                    Err(error) => {
+                        self.complete_download(key, Err(error));
+                    }
+                }
+            }
+            OpDone::Extract { key, result } => {
+                self.extract_active.remove(&key);
+                self.complete_download(key, result);
+            }
+            OpDone::Clone { target, result } => {
+                self.clone_active.remove(&target);
+                self.complete_clone(target, result);
+            }
+        }
+    }
+
+    fn complete_download(&mut self, key: String, result: Result<PathBuf, String>) {
+        let waiters = self.download_waiters.remove(&key).unwrap_or_default();
+        match result {
+            Ok(cache_path) => {
+                self.download_done.insert(key, cache_path.clone());
+                for spec in waiters {
+                    self.clone_queue.push_back(ReadyClone {
+                        spec,
+                        cache_path: cache_path.clone(),
+                    });
+                }
+            }
+            Err(error) => {
+                for spec in waiters {
+                    self.complete_clone(spec.target, Err(error.clone()));
+                }
+            }
+        }
+    }
+
+    fn complete_clone(&mut self, target: PathBuf, result: Result<(), String>) {
+        if result.is_ok() {
+            self.clone_done.insert(target.clone());
+        }
+
+        if let Some(waiters) = self.clone_waiters.remove(&target) {
+            for waiter in waiters {
+                let _ = waiter.send(result.clone());
+            }
+        }
+    }
+
+    fn fail_pending(&mut self, message: &str) {
+        for (_, waiters) in self.clone_waiters.drain() {
+            for waiter in waiters {
+                let _ = waiter.send(Err(message.to_string()));
+            }
+        }
+    }
+}
+
+fn clone_concurrency_limit() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| (n.get() * 2).clamp(4, 16))
+        .unwrap_or(8)
+}
+
+fn extract_concurrency_limit() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().clamp(2, 8))
+        .unwrap_or(4)
+}

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -453,3 +453,97 @@ fn extract_concurrency_limit() -> usize {
         .map(|n| n.get().clamp(2, 8))
         .unwrap_or(4)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn package(name: &str, version: &str) -> PackageFetch {
+        PackageFetch {
+            name: name.to_string(),
+            version: version.to_string(),
+            tarball_url: format!("https://registry.npmjs.org/{name}/-/{name}-{version}.tgz"),
+        }
+    }
+
+    fn clone_spec(name: &str, version: &str, target: &str) -> CloneSpec {
+        CloneSpec {
+            package: package(name, version),
+            target: PathBuf::from(target),
+        }
+    }
+
+    fn state() -> SchedulerState {
+        let (_tx, rx) = mpsc::unbounded_channel();
+        SchedulerState::new(rx)
+    }
+
+    #[test]
+    fn ensure_download_dedupes_inflight_package() {
+        let mut state = state();
+        let package = package("react", "18.2.0");
+        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
+
+        state.ensure_download(package.clone(), Some(waiter));
+        state.ensure_download(package, None);
+
+        assert_eq!(state.download_queue.len(), 1);
+        assert_eq!(state.download_waiters["react@18.2.0"].len(), 1);
+    }
+
+    #[test]
+    fn download_completion_releases_slot_and_queues_extract() {
+        let mut state = state();
+        let package = package("react", "18.2.0");
+        let key = package.key();
+        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
+
+        state.download_active.insert(key.clone());
+        state.download_waiters.insert(key.clone(), vec![waiter]);
+
+        state.handle_done(OpDone::Download {
+            package: package.clone(),
+            result: Ok(DownloadOutcome::Bytes(Bytes::from_static(b"tgz"))),
+        });
+
+        assert!(!state.download_active.contains(&key));
+        assert!(state.download_waiters.contains_key(&key));
+        assert_eq!(state.extract_queue.len(), 1);
+        assert_eq!(state.extract_queue[0].package.key(), key);
+    }
+
+    #[test]
+    fn extract_completion_wakes_clone_waiters() {
+        let mut state = state();
+        let key = "react@18.2.0".to_string();
+        let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
+        let cache_path = PathBuf::from("/tmp/cache/react/18.2.0");
+
+        state.extract_active.insert(key.clone());
+        state.download_waiters.insert(key.clone(), vec![waiter]);
+
+        state.handle_done(OpDone::Extract {
+            key: key.clone(),
+            result: Ok(cache_path.clone()),
+        });
+
+        assert!(!state.extract_active.contains(&key));
+        assert_eq!(state.download_done[&key], cache_path);
+        assert_eq!(state.clone_queue.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn queue_clone_dedupes_inflight_target() {
+        let mut state = state();
+        let target = PathBuf::from("/tmp/project/node_modules/react");
+        let spec = clone_spec("react", "18.2.0", target.to_string_lossy().as_ref());
+        let (first, _first_rx) = oneshot::channel();
+        let (second, _second_rx) = oneshot::channel();
+
+        state.queue_clone(spec.clone(), Some(first));
+        state.queue_clone(spec, Some(second));
+
+        assert_eq!(state.clone_waiters[&target].len(), 2);
+        assert_eq!(state.ops.len(), 1);
+    }
+}

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -142,7 +142,7 @@ struct SchedulerState {
     clone_limit: usize,
     download_done: HashMap<String, PathBuf>,
     download_active: HashSet<String>,
-    download_waiters: HashMap<String, Vec<CloneSpec>>,
+    fetch_waiters: HashMap<String, Vec<CloneSpec>>,
     download_queue: VecDeque<PackageFetch>,
     extract_active: HashSet<String>,
     extract_queue: VecDeque<DownloadedPackage>,
@@ -166,7 +166,7 @@ impl SchedulerState {
             clone_limit: clone_concurrency_limit(),
             download_done: HashMap::new(),
             download_active: HashSet::new(),
-            download_waiters: HashMap::new(),
+            fetch_waiters: HashMap::new(),
             download_queue: VecDeque::new(),
             extract_active: HashSet::new(),
             extract_queue: VecDeque::new(),
@@ -274,19 +274,20 @@ impl SchedulerState {
             return;
         }
 
-        if let Some(waiters) = self.download_waiters.get_mut(&key) {
+        if let Some(waiters) = self.fetch_waiters.get_mut(&key) {
             if let Some(spec) = waiter {
                 waiters.push(spec);
             }
             return;
         }
 
-        self.download_waiters
-            .insert(key, waiter.into_iter().collect());
+        self.fetch_waiters.insert(key, waiter.into_iter().collect());
         self.download_queue.push_back(package);
     }
 
     fn pump_downloads(&mut self) {
+        // Bound downloaded tarballs waiting for extraction so network prefetch
+        // cannot outrun CPU/disk extraction and pile up Bytes.
         while self.download_active.len() < self.download_limit
             && self.extract_backlog() < self.download_limit
         {
@@ -402,7 +403,7 @@ impl SchedulerState {
     }
 
     fn complete_download(&mut self, key: String, result: Result<PathBuf, String>) {
-        let waiters = self.download_waiters.remove(&key).unwrap_or_default();
+        let waiters = self.fetch_waiters.remove(&key).unwrap_or_default();
         match result {
             Ok(cache_path) => {
                 self.download_done.insert(key, cache_path.clone());
@@ -488,7 +489,7 @@ mod tests {
         state.ensure_download(package, None);
 
         assert_eq!(state.download_queue.len(), 1);
-        assert_eq!(state.download_waiters["react@18.2.0"].len(), 1);
+        assert_eq!(state.fetch_waiters["react@18.2.0"].len(), 1);
     }
 
     #[test]
@@ -499,7 +500,7 @@ mod tests {
         let waiter = clone_spec("react", "18.2.0", "/tmp/project/node_modules/react");
 
         state.download_active.insert(key.clone());
-        state.download_waiters.insert(key.clone(), vec![waiter]);
+        state.fetch_waiters.insert(key.clone(), vec![waiter]);
 
         state.handle_done(OpDone::Download {
             package: package.clone(),
@@ -507,7 +508,7 @@ mod tests {
         });
 
         assert!(!state.download_active.contains(&key));
-        assert!(state.download_waiters.contains_key(&key));
+        assert!(state.fetch_waiters.contains_key(&key));
         assert_eq!(state.extract_queue.len(), 1);
         assert_eq!(state.extract_queue[0].package.key(), key);
     }
@@ -520,7 +521,7 @@ mod tests {
         let cache_path = PathBuf::from("/tmp/cache/react/18.2.0");
 
         state.extract_active.insert(key.clone());
-        state.download_waiters.insert(key.clone(), vec![waiter]);
+        state.fetch_waiters.insert(key.clone(), vec![waiter]);
 
         state.handle_done(OpDone::Extract {
             key: key.clone(),
@@ -545,5 +546,52 @@ mod tests {
 
         assert_eq!(state.clone_waiters[&target].len(), 2);
         assert_eq!(state.ops.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn queue_clone_blocks_child_until_parent_completes() {
+        let mut state = state();
+        let parent_target = PathBuf::from("/tmp/project/node_modules/@scope");
+        let child_target = parent_target.join("child");
+        let parent = clone_spec("scope", "1.0.0", parent_target.to_string_lossy().as_ref());
+        let mut child = clone_spec("child", "1.0.0", child_target.to_string_lossy().as_ref());
+        child.parent = Some(parent_target.clone());
+
+        state.queue_clone(parent, None);
+        let parent_ops = state.ops.len();
+        state.queue_clone(child, None);
+
+        assert_eq!(state.blocked_by_parent[&parent_target].len(), 1);
+        assert_eq!(state.ops.len(), parent_ops);
+
+        state.complete_clone(parent_target.clone(), Ok(()));
+
+        assert!(!state.blocked_by_parent.contains_key(&parent_target));
+        assert_eq!(state.ops.len(), parent_ops + 1);
+    }
+
+    #[tokio::test]
+    async fn parent_clone_failure_wakes_blocked_children() {
+        let mut state = state();
+        let parent_target = PathBuf::from("/tmp/project/node_modules/@scope");
+        let child_target = parent_target.join("child");
+        let parent = clone_spec("scope", "1.0.0", parent_target.to_string_lossy().as_ref());
+        let mut child = clone_spec("child", "1.0.0", child_target.to_string_lossy().as_ref());
+        child.parent = Some(parent_target.clone());
+        let (child_tx, child_rx) = oneshot::channel();
+
+        state.queue_clone(parent, None);
+        state.queue_clone(child, Some(child_tx));
+
+        assert_eq!(state.blocked_by_parent[&parent_target].len(), 1);
+
+        state.complete_clone(parent_target.clone(), Err("boom".to_string()));
+
+        let error = child_rx.await.unwrap().unwrap_err();
+        let parent_path = parent_target.to_string_lossy();
+        assert!(error.contains("parent package"));
+        assert!(error.contains(parent_path.as_ref()));
+        assert!(!state.clone_waiters.contains_key(&child_target));
+        assert!(!state.blocked_by_parent.contains_key(&parent_target));
     }
 }

--- a/crates/pm/src/service/mod.rs
+++ b/crates/pm/src/service/mod.rs
@@ -6,6 +6,7 @@ pub mod dependency_graph;
 pub mod execute;
 pub mod init;
 pub mod install;
+pub mod install_scheduler;
 pub mod package;
 pub mod package_management;
 pub mod pipeline;

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
+use serde::de::DeserializeOwned;
 use tokio_retry::Retry;
 use utoo_ruborist::manifest::IdentityView;
 use utoo_ruborist::util::OnceMap;
@@ -31,6 +32,24 @@ static CLONE_COUNT: AtomicUsize = AtomicUsize::new(0);
 /// Returns the number of fresh clones performed (pnpm "added" equivalent).
 pub fn clone_count() -> usize {
     CLONE_COUNT.load(Ordering::Relaxed)
+}
+
+/// Clone a package from an already-resolved cache path without touching the
+/// global clone/download single-flight maps. Schedulers that own deduplication
+/// use this sync primitive from their worker pool.
+pub fn clone_package_from_cache_sync(
+    name: &str,
+    version: &str,
+    tarball_url: &str,
+    cache_path: &Path,
+    target_path: &Path,
+) -> Result<()> {
+    let is_git = is_git_url(tarball_url);
+    let fresh = clone_package_sync(cache_path, target_path, name, version, !is_git)?;
+    if fresh {
+        CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+    Ok(())
 }
 
 /// Normalize a target path into the canonical key used by `CLONE_CACHE`.
@@ -78,15 +97,17 @@ pub async fn clone_package_once(
     let tarball_url = tarball_url.to_string();
     let target_path = target_path.to_path_buf();
 
-    // Git packages are extracted flat (no `package/` wrapper directory),
-    // so skip `find_real_src` which would incorrectly pick a subdirectory.
-    let is_git = is_git_url(&tarball_url);
-
     CLONE_CACHE
         .get_or_init(key, || async move {
             let cache_path = resolve_cache_path(&name, &version, &tarball_url).await?;
-            let fresh = clone_package(&cache_path, &target_path, &name, &version, !is_git)
-                .await
+            tokio::task::spawn_blocking(move || {
+                clone_package_from_cache_sync(
+                    &name,
+                    &version,
+                    &tarball_url,
+                    &cache_path,
+                    &target_path,
+                )
                 .inspect_err(|e| {
                     tracing::warn!(
                         "Clone failed: {}@{} to {}: {:#}",
@@ -96,12 +117,10 @@ pub async fn clone_package_once(
                         e
                     )
                 })
-                .ok()?;
-
-            if fresh {
-                CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
-            }
-            Some(())
+                .ok()
+            })
+            .await
+            .ok()?
         })
         .await
         .map(|_| ())
@@ -172,83 +191,165 @@ mod hardlink_clone {
         Ok(())
     }
 
-    /// Clone directory using spawn_blocking for sync I/O.
-    /// Uses hardlink when possible, falls back to copy.
-    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
+    /// Clone directory using sync I/O. Uses hardlink when possible, falls back
+    /// to copy.
+    pub fn clone_dir_sync(src: &Path, dst: &Path) -> Result<()> {
         let err_msg = format!("Failed to clone {} to {}", src.display(), dst.display());
+
+        if !fs::metadata(src)?.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "Source is not a directory",
+            ))
+            .with_context(|| err_msg);
+        }
+
+        let mut force_copy = has_install_script_sync(src);
+
+        let mut files = Vec::new();
+        let mut dirs = Vec::new();
+        collect_entries(src, dst, &mut files, &mut dirs)?;
+
+        let mut created_dirs = HashSet::new();
+        for dir in &dirs {
+            if created_dirs.insert(dir.clone())
+                && let Err(e) = fs::create_dir_all(dir)
+                && e.kind() != io::ErrorKind::AlreadyExists
+            {
+                return Err(e).with_context(|| err_msg.clone());
+            }
+        }
+
+        let mut warned_per_file = false;
+        for entry in &files {
+            if force_copy {
+                copy_file_sync(&entry.src, &entry.dst)?;
+            } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
+                if e.kind() == io::ErrorKind::CrossesDevices {
+                    tracing::warn!(
+                        "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
+                        src.display(),
+                        dst.display(),
+                        e
+                    );
+                    force_copy = true;
+                } else if !warned_per_file {
+                    tracing::warn!(
+                        "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
+                        entry.src.display(),
+                        entry.dst.display(),
+                        e
+                    );
+                    warned_per_file = true;
+                }
+                copy_file_sync(&entry.src, &entry.dst)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Clone directory using spawn_blocking for callers that are still async.
+    pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
         let src = src.to_path_buf();
         let dst = dst.to_path_buf();
-
-        tokio::task::spawn_blocking(move || {
-            if !fs::metadata(&src)?.is_dir() {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotADirectory,
-                    "Source is not a directory",
-                ));
-            }
-
-            let mut force_copy = has_install_script_sync(&src);
-
-            // Phase 1: Collect all files and directories
-            let mut files = Vec::new();
-            let mut dirs = Vec::new();
-            collect_entries(&src, &dst, &mut files, &mut dirs)?;
-
-            // Phase 2: Create all directories
-            let mut created_dirs = HashSet::new();
-            for dir in &dirs {
-                if created_dirs.insert(dir.clone())
-                    && let Err(e) = fs::create_dir_all(dir)
-                    && e.kind() != io::ErrorKind::AlreadyExists
-                {
-                    return Err(e);
-                }
-            }
-
-            // Phase 3: Clone files (hardlink, fall back to copy on error).
-            //
-            // EXDEV (src cache and dst on different filesystems, e.g. a
-            // global install where ~/.cache/nm lives on a different volume
-            // than /usr/local) is a property of the src/dst pair — every
-            // remaining file would fail the same way, so latch `force_copy`
-            // and skip hardlink for the rest of this clone.
-            //
-            // Any other hardlink error (EMLINK on a single inode whose link
-            // count is exhausted, EPERM on a specific file, etc.) is
-            // per-file: copy this one and keep trying hardlink on the next.
-            // We warn only on the first such failure per package to avoid
-            // spamming hundreds of identical warnings when an entire package
-            // can't be hardlinked.
-            let mut warned_per_file = false;
-            for entry in &files {
-                if force_copy {
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                } else if let Err(e) = fs::hard_link(&entry.src, &entry.dst) {
-                    if e.kind() == io::ErrorKind::CrossesDevices {
-                        tracing::warn!(
-                            "cross-device hardlink {} -> {}: {}; falling back to copy for remaining files",
-                            src.display(),
-                            dst.display(),
-                            e
-                        );
-                        force_copy = true;
-                    } else if !warned_per_file {
-                        tracing::warn!(
-                            "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
-                            entry.src.display(),
-                            entry.dst.display(),
-                            e
-                        );
-                        warned_per_file = true;
-                    }
-                    copy_file_sync(&entry.src, &entry.dst)?;
-                }
-            }
-            Ok(())
-        })
-        .await?
-        .with_context(|| err_msg)
+        tokio::task::spawn_blocking(move || clone_dir_sync(&src, &dst)).await?
     }
+}
+
+fn load_package_json_sync<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    let pkg_path = path.join("package.json");
+    let content = std::fs::read_to_string(&pkg_path)
+        .with_context(|| format!("Failed to read file {pkg_path:?}"))?;
+
+    match serde_json::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(original_err) => match serde_json::from_str::<serde_json::Value>(&content) {
+            Ok(value) => serde_json::from_value(value)
+                .with_context(|| format!("Failed to deserialize {pkg_path:?}")),
+            Err(_) => {
+                Err(original_err).with_context(|| format!("Failed to parse JSON from {pkg_path:?}"))
+            }
+        },
+    }
+}
+
+fn validate_name_version_sync(dst: &Path, name: &str, version: &str) -> bool {
+    let Ok(pkg) = load_package_json_sync::<IdentityView>(dst) else {
+        return false;
+    };
+    pkg.name == name && pkg.version == version
+}
+
+fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(src).ok()? {
+        let entry = entry.ok()?;
+        if entry.file_type().ok()?.is_dir() {
+            let path = entry.path();
+            if path.file_name().is_some_and(|name| name != ".utoo_built") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    let src_c = CString::new(real_src.as_os_str().as_bytes())?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
+    let mut last_error = None;
+
+    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
+
+        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
+            0 => return Ok(()),
+            _ => {
+                let err = std::io::Error::last_os_error();
+                let _ = std::fs::remove_dir_all(dst);
+                last_error = Some(err);
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "clonefile {} -> {}: {}",
+        real_src.display(),
+        dst.display(),
+        last_error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string())
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    hardlink_clone::clone_dir_sync(real_src, dst)
+        .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))
+}
+
+fn clone_sync(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
+    let real_src = if find_real {
+        find_real_src_sync(src)
+            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?
+    } else {
+        src.to_path_buf()
+    };
+
+    if dst.try_exists()?
+        && let Err(e) = std::fs::remove_dir_all(dst)
+    {
+        tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+    }
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    clone_dir_native_sync(&real_src, dst)?;
+    Ok(())
 }
 
 async fn validate_directory(src: &Path, dst: &Path) -> Result<bool> {
@@ -442,6 +543,26 @@ pub async fn clone_package(
         }
     }
     clone(src, dst, find_real).await?;
+    Ok(true)
+}
+
+/// Sync clone path with the same name/version validation as [`clone_package`].
+fn clone_package_sync(
+    src: &Path,
+    dst: &Path,
+    name: &str,
+    version: &str,
+    find_real: bool,
+) -> Result<bool> {
+    if dst.try_exists()? {
+        if validate_name_version_sync(dst, name, version) {
+            return Ok(false);
+        }
+        if let Err(e) = std::fs::remove_dir_all(dst) {
+            tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+        }
+    }
+    clone_sync(src, dst, find_real)?;
     Ok(true)
 }
 
@@ -800,6 +921,31 @@ mod tests {
         // Should be cloned
         assert!(dst_dir.join("package.json").exists());
         let content = fs::read_to_string(dst_dir.join("package.json")).await?;
+        assert!(content.contains("lodash"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_clone_package_from_cache_sync_fresh_install() -> Result<()> {
+        let temp = TempDir::new()?;
+        let cache_dir = temp.path().join("cache/lodash/4.17.21");
+        let src_dir = cache_dir.join("package");
+        let dst_dir = temp.path().join("node_modules/lodash");
+
+        std::fs::create_dir_all(&src_dir)?;
+        let pkg_json = create_package_json("lodash", "4.17.21");
+        std::fs::write(src_dir.join("package.json"), &pkg_json)?;
+
+        clone_package_from_cache_sync(
+            "lodash",
+            "4.17.21",
+            "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            &cache_dir,
+            &dst_dir,
+        )?;
+
+        assert!(dst_dir.join("package.json").exists());
+        let content = std::fs::read_to_string(dst_dir.join("package.json"))?;
         assert!(content.contains("lodash"));
         Ok(())
     }

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -123,21 +123,40 @@ pub async fn http_tarball_cache_lookup(name: &str, tarball_url: &str) -> Option<
     slot_cache_lookup(name, http_cache_slot(tarball_url)).await
 }
 
+/// Resolve cache slots that may have been seeded during dependency resolution
+/// without falling through to registry download. `Ok(None)` means this is a
+/// registry-style HTTP tarball that should be downloaded into `<name>/<version>`.
+pub async fn resolve_seeded_cache_path(
+    name: &str,
+    version: &str,
+    tarball_url: &str,
+) -> Result<Option<PathBuf>> {
+    match tarball_url.parse::<Protocol>() {
+        Ok(Protocol::Git) => git_cache_lookup(name, version, tarball_url)
+            .await
+            .map(Some)
+            .ok_or_else(|| anyhow::anyhow!("git cache not found for {name}@{version}")),
+        Ok(Protocol::File) => file_cache_lookup(name, tarball_url)
+            .await
+            .map(Some)
+            .ok_or_else(|| anyhow::anyhow!("file tarball cache not found for {name}@{version}")),
+        _ => Ok(http_tarball_cache_lookup(name, tarball_url).await),
+    }
+}
+
 /// Resolve the local cache path for a package, downloading if necessary.
 ///
 /// The cloner calls this with a fully-qualified URL (never a relative
 /// path) — the install loop is responsible for any lockfile-format
 /// rewriting before we get here.
 pub async fn resolve_cache_path(name: &str, version: &str, tarball_url: &str) -> Option<PathBuf> {
-    match tarball_url.parse::<Protocol>() {
-        Ok(Protocol::Git) => git_cache_lookup(name, version, tarball_url).await,
-        Ok(Protocol::File) => file_cache_lookup(name, tarball_url).await,
-        // Otherwise try the URL-hashed http slot BFS may have seeded,
-        // then fall through to the registry `<name>/<version>/` path.
-        _ => match http_tarball_cache_lookup(name, tarball_url).await {
-            Some(p) => Some(p),
-            None => download_to_cache(name, version, tarball_url).await,
-        },
+    match resolve_seeded_cache_path(name, version, tarball_url).await {
+        Ok(Some(path)) => Some(path),
+        Ok(None) => download_to_cache(name, version, tarball_url).await,
+        Err(e) => {
+            tracing::warn!("{e:#}");
+            None
+        }
     }
 }
 
@@ -155,21 +174,13 @@ pub async fn download_to_cache(name: &str, version: &str, tarball_url: &str) -> 
         return Some((*cache_path).clone());
     }
 
-    let cache_dir = get_cache_dir();
     let name = name.to_string();
     let version = version.to_string();
     let tarball_url = tarball_url.to_string();
 
     DOWNLOAD_CACHE
         .get_or_init(key, || async move {
-            let cache_path = cache_dir.join(&name).join(&version);
-
-            // Fast path: already extracted in cache
-            if crate::fs::try_exists(&cache_path.join("_resolved"))
-                .await
-                .unwrap_or(false)
-            {
-                REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+            if let Ok(Some(cache_path)) = registry_cache_lookup(&name, &version).await {
                 return Some(cache_path);
             }
 
@@ -179,39 +190,81 @@ pub async fn download_to_cache(name: &str, version: &str, tarball_url: &str) -> 
             let semaphore = DOWNLOAD_SEMAPHORE
                 .get_or_init(|| Semaphore::new(get_manifests_concurrency_limit_sync()));
             let _permit = semaphore.acquire().await.ok()?;
-            let bytes = download_bytes(&tarball_url)
+            download_and_extract_to_cache(&name, &version, &tarball_url)
                 .await
                 .inspect_err(|e| {
                     tracing::warn!(
-                        "Download {}@{} from {}: {:#}",
+                        "Download/extract {}@{} from {} into {}: {:#}",
                         name,
                         version,
                         tarball_url,
+                        registry_cache_path(&name, &version).display(),
                         e
                     )
                 })
-                .ok()?;
-
-            // Extract
-            extract_and_write(bytes, &cache_path)
-                .await
-                .inspect_err(|e| {
-                    tracing::warn!(
-                        "Extract {}@{} into {}: {:#}",
-                        name,
-                        version,
-                        cache_path.display(),
-                        e
-                    )
-                })
-                .ok()?;
-
-            DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
-            Some(cache_path)
+                .ok()
         })
         .await
         .as_deref()
         .cloned()
+}
+
+/// Download and extract a registry tarball without global single-flight or
+/// semaphore state. Callers that already own scheduling/deduplication should use
+/// this primitive directly.
+pub async fn download_and_extract_to_cache(
+    name: &str,
+    version: &str,
+    tarball_url: &str,
+) -> Result<PathBuf> {
+    if let Some(cache_path) = registry_cache_lookup(name, version).await? {
+        return Ok(cache_path);
+    }
+
+    let bytes = download_bytes(tarball_url)
+        .await
+        .with_context(|| format!("Download {name}@{version} from {tarball_url}"))?;
+
+    extract_to_cache(name, version, bytes).await
+}
+
+/// Return the registry cache path for a package version.
+pub fn registry_cache_path(name: &str, version: &str) -> PathBuf {
+    get_cache_dir().join(name).join(version)
+}
+
+/// Look up an already extracted registry package cache.
+pub async fn registry_cache_lookup(name: &str, version: &str) -> Result<Option<PathBuf>> {
+    let cache_path = registry_cache_path(name, version);
+    if crate::fs::try_exists(&cache_path.join("_resolved"))
+        .await
+        .unwrap_or(false)
+    {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        Ok(Some(cache_path))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Extract already downloaded registry tarball bytes into the package cache.
+pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
+    let cache_path = registry_cache_path(name, version);
+
+    if crate::fs::try_exists(&cache_path.join("_resolved"))
+        .await
+        .unwrap_or(false)
+    {
+        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
+        return Ok(cache_path);
+    }
+
+    extract_and_write(bytes, &cache_path)
+        .await
+        .with_context(|| format!("Extract {name}@{version} into {}", cache_path.display()))?;
+
+    DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
+    Ok(cache_path)
 }
 
 /// Download tarball bytes with retries (network phase only).


### PR DESCRIPTION
## Summary
- Add InstallScheduler state machine for download/extract/clone de-duplication.
- Add coverage for fetch dedupe, extract handoff, clone dedupe, and parent clone barriers.

## Review Focus
- State machine invariants, parent-child clone ordering, and worker error propagation.