### PR TITLE
perf(pm): demand resolver edge-selection module (select)

### DIFF
--- a/crates/ruborist/src/resolver/demand/mod.rs
+++ b/crates/ruborist/src/resolver/demand/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! - [`state`] — per-run manifest store (cache, waiters, failures).
 //! - [`queue`] — fetch scheduling, single-flight de-duplication, priority.
+//! - [`select`] — per-edge resolution decision (pure; reads the store).
 //!
-//! The two are independent; the driver that coordinates them (and exposes
+//! These are independent leaf concerns; the driver that coordinates them (and exposes
 //! `run_main_loop_bfs`) lands in the follow-up PR. Until then they are staged
 //! here and exercised by their own unit tests.
 
@@ -12,4 +13,5 @@
 #![allow(dead_code)]
 
 mod queue;
+mod select;
 mod state;

--- a/crates/ruborist/src/resolver/demand/select.rs
+++ b/crates/ruborist/src/resolver/demand/select.rs
@@ -38,14 +38,6 @@ fn resolve_version_from_versions<RE>(
     Ok(Some(version))
 }
 
-fn resolve_version_from_full_manifest<RE>(
-    edge: &DependencyEdgeInfo,
-    full: &FullManifest,
-    real_spec: &str,
-) -> Result<Option<String>, ResolveError<RE>> {
-    resolve_version_from_versions(edge, &full.name, full.into(), real_spec)
-}
-
 /// What to do with one registry dependency edge, decided from the current store
 /// without mutating it. The caller applies the side effects (cache alias,
 /// parking the waiter, enqueueing the fetch), so this stays a pure, testable
@@ -93,6 +85,28 @@ enum ExactFetch {
     Version,
 }
 
+/// Terminal outcome when `(name, lookup_key)` is already settled in the store:
+/// a recorded failure -> [`EdgeStep::Fail`], or a cached manifest ->
+/// [`EdgeStep::Resolve`]. `spec` is the edge's requested spec; it's used for the
+/// failure message and, when the lookup key is a resolved version
+/// (`lookup_key != spec`), to alias the manifest back under the spec.
+fn settled_step(
+    state: &ManifestState,
+    name: &str,
+    lookup_key: &str,
+    spec: &str,
+) -> Option<EdgeStep> {
+    if let Some(error) = state.get_version_failure(name, lookup_key) {
+        return Some(EdgeStep::Fail(format!("{name}@{spec}: {error}")));
+    }
+    state
+        .get_version_manifest(name, lookup_key)
+        .map(|manifest| EdgeStep::Resolve {
+            manifest,
+            alias: (lookup_key != spec).then(|| (name.to_string(), spec.to_string())),
+        })
+}
+
 /// Decide what to do with `edge` given the current store. `Err` is a fatal
 /// version-resolution error; `Ok(EdgeStep::Fail)` is a recorded fetch failure
 /// the caller treats as skip-or-error by dependency kind.
