### PR TITLE
perf(pm): add resolver demand manifest store

### DIFF
--- a/crates/ruborist/src/resolver/demand/mod.rs
+++ b/crates/ruborist/src/resolver/demand/mod.rs
@@ -1,0 +1,13 @@
+//! Demand-driven resolver, split by concern:
+//!
+//! - [`state`] — per-run manifest store (cache, waiters, failures).
+//!
+//! The fetch scheduler ([`queue`]) and the driver that coordinates them land in
+//! the follow-up PRs; until then the store is staged here and exercised by its
+//! own unit tests.
+
+// Staged ahead of the driver: the only consumers so far are the unit tests, so
+// the driver-facing API is dead in this PR.
+#![allow(dead_code)]
+
+mod state;

--- a/crates/ruborist/src/resolver/demand/state.rs
+++ b/crates/ruborist/src/resolver/demand/state.rs
@@ -1,0 +1,261 @@
+//! Per-run manifest store for the demand resolver.
+//!
+//! Holds the resolved-manifest cache, the edges waiting on each pending fetch,
+//! and recorded failures — one slot per manifest kind. Pure storage with no
+//! scheduling (that lives in [`super::queue`]) and no fetch orchestration (that
+//! lives in the driver, which owns both this store and the queue).
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+use std::sync::Arc;
+
+use petgraph::graph::NodeIndex;
+
+use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::resolver::edges::DependencyEdgeInfo;
+use crate::service::VersionsInfo;
+
+/// A parked edge waiting on a pending fetch: its node and the dependency edge.
+type WaitingEdge = (NodeIndex, DependencyEdgeInfo);
+
+/// Resolved version manifests produced by one run, as neutral
+/// `(name, spec, manifest)` tuples. The persistence layer (`ProjectCacheData`)
+/// adapts these to/from disk; the store itself stays format-agnostic.
+#[derive(Default)]
+pub(crate) struct ResolverManifestCache {
+    pub(crate) entries: Vec<(String, String, Arc<CoreVersionManifest>)>,
+}
+
+/// A manifest cache slot: resolved entries, edges waiting on them, and failures.
+///
+/// The resolver keeps one slot per manifest kind (full package manifests keyed
+/// by name, version manifests keyed by `(name, spec)`), so the demand loop can
+/// dedupe fetches, park waiters, and remember failures uniformly.
+///
+/// Invariant: a key is in `cache` *or* `failures`, never both — the driver
+/// fetches each key once (single-flight) and records exactly one outcome.
+pub(crate) struct ManifestSlot<K, V> {
+    pub(crate) cache: HashMap<K, Arc<V>>,
+    pub(crate) waiters: HashMap<K, Vec<WaitingEdge>>,
+    pub(crate) failures: HashMap<K, String>,
+}
+
+// Manual `Default` so the slot does not require `K: Default`/`V: Default`.
+impl<K, V> Default for ManifestSlot<K, V> {
+    fn default() -> Self {
+        Self {
+            cache: HashMap::new(),
+            waiters: HashMap::new(),
+            failures: HashMap::new(),
+        }
+    }
+}
+
+impl<K: Eq + Hash + Clone, V> ManifestSlot<K, V> {
+    /// Already resolved or failed — no need to fetch again.
+    pub(crate) fn is_settled(&self, key: &K) -> bool {
+        self.cache.contains_key(key) || self.failures.contains_key(key)
+    }
+
+    /// Move every edge waiting on `key` into `pending` so they retry next pass.
+    pub(crate) fn wake(&mut self, key: &K, pending: &mut VecDeque<WaitingEdge>) {
+        if let Some(waiters) = self.waiters.remove(key) {
+            pending.extend(waiters);
+        }
+    }
+}
+
+/// The per-run manifest store: one slot per manifest kind plus the versions
+/// lists. Read/written by the driver through the methods below; the driver owns
+/// scheduling separately (see [`super::queue`]).
+#[derive(Default)]
+pub(crate) struct ManifestState {
+    /// Full package manifests, keyed by package name.
+    pub(crate) full: ManifestSlot<String, FullManifest>,
+    /// Version manifests, keyed by `(name, spec)`.
+    pub(crate) version: ManifestSlot<(String, String), CoreVersionManifest>,
+    /// Versions lists from 304/abbreviated responses (a `Full` job by-product).
+    pub(crate) versions_cache: HashMap<String, Arc<VersionsInfo>>,
+}
+
+impl ManifestState {
+    /// Build a store pre-seeded with already-resolved `(name, spec, manifest)`
+    /// entries (e.g. from a warm project cache). The caller adapts whatever
+    /// persistence format it has into these neutral tuples.
+    pub(crate) fn seeded(entries: Vec<(String, String, Arc<CoreVersionManifest>)>) -> Self {
+        let mut state = Self::default();
+        for (name, spec, manifest) in entries {
+            state.cache_version(name, spec, manifest);
+        }
+        state
+    }
+
+    /// Drain the resolved version manifests as neutral tuples (for persistence).
+    pub(crate) fn into_resolver_cache(self) -> ResolverManifestCache {
+        ResolverManifestCache {
+            entries: self
+                .version
+                .cache
+                .into_iter()
+                .map(|((name, spec), manifest)| (name, spec, manifest))
+                .collect(),
+        }
+    }
+
+    /// Look up a cached version manifest by `(name, spec)`.
+    pub(crate) fn get_version_manifest(
+        &self,
+        name: &str,
+        spec: &str,
+    ) -> Option<Arc<CoreVersionManifest>> {
+        self.version
+            .cache
+            .get(&(name.to_string(), spec.to_string()))
+            .cloned()
+    }
+
+    /// Look up a recorded fetch failure for `(name, spec)`.
+    pub(crate) fn get_version_failure(&self, name: &str, spec: &str) -> Option<&str> {
+        self.version
+            .failures
+            .get(&(name.to_string(), spec.to_string()))
+            .map(String::as_str)
+    }
+
+    /// Whether `(name, spec)` is already resolved or failed — no refetch needed.
+    pub(crate) fn is_version_settled(&self, name: &str, spec: &str) -> bool {
+        self.version
+            .is_settled(&(name.to_string(), spec.to_string()))
+    }
+
+    /// Record a fetch failure for `(name, spec)`.
+    pub(crate) fn fail_version(&mut self, name: &str, spec: &str, error: String) {
+        self.version
+            .failures
+            .insert((name.to_string(), spec.to_string()), error);
+    }
+
+    /// Move every edge waiting on `(name, spec)` into `ready` so it retries.
+    pub(crate) fn wake_version(
+        &mut self,
+        name: &str,
+        spec: &str,
+        ready: &mut VecDeque<WaitingEdge>,
+    ) {
+        self.version
+            .wake(&(name.to_string(), spec.to_string()), ready);
+    }
+
+    /// Cache a version manifest under both its requested spec and its resolved
+    /// version, so later lookups by either key hit memory.
+    pub(crate) fn cache_version(
+        &mut self,
+        name: String,
+        spec: String,
+        manifest: Arc<CoreVersionManifest>,
+    ) {
+        let version = manifest.version.clone();
+        self.version
+            .cache
+            .insert((name.clone(), spec), Arc::clone(&manifest));
+        self.version
+            .cache
+            .entry((name, version))
+            .or_insert(manifest);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(name: &str, version: &str) -> Arc<CoreVersionManifest> {
+        Arc::new(CoreVersionManifest {
+            name: name.to_string(),
+            version: version.to_string(),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_cache_version_indexes_by_spec_and_version() {
+        let mut state = ManifestState::default();
+        state.cache_version(
+            "pkg".to_string(),
+            "^1.0.0".to_string(),
+            manifest("pkg", "1.2.3"),
+        );
+        // Reachable by both the requested spec and the resolved version, and it
+        // is the manifest we stored — not merely *some* entry.
+        assert_eq!(
+            state.get_version_manifest("pkg", "^1.0.0").unwrap().version,
+            "1.2.3"
+        );
+        assert_eq!(
+            state.get_version_manifest("pkg", "1.2.3").unwrap().version,
+            "1.2.3"
+        );
+        assert!(state.get_version_manifest("pkg", "^9.0.0").is_none());
+    }
+
+    #[test]
+    fn test_cache_version_collapses_when_spec_equals_version() {
+        // An exact-version spec keys both inserts to the same slot → one entry.
+        let mut state = ManifestState::default();
+        state.cache_version(
+            "pkg".to_string(),
+            "1.2.3".to_string(),
+            manifest("pkg", "1.2.3"),
+        );
+        assert_eq!(
+            state.get_version_manifest("pkg", "1.2.3").unwrap().version,
+            "1.2.3"
+        );
+        assert_eq!(state.into_resolver_cache().entries.len(), 1);
+    }
+
+    #[test]
+    fn test_seeded_preloads_entries() {
+        let state = ManifestState::seeded(vec![(
+            "a".to_string(),
+            "^1".to_string(),
+            manifest("a", "1.0.0"),
+        )]);
+        assert_eq!(
+            state.get_version_manifest("a", "^1").unwrap().version,
+            "1.0.0"
+        );
+        assert_eq!(
+            state.get_version_manifest("a", "1.0.0").unwrap().version,
+            "1.0.0"
+        );
+    }
+
+    #[test]
+    fn test_fail_version_records_and_settles() {
+        let mut state = ManifestState::default();
+        assert!(!state.is_version_settled("pkg", "^1"));
+        state.fail_version("pkg", "^1", "boom".to_string());
+        assert_eq!(state.get_version_failure("pkg", "^1"), Some("boom"));
+        assert!(state.is_version_settled("pkg", "^1"));
+    }
+
+    #[test]
+    fn test_into_resolver_cache_drains_both_keys() {
+        let mut state = ManifestState::default();
+        state.cache_version(
+            "pkg".to_string(),
+            "^1.0.0".to_string(),
+            manifest("pkg", "1.2.3"),
+        );
+        // Drains both the requested-spec and resolved-version entries.
+        let mut specs: Vec<String> = state
+            .into_resolver_cache()
+            .entries
+            .into_iter()
+            .map(|(_, spec, _)| spec)
+            .collect();
+        specs.sort();
+        assert_eq!(specs, ["1.2.3", "^1.0.0"]);
+    }
+}

--- a/crates/ruborist/src/resolver/mod.rs
+++ b/crates/ruborist/src/resolver/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod builder;
 pub mod common;
+pub(crate) mod demand;
 pub mod edges;
 #[cfg(feature = "native-git")]
 pub mod git;


### PR DESCRIPTION
Part of the resolver demand-loop rework (split from the old combined #3079). The per-run manifest **store**, an independent module.

`crates/ruborist/src/resolver/demand/state.rs`:
- `ManifestSlot<K,V>` — `{ cache, waiters, failures }` per manifest kind (full keyed by name, version by `(name, spec)`), with `is_settled` / `wake`.
- `ManifestState` — the slots + `versions_cache`, with get/set accessors (`version_manifest` / `version_failure` / `is_version_settled` / `cache_version` / `fail_version` / `wake_version`), `seeded(...)`, and neutral `ResolverManifestCache` output.

Pure storage: **no fetch scheduling** (that is #3080, `queue`) and **no orchestration** (that is the driver, #3078). **Format-agnostic** — speaks neutral `(name, spec, manifest)` tuples; the `ProjectCacheData` ↔ tuples adapter lives on `ProjectCacheData` itself (in #3078), so the store never knows the on-disk format.

Bottom of the stack: #3080 (scheduler) and #3078 (driver) build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)