### PR TITLE
perf(pm): make install cache util stateless

### DIFF
--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -16,8 +16,8 @@ use super::workspace::find_workspace_path;
 use crate::fs;
 use crate::helper::workspace::find_workspaces;
 use crate::util::cli_enum::{PackageAction, SaveType};
-use crate::util::cloner::clone_package;
-use crate::util::downloader::{download_and_extract_to_cache, is_git_url};
+use crate::util::cloner::{PackageClone, clone_package};
+use crate::util::downloader::download_and_extract_to_cache;
 use crate::util::git_resolver::{resolve_git_spec, resolve_github_spec};
 use crate::util::json::{load_package_lock_json_from_path, read_json_file};
 
@@ -290,13 +290,13 @@ pub async fn prepare_global_package_json(npm_spec: &str, prefix: Option<&str>) -
         cache_path.display(),
         package_path.display()
     );
-    clone_package(
-        &cache_path,
-        &package_path,
-        &name,
-        &resolved.version,
-        !is_git_url(tarball_url),
-    )
+    clone_package(&PackageClone {
+        name: &name,
+        version: &resolved.version,
+        tarball_url,
+        cache: &cache_path,
+        target: &package_path,
+    })
     .await
     .context("Failed to clone package")?;
 

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -17,8 +17,6 @@ use crate::helper::workspace::init_project_root;
 use crate::model::package::PackageInfo;
 use crate::service::rebuild::RebuildService;
 use crate::util::cli_enum::{OmitType, PackageAction, SaveType};