@@ -104,24 +118,18 @@ pub(super) fn select_edge<RE>(
     mode: ResolutionMode,
 ) -> Result<EdgeStep, ResolveError<RE>> {
     match mode {
+        // Semver registries resolve the spec server-side, so a cached/failed
+        // spec settles the edge; otherwise fetch the version manifest directly.
         ResolutionMode::Semver => {
-            // The registry resolves the spec server-side: fetch it directly.
-            if let Some(error) = state.get_version_failure(name, spec) {
-                return Ok(EdgeStep::Fail(format!("{name}@{spec}: {error}")));
-            }
-            if let Some(manifest) = state.get_version_manifest(name, spec) {
-                return Ok(EdgeStep::Resolve {
-                    manifest,
-                    alias: None,
-                });
-            }
-            Ok(EdgeStep::Park {
-                wait: WaitKey::Version((name.to_string(), spec.to_string())),
-                fetch: FetchPlan::Registry {
-                    name: name.to_string(),
-                    spec: spec.to_string(),
-                },
-            })
+            Ok(
+                settled_step(state, name, spec, spec).unwrap_or_else(|| EdgeStep::Park {
+                    wait: WaitKey::Version((name.to_string(), spec.to_string())),
+                    fetch: FetchPlan::Registry {
+                        name: name.to_string(),
+                        spec: spec.to_string(),
+                    },
+                }),
+            )
         }
         ResolutionMode::FullManifest => select_full_manifest::<RE>(state, edge, name, spec),
     }
@@ -135,39 +143,42 @@ fn select_full_manifest<RE>(
     name: &str,
     spec: &str,
 ) -> Result<EdgeStep, ResolveError<RE>> {
+    // A failed full-manifest fetch is a package-level failure (no version can
+    // resolve), so it shadows the per-version checks below.
     if let Some(error) = state.full.failures.get(name) {
         return Ok(EdgeStep::Fail(format!("{name}: {error}")));
     }
-    if let Some(error) = state.get_version_failure(name, spec) {
-        return Ok(EdgeStep::Fail(format!("{name}@{spec}: {error}")));
-    }
-    if let Some(manifest) = state.get_version_manifest(name, spec) {
-        return Ok(EdgeStep::Resolve {
-            manifest,
-            alias: None,
-        });
+    if let Some(step) = settled_step(state, name, spec, spec) {
+        return Ok(step);
     }
 
+    // Resolve the version client-side from whatever version source is cached.
     if let Some(full) = state.full.cache.get(name).cloned() {
-        let Some(version) = resolve_version_from_full_manifest::<RE>(edge, &full, spec)? else {
+        let Some(version) = resolve_version_from_versions::<RE>(edge, name, (&*full).into(), spec)?
+        else {
             return Ok(EdgeStep::Skip);
         };
-        return select_resolved_version::<RE>(
+        return Ok(select_resolved_version(
             state,
             name,
             spec,
             version,
             ExactFetch::Extract(full),
-        );
+        ));
     }
-
     if let Some(versions) = state.versions_cache.get(name).cloned() {
         let Some(version) =
             resolve_version_from_versions::<RE>(edge, name, (&*versions).into(), spec)?
         else {
             return Ok(EdgeStep::Skip);
         };
-        return select_resolved_version::<RE>(state, name, spec, version, ExactFetch::Version);
+        return Ok(select_resolved_version(
+            state,
+            name,
+            spec,
+            version,
+            ExactFetch::Version,
+        ));
     }
 
     Ok(EdgeStep::Park {
@@ -181,21 +192,15 @@ fn select_full_manifest<RE>(
 
 /// Decide an edge whose exact `version` is already known (resolved
 /// client-side). Shared by the full-manifest-cache and versions-list paths.
-fn select_resolved_version<RE>(
+fn select_resolved_version(
     state: &ManifestState,
     name: &str,
     spec: &str,
     version: String,
     fetch: ExactFetch,
-) -> Result<EdgeStep, ResolveError<RE>> {
-    if let Some(error) = state.get_version_failure(name, &version) {
-        return Ok(EdgeStep::Fail(format!("{name}@{spec}: {error}")));
-    }
-    if let Some(manifest) = state.get_version_manifest(name, &version) {
-        return Ok(EdgeStep::Resolve {
-            manifest,
-            alias: Some((name.to_string(), spec.to_string())),
-        });
+) -> EdgeStep {
+    if let Some(step) = settled_step(state, name, &version, spec) {
+        return step;
     }
     let fetch = match fetch {
         ExactFetch::Extract(full) => FetchPlan::Extract {
@@ -208,14 +213,13 @@ fn select_resolved_version<RE>(
             version: version.clone(),
         },
     };
-    Ok(EdgeStep::Park {
+    EdgeStep::Park {
         wait: WaitKey::Version((name.to_string(), version)),
         fetch,
-    })
+    }
 }
 
 /// How a registry resolves versions: server-side semver vs full-manifest fetch.
-/// Replaces a bare `supports_semver: bool` threaded through the resolve loop.
 #[derive(Clone, Copy)]
 pub(crate) enum ResolutionMode {
     /// Registry resolves semver server-side — fetch version manifests directly.

--- a/crates/ruborist/src/resolver/demand/select.rs
+++ b/crates/ruborist/src/resolver/demand/select.rs
@@ -10,7 +10,7 @@ use crate::resolver::edges::DependencyEdgeInfo;
 use crate::resolver::registry::ResolveError;
 use crate::resolver::version::resolve_target_version;
 
-use super::state::ManifestState;
+use super::state::{ManifestState, PackageVersions};
 
 fn resolve_version_from_versions<RE>(
     edge: &DependencyEdgeInfo,
@@ -143,51 +143,53 @@ fn select_full_manifest<RE>(
     name: &str,
     spec: &str,
 ) -> Result<EdgeStep, ResolveError<RE>> {
-    // A failed full-manifest fetch is a package-level failure (no version can
-    // resolve), so it shadows the per-version checks below.
-    if let Some(error) = state.full.failures.get(name) {
-        return Ok(EdgeStep::Fail(format!("{name}: {error}")));
-    }
+    // A cached or failed version for the spec settles the edge first — a cached
+    // manifest still resolves even if the package's full fetch later failed.
     if let Some(step) = settled_step(state, name, spec, spec) {
         return Ok(step);
     }
 
-    // Resolve the version client-side from whatever version source is cached.
-    if let Some(full) = state.full.cache.get(name).cloned() {
-        let Some(version) = resolve_version_from_versions::<RE>(edge, name, (&*full).into(), spec)?
-        else {
-            return Ok(EdgeStep::Skip);
-        };
-        return Ok(select_resolved_version(
-            state,
-            name,
-            spec,
-            version,
-            ExactFetch::Extract(full),
-        ));
+    // Otherwise resolve a version client-side from the package's cached source.
+    match state.package(name) {
+        Some(PackageVersions::Failed(error)) => Ok(EdgeStep::Fail(format!("{name}: {error}"))),
+        Some(PackageVersions::Full(full)) => {
+            let full = Arc::clone(full);
+            let Some(version) =
+                resolve_version_from_versions::<RE>(edge, name, (&*full).into(), spec)?
+            else {
+                return Ok(EdgeStep::Skip);
+            };
+            Ok(select_resolved_version(
+                state,
+                name,
+                spec,
+                version,
+                ExactFetch::Extract(full),
+            ))
+        }
+        Some(PackageVersions::List(list)) => {
+            let list = Arc::clone(list);
+            let Some(version) =
+                resolve_version_from_versions::<RE>(edge, name, (&*list).into(), spec)?
+            else {
+                return Ok(EdgeStep::Skip);
+            };
+            Ok(select_resolved_version(
+                state,
+                name,
+                spec,
+                version,
+                ExactFetch::Version,
+            ))
+        }
+        None => Ok(EdgeStep::Park {
+            wait: WaitKey::Full(name.to_string()),
+            fetch: FetchPlan::Registry {
+                name: name.to_string(),
+                spec: spec.to_string(),
+            },
+        }),
     }
-    if let Some(versions) = state.versions_cache.get(name).cloned() {
-        let Some(version) =
-            resolve_version_from_versions::<RE>(edge, name, (&*versions).into(), spec)?
-        else {
-            return Ok(EdgeStep::Skip);
-        };
-        return Ok(select_resolved_version(
-            state,
-            name,
-            spec,
-            version,
-            ExactFetch::Version,
-        ));
-    }
-
-    Ok(EdgeStep::Park {
-        wait: WaitKey::Full(name.to_string()),
-        fetch: FetchPlan::Registry {
-            name: name.to_string(),
-            spec: spec.to_string(),
-        },
-    })
 }
 
 /// Decide an edge whose exact `version` is already known (resolved
@@ -320,7 +322,7 @@ mod tests {
     #[test]
     fn full_manifest_failure_returns_fail() {
         let mut state = ManifestState::default();
-        state.full.failures.insert("pkg".into(), "gone".into());
+        state.set_package("pkg".into(), PackageVersions::Failed("gone".into()));
         let e = edge("pkg", "^1.0.0", EdgeType::Prod);
         match select(&state, &e, ResolutionMode::FullManifest) {
             EdgeStep::Fail(msg) => assert!(msg.contains("gone")),
@@ -344,10 +346,10 @@ mod tests {
     #[test]
     fn full_cache_resolves_version_then_parks_for_extract() {
         let mut state = ManifestState::default();
-        state
-            .full
-            .cache
-            .insert("pkg".into(), full_manifest("pkg", &["1.2.3"]));
+        state.set_package(
+            "pkg".into(),
+            PackageVersions::Full(full_manifest("pkg", &["1.2.3"])),
+        );
         let e = edge("pkg", "^1.0.0", EdgeType::Prod);
         match select(&state, &e, ResolutionMode::FullManifest) {
             EdgeStep::Park {
@@ -364,14 +366,35 @@ mod tests {
     #[test]
     fn optional_with_no_matching_version_skips() {
         let mut state = ManifestState::default();
-        state
-            .full
-            .cache
-            .insert("pkg".into(), full_manifest("pkg", &["1.2.3"]));
+        state.set_package(
+            "pkg".into(),
+            PackageVersions::Full(full_manifest("pkg", &["1.2.3"])),
+        );
         let e = edge("pkg", "^9.0.0", EdgeType::Optional);
         match select(&state, &e, ResolutionMode::FullManifest) {
             EdgeStep::Skip => {}
             _ => panic!("expected Skip"),
+        }
+    }
+
+    #[test]
+    fn cached_version_resolves_despite_package_failure() {
+        // A cached version manifest settles the edge even when the package's
+        // full-manifest fetch failed (e.g. a warm-cache hit + a flaky refetch).
+        let mut state = ManifestState::default();
+        state.set_package(
+            "pkg".into(),
+            PackageVersions::Failed("full fetch boom".into()),
+        );
+        state.cache_version(
+            "pkg".into(),
+            "^1.0.0".into(),
+            version_manifest("pkg", "1.2.3"),
+        );
+        let e = edge("pkg", "^1.0.0", EdgeType::Prod);
+        match select(&state, &e, ResolutionMode::FullManifest) {
+            EdgeStep::Resolve { manifest, .. } => assert_eq!(manifest.version, "1.2.3"),
+            _ => panic!("expected Resolve"),
         }
     }
 }

--- a/crates/ruborist/src/resolver/demand/select.rs
+++ b/crates/ruborist/src/resolver/demand/select.rs
@@ -1,0 +1,373 @@
+//! Per-edge resolution decisions over the manifest store — no I/O, no graph
+//! mutation. The testable core of the driver: given the store and an edge,
+//! decide whether to resolve now, skip, fail, or park + fetch.
+
+use std::sync::Arc;
+
+use crate::model::manifest::{CoreVersionManifest, FullManifest, VersionsRef};
+use crate::model::node::EdgeType;
+use crate::resolver::edges::DependencyEdgeInfo;
+use crate::resolver::registry::ResolveError;
+use crate::resolver::version::resolve_target_version;
+
+use super::state::ManifestState;
+
+fn resolve_version_from_versions<RE>(
+    edge: &DependencyEdgeInfo,
+    package_name: &str,
+    versions: VersionsRef<'_>,
+    real_spec: &str,
+) -> Result<Option<String>, ResolveError<RE>> {
+    if versions.versions.is_empty() {
+        if edge.edge_type == EdgeType::Optional {
+            return Ok(None);
+        }
+        return Err(ResolveError::NoVersions(package_name.to_string()));
+    }
+
+    let version = match resolve_target_version(versions, real_spec) {
+        Ok(version) => version,
+        Err(_) if edge.edge_type == EdgeType::Optional => return Ok(None),
+        Err(e) => {
+            return Err(ResolveError::Version(format!(
+                "{}@{}: {}",
+                edge.name, real_spec, e
+            )));
+        }
+    };
+    Ok(Some(version))
+}
+
+fn resolve_version_from_full_manifest<RE>(
+    edge: &DependencyEdgeInfo,
+    full: &FullManifest,
+    real_spec: &str,
+) -> Result<Option<String>, ResolveError<RE>> {
+    resolve_version_from_versions(edge, &full.name, full.into(), real_spec)
+}
+
+/// What to do with one registry dependency edge, decided from the current store
+/// without mutating it. The caller applies the side effects (cache alias,
+/// parking the waiter, enqueueing the fetch), so this stays a pure, testable
+/// decision over the store.
+pub(super) enum EdgeStep {
+    /// Manifest already in the store — resolve the edge now. `alias` is an extra
+    /// `(name, spec)` key to cache the manifest under first (so a manifest found
+    /// by its resolved version is also reachable by the requested spec).
+    Resolve {
+        manifest: Arc<CoreVersionManifest>,
+        alias: Option<(String, String)>,
+    },
+    /// Optional dependency with no matching/available version — skip it.
+    Skip,
+    /// A recorded fetch failure; the caller skips (optional) or errors.
+    Fail(String),
+    /// Park the edge on `wait`, then enqueue `fetch` to wake it later.
+    Park { wait: WaitKey, fetch: FetchPlan },
+}
+
+/// Which waiter list a parked edge joins.
+pub(super) enum WaitKey {
+    Full(String),
+    Version((String, String)),
+}
+
+/// The fetch to enqueue for a parked edge.
+pub(super) enum FetchPlan {
+    /// `schedule_registry_fetch` — a full or version job depending on the mode.
+    Registry { name: String, spec: String },
+    /// Extract an exact version from an already-fetched full manifest.
+    Extract {
+        name: String,
+        version: String,
+        full: Arc<FullManifest>,
+    },
+    /// Fetch an exact version manifest directly.
+    VersionFetch { name: String, version: String },
+}
+
+/// Whether a resolved exact version is extracted from a cached full manifest or
+/// fetched directly.
+enum ExactFetch {
+    Extract(Arc<FullManifest>),
+    Version,
+}
+
+/// Decide what to do with `edge` given the current store. `Err` is a fatal
+/// version-resolution error; `Ok(EdgeStep::Fail)` is a recorded fetch failure
+/// the caller treats as skip-or-error by dependency kind.
+pub(super) fn select_edge<RE>(
+    state: &ManifestState,
+    edge: &DependencyEdgeInfo,
+    name: &str,
+    spec: &str,
+    mode: ResolutionMode,
+) -> Result<EdgeStep, ResolveError<RE>> {
+    match mode {
+        ResolutionMode::Semver => {
+            // The registry resolves the spec server-side: fetch it directly.
+            if let Some(error) = state.get_version_failure(name, spec) {
+                return Ok(EdgeStep::Fail(format!("{name}@{spec}: {error}")));
+            }
+            if let Some(manifest) = state.get_version_manifest(name, spec) {
+                return Ok(EdgeStep::Resolve {
+                    manifest,
+                    alias: None,
+                });
+            }
+            Ok(EdgeStep::Park {
+                wait: WaitKey::Version((name.to_string(), spec.to_string())),
+                fetch: FetchPlan::Registry {
+                    name: name.to_string(),
+                    spec: spec.to_string(),
+                },
+            })
+        }
+        ResolutionMode::FullManifest => select_full_manifest::<RE>(state, edge, name, spec),
+    }
+}
+
+/// Full-manifest mode: resolve the version client-side, falling through the
+/// full-manifest cache, then the versions list, then a full fetch.
+fn select_full_manifest<RE>(
+    state: &ManifestState,
+    edge: &DependencyEdgeInfo,
+    name: &str,
+    spec: &str,
+) -> Result<EdgeStep, ResolveError<RE>> {
+    if let Some(error) = state.full.failures.get(name) {
+        return Ok(EdgeStep::Fail(format!("{name}: {error}")));
+    }
+    if let Some(error) = state.get_version_failure(name, spec) {
+        return Ok(EdgeStep::Fail(format!("{name}@{spec}: {error}")));
+    }
+    if let Some(manifest) = state.get_version_manifest(name, spec) {
+        return Ok(EdgeStep::Resolve {
+            manifest,
+            alias: None,
+        });
+    }
+
+    if let Some(full) = state.full.cache.get(name).cloned() {
+        let Some(version) = resolve_version_from_full_manifest::<RE>(edge, &full, spec)? else {
+            return Ok(EdgeStep::Skip);
+        };
+        return select_resolved_version::<RE>(
+            state,
+            name,
+            spec,
+            version,
+            ExactFetch::Extract(full),
+        );
+    }
+
+    if let Some(versions) = state.versions_cache.get(name).cloned() {
+        let Some(version) =
+            resolve_version_from_versions::<RE>(edge, name, (&*versions).into(), spec)?
+        else {
+            return Ok(EdgeStep::Skip);
+        };
+        return select_resolved_version::<RE>(state, name, spec, version, ExactFetch::Version);
+    }
+
+    Ok(EdgeStep::Park {
+        wait: WaitKey::Full(name.to_string()),
+        fetch: FetchPlan::Registry {
+            name: name.to_string(),
+            spec: spec.to_string(),
+        },
+    })
+}
+
+/// Decide an edge whose exact `version` is already known (resolved
+/// client-side). Shared by the full-manifest-cache and versions-list paths.
+fn select_resolved_version<RE>(
+    state: &ManifestState,
+    name: &str,
+    spec: &str,
+    version: String,
+    fetch: ExactFetch,
+) -> Result<EdgeStep, ResolveError<RE>> {
+    if let Some(error) = state.get_version_failure(name, &version) {
+        return Ok(EdgeStep::Fail(format!("{name}@{spec}: {error}")));
+    }
+    if let Some(manifest) = state.get_version_manifest(name, &version) {
+        return Ok(EdgeStep::Resolve {
+            manifest,
+            alias: Some((name.to_string(), spec.to_string())),
+        });
+    }
+    let fetch = match fetch {
+        ExactFetch::Extract(full) => FetchPlan::Extract {
+            name: name.to_string(),
+            version: version.clone(),
+            full,
+        },
+        ExactFetch::Version => FetchPlan::VersionFetch {
+            name: name.to_string(),
+            version: version.clone(),
+        },
+    };
+    Ok(EdgeStep::Park {
+        wait: WaitKey::Version((name.to_string(), version)),
+        fetch,
+    })
+}
+
+/// How a registry resolves versions: server-side semver vs full-manifest fetch.
+/// Replaces a bare `supports_semver: bool` threaded through the resolve loop.
+#[derive(Clone, Copy)]
+pub(crate) enum ResolutionMode {
+    /// Registry resolves semver server-side — fetch version manifests directly.
+    Semver,
+    /// Fetch the full manifest and resolve versions client-side.
+    FullManifest,
+}
+
+impl ResolutionMode {
+    pub(crate) fn from_supports_semver(supports: bool) -> Self {
+        if supports {
+            ResolutionMode::Semver
+        } else {
+            ResolutionMode::FullManifest
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use petgraph::graph::EdgeIndex;
+
+    fn edge(name: &str, spec: &str, edge_type: EdgeType) -> DependencyEdgeInfo {
+        DependencyEdgeInfo {
+            edge_id: EdgeIndex::new(0),
+            name: name.to_string(),
+            spec: spec.to_string(),
+            edge_type,
+        }
+    }
+
+    fn version_manifest(name: &str, version: &str) -> Arc<CoreVersionManifest> {
+        Arc::new(CoreVersionManifest {
+            name: name.to_string(),
+            version: version.to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn full_manifest(name: &str, versions: &[&str]) -> Arc<FullManifest> {
+        Arc::new(FullManifest {
+            name: name.to_string(),
+            versions: versions.iter().map(|v| v.to_string()).collect(),
+            ..Default::default()
+        })
+    }
+
+    fn select(state: &ManifestState, e: &DependencyEdgeInfo, mode: ResolutionMode) -> EdgeStep {
+        select_edge::<()>(state, e, &e.name, &e.spec, mode).expect("no fatal version error")
+    }
+
+    #[test]
+    fn semver_cache_hit_resolves_without_alias() {
+        let mut state = ManifestState::default();
+        state.cache_version(
+            "pkg".into(),
+            "^1.0.0".into(),
+            version_manifest("pkg", "1.2.3"),
+        );
+        let e = edge("pkg", "^1.0.0", EdgeType::Prod);
+        match select(&state, &e, ResolutionMode::Semver) {
+            EdgeStep::Resolve { manifest, alias } => {
+                assert_eq!(manifest.version, "1.2.3");
+                assert!(alias.is_none());
+            }
+            _ => panic!("expected Resolve"),
+        }
+    }
+
+    #[test]
+    fn recorded_failure_returns_fail() {
+        let mut state = ManifestState::default();
+        state.fail_version("pkg", "^1.0.0", "boom".into());
+        let e = edge("pkg", "^1.0.0", EdgeType::Prod);
+        match select(&state, &e, ResolutionMode::Semver) {
+            EdgeStep::Fail(msg) => assert!(msg.contains("boom")),
+            _ => panic!("expected Fail"),
+        }
+    }
+
+    #[test]
+    fn semver_miss_parks_on_version_and_fetches_registry() {
+        let state = ManifestState::default();
+        let e = edge("pkg", "^1.0.0", EdgeType::Prod);
+        match select(&state, &e, ResolutionMode::Semver) {
+            EdgeStep::Park {
+                wait: WaitKey::Version(key),
+                fetch: FetchPlan::Registry { name, spec },
+            } => {
+                assert_eq!(key, ("pkg".into(), "^1.0.0".into()));
+                assert_eq!((name.as_str(), spec.as_str()), ("pkg", "^1.0.0"));
+            }
+            _ => panic!("expected Park(Version, Registry)"),
+        }
+    }
+
+    #[test]
+    fn full_manifest_failure_returns_fail() {
+        let mut state = ManifestState::default();
+        state.full.failures.insert("pkg".into(), "gone".into());
+        let e = edge("pkg", "^1.0.0", EdgeType::Prod);
+        match select(&state, &e, ResolutionMode::FullManifest) {
+            EdgeStep::Fail(msg) => assert!(msg.contains("gone")),
+            _ => panic!("expected Fail"),
+        }
+    }
+
+    #[test]
+    fn full_manifest_miss_parks_on_full() {
+        let state = ManifestState::default();
+        let e = edge("pkg", "^1.0.0", EdgeType::Prod);
+        match select(&state, &e, ResolutionMode::FullManifest) {
+            EdgeStep::Park {
+                wait: WaitKey::Full(name),
+                fetch: FetchPlan::Registry { .. },
+            } => assert_eq!(name, "pkg"),
+            _ => panic!("expected Park(Full, Registry)"),
+        }
+    }
+
+    #[test]
+    fn full_cache_resolves_version_then_parks_for_extract() {
+        let mut state = ManifestState::default();
+        state
+            .full
+            .cache
+            .insert("pkg".into(), full_manifest("pkg", &["1.2.3"]));
+        let e = edge("pkg", "^1.0.0", EdgeType::Prod);
+        match select(&state, &e, ResolutionMode::FullManifest) {
+            EdgeStep::Park {
+                wait: WaitKey::Version(key),
+                fetch: FetchPlan::Extract { version, .. },
+            } => {
+                assert_eq!(key, ("pkg".into(), "1.2.3".into()));
+                assert_eq!(version, "1.2.3");
+            }
+            _ => panic!("expected Park(Version, Extract)"),
+        }
+    }
+
+    #[test]
+    fn optional_with_no_matching_version_skips() {
+        let mut state = ManifestState::default();
+        state
+            .full
+            .cache
+            .insert("pkg".into(), full_manifest("pkg", &["1.2.3"]));
+        let e = edge("pkg", "^9.0.0", EdgeType::Optional);
+        match select(&state, &e, ResolutionMode::FullManifest) {
+            EdgeStep::Skip => {}
+            _ => panic!("expected Skip"),
+        }
+    }
+}

--- a/crates/ruborist/src/resolver/demand/state.rs
+++ b/crates/ruborist/src/resolver/demand/state.rs
@@ -65,17 +65,32 @@ impl<K: Eq + Hash + Clone, V> ManifestSlot<K, V> {
     }
 }
 
-/// The per-run manifest store: one slot per manifest kind plus the versions
-/// lists. Read/written by the driver through the methods below; the driver owns
-/// scheduling separately (see [`super::queue`]).
+/// What the store knows about a package's available versions. A package has at
+/// most one source at a time — its full-manifest fetch failed, or we have its
+/// full manifest, or we have just its versions list (from a 304/abbreviated
+/// response). Folding these into one enum keeps the "at most one" invariant in
+/// the type and lets the resolver decide with a single lookup + `match`.
+pub(crate) enum PackageVersions {
+    /// The full-manifest fetch failed; no version of the package can resolve.
+    Failed(String),
+    /// Full manifest (all versions) — resolve a concrete version client-side.
+    Full(Arc<FullManifest>),
+    /// Versions list only — resolve a version, then fetch its manifest.
+    List(Arc<VersionsInfo>),
+}
+
+/// The per-run manifest store. `packages` holds each package's version source
+/// (failed / full manifest / versions list); `version` holds the resolved
+/// per-version manifests. Read/written by the driver through the methods below;
+/// scheduling lives separately (see [`super::queue`]).
 #[derive(Default)]
 pub(crate) struct ManifestState {
-    /// Full package manifests, keyed by package name.
-    pub(crate) full: ManifestSlot<String, FullManifest>,
-    /// Version manifests, keyed by `(name, spec)`.
+    /// Per-package version source/status, keyed by package name.
+    pub(crate) packages: HashMap<String, PackageVersions>,
+    /// Edges parked waiting on a package's full/versions fetch, keyed by name.
+    pub(crate) package_waiters: HashMap<String, Vec<WaitingEdge>>,
+    /// Resolved version manifests, keyed by `(name, spec)`.
     pub(crate) version: ManifestSlot<(String, String), CoreVersionManifest>,
-    /// Versions lists from 304/abbreviated responses (a `Full` job by-product).
-    pub(crate) versions_cache: HashMap<String, Arc<VersionsInfo>>,
 }
 
 impl ManifestState {
@@ -99,6 +114,34 @@ impl ManifestState {
                 .into_iter()
                 .map(|((name, spec), manifest)| (name, spec, manifest))
                 .collect(),
+        }
+    }
+
+    /// The cached version source for `name`, if any.
+    pub(crate) fn package(&self, name: &str) -> Option<&PackageVersions> {
+        self.packages.get(name)
+    }
+
+    /// Whether a version source (full manifest, versions list, or failure) is
+    /// already known for `name`, so its full manifest need not be re-fetched.
+    pub(crate) fn has_package_source(&self, name: &str) -> bool {
+        self.packages.contains_key(name)
+    }
+
+    /// Record a package's version source.
+    pub(crate) fn set_package(&mut self, name: String, source: PackageVersions) {
+        self.packages.insert(name, source);
+    }
+
+    /// Park an edge waiting on `name`'s package (full/versions) fetch.
+    pub(crate) fn park_on_package(&mut self, name: String, waiter: WaitingEdge) {
+        self.package_waiters.entry(name).or_default().push(waiter);
+    }
+
+    /// Move every edge waiting on `name`'s package fetch into `ready`.
+    pub(crate) fn wake_package(&mut self, name: &str, ready: &mut VecDeque<WaitingEdge>) {
+        if let Some(waiters) = self.package_waiters.remove(name) {
+            ready.extend(waiters);
         }
     }
 


### PR DESCRIPTION
## What

Third leaf module of the demand resolver, after `state` (#3079) and `queue` (#3080). `select` is the **pure per-edge resolution decision**:

```rust
fn select_edge(state, edge, name, spec, mode) -> EdgeStep
// EdgeStep = Resolve | Skip | Fail | Park { wait, fetch }
```

Given the current `ManifestState` and one dependency edge, it decides the outcome: resolve from cache now, skip (optional with no match), fail (recorded fetch failure), or park the edge and enqueue a fetch.

## Why it's a clean standalone module

It only **reads** `ManifestState` and returns a decision value — no `&mut`, no async, no I/O, no graph mutation. So it's **unit-testable in isolation**, which the integration-only tests never were. 7 tests cover: semver/full-manifest cache hits, recorded failures → `Fail`, cache miss → `Park`, client-side version resolution from a cached full manifest, and optional-dep skip.

## Staging

Dead-code-staged (`#![allow(dead_code)]`), exactly like `state`/`queue` were — the driver that consumes `select_edge` lands in the follow-up PR (the demand mainloop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)