### PR TITLE
perf(pm): demand resolver — provider trait + registry adapter (1/3)

### DIFF
--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -162,9 +162,15 @@ jobs:
           # can now overwrite target/.../release/utoo safely.
           git fetch origin next --depth=1
           # Overlay origin/next's working tree onto the current workdir
-          # without moving HEAD. After this every tracked file matches
-          # origin/next; submodule pointers may differ so re-init.
+          # without moving HEAD. `checkout -- .` restores next's tracked files
+          # but leaves files the PR adds that next lacks; drop those too, or new
+          # module dirs (e.g. registry/, driver/) shadow next's flat-file
+          # modules and the baseline build fails with E0761. Submodule pointers
+          # may differ so re-init.
           git checkout origin/next -- .
+          # --no-renames so rename targets (e.g. registry.rs -> registry/mod.rs)
+          # count as Added and get removed too, not paired away as renames.
+          git diff --no-renames --diff-filter=A --name-only origin/next HEAD | xargs -r rm -f
           git submodule update --init --recursive --depth 1
           cargo build --release --target x86_64-unknown-linux-gnu --bin utoo -p utoo-pm
       - name: Upload utoo-next binary

--- a/crates/ruborist/src/model/manifest.rs
+++ b/crates/ruborist/src/model/manifest.rs
@@ -128,9 +128,8 @@ impl FullManifest {
     /// subtree is visited in place — no intermediate `serde_json::Value`
     /// allocation.
     ///
-    /// `OnceMap` single-flight in `UnifiedRegistry` reduces the per-key
-    /// invocation count to one, so the per-call full-tree parse cost is
-    /// bounded.
+    /// The BFS resolver de-duplicates in-flight extract jobs per key, so the
+    /// per-call full-tree parse cost is bounded.
     fn extract_version<T: for<'de> Deserialize<'de>>(&self, version: &str) -> Option<T> {
         use simd_json::prelude::ValueObjectAccess;
         let mut buf = self.raw.to_vec();

--- a/crates/ruborist/src/model/mod.rs
+++ b/crates/ruborist/src/model/mod.rs
@@ -71,9 +71,9 @@
 //! cloning at every cache read and graph insertion:
 //!
 //! ```text
-//!   MemoryCache ──┐
-//!                 ├── Arc<CoreVersionManifest> ── (ref-count clone)
-//!   PackageNode ──┘
+//!   ManifestState ──┐
+//!                   ├── Arc<CoreVersionManifest> ── (ref-count clone)
+//!   PackageNode ────┘
 //!
 //!   Cold paths (disk I/O, serde) still use owned CoreVersionManifest,
 //!   wrapping in Arc::new() at the boundary.

--- a/crates/ruborist/src/service/cache.rs
+++ b/crates/ruborist/src/service/cache.rs
@@ -212,6 +212,49 @@ pub struct ProjectPackageCache {
     pub manifests: HashMap<String, CoreVersionManifest>,
 }
 
+// Bridges between the on-disk project cache and the demand resolver's
+// neutral `(name, spec, manifest)` tuples. Wired up in the resolver
+// cutover PR — staged here so the trait + adapter PRs stay self-contained.
+#[allow(dead_code)]
+impl ProjectCacheData {
+    /// Flatten into neutral `(name, spec, manifest)` tuples for seeding an
+    /// in-memory resolver store. The store stays unaware of this on-disk shape.
+    pub(crate) fn resolved_manifests(&self) -> Vec<(String, String, Arc<CoreVersionManifest>)> {
+        let mut out = Vec::new();
+        for (name, pkg) in &self.cache {
+            // Build one Arc per resolved version, then share it across every
+            // spec pointing at that version — sibling ranges commonly collapse
+            // to the same version, so this avoids cloning the manifest per spec.
+            let version_arcs: HashMap<&String, Arc<CoreVersionManifest>> = pkg
+                .manifests
+                .iter()
+                .map(|(version, manifest)| (version, Arc::new(manifest.clone())))
+                .collect();
+            for (spec, version) in &pkg.specs {
+                if let Some(arc) = version_arcs.get(version) {
+                    out.push((name.clone(), spec.clone(), Arc::clone(arc)));
+                }
+            }
+        }
+        out
+    }
+
+    /// Rebuild from the resolver's neutral `(name, spec, manifest)` tuples,
+    /// indexing each manifest under both its spec and its resolved version.
+    pub(crate) fn from_resolved(entries: Vec<(String, String, Arc<CoreVersionManifest>)>) -> Self {
+        let mut data = Self::default();
+        for (name, spec, manifest) in entries {
+            let version = manifest.version.clone();
+            let pkg = data.cache.entry(name).or_default();
+            pkg.specs.insert(spec, version.clone());
+            pkg.manifests
+                .entry(version)
+                .or_insert_with(|| (*manifest).clone());
+        }
+        data
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -13,12 +13,15 @@ use super::fetch::{
 };
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::resolver::version::resolve_target_version;
 
-/// Parse JSON bytes on rayon's CPU thread pool (native) or inline
-/// (wasm32). Keeps the tokio runtime free of `simd_json` work so other
-/// in-flight manifest fetches keep driving network IO while this one
-/// parses.
-pub(crate) async fn parse_json_off_runtime<T>(bytes: Bytes) -> Result<T, anyhow::Error>
+/// Parse a JSON buffer on rayon's CPU thread pool (native) or inline
+/// (wasm32). The buffer is consumed because `simd_json` mutates it in-place.
+/// Keeps the tokio runtime free of `simd_json` work so other in-flight
+/// manifest fetches keep driving network IO while this one parses.
+pub(crate) async fn parse_json_vec_off_runtime<T>(
+    mut parse_buf: Vec<u8>,
+) -> Result<T, anyhow::Error>
 where
     T: serde::de::DeserializeOwned + Send + 'static,
 {
@@ -26,7 +29,6 @@ where
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let mut parse_buf = bytes.to_vec();
             let result = simd_json::serde::from_slice::<T>(&mut parse_buf)
                 .map_err(|e| anyhow!("JSON parse error: {e}"));
             let _ = tx.send(result);
@@ -36,7 +38,6 @@ where
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut parse_buf = bytes.to_vec();
         simd_json::serde::from_slice::<T>(&mut parse_buf)
             .map_err(|e| anyhow!("JSON parse error: {e}"))
     }
@@ -49,21 +50,65 @@ where
 pub(crate) async fn parse_full_manifest_off_runtime(
     raw_bytes: Bytes,
 ) -> Result<FullManifest, anyhow::Error> {
+    parse_full_manifest_with_core_off_runtime(raw_bytes, None)
+        .await
+        .map(|(manifest, _)| manifest)
+}
+
+pub(crate) type FullManifestParseResult = (FullManifest, Option<(String, CoreVersionManifest)>);
+
+fn parse_full_manifest_with_core_sync(
+    raw_bytes: Bytes,
+    spec: Option<String>,
+) -> Result<FullManifestParseResult, anyhow::Error> {
+    // simd_json mutates the parse buffer; copy inside the worker so
+    // response-body bytes can stay immutable until parsing starts.
+    let mut parse_buf = raw_bytes.to_vec();
+    let mut manifest: FullManifest = simd_json::serde::from_slice::<FullManifest>(&mut parse_buf)
+        .map_err(|e| anyhow!("JSON parse error: {e}"))?;
+    manifest.raw = raw_bytes;
+
+    let speculative = match spec {
+        Some(spec) => match resolve_target_version((&manifest).into(), &spec) {
+            Ok(version) => match manifest.get_core_version(&version) {
+                Some(core) => Some((spec, core)),
+                None => {
+                    tracing::trace!(
+                        package = %manifest.name,
+                        spec = %spec,
+                        version = %version,
+                        "speculative manifest extract missed resolved version"
+                    );
+                    None
+                }
+            },
+            Err(error) => {
+                tracing::trace!(
+                    package = %manifest.name,
+                    spec = %spec,
+                    error = %error,
+                    "speculative manifest version resolution failed"
+                );
+                None
+            }
+        },
+        None => None,
+    };
+
+    Ok((manifest, speculative))
+}
+
+/// Parse a full wire-fetched manifest and optionally extract the current BFS
+/// edge's version in the same off-runtime worker task.
+pub(crate) async fn parse_full_manifest_with_core_off_runtime(
+    raw_bytes: Bytes,
+    spec: Option<String>,
+) -> Result<FullManifestParseResult, anyhow::Error> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
-            let result = (|| -> Result<FullManifest, anyhow::Error> {
-                // simd_json mutates the parse buffer; copy inside the worker so
-                // response-body bytes can stay immutable until parsing starts.
-                let mut parse_buf = raw_bytes.to_vec();
-                let mut manifest: FullManifest =
-                    simd_json::serde::from_slice::<FullManifest>(&mut parse_buf)
-                        .map_err(|e| anyhow!("JSON parse error: {e}"))?;
-                manifest.raw = raw_bytes;
-
-                Ok(manifest)
-            })();
+            let result = parse_full_manifest_with_core_sync(raw_bytes, spec);
             let _ = tx.send(result);
         });
         rx.await
@@ -71,9 +116,7 @@ pub(crate) async fn parse_full_manifest_off_runtime(
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let mut manifest: FullManifest = parse_json_off_runtime(raw_bytes.clone()).await?;
-        manifest.raw = raw_bytes;
-        Ok(manifest)
+        parse_full_manifest_with_core_sync(raw_bytes, spec)
     }
 }
 
@@ -220,6 +263,28 @@ pub async fn fetch_full_manifest_fresh(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+async fn read_body_vec(mut response: reqwest::Response) -> Result<Vec<u8>, FetchError> {
+    let capacity = response
+        .content_length()
+        .and_then(|len| usize::try_from(len).ok())
+        .unwrap_or(0);
+    let mut body = Vec::with_capacity(capacity);
+    while let Some(chunk) = response.chunk().await.map_err(classify_reqwest_error)? {
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn read_body_vec(response: reqwest::Response) -> Result<Vec<u8>, FetchError> {
+    response
+        .bytes()
+        .await
+        .map(|bytes| bytes.to_vec())
+        .map_err(classify_reqwest_error)
+}
+
 /// Options for fetching a version manifest.
 pub struct FetchVersionManifestOptions<'a> {
     pub registry_url: &'a str,
@@ -230,6 +295,17 @@ pub struct FetchVersionManifestOptions<'a> {
 
 /// Fetch version manifest bytes with retry, without parsing.
 pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>) -> Result<Bytes> {
+    fetch_version_manifest_vec(opts).await.map(Bytes::from)
+}
+
+/// Fetch version manifest into a mutable parse buffer with retry.
+///
+/// Unlike full manifests, exact-version manifests do not need to keep raw
+/// response bytes for later extraction. Reading directly into `Vec<u8>` avoids
+/// the hot-path `Bytes -> Vec` copy before `simd_json` parses in place.
+pub(crate) async fn fetch_version_manifest_vec(
+    opts: FetchVersionManifestOptions<'_>,
+) -> Result<Vec<u8>> {
     let url = format!("{}/{}/{}", opts.registry_url, opts.name, opts.spec);
 
     let accept = match opts.format {
@@ -251,7 +327,7 @@ pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>)
                     .map_err(classify_reqwest_error)?;
 
                 if response.status().is_success() {
-                    response.bytes().await.map_err(classify_reqwest_error)
+                    read_body_vec(response).await
                 } else {
                     Err(classify_status(response.status(), &url))
                 }
@@ -271,6 +347,65 @@ pub async fn fetch_version_manifest_bytes(opts: FetchVersionManifestOptions<'_>)
 pub async fn fetch_version_manifest(
     opts: FetchVersionManifestOptions<'_>,
 ) -> Result<CoreVersionManifest> {
-    let bytes = fetch_version_manifest_bytes(opts).await?;
-    parse_json_off_runtime::<CoreVersionManifest>(bytes).await
+    let bytes = fetch_version_manifest_vec(opts).await?;
+    parse_json_vec_off_runtime::<CoreVersionManifest>(bytes).await
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TinyManifest {
+        name: String,
+        version: String,
+    }
+
+    #[tokio::test]
+    async fn parse_json_vec_off_runtime_consumes_mutable_buffer() {
+        let parsed = parse_json_vec_off_runtime::<TinyManifest>(
+            br#"{"name":"demo","version":"1.0.0"}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            parsed,
+            TinyManifest {
+                name: "demo".to_string(),
+                version: "1.0.0".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_full_manifest_with_core_extracts_requested_spec() {
+        let raw = Bytes::from_static(
+            br#"{
+                "name":"demo",
+                "dist-tags":{"latest":"1.0.0"},
+                "versions":{
+                    "1.0.0":{
+                        "name":"demo",
+                        "version":"1.0.0",
+                        "dist":{"tarball":"https://registry.example/demo-1.0.0.tgz"}
+                    }
+                }
+            }"#,
+        );
+
+        let (manifest, speculative) =
+            parse_full_manifest_with_core_off_runtime(raw.clone(), Some("latest".to_string()))
+                .await
+                .unwrap();
+
+        assert_eq!(manifest.name, "demo");
+        assert_eq!(manifest.raw, raw);
+        let (spec, core) = speculative.unwrap();
+        assert_eq!(spec, "latest");
+        assert_eq!(core.name, "demo");
+        assert_eq!(core.version, "1.0.0");
+    }
 }

--- a/crates/ruborist/src/service/manifest_provider.rs
+++ b/crates/ruborist/src/service/manifest_provider.rs
@@ -80,21 +80,18 @@ pub enum ManifestJobDone {
 /// The driver clones the provider for each job it issues, so implementors
 /// should keep `Clone` cheap (for example by storing shared state behind `Arc`).
 ///
-/// The demand loop runs single-threaded — it polls fetch jobs on a
-/// `FuturesUnordered` and never spawns them onto other threads — so the
-/// provider needs no `Send`/`Sync` bound and uses `?Send` futures uniformly
-/// across native and wasm.
+/// On native the driver runs each fetch job as a `tokio::spawn`ed task, so the
+/// provider is `Send + Sync` and its job futures are `Send` — fetch + parse for
+/// independent manifests run in parallel across the multi-threaded runtime. On
+/// wasm32 there are no threads, so the provider is `?Send` and jobs run via
+/// `spawn_local`.
 ///
-/// Because the loop is single-threaded, CPU-bound work inside a job (manifest
-/// JSON parsing, version extraction) must be offloaded by the implementor, and
-/// the offload strategy differs per platform: on native, hand it to a CPU
-/// thread pool (the `*_off_runtime` helpers use `rayon` plus a oneshot
-/// back-channel) so the async runtime keeps driving network IO for the other
-/// in-flight jobs; on wasm32 there are no threads, so the same work runs
-/// inline. Confining this platform split to the provider is what lets the
-/// driver stay single-threaded and platform-agnostic.
-#[async_trait(?Send)]
-pub trait ManifestProvider: RegistryClient + Clone + 'static {
+/// CPU-bound work inside a job (manifest JSON parsing, version extraction) is
+/// offloaded by the implementor: on native the `*_off_runtime` helpers use
+/// `rayon` plus a oneshot back-channel; on wasm32 the same work runs inline.
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait ManifestProvider: RegistryClient + Clone + Send + Sync + 'static {
     /// Execute one manifest job. The provider owns I/O, persistence, and
     /// parse/extract offloading; scheduling, waiters, and inflight
     /// de-duplication stay in the demand loop.

--- a/crates/ruborist/src/service/mod.rs
+++ b/crates/ruborist/src/service/mod.rs
@@ -49,7 +49,7 @@ pub(crate) mod fetch;
 mod fs;
 pub(crate) mod http;
 pub(crate) mod manifest;
-mod provider;
+mod manifest_provider;
 mod registry;
 mod store;
 
@@ -65,6 +65,6 @@ pub use manifest::{
     FetchVersionManifestOptions, MetadataFormat, fetch_full_manifest, fetch_full_manifest_bytes,
     fetch_full_manifest_fresh, fetch_version_manifest, fetch_version_manifest_bytes,
 };
-pub use provider::{ManifestFullData, ManifestJob, ManifestJobDone, ManifestProvider};
+pub use manifest_provider::{ManifestFullData, ManifestJob, ManifestJobDone, ManifestProvider};
 pub use registry::UnifiedRegistry;
 pub use store::{ManifestStore, NoopStore};

--- a/crates/ruborist/src/service/registry/mod.rs
+++ b/crates/ruborist/src/service/registry/mod.rs
@@ -50,6 +50,11 @@ use crate::resolver::version::resolve_target_version;
 use crate::traits::registry::{RegistryClient, RegistryError, ResolvedPackage, is_npm_registry};
 use crate::util::OnceMap;
 
+/// `ManifestProvider` implementation for the demand BFS resolver. A child
+/// module so it can reach `UnifiedRegistry`'s private fields without widening
+/// their visibility.
+mod provider;
+
 /// Unified registry client that works on both native and WASM.
 ///
 /// Cache lookup order:

--- a/crates/ruborist/src/service/registry/provider.rs
+++ b/crates/ruborist/src/service/registry/provider.rs
@@ -1,0 +1,174 @@
+//! `UnifiedRegistry`'s [`ManifestProvider`] implementation.
+//!
+//! Executes a single manifest job (full / version / extract) against the
+//! network and the persistent [`ManifestStore`](super::super::store::ManifestStore).
+//! The demand BFS loop owns caching, waiters, and de-duplication; this module
+//! is the stateless I/O + parse boundary it drives.
+//!
+//! Lives as a child module of `registry` so it can reach `UnifiedRegistry`'s
+//! private fields without widening their visibility.
+
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use deno_semver::Version;
+
+use super::super::cache::{Versions, VersionsInfo};
+use super::super::manifest;
+use super::super::manifest_provider::{
+    ManifestFullData, ManifestJob, ManifestJobDone, ManifestProvider, ProviderFullManifestBytes,
+};
+use super::UnifiedRegistry;
+use crate::model::manifest::{CoreVersionManifest, extract_core_version_off_runtime};
+use crate::traits::registry::RegistryError;
+
+impl UnifiedRegistry {
+    /// Persist a resolved version manifest through the host store.
+    ///
+    /// De-duplicated by `(name, version)`: sibling specs frequently resolve to
+    /// the same version and version manifests are immutable, so the manifest is
+    /// persisted only on its first sighting this run.
+    fn store_version_manifest(&self, name: &str, manifest: Arc<CoreVersionManifest>) {
+        if self
+            .stored_version
+            .insert((name.to_string(), manifest.version.clone()))
+        {
+            self.store
+                .store_version_manifest(name, &manifest.version, Arc::clone(&manifest));
+        }
+    }
+
+    /// Fetch the full (abbreviated) manifest bytes, using the store's cached
+    /// ETag for a conditional GET. A 304 hands back the cached versions list.
+    async fn fetch_full_manifest_job(
+        &self,
+        name: &str,
+    ) -> Result<ProviderFullManifestBytes, RegistryError> {
+        let store_versions = self.store.load_versions(name).await.map(Arc::new);
+        let etag = store_versions.as_ref().and_then(|v| v.etag.clone());
+
+        match manifest::fetch_full_manifest_bytes(manifest::FetchManifestOptions {
+            registry_url: &self.registry_url,
+            name,
+            format: manifest::MetadataFormat::Abbreviated,
+            etag: etag.as_deref(),
+        })
+        .await
+        .map_err(RegistryError)?
+        {
+            manifest::FetchManifestBytesResult::Ok(bytes, etag) => {
+                Ok(ProviderFullManifestBytes::Fresh { bytes, etag })
+            }
+            manifest::FetchManifestBytesResult::NotModified => {
+                let versions = store_versions.ok_or_else(|| {
+                    RegistryError(anyhow!(
+                        "304 Not Modified without cached versions for {name}"
+                    ))
+                })?;
+                Ok(ProviderFullManifestBytes::NotModified { versions })
+            }
+        }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl ManifestProvider for UnifiedRegistry {
+    async fn execute_manifest_job(&self, job: ManifestJob) -> Result<ManifestJobDone, Self::Error> {
+        match job {
+            ManifestJob::Full { name, spec } => {
+                let data = match self.fetch_full_manifest_job(&name).await? {
+                    ProviderFullManifestBytes::Fresh { bytes, etag } => {
+                        let (manifest, speculative) =
+                            manifest::parse_full_manifest_with_core_off_runtime(bytes, spec)
+                                .await?;
+                        let manifest = Arc::new(manifest);
+                        let speculative = speculative.map(|(spec, core)| {
+                            let core = Arc::new(core);
+                            self.store_version_manifest(&name, Arc::clone(&core));
+                            (spec, core)
+                        });
+                        let versions = Arc::new(VersionsInfo {
+                            versions: Versions {
+                                version_list: manifest.versions.clone(),
+                                dist_tags: manifest.dist_tags.clone(),
+                            },
+                            etag,
+                            last_updated: super::current_timestamp_secs(),
+                        });
+                        self.store.store_versions(&name, versions);
+                        ManifestFullData::Full {
+                            manifest,
+                            speculative,
+                        }
+                    }
+                    ProviderFullManifestBytes::NotModified { versions } => {
+                        ManifestFullData::Versions(versions)
+                    }
+                };
+
+                Ok(ManifestJobDone::Full { name, data })
+            }
+            ManifestJob::Version {
+                name,
+                spec,
+                fetch_spec,
+                format,
+            } => {
+                if Version::parse_from_npm(&fetch_spec).is_ok()
+                    && let Some(manifest) =
+                        self.store.load_version_manifest(&name, &fetch_spec).await
+                {
+                    let manifest = Arc::new(manifest);
+                    return Ok(ManifestJobDone::Version {
+                        name,
+                        spec,
+                        manifest,
+                    });
+                }
+
+                let bytes =
+                    manifest::fetch_version_manifest_vec(manifest::FetchVersionManifestOptions {
+                        registry_url: &self.registry_url,
+                        name: &name,
+                        spec: &fetch_spec,
+                        format,
+                    })
+                    .await
+                    .map_err(RegistryError)?;
+                let manifest = Arc::new(
+                    manifest::parse_json_vec_off_runtime::<CoreVersionManifest>(bytes).await?,
+                );
+                self.store_version_manifest(&name, Arc::clone(&manifest));
+                Ok(ManifestJobDone::Version {
+                    name,
+                    spec,
+                    manifest,
+                })
+            }
+            ManifestJob::ExtractVersion {
+                name,
+                spec,
+                version,
+                full,
+            } => {
+                let (resolved_version, manifest) =
+                    extract_core_version_off_runtime(full, version).await;
+                let manifest = manifest.ok_or_else(|| {
+                    RegistryError(anyhow!(
+                        "Version {} not found in manifest for {}",
+                        resolved_version,
+                        name
+                    ))
+                })?;
+                self.store_version_manifest(&name, Arc::clone(&manifest));
+                Ok(ManifestJobDone::Version {
+                    name,
+                    spec,
+                    manifest,
+                })
+            }
+        }
+    }
+}

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -298,6 +298,7 @@ pub mod mock {
     use super::*;
 
     /// Internal package data for mock registry.
+    #[derive(Clone)]
     struct MockPackage {
         name: String,
         dist_tags: HashMap<String, String>,
@@ -305,6 +306,7 @@ pub mod mock {
     }
 
     /// Mock registry client that returns predefined packages.
+    #[derive(Clone)]
     pub struct MockRegistryClient {
         packages: HashMap<String, MockPackage>,
     }
@@ -391,6 +393,71 @@ pub mod mock {
                 raw: bytes::Bytes::from(raw),
                 ..Default::default()
             }))
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl crate::service::ManifestProvider for MockRegistryClient {
+        async fn execute_manifest_job(
+            &self,
+            job: crate::service::ManifestJob,
+        ) -> Result<crate::service::ManifestJobDone, Self::Error> {
+            use crate::service::{ManifestFullData, ManifestJob, ManifestJobDone};
+
+            match job {
+                ManifestJob::Full { name, spec } => {
+                    let full = self.fetch_full_manifest(&name).await?;
+                    let speculative = spec.and_then(|spec| {
+                        resolve_target_version((&*full).into(), &spec)
+                            .ok()
+                            .and_then(|version| {
+                                full.get_core_version(&version)
+                                    .map(|core| (spec, Arc::new(core)))
+                            })
+                    });
+                    Ok(ManifestJobDone::Full {
+                        name,
+                        data: ManifestFullData::Full {
+                            manifest: full,
+                            speculative,
+                        },
+                    })
+                }
+                ManifestJob::Version {
+                    name,
+                    spec,
+                    fetch_spec,
+                    format: _,
+                } => {
+                    let manifest = self.fetch_version_manifest(&name, &fetch_spec).await?;
+                    Ok(ManifestJobDone::Version {
+                        name,
+                        spec,
+                        manifest,
+                    })
+                }
+                ManifestJob::ExtractVersion {
+                    name,
+                    spec,
+                    version,
+                    full,
+                } => {
+                    let manifest =
+                        full.get_core_version(&version)
+                            .map(Arc::new)
+                            .ok_or_else(|| {
+                                MockError(format!(
+                                    "Version {version} not found in manifest for {name}"
+                                ))
+                            })?;
+                    Ok(ManifestJobDone::Version {
+                        name,
+                        spec,
+                        manifest,
+                    })
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Part **1/3** of the demand-resolver rework (#3028), split from the all-in-one #3084 into three reviewable layers.

Introduces the `ManifestProvider` trait and its registry-backed adapter. Nothing calls it yet — dead-code-staged, same pattern as #3079 / #3083.

## Stack

```
next
 └─ #3085  provider trait + adapter   ◄ this PR
     └─ #3086  demand driver loop
         └─ #3087  entry-point cutover   (perf lands here)
```

## What this layer is

```
   resolver ──manifest jobs──►  ManifestProvider  (trait)    ◄ new
                                      │
                                      ▼
                             UnifiedRegistry  (adapter)       ◄ new
                                      │
                         ┌────────────┴────────────┐
                         ▼                          ▼
                    memory cache            registry.npmjs.org
```

The trait + adapter compile but have no caller until the cutover (#3087); bench is therefore flat vs `next`.
