### PR TITLE
fix(pm): prevent concurrent clone cache corruption

### DIFF
--- a/crates/pm/src/service/package_management.rs
+++ b/crates/pm/src/service/package_management.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::install::InstallService;
 use crate::helper::lock::resolve_package_spec;
+use crate::util::process_lock;
 
 /// Package management service for handling package installation and caching
 pub struct PackageManagementService;
@@ -23,6 +24,16 @@ impl PackageManagementService {
         package_name.replace("/", "_")
     }
 
+    async fn write_install_complete_marker(package_cache_dir: &Path) -> Result<()> {
+        let marker = package_cache_dir.join(".utoo-install-complete");
+        let temp_marker = package_cache_dir.join(".utoo-install-complete.tmp");
+
+        crate::fs::write(&temp_marker, b"ok").await?;
+        crate::fs::rename(&temp_marker, &marker).await?;
+
+        Ok(())
+    }
+
     /// Install a package to the utoo cache directory using utoo's own installation logic
     /// This function is similar to prepare_global_package_json but installs to ~/.utoo/utx
     pub async fn install_package_to_cache(package_name: &str) -> Result<PathBuf> {
@@ -35,8 +46,24 @@ impl PackageManagementService {
             version
         ));
 
-        // Check if already installed
-        if crate::fs::try_exists(&package_cache_dir.join("bin")).await? {
+        let complete_marker = package_cache_dir.join(".utoo-install-complete");
+
+        // Check if already installed.  The `bin/` directory is created before
+        // binaries are fully linked, so only the explicit marker means that
+        // the install finished successfully.
+        if crate::fs::try_exists(&complete_marker).await? {
+            tracing::debug!(
+                "Package {} already cached at {}",
+                name,
+                package_cache_dir.display()
+            );
+            return Ok(package_cache_dir);
+        }
+
+        let lock_path = process_lock::lock_path_for(&package_cache_dir, ".install-lock");
+        let _lock = process_lock::lock_exclusive(&lock_path).await?;
+
+        if crate::fs::try_exists(&complete_marker).await? {
             tracing::debug!(
                 "Package {} already cached at {}",
                 name,
@@ -51,6 +78,7 @@ impl PackageManagementService {
             Some(package_cache_dir.to_string_lossy().into_owned().as_str()),
         )
         .await?;
+        Self::write_install_complete_marker(&package_cache_dir).await?;
         tracing::debug!("Package {name} installed successfully");
 
         Ok(package_cache_dir)

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -116,9 +116,13 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "macos")]
 use libc::clonefile;
 
+#[cfg(unix)]
+use libc;
+
 #[cfg(not(target_os = "macos"))]
 mod hardlink_clone {
     use std::collections::HashSet;
+    use std::io::{Read, Write};
     use std::path::{Path, PathBuf};
     use std::{fs, io};
 
@@ -135,13 +139,61 @@ mod hardlink_clone {
         })
     }
 
+    /// Copy a file from `src` to `dst`, using exclusive creation to avoid
+    /// corrupting files written by a concurrent clone of the same package.
+    ///
+    /// When multiple `utx` processes clone the same package concurrently (e.g.
+    /// the AgentPackageInstaller spawns N `utx @antskill/agentic-installer …`
+    /// commands), they can all race to create the same destination file.  A
+    /// plain `fs::copy` would `open(O_CREAT|O_TRUNC)`, which zeroes an existing
+    /// file that a sibling process is still writing — the loser truncates the
+    /// winner's output.
+    ///
+    /// Instead, we use `O_CREAT|O_EXCL` (exclusive create): the first writer
+    /// wins and proceeds normally; later writers see `AlreadyExists`, check
+    /// whether the file is already complete (same size as source), and if so
+    /// skip it.  If a previous writer crashed mid-write (size mismatch), the
+    /// incomplete destination is removed and the copy is retried once.
     fn copy_file_sync(src: &Path, dst: &Path) -> io::Result<()> {
-        fs::copy(src, dst)?;
+        // Fast path: if the destination already exists and has the same size
+        // as the source, a concurrent clone likely completed it — skip.
+        if let (Ok(src_meta), Ok(dst_meta)) = (fs::metadata(src), fs::metadata(dst)) {
+            if src_meta.len() > 0 && src_meta.len() == dst_meta.len() {
+                // Still need to fixup permissions on the early-return path.
+                #[cfg(unix)]
+                {
+                    let src_perms = src_meta.permissions();
+                    fs::set_permissions(dst, src_perms)?;
+                }
+                return Ok(());
+            }
+            // Destination exists but is incomplete (size mismatch from a
+            // crashed concurrent writer).  Remove it so we can retry.
+            let _ = fs::remove_file(dst);
+        }
+
+        let mut src_file = fs::File::open(src)?;
+        let mut dst_file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true) // O_CREAT | O_EXCL — fail if already exists
+            .open(dst)?;
+
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let n = src_file.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            dst_file.write_all(&buf[..n])?;
+        }
+        drop(dst_file); // ensure data is flushed before the size check below
+
         #[cfg(unix)]
         {
             let src_perms = fs::metadata(src)?.permissions();
             fs::set_permissions(dst, src_perms)?;
         }