-use crate::util::cloner::clone_count;
-use crate::util::downloader::download_stats;
 use crate::util::json::load_package_lock_json_from_path;
 use crate::util::linker::link;
 use crate::util::logger::{
@@ -247,11 +245,6 @@ impl InstallService {
         root_path: &Path,
         omit: &HashSet<OmitType>,
     ) -> Result<()> {
-        // Snapshot counts so nested install() calls (e.g. global install)
-        // report only their own delta instead of the whole process total.
-        let clone_baseline = clone_count();
-        let download_baseline = download_stats();
-
         let lock_path = root_path.join("package-lock.json");
         // Treat a failing freshness check as stale: regenerate rather than
         // install from a lockfile we couldn't validate. `is_pkg_lock_outdated`
@@ -261,7 +254,7 @@ impl InstallService {
         let scheduler_handle = super::install_scheduler::InstallSchedulerHandle::start();
         let scheduler = scheduler_handle.scheduler();
 
-        let (package_lock, used_scheduler_prefetch) = if use_fresh_lock {
+        let (package_lock, _) = if use_fresh_lock {
             let lock = match load_package_lock_json_from_path(root_path).await {
                 Ok(lock) => lock,
                 Err(e) => {
@@ -297,18 +290,13 @@ impl InstallService {
             .await
             .context("Failed to install packages");
 
-        scheduler_handle.shutdown().await;
-        if used_scheduler_prefetch {
-            super::install_scheduler::print_summary();
-        }
+        let counts = scheduler_handle.shutdown().await;
         install_result?;
         finish_progress_bar("node_modules cloned", Some(link_start.elapsed()));
 
         RebuildService::rebuild(&package_lock, root_path, scripts).await?;
 
-        let added = clone_count().saturating_sub(clone_baseline);
-        let download_delta = download_stats() - download_baseline;
-        print_install_counts(added, download_delta.reused, download_delta.downloaded);
+        print_install_counts(counts.cloned, counts.reused, counts.downloaded);
         Ok(())
     }
 

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -7,9 +7,9 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use utoo_ruborist::progress::{BuildEvent, EventReceiver};
 
-use crate::util::cloner::{clone_count, clone_package_from_cache_sync};
+use crate::util::cloner::{PackageClone, clone_package_sync};
 use crate::util::downloader::{
-    download_bytes, download_stats, extract_to_cache, is_registry_tarball_url,
+    ExtractOutcome, download_bytes, extract_to_cache, is_registry_tarball_url,
     registry_cache_lookup, resolve_seeded_cache_path,
 };
 use crate::util::user_config::get_manifests_concurrency_limit_sync;
@@ -67,14 +67,6 @@ impl<R: EventReceiver> EventReceiver for InstallEventReceiver<R> {
     }
 }
 
-pub(crate) fn print_summary() {
-    tracing::debug!(
-        "Install scheduler stats: downloaded={}, cloned={}",
-        download_stats().downloaded,
-        clone_count(),
-    );
-}
-
 #[derive(Clone, Debug)]
 struct PackageFetch {
     name: String,
@@ -125,17 +117,26 @@ enum OpDone {
     },
     Extract {
         key: String,
-        result: Result<PathBuf, String>,
+        result: Result<ExtractOutcome, String>,
     },
     Clone {
         target: PathBuf,
-        result: Result<(), String>,
+        result: Result<bool, String>,
     },
 }
 
 enum DownloadOutcome {
     Cached(PathBuf),
     Bytes(Bytes),
+}
+
+/// pnpm-style install outcome counts, owned by the scheduler instead of global
+/// atomic counters in the util layer.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct InstallCounts {
+    pub downloaded: usize,
+    pub reused: usize,
+    pub cloned: usize,
 }
 
 #[derive(Clone)]
@@ -145,15 +146,13 @@ pub(crate) struct InstallScheduler {
 
 pub(crate) struct InstallSchedulerHandle {
     scheduler: InstallScheduler,
-    handle: tokio::task::JoinHandle<()>,
+    handle: tokio::task::JoinHandle<InstallCounts>,
 }
 
 impl InstallSchedulerHandle {
     pub(crate) fn start() -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
-        let handle = tokio::spawn(async move {
-            SchedulerState::new(rx).run().await;
-        });
+        let handle = tokio::spawn(async move { SchedulerState::new(rx).run().await });
         Self {
             scheduler: InstallScheduler { tx },
             handle,
@@ -164,10 +163,16 @@ impl InstallSchedulerHandle {
         self.scheduler.clone()
     }
 
-    pub(crate) async fn shutdown(self) {
+    /// Signal shutdown, wait for in-flight work to drain, and return the
+    /// scheduler's own install counts.
+    pub(crate) async fn shutdown(self) -> InstallCounts {
         let _ = self.scheduler.tx.send(Command::Shutdown);
-        if let Err(e) = self.handle.await {
-            tracing::warn!("Install scheduler task failed: {e}");
+        match self.handle.await {
+            Ok(counts) => counts,
+            Err(e) => {
+                tracing::warn!("Install scheduler task failed: {e}");
+                InstallCounts::default()
+            }
         }
     }
 }
@@ -251,6 +256,7 @@ struct SchedulerState {
     done_tx: mpsc::UnboundedSender<OpDone>,
     done_rx: mpsc::UnboundedReceiver<OpDone>,
     ops: FuturesUnordered<tokio::task::JoinHandle<OpDone>>,
+    counts: InstallCounts,
 }
 
 impl SchedulerState {
@@ -276,10 +282,11 @@ impl SchedulerState {
             done_tx,
             done_rx,
             ops: FuturesUnordered::new(),
+            counts: InstallCounts::default(),
         }
     }
 
-    async fn run(mut self) {
+    async fn run(mut self) -> InstallCounts {
         loop {
             self.pump_downloads();
             self.pump_extracts();
@@ -322,6 +329,7 @@ impl SchedulerState {
         }
 
         self.fail_pending("install scheduler stopped before work completed");
+        self.counts
     }
 
     fn is_idle(&self) -> bool {
@@ -469,13 +477,13 @@ impl SchedulerState {
             let done_tx = self.done_tx.clone();
             rayon::spawn(move || {
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    clone_package_from_cache_sync(
-                        &job.spec.package.name,
-                        &job.spec.package.version,
-                        &job.spec.package.tarball_url,
-                        &job.cache_path,
-                        &job.spec.target,
-                    )
+                    clone_package_sync(&PackageClone {
+                        name: &job.spec.package.name,
+                        version: &job.spec.package.version,
+                        tarball_url: &job.spec.package.tarball_url,
+                        cache: &job.cache_path,
+                        target: &job.spec.target,
+                    })
                     .map_err(|e| format!("{e:#}"))
                 }))
                 .unwrap_or_else(|_| Err("install clone worker panicked".to_string()));
@@ -496,6 +504,7 @@ impl SchedulerState {
                 self.download_active.remove(&key);
                 match result {
                     Ok(DownloadOutcome::Cached(cache_path)) => {
+                        self.counts.reused += 1;
                         self.complete_download(key, Ok(cache_path));
                     }
                     Ok(DownloadOutcome::Bytes(bytes)) => {
@@ -509,11 +518,31 @@ impl SchedulerState {
             }
             OpDone::Extract { key, result } => {
                 self.extract_active.remove(&key);
-                self.complete_download(key, result);
+                let path_result = match result {
+                    Ok(ExtractOutcome::Extracted(path)) => {
+                        self.counts.downloaded += 1;
+                        Ok(path)
+                    }
+                    Ok(ExtractOutcome::Reused(path)) => {
+                        self.counts.reused += 1;
+                        Ok(path)
+                    }
+                    Err(e) => Err(e),
+                };
+                self.complete_download(key, path_result);
             }
             OpDone::Clone { target, result } => {
                 self.clone_active.remove(&target);
-                self.complete_clone(target, result);
+                let clone_result = match result {
+                    Ok(fresh) => {
+                        if fresh {
+                            self.counts.cloned += 1;
+                        }
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                };
+                self.complete_clone(target, clone_result);
             }
         }
     }
@@ -655,7 +684,7 @@ mod tests {
 
         state.handle_done(OpDone::Extract {
             key: key.clone(),
-            result: Ok(cache_path.clone()),
+            result: Ok(ExtractOutcome::Extracted(cache_path.clone())),
         });
 
         assert!(!state.extract_active.contains(&key));

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
@@ -11,31 +10,38 @@ use super::json::load_package_json;
 use super::retry::create_retry_strategy;
 use crate::fs;
 
-/// Number of `node_modules/` directories freshly materialized this run.
-/// Mirrors pnpm's "added" semantic.
-static CLONE_COUNT: AtomicUsize = AtomicUsize::new(0);
-
-/// Returns the number of fresh clones performed (pnpm "added" equivalent).
-pub fn clone_count() -> usize {
-    CLONE_COUNT.load(Ordering::Relaxed)
+/// How a cached package's real contents are laid out under its cache dir.
+/// Derived from the resolved tarball URL so callers never pass a bare bool.
+#[derive(Clone, Copy)]
+enum CacheLayout {
+    /// Registry tarball: contents live under a `package/` subdir, so the clone
+    /// descends into the first real subdirectory.
+    Wrapped,
+    /// Git checkout: extracted flat at the cache root; clone the dir as-is.
+    Flat,
 }
 
-/// Clone a package from an already-resolved cache path without touching the
-/// global clone/download single-flight maps. Schedulers that own deduplication
-/// use this sync primitive from their worker pool.
-pub fn clone_package_from_cache_sync(
-    name: &str,
-    version: &str,
-    tarball_url: &str,
-    cache_path: &Path,
-    target_path: &Path,
-) -> Result<()> {
-    let is_git = is_git_url(tarball_url);
-    let fresh = clone_package_sync(cache_path, target_path, name, version, !is_git)?;
-    if fresh {
-        CLONE_COUNT.fetch_add(1, Ordering::Relaxed);
+impl CacheLayout {
+    fn from_tarball_url(tarball_url: &str) -> Self {
+        if is_git_url(tarball_url) {
+            CacheLayout::Flat
+        } else {
+            CacheLayout::Wrapped
+        }
     }
-    Ok(())
+}
+
+/// A request to materialize a cached package into a `node_modules` target.
+///
+/// Bundles the package identity, its resolved cache dir, and the destination so
+/// the clone entry points take one coherent argument instead of five positional
+/// ones, and new fields stay additive.
+pub struct PackageClone<'a> {
+    pub name: &'a str,
+    pub version: &'a str,
+    pub tarball_url: &'a str,
+    pub cache: &'a Path,
+    pub target: &'a Path,
 }
 
 #[cfg(target_os = "macos")]
@@ -241,12 +247,11 @@ fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
         .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))
 }
 
-fn clone_sync(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
-    let real_src = if find_real {
-        find_real_src_sync(src)
-            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?
-    } else {
-        src.to_path_buf()
+fn clone_sync(src: &Path, dst: &Path, layout: CacheLayout) -> Result<()> {
+    let real_src = match layout {
+        CacheLayout::Wrapped => find_real_src_sync(src)
+            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?,
+        CacheLayout::Flat => src.to_path_buf(),
     };
 
     if dst.try_exists()?
@@ -360,13 +365,12 @@ pub async fn find_real_src<P: AsRef<Path>>(src: P) -> Option<PathBuf> {
     None
 }
 
-async fn clone(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
-    let real_src = if find_real {
-        find_real_src(src)
+async fn clone(src: &Path, dst: &Path, layout: CacheLayout) -> Result<()> {
+    let real_src = match layout {
+        CacheLayout::Wrapped => find_real_src(src)
             .await
-            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?
-    } else {
-        src.to_path_buf()
+            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?,
+        CacheLayout::Flat => src.to_path_buf(),
     };
 
     if crate::fs::try_exists(dst).await? {
@@ -431,49 +435,59 @@ async fn validate_name_version(dst: &Path, name: &str, version: &str) -> bool {
     pkg.name == name && pkg.version == version
 }
 
-/// Clone a package from cache to destination with name/version validation.
+/// Clone a package from its cache dir to the target with name/version
+/// validation. The cache layout (registry `package/` wrapper vs flat git
+/// checkout) is derived from the tarball URL.
 ///
-/// `find_real`: if `true`, look for the first subdirectory in `src` (registry
-/// tarballs use a `package/` wrapper); if `false`, use `src` directly (git
-/// packages are extracted flat).
-/// Returns `Ok(true)` when the package was freshly materialized at `dst`,
-/// `Ok(false)` when a valid existing directory was reused.
-pub async fn clone_package(
-    src: &Path,
-    dst: &Path,
-    name: &str,
-    version: &str,
-    find_real: bool,
-) -> Result<bool> {
-    if crate::fs::try_exists(dst).await? {
-        if validate_name_version(dst, name, version).await {
+/// Returns `Ok(true)` when the package was freshly materialized, `Ok(false)`
+/// when a valid existing directory was reused.
+pub async fn clone_package(req: &PackageClone<'_>) -> Result<bool> {
+    if crate::fs::try_exists(req.target).await? {
+        if validate_name_version(req.target, req.name, req.version).await {
             return Ok(false);
         }
-        if let Err(e) = fs::remove_dir_all(dst).await {
-            tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+        if let Err(e) = fs::remove_dir_all(req.target).await {
+            tracing::warn!(
+                "Failed to clean target directory {}: {}",
+                req.target.display(),
+                e
+            );
         }
     }
-    clone(src, dst, find_real).await?;
+    clone(
+        req.cache,
+        req.target,
+        CacheLayout::from_tarball_url(req.tarball_url),
+    )
+    .await?;
     Ok(true)
 }
 
-/// Sync clone path with the same name/version validation as [`clone_package`].
-fn clone_package_sync(
-    src: &Path,
-    dst: &Path,
-    name: &str,
-    version: &str,
-    find_real: bool,
-) -> Result<bool> {
-    if dst.try_exists()? {
-        if validate_name_version_sync(dst, name, version) {
+/// Sync clone from a resolved cache dir to `target_path`, with the same
+/// name/version validation as [`clone_package`]. The cache layout (registry
+/// `package/` wrapper vs flat git checkout) is derived from `tarball_url`.
+///
+/// Returns `Ok(true)` when freshly materialized, `Ok(false)` when an existing
+/// valid directory was reused. Stateless — callers (the install scheduler) own
+/// dedup and counting.
+pub fn clone_package_sync(req: &PackageClone<'_>) -> Result<bool> {
+    if req.target.try_exists()? {
+        if validate_name_version_sync(req.target, req.name, req.version) {
             return Ok(false);
         }
-        if let Err(e) = std::fs::remove_dir_all(dst) {
-            tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
+        if let Err(e) = std::fs::remove_dir_all(req.target) {
+            tracing::warn!(
+                "Failed to clean target directory {}: {}",
+                req.target.display(),
+                e
+            );
         }
     }
-    clone_sync(src, dst, find_real)?;
+    clone_sync(
+        req.cache,
+        req.target,
+        CacheLayout::from_tarball_url(req.tarball_url),
+    )?;
     Ok(true)
 }
 
@@ -644,7 +658,7 @@ mod tests {
         .await?;
 
         // Test cloning with find_real=false
-        clone(&src_dir, &dst_dir, false).await?;
+        clone(&src_dir, &dst_dir, CacheLayout::Flat).await?;
 
         // Verify everything was cloned
         assert!(dst_dir.join("real_dir").exists());
@@ -668,7 +682,7 @@ mod tests {
         create_test_structure(&dst_dir, &[("file.txt", Some(b"old content"))]).await?;
 
         // Clone should succeed and skip since content is identical
-        clone(&src_dir, &dst_dir, false).await?;
+        clone(&src_dir, &dst_dir, CacheLayout::Flat).await?;
         assert_eq!(
             fs::read_to_string(dst_dir.join("file.txt")).await?,
             "old content"
@@ -678,7 +692,7 @@ mod tests {
         create_test_structure(&src_dir, &[("file.txt", Some(b"content changed"))]).await?;
 
         // Clone should update the destination
-        clone(&src_dir, &dst_dir, false).await?;
+        clone(&src_dir, &dst_dir, CacheLayout::Flat).await?;
         assert_eq!(
             fs::read_to_string(dst_dir.join("file.txt")).await?,
             "content changed"
@@ -763,7 +777,14 @@ mod tests {
         // Add a marker file to verify it wasn't re-cloned
         fs::write(dst_dir.join("marker.txt"), "original").await?;
 
-        clone_package(&cache_dir, &dst_dir, "lodash", "4.17.21", true).await?;
+        clone_package(&PackageClone {
+            name: "lodash",
+            version: "4.17.21",
+            tarball_url: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            cache: &cache_dir,
+            target: &dst_dir,
+        })
+        .await?;
 
         // Marker file should still exist (wasn't deleted and re-cloned)
         assert!(dst_dir.join("marker.txt").exists());
@@ -788,7 +809,14 @@ mod tests {
         fs::write(dst_dir.join("package.json"), &old_pkg_json).await?;
         fs::write(dst_dir.join("marker.txt"), "should be deleted").await?;
 
-        clone_package(&cache_dir, &dst_dir, "lodash", "4.17.21", true).await?;
+        clone_package(&PackageClone {
+            name: "lodash",
+            version: "4.17.21",
+            tarball_url: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            cache: &cache_dir,
+            target: &dst_dir,
+        })
+        .await?;
 
         // Marker file should be gone (directory was deleted and re-cloned)
         assert!(!dst_dir.join("marker.txt").exists());
@@ -813,7 +841,14 @@ mod tests {
         // Destination doesn't exist
         assert!(!dst_dir.exists());
 
-        clone_package(&cache_dir, &dst_dir, "lodash", "4.17.21", true).await?;
+        clone_package(&PackageClone {
+            name: "lodash",
+            version: "4.17.21",
+            tarball_url: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            cache: &cache_dir,
+            target: &dst_dir,
+        })
+        .await?;
 
         // Should be cloned
         assert!(dst_dir.join("package.json").exists());
@@ -823,7 +858,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clone_package_from_cache_sync_fresh_install() -> Result<()> {
+    fn test_clone_package_sync_fresh_install() -> Result<()> {
         let temp = TempDir::new()?;
         let cache_dir = temp.path().join("cache/lodash/4.17.21");
         let src_dir = cache_dir.join("package");
@@ -833,13 +868,13 @@ mod tests {
         let pkg_json = create_package_json("lodash", "4.17.21");
         std::fs::write(src_dir.join("package.json"), &pkg_json)?;
 
-        clone_package_from_cache_sync(
-            "lodash",
-            "4.17.21",
-            "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            &cache_dir,
-            &dst_dir,
-        )?;
+        clone_package_sync(&PackageClone {
+            name: "lodash",
+            version: "4.17.21",
+            tarball_url: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            cache: &cache_dir,
+            target: &dst_dir,
+        })?;
 
         assert!(dst_dir.join("package.json").exists());
         let content = std::fs::read_to_string(dst_dir.join("package.json"))?;
@@ -861,7 +896,14 @@ mod tests {
         fs::write(cache_dir.join("package.json"), &pkg_json).await?;
         fs::write(cache_dir.join("index.js"), "module.exports = {}").await?;
 
-        clone_package(&cache_dir, &dst_dir, "my-git-pkg", "1.0.0", false).await?;
+        clone_package(&PackageClone {
+            name: "my-git-pkg",
+            version: "1.0.0",
+            tarball_url: "git+https://github.com/u/my-git-pkg.git#abc123",
+            cache: &cache_dir,
+            target: &dst_dir,
+        })
+        .await?;
 
         // Should clone directly from cache root (not looking for package/ subdir)
         assert!(dst_dir.join("package.json").exists());

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
@@ -17,36 +17,21 @@ use super::retry::{RetryableError, build_dns_cached_client, create_retry_strateg
 // the caller's scheduler.
 static DOWNLOADER_CLIENT: Lazy<Client> = Lazy::new(build_dns_cached_client);
 
-static DOWNLOAD_COUNT: AtomicUsize = AtomicUsize::new(0);
-static REUSE_COUNT: AtomicUsize = AtomicUsize::new(0);
-
-/// Process-global counters for tarball outcomes, matching pnpm's
-/// vocabulary. Scheduler-level dedupe keeps each unique `(name, version)` pair
-/// in exactly one bucket; git/file/link packages bypass this path and are not
-/// counted in either bucket.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct DownloadStats {
-    /// Tarballs fetched from the registry this run.
-    pub downloaded: usize,
-    /// Tarballs served from the local cache (no network).
-    pub reused: usize,
+/// Outcome of materializing a registry tarball into the cache. Returned so the
+/// caller (the install scheduler) keeps its own download/reuse counts instead
+/// of the util layer owning global counters.
+pub enum ExtractOutcome {
+    /// Served from an already-extracted cache directory (no work done).
+    Reused(PathBuf),
+    /// Freshly extracted from downloaded bytes.
+    Extracted(PathBuf),
 }
 
-impl std::ops::Sub for DownloadStats {
-    type Output = DownloadStats;
-    fn sub(self, rhs: Self) -> Self {
-        DownloadStats {
-            downloaded: self.downloaded.saturating_sub(rhs.downloaded),
-            reused: self.reused.saturating_sub(rhs.reused),
+impl ExtractOutcome {
+    pub fn into_path(self) -> PathBuf {
+        match self {
+            ExtractOutcome::Reused(p) | ExtractOutcome::Extracted(p) => p,
         }
-    }
-}
-
-/// Snapshot the current download/reuse counters.
-pub fn download_stats() -> DownloadStats {
-    DownloadStats {
-        downloaded: DOWNLOAD_COUNT.load(Ordering::Relaxed),
-        reused: REUSE_COUNT.load(Ordering::Relaxed),
     }
 }
 
@@ -155,7 +140,7 @@ pub async fn download_and_extract_to_cache(
         .await
         .with_context(|| format!("Download {name}@{version} from {tarball_url}"))?;
 
-    extract_to_cache(name, version, bytes).await
+    Ok(extract_to_cache(name, version, bytes).await?.into_path())
 }
 
 /// Return the registry cache path for a package version.
@@ -170,7 +155,6 @@ pub async fn registry_cache_lookup(name: &str, version: &str) -> Result<Option<P
         .await
         .unwrap_or(false)
     {
-        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
         Ok(Some(cache_path))
     } else {
         Ok(None)
@@ -178,23 +162,21 @@ pub async fn registry_cache_lookup(name: &str, version: &str) -> Result<Option<P
 }
 
 /// Extract already downloaded registry tarball bytes into the package cache.
-pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result<PathBuf> {
+pub async fn extract_to_cache(name: &str, version: &str, bytes: Bytes) -> Result<ExtractOutcome> {
     let cache_path = registry_cache_path(name, version);
 
     if crate::fs::try_exists(&cache_path.join("_resolved"))
         .await
         .unwrap_or(false)
     {
-        REUSE_COUNT.fetch_add(1, Ordering::Relaxed);
-        return Ok(cache_path);
+        return Ok(ExtractOutcome::Reused(cache_path));
     }
 
     extract_and_write(bytes, &cache_path)
         .await
         .with_context(|| format!("Extract {name}@{version} into {}", cache_path.display()))?;
 
-    DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
-    Ok(cache_path)
+    Ok(ExtractOutcome::Extracted(cache_path))
 }
 
 /// Download tarball bytes with retries (network phase only).


### PR DESCRIPTION
Architecture cleanup on top of #3029 (install scheduler), validating the review conclusions — the util layer becomes fully stateless.

- Install-stats ownership moved into `SchedulerState` (`InstallCounts`); global `CLONE_COUNT`/`DOWNLOAD_COUNT`/`REUSE_COUNT` atomics and the `install.rs` baseline/delta hack removed (each install owns its scheduler).
- `find_real` bool → `CacheLayout` enum (Wrapped/Flat).
- 5-arg clone entry points → `PackageClone` struct; trivial `clone_package_from_cache_sync` wrapper removed.
- `extract_to_cache` → `ExtractOutcome {Reused, Extracted}`.

**Purpose: confirm no perf regression vs #3029** (baseline commit `1b02caa`). Compare pm-bench-phases p0/p1/p3/p4 wall/ctx/RSS.

Base is #3029's branch so the diff shows only the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)