### PR TITLE
fix(pm): install global/utx packages as deps, not root projects

### DIFF
--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -16,8 +16,6 @@ use super::workspace::find_workspace_path;
 use crate::fs;
 use crate::helper::workspace::find_workspaces;
 use crate::util::cli_enum::{PackageAction, SaveType};
-use crate::util::cloner::clone_package;
-use crate::util::downloader::{is_git_url, resolve_cache_path};
 use crate::util::git_resolver::{resolve_git_spec, resolve_github_spec};
 use crate::util::json::{load_package_lock_json_from_path, read_json_file};
 
@@ -230,13 +228,30 @@ pub async fn resolve_package_spec(spec: &str) -> Result<(String, String, String)
     }
 }
 
-pub async fn prepare_global_package_json(npm_spec: &str, prefix: Option<&str>) -> Result<PathBuf> {
-    // Parse package name and version
-    let (name, _version, version_spec) = resolve_package_spec(npm_spec).await?;
-    let lib_path = match prefix {
+/// Generate (or extend) the wrapper project that holds globally-installed
+/// packages as *dependencies*, returning the resolved package name and the
+/// wrapper project directory.
+///
+/// Globally-installed packages (`utoo install -g`, `utoo x`) are installed as
+/// dependencies of this wrapper rather than as root projects. As dependencies
+/// they run the install lifecycle (`preinstall`/`install`/`postinstall`, e.g.
+/// esbuild's binary download in `postinstall`) but never `prepare`/`prepublish`,
+/// and their `devDependencies` are not installed — matching `npm install -g`
+/// and bun. This means we no longer rewrite the package's own package.json: the
+/// previous root-install approach deleted `devDependencies`/`prepare` in place,
+/// which both ran prepare on published tarballs (wrong) and raced under
+/// concurrent installs sharing the cache dir.
+pub async fn prepare_global_package_json(
+    npm_spec: &str,
+    prefix: Option<&str>,
+) -> Result<(String, PathBuf)> {
+    let (name, version, _version_spec) = resolve_package_spec(npm_spec).await?;
+
+    // Wrapper project root = parent of the global node_modules dir.
+    // Unix: `<prefix>/lib`  ·  Windows: `<prefix>`.
+    let global_node_modules = match prefix {
         Some(prefix) => PathBuf::from(prefix).join(GLOBAL_NODE_MODULES),
         None => {
-            // Get current executable path
             let current_exe = std::env::current_exe()?;
             current_exe
                 .parent()
@@ -246,88 +261,68 @@ pub async fn prepare_global_package_json(npm_spec: &str, prefix: Option<&str>) -
                 .join(GLOBAL_NODE_MODULES)
         }
     };
+    let wrapper_dir = global_node_modules
+        .parent()
+        .ok_or_else(|| {
+            anyhow!(
+                "global node_modules has no parent: {}",
+                global_node_modules.display()
+            )
+        })?
+        .to_path_buf();
+    fs::create_dir_all(&wrapper_dir).await?;
 
-    tracing::debug!("lib_path: {}", lib_path.to_string_lossy());
+    upsert_wrapper_dependency(&wrapper_dir, &name, &version).await?;
 
-    // Create global package directory
-    let package_path = lib_path.join(&name);
-    fs::create_dir_all(&package_path).await?;
+    tracing::debug!("wrapper_dir: {}", wrapper_dir.to_string_lossy());
+    Ok((name, wrapper_dir))
+}
 
-    // Get package info from registry
-    let resolved = resolve_package(&Context::registry(), &name, &version_spec)
-        .await
-        .context("Failed to resolve package")?;
+/// Add or update `name@version` in the wrapper project's `package.json`
+/// dependencies, accumulating across `install -g` calls.
+///
+/// Written atomically (temp file + rename) so concurrent writers never observe
+/// a half-written file; skips the write entirely when the entry is already
+/// present and identical (the common concurrent `utx` re-install case).
+async fn upsert_wrapper_dependency(wrapper_dir: &Path, name: &str, version: &str) -> Result<()> {
+    let pkg_json_path = wrapper_dir.join("package.json");
 
-    // Get tarball URL from manifest
-    let tarball_url = resolved
-        .manifest
-        .dist
-        .tarball
-        .as_ref()
-        .ok_or_else(|| anyhow!("Failed to get tarball URL from manifest"))?;
+    let mut package_json: Value = if fs::try_exists(&pkg_json_path).await.unwrap_or(false) {
+        let content = fs::read_to_string(&pkg_json_path).await?;
+        serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
 
-    // Download and extract package to cache.
-    let cache_path = resolve_cache_path(&name, &resolved.version, tarball_url)
-        .await
-        .ok_or_else(|| anyhow!("Failed to download package {name}"))?;
-
-    // If the package has install scripts, create a flag file
-    // in linux, we can use hardlink when FICLONE is not supported
-    // so we need to copy the file to the package directory to avoid effect other packages
-    if resolved.manifest.has_install_script == Some(true) {
-        let has_install_script_flag_path = cache_path.join("_hasInstallScript");
-        if !fs::try_exists(&has_install_script_flag_path)
-            .await
-            .unwrap_or(false)
-        {
-            fs::write(has_install_script_flag_path, "").await?;
-        }
-    }
-
-    // Clone to package directory
-    tracing::debug!(
-        "Cloning {} to {}",
-        cache_path.display(),
-        package_path.display()
-    );
-    clone_package(
-        &cache_path,
-        &package_path,
-        &name,
-        &resolved.version,
-        !is_git_url(tarball_url),
-    )
-    .await
-    .context("Failed to clone package")?;
-
-    // Remove devDependencies from package.json
-    let package_json_path = package_path.join("package.json");
-    let package_json_content = fs::read_to_string(&package_json_path).await?;
-    let mut package_json: Value = serde_json::from_str(&package_json_content)?;
-
-    // Remove specified dependency fields and scripts.prepare
-    let package_obj = package_json
+    let obj = package_json
         .as_object_mut()
-        .expect("package.json must be an object");
-    package_obj.remove("devDependencies");
+        .ok_or_else(|| anyhow!("wrapper package.json is not a JSON object"))?;
+    obj.entry("name")
+        .or_insert_with(|| Value::String("utoo-global".to_string()));
+    obj.entry("version")
+        .or_insert_with(|| Value::String("0.0.0".to_string()));
+    obj.entry("private").or_insert(Value::Bool(true));
 
-    // Remove scripts.prepare if it exists
-    if let Some(scripts) = package_obj.get_mut("scripts")
-        && let Some(scripts_obj) = scripts.as_object_mut()
-    {
-        scripts_obj.remove("prepare");
-        scripts_obj.remove("prepublish");
+    let deps = obj
+        .entry("dependencies")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let deps_obj = deps
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("wrapper dependencies is not a JSON object"))?;
+
+    let new_value = Value::String(version.to_string());
+    if deps_obj.get(name) == Some(&new_value) {
+        // Already recorded (e.g. a concurrent utx of the same package).
+        return Ok(());
     }
+    deps_obj.insert(name.to_string(), new_value);
 
-    // Write back the modified package.json
-    fs::write(
-        &package_json_path,
-        serde_json::to_string_pretty(&package_json)?,
-    )
-    .await?;
+    let content = serde_json::to_string_pretty(&package_json)?;
+    let tmp_path = wrapper_dir.join(format!(".package.json.{}.tmp", std::process::id()));
+    fs::write(&tmp_path, content).await?;
+    fs::rename(&tmp_path, &pkg_json_path).await?;
 
-    tracing::debug!("package_path: {}", package_path.to_string_lossy());
-    Ok(package_path)
+    Ok(())
 }
 
 /// Extract the relative package name from a package directory path string.

--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -245,7 +245,7 @@ pub async fn prepare_global_package_json(
     npm_spec: &str,
     prefix: Option<&str>,
 ) -> Result<(String, PathBuf)> {
-    let (name, version, _version_spec) = resolve_package_spec(npm_spec).await?;
+    let (name, version, version_spec) = resolve_package_spec(npm_spec).await?;
 
     // Wrapper project root = parent of the global node_modules dir.
     // Unix: `<prefix>/lib`  ·  Windows: `<prefix>`.
@@ -272,7 +272,13 @@ pub async fn prepare_global_package_json(
         .to_path_buf();
     fs::create_dir_all(&wrapper_dir).await?;
 
-    upsert_wrapper_dependency(&wrapper_dir, &name, &version).await?;
+    // Record the dependency using the user's spec converted for package.json
+    // via `format_save_spec` (registry range/dist-tag pinned to the resolved
+    // version; git/file/url specs kept as-is), not the bare resolved semver —
+    // otherwise a git/github global would be recorded as a plain version and
+    // re-resolved from the registry.
+    let dep_spec = format_save_spec(&version_spec, &version);
+    upsert_wrapper_dependency(&wrapper_dir, &name, &dep_spec).await?;
 
     tracing::debug!("wrapper_dir: {}", wrapper_dir.to_string_lossy());
     Ok((name, wrapper_dir))
@@ -289,7 +295,14 @@ async fn upsert_wrapper_dependency(wrapper_dir: &Path, name: &str, version: &str
 
     let mut package_json: Value = if fs::try_exists(&pkg_json_path).await.unwrap_or(false) {
         let content = fs::read_to_string(&pkg_json_path).await?;
-        serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({}))
+        // Do NOT silently reset a corrupt wrapper to `{}` — that would drop
+        // every previously-recorded global dependency. Surface the error.
+        serde_json::from_str(&content).with_context(|| {
+            format!(
+                "global wrapper package.json is corrupt: {}",
+                pkg_json_path.display()
+            )
+        })?
     } else {
         serde_json::json!({})
     };
@@ -318,9 +331,16 @@ async fn upsert_wrapper_dependency(wrapper_dir: &Path, name: &str, version: &str
     deps_obj.insert(name.to_string(), new_value);
 
     let content = serde_json::to_string_pretty(&package_json)?;
-    let tmp_path = wrapper_dir.join(format!(".package.json.{}.tmp", std::process::id()));
+    // Unique temp name (pid + sequence) so concurrent upserts — even two within
+    // the same process — never share a temp file; clean it up if rename fails.
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp_path = wrapper_dir.join(format!(".package.json.{}.{}.tmp", std::process::id(), seq));
     fs::write(&tmp_path, content).await?;
-    fs::rename(&tmp_path, &pkg_json_path).await?;
+    if let Err(e) = fs::rename(&tmp_path, &pkg_json_path).await {
+        let _ = fs::remove_file(&tmp_path).await;
+        return Err(e).context("Failed to publish wrapper package.json");
+    }
 
     Ok(())
 }

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -284,19 +284,24 @@ impl InstallService {
     }
 
     pub async fn install_global_package(npm_spec: &str, prefix: Option<&str>) -> Result<()> {
-        // Prepare global package directory and package.json
-        let package_path = prepare_global_package_json(npm_spec, prefix)
+        // Install the package as a *dependency* of a generated wrapper project
+        // rather than as a root project. As a dependency it runs the install
+        // lifecycle (preinstall/install/postinstall, e.g. esbuild's binary
+        // download) but never prepare/prepublish, and its devDependencies are
+        // not installed — matching `npm install -g`.
+        let (name, wrapper_dir) = prepare_global_package_json(npm_spec, prefix)
             .await
             .context("Failed to prepare global package.json")?;
 
         tracing::debug!("Installing global package: {npm_spec}");
 
-        // Install dependencies (global install never omits)
-        Self::install(ScriptPolicy::Run, &package_path, &HashSet::new())
+        Self::install(ScriptPolicy::Run, &wrapper_dir, &HashSet::new())
             .await
             .context("Failed to install global package dependencies")?;
 
-        // Create package info from path
+        // The package now lives at `<wrapper_dir>/node_modules/<name>`; link its
+        // bins into the global bin dir so they are runnable.
+        let package_path = wrapper_dir.join("node_modules").join(&name);
         let package_info = PackageInfo::from_path(&package_path)
             .await
             .context("Failed to create package info from path")?;

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
@@ -206,12 +206,43 @@ pub async fn download_to_cache(name: &str, version: &str, tarball_url: &str) -> 
                 })
                 .ok()?;
 
+            // Mark packages that declare install scripts so the cloner
+            // force-copies them instead of hardlinking from the shared cache:
+            // an in-place `postinstall` mutation on a hardlinked file would
+            // corrupt the cache inode shared with other installs.
+            write_install_script_flag(&cache_path).await;
+
             DOWNLOAD_COUNT.fetch_add(1, Ordering::Relaxed);
             Some(cache_path)
         })
         .await
         .as_deref()
         .cloned()
+}
+
+/// If a freshly-extracted registry package declares `preinstall`/`install`/
+/// `postinstall`, drop a `_hasInstallScript` marker in its cache dir so
+/// `cloner::has_install_script_sync` makes the clone force-copy rather than
+/// hardlink. Best-effort: a missing/unreadable manifest just skips the marker.
+async fn write_install_script_flag(cache_path: &Path) {
+    // Registry tarballs extract under a `package/` wrapper dir.
+    let pkg_json = cache_path.join("package").join("package.json");
+    let Ok(content) = crate::fs::read_to_string(&pkg_json).await else {
+        return;
+    };
+    let has_install_script = serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .as_ref()
+        .and_then(|v| v.get("scripts"))
+        .and_then(|scripts| scripts.as_object())
+        .is_some_and(|scripts| {
+            ["preinstall", "install", "postinstall"]
+                .iter()
+                .any(|hook| scripts.contains_key(*hook))
+        });
+    if has_install_script {
+        let _ = crate::fs::write(cache_path.join("_hasInstallScript"), b"").await;
+    }
 }
 
 /// Download tarball bytes with retries (network phase only).


### PR DESCRIPTION
## Background

While investigating #3074 (concurrent utx cache corruption) we found that
`install_global_package` — shared by `utoo install -g` and `utoo x` — installs
the target package as a **root project**, not as a dependency. It clones the
package into `<prefix>/lib/node_modules/<name>` and runs the project lifecycle
on it. To make that "work", `prepare_global_package_json` rewrote the package's
own `package.json` in place:

```rust
package_obj.remove("devDependencies");
scripts_obj.remove("prepare");
scripts_obj.remove("prepublish");
```

That in-place rewrite is a workaround for three symptoms of treating a
published registry tarball as a root project:

1. **`prepare`/`prepublish` ran on it** — but a published tarball is already
   prepared; only git/source dependencies should run `prepare`. (npm only runs
   `prepare` for `node.isLink` nodes — `rebuild.js`; bun only for
   `.git/.github/.root/.workspace` resolution tags — `Scripts.zig`.)
2. **its `devDependencies` were installed** — hence the manual `remove`.
3. **the in-place `package.json` rewrite raced** under concurrent installs
   sharing the cache dir (`EOF while parsing a value at line 1 column 0`).

## Change

Install the package as a **dependency of a generated wrapper project** instead:

```
{prefix}/lib/
├── package.json        # { name: utoo-global, private: true, dependencies: { <tool>: <ver> } }
└── node_modules/
    ├── <tool>/         # the tool, installed as a dep
    └── @scope/...      # its (optional) platform deps
{prefix}/bin/<bin>      # linked from the tool's bin (unchanged)
```

As a dependency the tool runs the install lifecycle
(`preinstall`/`install`/`postinstall`, e.g. esbuild's binary download) but
**never `prepare`/`prepublish`**, and its **`devDependencies` are not
installed** — matching `npm install -g` and bun. The existing deps-vs-project
lifecycle split does this automatically, so no lifecycle code changes are
needed. The wrapper `package.json` is written **atomically** (temp + rename)
and accumulates deps across `install -g` calls.

The package's own `package.json` is never modified.

## Side effects

- **`optionalDependencies` are now installed** (e.g. `@esbuild/linux-x64`) —
  they were silently skipped under the root-install path.
- The in-place `package.json` rewrite **and its concurrent-write corruption**
  are gone.

## Scope

This is an **architecture fix** (align global/utx installs with npm/bun's
dependency semantics). It is *not* a fix for the broader concurrent-install
corruption discussed in #3074 — that is dominated by packages' own
`postinstall` writing a shared `bin/` and is a usage-layer concern (npx/bun are
equally affected); it is out of scope here.

## Verification (Linux x86_64)

- `cargo test -p utoo-pm` — **264 passed, 0 failed**
- `cargo clippy -p utoo-pm --all-targets -- -D warnings` — clean
- single `utoo x esbuild --version` → `0.28.0`; layout = wrapper deps, tool at
  `lib/node_modules/esbuild`, `@esbuild/linux-x64` present, `bin/esbuild`
  linked, the tool's own `package.json` untouched
- 8×32 concurrent `utoo x esbuild`: the `EOF while parsing package.json`
  corruption class is gone; no `utoo-global`/wrapper corruption (atomic write
  holds); remaining failures are all the independent `postinstall`/`bin`
  contention (out of scope, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
