### PR TITLE
perf(pm): add resolver ManifestProvider boundary

### DIFF
--- a/crates/pm/src/helper/ruborist_context.rs
+++ b/crates/pm/src/helper/ruborist_context.rs
@@ -50,13 +50,13 @@ impl Context {
         receiver: R,
     ) -> BuildDepsOptions<GlobImpl, R> {
         let catalogs = get_catalogs().await;
-        let warm_project_cache = Some(project_cache::load(&cwd).await);
+        let project_cache = Some(project_cache::load(&cwd).await);
         BuildDepsOptions {
             cwd,
             registry_url: get_registry(),
             cache_dir: Some(get_cache_dir()),
             manifest_store: Self::manifest_store(),
-            warm_project_cache,
+            project_cache,
             concurrency: get_manifests_concurrency_limit().await,
             peer_deps: get_peer_deps().await,
             glob: TokioGlob,

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -32,6 +32,7 @@ use crate::model::node::EdgeType;
 use crate::model::package_json::PackageJson;
 use crate::resolver::preload::{PreloadConfig, preload_manifests};
 use crate::resolver::registry::{ResolveError, resolve_registry_dep};
+use crate::service::ProjectCacheData;
 use crate::spec::{Catalogs, PackageSpec, Protocol};
 use crate::traits::progress::{BuildEvent, EventReceiver, NoopReceiver};
 use crate::traits::registry::{RegistryClient, ResolvedPackage};
@@ -117,6 +118,9 @@ pub struct BuildDepsConfig {
     /// Catalog definitions for the `catalog:` dependency protocol.
     /// Key `""` = default catalog, other keys = named catalogs.
     pub catalogs: Catalogs,
+    /// Host-provided project cache used to seed the resolver-owned manifest
+    /// cache. Consumed by the demand mainloop; the preload path ignores it.
+    pub project_cache: Option<ProjectCacheData>,
 }
 
 impl Default for BuildDepsConfig {
@@ -129,6 +133,7 @@ impl Default for BuildDepsConfig {
             git_clone_cache: Arc::new(GitCloneCache::new()),
             http_fetch_cache: Arc::new(HttpFetchCache::new()),
             catalogs: HashMap::new(),
+            project_cache: None,
         }
     }
 }
@@ -161,6 +166,12 @@ impl BuildDepsConfig {
     /// Set catalog definitions for `catalog:` protocol resolution.
     pub fn with_catalogs(mut self, catalogs: Catalogs) -> Self {
         self.catalogs = catalogs;
+        self
+    }
+
+    /// Seed the resolver-owned manifest cache with a host-provided project cache.
+    pub fn with_project_cache(mut self, project_cache: Option<ProjectCacheData>) -> Self {
+        self.project_cache = project_cache;
         self
     }
 }

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -56,7 +56,7 @@ pub struct BuildDepsOptions<G, R> {
     pub manifest_store: Arc<dyn ManifestStore>,
     /// Project-level warm cache pre-loaded by the host. Pre-populates the
     /// in-memory manifest cache to skip the preload phase on a warm install.
-    pub warm_project_cache: Option<ProjectCacheData>,
+    pub project_cache: Option<ProjectCacheData>,
     /// Maximum concurrent network requests
     pub concurrency: usize,
     /// How to handle peer dependencies.
@@ -84,7 +84,7 @@ impl<G, R> BuildDepsOptions<G, R> {
             registry_url: "https://registry.npmmirror.com".to_string(),
             cache_dir: None,
             manifest_store: Arc::new(NoopStore),
-            warm_project_cache: None,
+            project_cache: None,
             concurrency: 20,
             peer_deps: PeerDeps::Skip,
             glob,
@@ -125,7 +125,7 @@ where
         registry_url,
         cache_dir,
         manifest_store,
-        warm_project_cache,
+        project_cache,
         concurrency,
         peer_deps,
         glob,
@@ -208,7 +208,7 @@ where
     // project cache (host-supplied; `None` for cold runs).
     let package_cache = Arc::new(PackageCache::default());
     let (cache_count, missing_count) =
-        prepopulate_warm_cache(&package_cache, warm_project_cache.as_ref());
+        prepopulate_warm_cache(&package_cache, project_cache.as_ref());
     if missing_count > 0 {
         tracing::warn!(
             "Project cache has {missing_count} specs with missing manifests, will re-fetch from registry"
@@ -317,7 +317,7 @@ mod tests {
             registry_url: "https://registry.npmmirror.com".to_string(),
             cache_dir: None,
             manifest_store: Arc::new(NoopStore),
-            warm_project_cache: None,
+            project_cache: None,
             concurrency: 20,
             peer_deps: PeerDeps::Skip,
             glob: NoopGlob,

--- a/crates/ruborist/src/service/cache.rs
+++ b/crates/ruborist/src/service/cache.rs
@@ -193,7 +193,7 @@ pub type PackageCache = MemoryCache;
 ///
 /// Stores resolved package information for a specific project. Hosts persist
 /// this (typically as `node_modules/.utoo-manifest.json`) and pass it back via
-/// `BuildDepsOptions::warm_project_cache`.
+/// `BuildDepsOptions::project_cache`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProjectCacheData {
     /// package name -> per-package cache

--- a/crates/ruborist/src/service/mod.rs
+++ b/crates/ruborist/src/service/mod.rs
@@ -49,6 +49,7 @@ pub(crate) mod fetch;
 mod fs;
 pub(crate) mod http;
 pub(crate) mod manifest;
+mod provider;
 mod registry;
 mod store;
 
@@ -64,5 +65,6 @@ pub use manifest::{
     FetchVersionManifestOptions, MetadataFormat, fetch_full_manifest, fetch_full_manifest_bytes,
     fetch_full_manifest_fresh, fetch_version_manifest, fetch_version_manifest_bytes,
 };
+pub use provider::{ManifestFullData, ManifestJob, ManifestJobDone, ManifestProvider};
 pub use registry::UnifiedRegistry;
 pub use store::{ManifestStore, NoopStore};

--- a/crates/ruborist/src/service/provider.rs
+++ b/crates/ruborist/src/service/provider.rs
@@ -1,0 +1,109 @@
+//! Manifest provider boundary for resolver drivers.
+//!
+//! The demand loop owns per-run cache, waiters, and inflight de-duplication.
+//! A provider only executes one manifest job and hides whether it satisfied the
+//! job from memory, disk/OPFS, or the network.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use super::cache::VersionsInfo;
+use super::manifest::MetadataFormat;
+use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::traits::registry::RegistryClient;
+
+/// Full-manifest data returned by a provider job.
+#[derive(Debug, Clone)]
+pub enum ManifestFullData {
+    /// A parsed full manifest. When the original job carried a spec, the
+    /// provider may also return the matching version manifest extracted in the
+    /// same worker task so the main loop can avoid an extra extract hop.
+    Full {
+        manifest: Arc<FullManifest>,
+        speculative: Option<(String, Arc<CoreVersionManifest>)>,
+    },
+    /// A validated versions list, usually from a 304 path. The main loop can
+    /// resolve a concrete version and schedule a version-manifest job.
+    Versions(Arc<VersionsInfo>),
+}
+
+/// Unit of work executed by the demand loop.
+#[derive(Debug, Clone)]
+pub enum ManifestJob {
+    Full {
+        name: String,
+        /// Optional range/tag from the edge that caused this full-manifest
+        /// fetch. The provider can use it to speculatively extract the current
+        /// version while the full manifest bytes are already on a CPU worker.
+        spec: Option<String>,
+    },
+    Version {
+        name: String,
+        /// Cache/waiter key owned by the main loop.
+        spec: String,
+        /// Registry request spec. For npmjs 304 flows this is the resolved
+        /// exact version, while `spec` remains the original range key.
+        fetch_spec: String,
+        /// Metadata format for the version endpoint. Semver-capable registries
+        /// accept install-v1 for range/tag queries; npmjs exact-version
+        /// fallback requires the complete metadata format.
+        format: MetadataFormat,
+    },
+    ExtractVersion {
+        name: String,
+        spec: String,
+        version: String,
+        full: Arc<FullManifest>,
+    },
+}
+
+/// Result of one provider job.
+#[derive(Debug, Clone)]
+pub enum ManifestJobDone {
+    Full {
+        name: String,
+        data: ManifestFullData,
+    },
+    Version {
+        name: String,
+        spec: String,
+        manifest: Arc<CoreVersionManifest>,
+    },
+}
+
+/// Lower-level manifest provider used by the demand loop.
+///
+/// The driver clones the provider for each job it issues, so implementors
+/// should keep `Clone` cheap (for example by storing shared state behind `Arc`).
+///
+/// The demand loop runs single-threaded — it polls fetch jobs on a
+/// `FuturesUnordered` and never spawns them onto other threads — so the
+/// provider needs no `Send`/`Sync` bound and uses `?Send` futures uniformly
+/// across native and wasm.
+///
+/// Because the loop is single-threaded, CPU-bound work inside a job (manifest
+/// JSON parsing, version extraction) must be offloaded by the implementor, and
+/// the offload strategy differs per platform: on native, hand it to a CPU
+/// thread pool (the `*_off_runtime` helpers use `rayon` plus a oneshot
+/// back-channel) so the async runtime keeps driving network IO for the other
+/// in-flight jobs; on wasm32 there are no threads, so the same work runs
+/// inline. Confining this platform split to the provider is what lets the
+/// driver stay single-threaded and platform-agnostic.
+#[async_trait(?Send)]
+pub trait ManifestProvider: RegistryClient + Clone + 'static {
+    /// Execute one manifest job. The provider owns I/O, persistence, and
+    /// parse/extract offloading; scheduling, waiters, and inflight
+    /// de-duplication stay in the demand loop.
+    async fn execute_manifest_job(&self, job: ManifestJob) -> Result<ManifestJobDone, Self::Error>;
+}
+
+/// Raw full-manifest bytes fetched by a provider before parsing.
+#[derive(Debug, Clone)]
+pub(crate) enum ProviderFullManifestBytes {
+    Fresh { bytes: Bytes, etag: Option<String> },
+    NotModified { versions: Arc<VersionsInfo> },
+}

--- a/crates/utoo-wasm/src/deps.rs
+++ b/crates/utoo-wasm/src/deps.rs
@@ -39,7 +39,7 @@ pub async fn build_deps_from_file(
         registry_url: registry_url.unwrap_or(DEFAULT_REGISTRY).to_string(),
         cache_dir: None,
         manifest_store: Arc::new(NoopStore),
-        warm_project_cache: None,
+        project_cache: None,
         concurrency: concurrency.unwrap_or(DEFAULT_CONCURRENCY),
         peer_deps: PeerDeps::Skip,
         glob: OpfsGlob,


### PR DESCRIPTION
PR 1 of 2 (base `next`). Front-loads the **provider boundary** that the demand mainloop (#3078) consumes — interface only: no runtime state, no production impl, no driver.

### What's in this PR
- **`service/provider.rs` (new)** — the `ManifestProvider` trait + `ManifestJob` / `ManifestJobDone` / `ManifestFullData` / `ProviderFullManifestBytes` (`Debug`+`Clone`). Single-threaded `#[async_trait(?Send)]`: the driver polls jobs on a `FuturesUnordered` and never spawns, so a provider needs no `Send`/`Sync`. CPU offload is the implementor's responsibility and differs by platform (native → rayon thread pool; wasm32 → inline) — documented on the trait.
- **`service/mod.rs`** — re-export the provider types.
- **`project_cache` rename** — `warm_project_cache` → `project_cache` across the resolver and its callers (`pm/helper/ruborist_context`, `utoo-wasm/deps`, `service/api`), plus `BuildDepsConfig::project_cache` + `with_project_cache`.

### Why so small / why no impl here
The trait carries no logic, and its production impl (`impl ManifestProvider for UnifiedRegistry`) is **not** in this PR by design: that impl is coupled to making `UnifiedRegistry` stateless (dropping its internal `OnceMap` single-flight + memory cache), which only becomes correct once the mainloop owns scheduling/dedup. So the impl + statelessness + driver move together in #3078. This PR is intentionally just the reviewed seam, not a vertical slice — it's prep for the mainloop architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)