+
         Ok(())
     }
 
@@ -213,6 +265,11 @@ mod hardlink_clone {
             // remaining file would fail the same way, so latch `force_copy`
             // and skip hardlink for the rest of this clone.
             //
+            // AlreadyExists: a concurrent process may have already created
+            // the destination file.  This is benign — `copy_file_sync`
+            // handles this gracefully (it skips existing files with matching
+            // size).
+            //
             // Any other hardlink error (EMLINK on a single inode whose link
             // count is exhausted, EPERM on a specific file, etc.) is
             // per-file: copy this one and keep trying hardlink on the next.
@@ -232,6 +289,11 @@ mod hardlink_clone {
                             e
                         );
                         force_copy = true;
+                    } else if e.kind() == io::ErrorKind::AlreadyExists {
+                        // Destination already exists (likely from a concurrent
+                        // clone of the same package).  `copy_file_sync` will
+                        // skip it if the file is already complete (same size),
+                        // or remove-and-retry if it was left incomplete.
                     } else if !warned_per_file {
                         tracing::warn!(
                             "hardlink failed for {} -> {}: {}; falling back to copy (further per-file failures suppressed)",
@@ -421,6 +483,13 @@ async fn validate_name_version(dst: &Path, name: &str, version: &str) -> bool {
 
 /// Clone a package from cache to destination with name/version validation.
 ///
+/// Uses an advisory file lock (`<dst>.clone-lock`) to prevent concurrent
+/// processes from racing on the same destination directory.  Multiple `utx`
+/// invocations (e.g. `AgentPackageInstaller` spawning N parallel
+/// `utx @antskill/agentic-installer …` commands) can all try to clone the
+/// same package simultaneously; without the lock they corrupt each other's
+/// output and, on overlayfs, can zero out the source cache files.
+///
 /// `find_real`: if `true`, look for the first subdirectory in `src` (registry
 /// tarballs use a `package/` wrapper); if `false`, use `src` directly (git
 /// packages are extracted flat).
@@ -433,16 +502,107 @@ pub async fn clone_package(
     version: &str,
     find_real: bool,
 ) -> Result<bool> {
+    // ── Cross-process mutual exclusion ──────────────────────────────
+    // The in-process `CLONE_CACHE` deduplicates clones *within* a single
+    // utoo process, but it cannot synchronise with other `utx` child
+    // processes that the agent scheduler spawns in parallel.  Each child
+    // enters `clone_package` independently, and without a lock they all
+    // race to `remove_dir_all` + `clone_dir` the same destination —
+    // truncating each other's in-flight writes and, on overlayfs, zeroing
+    // the npm-cache source files (see the `copy_file_sync` fix below).
+    let lock_path = dst.with_extension("clone-lock");
+    let lock_file = acquire_clone_lock(&lock_path).await?;
+
+    // Re-validate after acquiring the lock — another process may have
+    // finished cloning while we waited.
     if crate::fs::try_exists(dst).await? {
         if validate_name_version(dst, name, version).await {
+            release_clone_lock(lock_file, &lock_path).await;
             return Ok(false);
         }
         if let Err(e) = fs::remove_dir_all(dst).await {
             tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
         }
     }
+
     clone(src, dst, find_real).await?;
+
+    release_clone_lock(lock_file, &lock_path).await;
     Ok(true)
+}
+
+// ── Advisory file lock helpers ──────────────────────────────────────
+
+/// Acquire an exclusive advisory lock on `lock_path`.
+///
+/// Uses `flock(LOCK_EX)` on Unix and `LockFileEx` on Windows so that
+/// multiple *processes* serialise access to the same destination directory.
+#[cfg(unix)]
+async fn acquire_clone_lock(lock_path: &Path) -> Result<std::fs::File> {
+    use std::os::unix::io::AsRawFd;
+
+    let lock_path = lock_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        // Ensure the parent directory exists before creating the lock file.
+        if let Some(parent) = lock_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("Failed to create clone lock file {}", lock_path.display()))?;
+
+        let fd = file.as_raw_fd();
+        let ret = unsafe { libc::flock(fd, libc::LOCK_EX) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            return Err(anyhow::anyhow!(
+                "Failed to acquire clone lock on {}: {}",
+                lock_path.display(),
+                err
+            ));
+        }
+        Ok(file)
+    })
+    .await?
+}
+
+#[cfg(windows)]
+async fn acquire_clone_lock(lock_path: &Path) -> Result<std::fs::File> {
+    // Windows: use std::fs::File with LockFileEx via the windows-sys crate,
+    // or fall back to a simpler rename-based mutex if windows-sys is not
+    // available.  For now, we create the lock file without actual locking on
+    // Windows — the concurrent-clone race is primarily a Linux/overlayfs
+    // issue where multiple `utx` child processes are spawned.
+    let lock_path = lock_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        if let Some(parent) = lock_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("Failed to create clone lock file {}", lock_path.display()))?;
+        Ok(file)
+    })
+    .await?
+}
+
+/// Release the advisory lock by dropping the file handle (which releases
+/// `flock`) and best-effort removing the lock file.
+async fn release_clone_lock(lock_file: std::fs::File, lock_path: &Path) {
+    let lock_path = lock_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        // Dropping the File releases flock(LOCK_UN) automatically.
+        drop(lock_file);
+        let _ = std::fs::remove_file(&lock_path);
+    })
+    .await
+    .ok();
 }
 
 #[cfg(test)]

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -9,6 +9,7 @@ use utoo_ruborist::util::OnceMap;
 
 use super::downloader::{is_git_url, resolve_cache_path};
 use super::json::load_package_json;
+use super::process_lock;
 use super::retry::create_retry_strategy;
 use crate::fs;
 
@@ -116,9 +117,6 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "macos")]
 use libc::clonefile;
 
-#[cfg(unix)]
-use libc;
-
 #[cfg(not(target_os = "macos"))]
 mod hardlink_clone {
     use std::collections::HashSet;
@@ -142,12 +140,10 @@ mod hardlink_clone {
     /// Copy a file from `src` to `dst`, using exclusive creation to avoid
     /// corrupting files written by a concurrent clone of the same package.
     ///
-    /// When multiple `utx` processes clone the same package concurrently (e.g.
-    /// the AgentPackageInstaller spawns N `utx @antskill/agentic-installer …`
-    /// commands), they can all race to create the same destination file.  A
-    /// plain `fs::copy` would `open(O_CREAT|O_TRUNC)`, which zeroes an existing
-    /// file that a sibling process is still writing — the loser truncates the
-    /// winner's output.
+    /// When multiple processes clone the same package concurrently, they can
+    /// all race to create the same destination file. A plain `fs::copy` would
+    /// `open(O_CREAT|O_TRUNC)`, which zeroes an existing file that a sibling
+    /// process is still writing.
     ///
     /// Instead, we use `O_CREAT|O_EXCL` (exclusive create): the first writer
     /// wins and proceeds normally; later writers see `AlreadyExists`, check
@@ -410,27 +406,17 @@ pub async fn find_real_src<P: AsRef<Path>>(src: P) -> Option<PathBuf> {
     None
 }
 
-async fn clone(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
-    let real_src = if find_real {
+async fn real_source_path(src: &Path, find_real: bool) -> Result<PathBuf> {
+    if find_real {
         find_real_src(src)
             .await
-            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))?
+            .ok_or_else(|| anyhow::anyhow!("Cannot find valid source directory in {src:?}"))
     } else {
-        src.to_path_buf()
-    };
-
-    if crate::fs::try_exists(dst).await? {
-        let is_valid = validate_directory(&real_src, dst).await.unwrap_or(false);
-
-        if is_valid {
-            return Ok(());
-        }
-
-        if let Err(e) = fs::remove_dir_all(dst).await {
-            tracing::warn!("Failed to clean target directory {}: {}", dst.display(), e);
-        }
+        Ok(src.to_path_buf())
     }
+}
 
+async fn clone_materialized_dir(real_src: &Path, dst: &Path) -> Result<()> {
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent).await?;
     }
@@ -441,6 +427,7 @@ async fn clone(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
         let dst_c = CString::new(dst.as_os_str().as_bytes())?;
 
         Retry::spawn(create_retry_strategy(), || async {
+            let _ = fs::remove_dir_all(dst).await;
             match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
                 0 => Ok(()),
                 _ => {
@@ -460,7 +447,7 @@ async fn clone(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
     #[cfg(not(target_os = "macos"))]
     {
         Retry::spawn(create_retry_strategy(), || async {
-            hardlink_clone::clone_dir(&real_src, dst)
+            hardlink_clone::clone_dir(real_src, dst)
                 .await
                 .with_context(|| {
                     format!("clone_dir {} -> {}", real_src.display(), dst.display())
@@ -471,6 +458,18 @@ async fn clone(src: &Path, dst: &Path, find_real: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn clone_to_stage(real_src: &Path, parent: &Path) -> Result<PathBuf> {
+    let temp_dir = tempfile::Builder::new()
+        .prefix(".utoo-clone-")
+        .tempdir_in(parent)
+        .with_context(|| format!("Failed to create clone staging dir in {}", parent.display()))?;
+    let stage = temp_dir.path().to_path_buf();
+
+    clone_materialized_dir(real_src, &stage).await?;
+
+    Ok(temp_dir.keep())
 }
 
 /// Validate that the package.json in dst has matching name and version
@@ -484,11 +483,10 @@ async fn validate_name_version(dst: &Path, name: &str, version: &str) -> bool {
 /// Clone a package from cache to destination with name/version validation.
 ///
 /// Uses an advisory file lock (`<dst>.clone-lock`) to prevent concurrent
-/// processes from racing on the same destination directory.  Multiple `utx`
-/// invocations (e.g. `AgentPackageInstaller` spawning N parallel
-/// `utx @antskill/agentic-installer …` commands) can all try to clone the
-/// same package simultaneously; without the lock they corrupt each other's
-/// output and, on overlayfs, can zero out the source cache files.
+/// processes from racing on the same destination directory. Multiple `utx`
+/// invocations can all try to clone the same package simultaneously; without
+/// the lock they corrupt each other's output and can zero out source cache
+/// files through hardlink fallback copies.
 ///
 /// `find_real`: if `true`, look for the first subdirectory in `src` (registry
 /// tarballs use a `package/` wrapper); if `false`, use `src` directly (git
@@ -502,22 +500,14 @@ pub async fn clone_package(
     version: &str,
     find_real: bool,
 ) -> Result<bool> {
-    // ── Cross-process mutual exclusion ──────────────────────────────
-    // The in-process `CLONE_CACHE` deduplicates clones *within* a single
-    // utoo process, but it cannot synchronise with other `utx` child
-    // processes that the agent scheduler spawns in parallel.  Each child
-    // enters `clone_package` independently, and without a lock they all
-    // race to `remove_dir_all` + `clone_dir` the same destination —
-    // truncating each other's in-flight writes and, on overlayfs, zeroing
-    // the npm-cache source files (see the `copy_file_sync` fix below).
-    let lock_path = dst.with_extension("clone-lock");
-    let lock_file = acquire_clone_lock(&lock_path).await?;
+    let real_src = real_source_path(src, find_real).await?;
+    let lock_path = process_lock::lock_path_for(dst, ".clone-lock");
+    let _lock = process_lock::lock_exclusive(&lock_path).await?;
 
     // Re-validate after acquiring the lock — another process may have
     // finished cloning while we waited.
     if crate::fs::try_exists(dst).await? {
         if validate_name_version(dst, name, version).await {
-            release_clone_lock(lock_file, &lock_path).await;
             return Ok(false);
         }
         if let Err(e) = fs::remove_dir_all(dst).await {
@@ -525,84 +515,60 @@ pub async fn clone_package(
         }
     }
 
-    clone(src, dst, find_real).await?;
+    let parent = dst
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("clone destination has no parent: {}", dst.display()))?;
+    fs::create_dir_all(parent).await?;
 
-    release_clone_lock(lock_file, &lock_path).await;
-    Ok(true)
-}
+    let stage = clone_to_stage(&real_src, parent).await?;
 
-// ── Advisory file lock helpers ──────────────────────────────────────
+    if !validate_name_version(&stage, name, version).await {
+        let _ = fs::remove_dir_all(&stage).await;
+        anyhow::bail!(
+            "Cloned package identity mismatch for {}@{} in {}",
+            name,
+            version,
+            stage.display()
+        );
+    }
+    if !validate_directory(&real_src, &stage).await.unwrap_or(false) {
+        let _ = fs::remove_dir_all(&stage).await;
+        anyhow::bail!(
+            "Cloned package contents did not validate for {}@{} in {}",
+            name,
+            version,
+            stage.display()
+        );
+    }
 
-/// Acquire an exclusive advisory lock on `lock_path`.
-///
-/// Uses `flock(LOCK_EX)` on Unix and `LockFileEx` on Windows so that
-/// multiple *processes* serialise access to the same destination directory.
-#[cfg(unix)]
-async fn acquire_clone_lock(lock_path: &Path) -> Result<std::fs::File> {
-    use std::os::unix::io::AsRawFd;
-
-    let lock_path = lock_path.to_path_buf();
-    tokio::task::spawn_blocking(move || {
-        // Ensure the parent directory exists before creating the lock file.
-        if let Some(parent) = lock_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+    match fs::rename(&stage, dst).await {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            if validate_name_version(dst, name, version).await {
+                let _ = fs::remove_dir_all(&stage).await;
+                Ok(false)
+            } else {
+                fs::remove_dir_all(dst).await.with_context(|| {
+                    format!(
+                        "Failed to replace invalid target directory {}",
+                        dst.display()
+                    )
+                })?;
+                fs::rename(&stage, dst).await.with_context(|| {
+                    format!("Failed to publish staged clone to {}", dst.display())
+                })?;
+                Ok(true)
+            }
         }
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&lock_path)
-            .with_context(|| format!("Failed to create clone lock file {}", lock_path.display()))?;
-
-        let fd = file.as_raw_fd();
-        let ret = unsafe { libc::flock(fd, libc::LOCK_EX) };
-        if ret != 0 {
-            let err = std::io::Error::last_os_error();
-            return Err(anyhow::anyhow!(
-                "Failed to acquire clone lock on {}: {}",
-                lock_path.display(),
-                err
-            ));
+        Err(e) => {
+            let _ = fs::remove_dir_all(&stage).await;
+            Err(anyhow::anyhow!(
+                "Failed to publish staged clone to {}: {}",
+                dst.display(),
+                e
+            ))
         }
-        Ok(file)
-    })
-    .await?
-}
-
-#[cfg(windows)]
-async fn acquire_clone_lock(lock_path: &Path) -> Result<std::fs::File> {
-    // Windows: use std::fs::File with LockFileEx via the windows-sys crate,
-    // or fall back to a simpler rename-based mutex if windows-sys is not
-    // available.  For now, we create the lock file without actual locking on
-    // Windows — the concurrent-clone race is primarily a Linux/overlayfs
-    // issue where multiple `utx` child processes are spawned.
-    let lock_path = lock_path.to_path_buf();
-    tokio::task::spawn_blocking(move || {
-        if let Some(parent) = lock_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&lock_path)
-            .with_context(|| format!("Failed to create clone lock file {}", lock_path.display()))?;
-        Ok(file)
-    })
-    .await?
-}
-
-/// Release the advisory lock by dropping the file handle (which releases
-/// `flock`) and best-effort removing the lock file.
-async fn release_clone_lock(lock_file: std::fs::File, lock_path: &Path) {
-    let lock_path = lock_path.to_path_buf();
-    tokio::task::spawn_blocking(move || {
-        // Dropping the File releases flock(LOCK_UN) automatically.
-        drop(lock_file);
-        let _ = std::fs::remove_file(&lock_path);
-    })
-    .await
-    .ok();
+    }
 }
 
 #[cfg(test)]
@@ -786,7 +752,7 @@ mod tests {
         .await?;
 
         // Test cloning with find_real=false
-        clone(&src_dir, &dst_dir, false).await?;
+        clone_materialized_dir(&src_dir, &dst_dir).await?;
 
         // Verify everything was cloned
         assert!(dst_dir.join("real_dir").exists());
@@ -809,8 +775,8 @@ mod tests {
         create_test_structure(&src_dir, &[("file.txt", Some(b"old content"))]).await?;
         create_test_structure(&dst_dir, &[("file.txt", Some(b"old content"))]).await?;
 
-        // Clone should succeed and skip since content is identical
-        clone(&src_dir, &dst_dir, false).await?;
+        // Clone should succeed when content is identical
+        clone_materialized_dir(&src_dir, &dst_dir).await?;
         assert_eq!(
             fs::read_to_string(dst_dir.join("file.txt")).await?,
             "old content"
@@ -820,7 +786,7 @@ mod tests {
         create_test_structure(&src_dir, &[("file.txt", Some(b"content changed"))]).await?;
 
         // Clone should update the destination
-        clone(&src_dir, &dst_dir, false).await?;
+        clone_materialized_dir(&src_dir, &dst_dir).await?;
         assert_eq!(
             fs::read_to_string(dst_dir.join("file.txt")).await?,
             "content changed"
@@ -985,6 +951,55 @@ mod tests {
         assert!(dst_dir.join("index.js").exists());
         let content = fs::read_to_string(dst_dir.join("package.json")).await?;
         assert!(content.contains("my-git-pkg"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_clone_package_concurrent_same_destination() -> Result<()> {
+        let temp = TempDir::new()?;
+        let cache_dir = temp.path().join("cache/lodash/4.17.21");
+        let src_dir = cache_dir.join("package");
+        let dst_dir = temp.path().join("node_modules/lodash");
+
+        fs::create_dir_all(&src_dir).await?;
+        let pkg_json = create_package_json("lodash", "4.17.21");
+        fs::write(src_dir.join("package.json"), &pkg_json).await?;
+        fs::write(src_dir.join("index.js"), "module.exports = 'stable';").await?;
+
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let cache_dir = cache_dir.clone();
+            let dst_dir = dst_dir.clone();
+            tasks.push(tokio::spawn(async move {
+                clone_package(&cache_dir, &dst_dir, "lodash", "4.17.21", true).await
+            }));
+        }
+
+        for task in tasks {
+            task.await??;
+        }
+
+        assert!(validate_name_version(&dst_dir, "lodash", "4.17.21").await);
+        assert_eq!(
+            fs::read_to_string(src_dir.join("index.js")).await?,
+            "module.exports = 'stable';"
+        );
+        assert_eq!(
+            fs::read_to_string(dst_dir.join("index.js")).await?,
+            "module.exports = 'stable';"
+        );
+
+        let parent = dst_dir.parent().unwrap();
+        let mut read_dir = fs::read_dir(parent).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
+            let name = entry.file_name();
+            assert!(
+                !name.to_string_lossy().starts_with(".utoo-clone-"),
+                "stale clone staging directory left behind: {}",
+                entry.path().display()
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -313,4 +313,42 @@ mod tests {
         assert!(dest.join("_resolved").exists());
         assert!(dest.join("file.txt").exists());
     }
+
+    #[tokio::test]
+    async fn test_extract_and_write_concurrent_same_destination() {
+        let tar_gz = create_tar_gz();
+        let temp_dir = TempDir::new().unwrap();
+        let dest = temp_dir.path().join("pkg");
+
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let tar_gz = tar_gz.clone();
+            let dest = dest.clone();
+            tasks.push(tokio::spawn(async move {
+                extract_and_write(Bytes::from(tar_gz), &dest).await
+            }));
+        }
+
+        for task in tasks {
+            task.await.unwrap().unwrap();
+        }
+
+        assert!(dest.join("_resolved").exists());
+        assert_eq!(
+            crate::fs::read_to_string(dest.join("file.txt"))
+                .await
+                .unwrap(),
+            "hello world"
+        );
+
+        let mut read_dir = crate::fs::read_dir(temp_dir.path()).await.unwrap();
+        while let Some(entry) = read_dir.next_entry().await.unwrap() {
+            let name = entry.file_name();
+            assert!(
+                !name.to_string_lossy().starts_with(".utoo-extract-"),
+                "stale extraction staging directory left behind: {}",
+                entry.path().display()
+            );
+        }
+    }
 }

--- a/crates/pm/src/util/extractor.rs
+++ b/crates/pm/src/util/extractor.rs
@@ -4,6 +4,8 @@ use bytes::Bytes;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
+use super::process_lock;
+
 const MIN_ESTIMATED_SIZE: usize = 16;
 const MAX_ESTIMATED_SIZE: usize = 512 * 1024 * 1024; // 512MB
 const DECOMPRESSION_RETRY_FACTOR: usize = 4;
@@ -19,11 +21,78 @@ pub async fn extract_and_write(gzip_bytes: Bytes, dest: &Path) -> Result<()> {
         return Ok(());
     }
 
-    crate::fs::create_dir_all(dest)
-        .await
-        .with_context(|| format!("Failed to create destination directory: {}", dest.display()))?;
+    let lock_path = process_lock::lock_path_for(dest, ".extract-lock");
+    let _lock = process_lock::lock_exclusive(&lock_path).await?;
 
-    extract_tarball(gzip_bytes, dest).await
+    if crate::fs::try_exists(&resolved_path).await? {
+        tracing::debug!("Extract skipped, already resolved: {}", dest.display());
+        return Ok(());
+    }
+
+    let parent = dest
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("cache destination has no parent: {}", dest.display()))?;
+    crate::fs::create_dir_all(parent).await.with_context(|| {
+        format!(
+            "Failed to create cache parent directory: {}",
+            parent.display()
+        )
+    })?;
+
+    let temp_dir = tempfile::Builder::new()
+        .prefix(".utoo-extract-")
+        .tempdir_in(parent)
+        .with_context(|| {
+            format!(
+                "Failed to create extraction staging dir in {}",
+                parent.display()
+            )
+        })?;
+    let stage = temp_dir.path().to_path_buf();
+
+    extract_tarball(gzip_bytes, &stage).await?;
+    let stage = temp_dir.keep();
+
+    publish_extracted_cache(&stage, dest).await
+}
+
+async fn publish_extracted_cache(stage: &Path, dest: &Path) -> Result<()> {
+    let resolved_path = dest.join("_resolved");
+    if crate::fs::try_exists(&resolved_path).await? {
+        let _ = crate::fs::remove_dir_all(stage).await;
+        return Ok(());
+    }
+
+    if crate::fs::try_exists(dest).await? {
+        crate::fs::remove_dir_all(dest)
+            .await
+            .with_context(|| format!("Failed to remove incomplete cache {}", dest.display()))?;
+    }
+
+    match crate::fs::rename(stage, dest).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            if crate::fs::try_exists(&resolved_path).await? {
+                let _ = crate::fs::remove_dir_all(stage).await;
+                Ok(())
+            } else {
+                let _ = crate::fs::remove_dir_all(stage).await;
+                Err(anyhow::anyhow!(
+                    "Failed to publish extracted cache to {}: {}",
+                    dest.display(),
+                    e
+                ))
+            }
+        }
+        Err(e) => {
+            let _ = crate::fs::remove_dir_all(stage).await;
+            Err(anyhow::anyhow!(
+                "Failed to publish extracted cache to {}: {}",
+                dest.display(),
+                e
+            ))
+        }
+    }
 }
 
 /// Estimate uncompressed size from gzip footer (last 4 bytes store original size mod 2^32).

--- a/crates/pm/src/util/mod.rs
+++ b/crates/pm/src/util/mod.rs
@@ -14,6 +14,7 @@ pub mod linker;
 pub mod logger;
 pub mod manifest_store;
 pub mod platform_const;
+pub mod process_lock;
 pub mod project_cache;
 pub mod registry;
 pub mod retry;

--- a/crates/pm/src/util/process_lock.rs
+++ b/crates/pm/src/util/process_lock.rs
@@ -1,0 +1,125 @@
+use std::path::{Path, PathBuf};
+#[cfg(windows)]
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+#[cfg(unix)]
+pub struct ProcessLock {
+    file: std::fs::File,
+}
+
+#[cfg(windows)]
+pub struct ProcessLock {
+    lock_dir: PathBuf,
+}
+
+/// Acquire a best-effort cross-process exclusive lock.
+///
+/// Unix uses `flock`, where stale locks are released by the kernel when the
+/// owning process exits. The lock file is intentionally left on disk: deleting
+/// it while another process is waiting can split the lock across two inodes.
+#[cfg(unix)]
+pub async fn lock_exclusive(lock_path: &Path) -> Result<ProcessLock> {
+    use std::os::unix::io::AsRawFd;
+
+    let lock_path = lock_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create lock parent directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("Failed to open lock file {}", lock_path.display()))?;
+
+        let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            anyhow::bail!("Failed to acquire lock on {}: {}", lock_path.display(), err);
+        }
+
+        Ok(ProcessLock { file })
+    })
+    .await?
+}
+
+#[cfg(unix)]
+impl Drop for ProcessLock {
+    fn drop(&mut self) {
+        use std::os::unix::io::AsRawFd;
+
+        let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+/// Windows fallback: an atomic lock directory with stale-lock recovery.
+///
+/// This avoids an unbounded hang if a process crashes while holding the lock.
+/// It is less perfect than kernel-backed locking but keeps the install path
+/// recoverable on platforms where this crate has no Windows locking dependency.
+#[cfg(windows)]
+pub async fn lock_exclusive(lock_path: &Path) -> Result<ProcessLock> {
+    let lock_dir = lock_path.with_extension("lockdir");
+    let stale_after = Duration::from_secs(30 * 60);
+    if let Some(parent) = lock_dir.parent() {
+        tokio::fs::create_dir_all(parent).await.with_context(|| {
+            format!(
+                "Failed to create lock parent directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    loop {
+        match tokio::fs::create_dir(&lock_dir).await {
+            Ok(()) => return Ok(ProcessLock { lock_dir }),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if let Ok(meta) = tokio::fs::metadata(&lock_dir).await
+                    && let Ok(modified) = meta.modified()
+                    && modified.elapsed().unwrap_or_default() > stale_after
+                {
+                    let _ = tokio::fs::remove_dir_all(&lock_dir).await;
+                    continue;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "Failed to create lock directory {}: {}",
+                    lock_dir.display(),
+                    e
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ProcessLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.lock_dir);
+    }
+}
+
+pub fn lock_path_for(path: &Path, suffix: &str) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .map(|name| {
+            let mut name = name.to_os_string();
+            name.push(suffix);
+            name
+        })
+        .unwrap_or_else(|| suffix.into());
+
+    path.with_file_name(file_name)
+}


### PR DESCRIPTION
## Summary

Fix concurrent `utx` package installation corruption in the package manager cache.

When multiple `utx` processes install the same package at the same time, they can race on the same cache and install destination. This change adds cross-process locking, staged directory publication, and explicit install completion markers so sibling processes either wait for a complete install or publish a fully validated directory atomically.

## Problem Analysis

The original in-process clone deduplication only works inside a single `utoo` process. It does not synchronize sibling `utx` child processes.

For concurrent installs of the same package, multiple processes could independently enter the clone/install path and operate on the same destination directory:

- one process writes files into the destination
- another process validates the same destination as incomplete or invalid
- the second process removes the destination while the first process is still writing
- later writers can truncate files through copy fallback behavior
- postinstall scripts can observe partially materialized package contents

The `utx` package cache also used the existence of the `bin/` directory as the install-complete signal. That is too early because the directory can exist before binaries are fully linked and before package install scripts have completed.

Registry cache extraction had a similar cross-process race: tarballs were extracted directly into the final cache directory, with `_resolved` written only at the end.

## Reproduction

I reproduced the issue with the pre-fix binary using parallel `utx` execution:

```bash
/tmp/utoo-before-bin/utoo x esbuild --version
```

Stress setup:

- 6 trials
- 19 parallel processes per trial
- fresh `HOME` and `UTOO_CACHE_DIR` per trial
- registry: `https://registry.npmjs.org`

Observed pre-fix result:

```text
trials=6
parallel=19
process_failures=10
```

The failures included real corruption during `esbuild` postinstall validation. One representative failure:

```text
Error: Command failed: node .../lib/node_modules/esbuild/bin/esbuild --version
.../lib/node_modules/esbuild/bin/esbuild:1
....

SyntaxError: Invalid or unexpected token
```

This means a process observed or executed a corrupted package binary during concurrent installation.

## Fix Strategy

The fix is based on three principles:

1. Cross-process synchronization must happen outside the in-process `OnceMap`.
2. Shared cache directories must not be exposed until they are complete.
3. Install completion must be represented by an explicit marker written only after the full install succeeds.

## Implemented Changes

### Cross-process locks

Added a shared process lock utility:

- Unix: `flock(LOCK_EX)` on a stable lock file
- Windows fallback: atomic lock directory with stale-lock recovery
- lock files are intentionally not deleted on Unix to avoid splitting locks across different inodes

### Safe package clone publication

Updated package cloning to:

- acquire a `<destination>.clone-lock`
- clone into a sibling staging directory
- validate package identity and copied contents before publishing
- publish via `rename`
- avoid exposing partially cloned directories as final package contents

### Safe registry cache extraction

Updated tarball extraction to:

- acquire a `<cache>.extract-lock`
- extract into a staging directory
- publish the completed extraction via `rename`
- keep `_resolved` as the cache-ready marker

### Safe `utx` package install cache

Updated `install_package_to_cache` to:

- acquire a package-level `<package>.install-lock`
- stop using `bin/` as the completion signal
- write `.utoo-install-complete` only after `install_global_package` succeeds
- let sibling `utx` processes reuse the cache only after the completion marker exists

### Tests

Added concurrent tests for:

- cloning the same package into the same destination
- extracting the same tarball into the same cache destination

## Verification

### Unit and quality checks

```bash
cargo fmt
cargo test -p utoo-pm
cargo clippy --all-targets -- -D warnings --no-deps
npx --yes @biomejs/biome@2.1.2 check .
```

Results:

```text
cargo test -p utoo-pm:
258 passed; 0 failed; 3 ignored

cargo clippy:
passed

biome:
Checked 263 files. No fixes applied.
```

### Post-fix stress test

I rebuilt the fixed binary and reran the same style of concurrent `utx` stress test:

```bash
/tmp/utoo-after-bin/utoo x esbuild --version
```

Stress setup:

- 8 trials
- 19 parallel processes per trial
- fresh `HOME` and `UTOO_CACHE_DIR` per trial
- registry: `https://registry.npmjs.org`

Observed post-fix result:

```text
trials=8
parallel=19
process_failures=0
network_fail_logs=0
corruption_fail_logs=0
missing_bin_trials=0
non_marker_zero_files=0
```

The post-fix stress run did not reproduce the pre-fix corrupted `esbuild` binary behavior.

## Risk Notes

The fix keeps the main flow conservative:

- locks are scoped to exact cache/install destinations
- Unix locks are released by the kernel if a process exits
- Windows fallback includes stale-lock recovery
- final package/cache directories are only published after staged writes complete
- incomplete or invalid destinations are repaired under the relevant lock
- warm-cache paths remain fast through explicit completion markers
