### PR TITLE
perf(pm): demand resolver — driver loop + graph helpers (2/3)

### DIFF
--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -27,12 +27,13 @@ use std::sync::Arc;
 use anyhow::Context as _;
 
 use crate::model::graph::{DependencyGraph, FindResult, PackageNode};
-use crate::model::manifest::NodeManifest;
+use crate::model::manifest::{CoreVersionManifest, NodeManifest};
 use crate::model::node::EdgeType;
 use crate::model::package_json::PackageJson;
+use crate::resolver::demand::{ResolverManifestCache, run_main_loop_bfs};
 use crate::resolver::preload::{PreloadConfig, preload_manifests};
 use crate::resolver::registry::{ResolveError, resolve_registry_dep};
-use crate::service::ProjectCacheData;
+use crate::service::{ManifestProvider, ProjectCacheData};
 use crate::spec::{Catalogs, PackageSpec, Protocol};
 use crate::traits::progress::{BuildEvent, EventReceiver, NoopReceiver};
 use crate::traits::registry::{RegistryClient, ResolvedPackage};
@@ -756,6 +757,40 @@ pub async fn build_deps_with_config<R: RegistryClient, E: EventReceiver>(
     Ok(())
 }
 
+// Wired by the cutover PR (“demand cutover”) where `api.rs` switches to
+// this output-returning entry; staged here so the trait, the driver, and the
+// entry-point flip arrive in three separately reviewable PRs.
+#[allow(dead_code)]
+/// Demand-driven dependency resolution: a single BFS loop that schedules
+/// manifest jobs through the [`ManifestProvider`] while owning the per-run
+/// manifest cache, waiters, and in-flight de-duplication. Returns the
+/// manifests resolved this run for the host to persist.
+pub(crate) async fn build_deps_with_config_output<R, E>(
+    graph: &mut DependencyGraph,
+    registry: &R,
+    config: BuildDepsConfig,
+    receiver: &E,
+) -> Result<ResolverManifestCache, ResolveError<R::Error>>
+where
+    R: ManifestProvider,
+    R::Error: Send,
+    E: EventReceiver,
+{
+    tracing::debug!(
+        "Starting demand dependency build, peer_deps: {:?}, concurrency: {}",
+        config.peer_deps,
+        config.concurrency
+    );
+
+    let manifest_cache = run_main_loop_bfs(graph, registry, &config, receiver).await?;
+
+    receiver.on_event(BuildEvent::Complete {
+        total_nodes: graph.graph.node_count(),
+    });
+
+    Ok(manifest_cache)
+}
+
 /// Run the preload phase to warm up the cache with manifests.
 async fn run_preload_phase<R: RegistryClient, E: EventReceiver>(
     graph: &DependencyGraph,
@@ -979,6 +1014,122 @@ fn graph_to_package_lock(
 ) -> PackageLock {
     let (packages, _total) = graph.serialize_to_packages(root_path);
     PackageLock::new(&pkg.name, &pkg.version, packages)
+}
+
+// ---- demand-resolver graph building (moved from demand::driver) ----
+
+/// Resolve `edge` onto an already-present compatible node: mark the edge
+/// resolved and update that node's type from the edge. Shared by the pre-fetch
+/// reuse probe ([`try_reuse_dependency`]) and the post-resolution placement
+/// ([`process_dependency_with_resolved`]), whose `FindResult::Reuse` arms are
+/// otherwise identical.
+fn reuse_existing_node(
+    graph: &mut DependencyGraph,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    existing_index: NodeIndex,
+) -> ProcessResult {
+    graph.mark_dependency_resolved(edge.edge_id, existing_index);
+    update_node_type_from_edge(graph, parent, existing_index, &edge.edge_type);
+    ProcessResult::Reused(existing_index)
+}
+
+pub(crate) fn try_reuse_dependency(
+    graph: &mut DependencyGraph,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+) -> Option<ProcessResult> {
+    match graph.find_compatible_node(parent, &edge.name, &edge.spec) {
+        FindResult::Reuse(existing_index) => {
+            Some(reuse_existing_node(graph, parent, edge, existing_index))
+        }
+        FindResult::Conflict(_) | FindResult::New(_) => None,
+    }
+}
+
+pub fn process_dependency_with_resolved(
+    graph: &mut DependencyGraph,
+    node_index: NodeIndex,
+    edge_info: &DependencyEdgeInfo,
+    resolved: &ResolvedPackage,
+    config: &BuildDepsConfig,
+) -> ProcessResult {
+    match graph.find_compatible_node(node_index, &edge_info.name, &edge_info.spec) {
+        FindResult::Reuse(existing_index) => {
+            reuse_existing_node(graph, node_index, edge_info, existing_index)
+        }
+        FindResult::Conflict(conflict_parent) | FindResult::New(conflict_parent) => {
+            let new_node = create_package_node(&edge_info.name, resolved, conflict_parent, graph);
+            let new_index = graph.add_node(new_node);
+            graph.add_physical_edge(conflict_parent, new_index);
+            graph.mark_dependency_resolved(edge_info.edge_id, new_index);
+            update_node_type_from_edge(graph, node_index, new_index, &edge_info.edge_type);
+            add_edges_from(
+                graph,
+                new_index,
+                &*resolved.manifest,
+                &EdgeContext::new(config.peer_deps, DevDeps::Exclude),
+            );
+            ProcessResult::Created(new_index)
+        }
+    }
+}
+
+pub(crate) fn chain_err<E>(
+    graph: &DependencyGraph,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    inner: ResolveError<E>,
+) -> ResolveError<E> {
+    let mut chain = graph.logical_ancestry(parent);
+    chain.push((edge.name.clone(), edge.spec.clone()));
+    ResolveError::WithChain {
+        chain,
+        source: Box::new(inner),
+    }
+}
+
+pub(crate) async fn handle_resolved_registry_manifest<R, E>(
+    graph: &mut DependencyGraph,
+    registry: &R,
+    receiver: &E,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    manifest: Arc<CoreVersionManifest>,
+    config: &BuildDepsConfig,
+) -> Result<ProcessResult, ResolveError<R::Error>>
+where
+    R: RegistryClient,
+    E: EventReceiver,
+{
+    let resolved = ResolvedPackage {
+        name: edge.name.clone(),
+        version: manifest.version.clone(),
+        manifest,
+    };
+
+    // Apply an override keyed on the resolved version by re-resolving the
+    // override spec directly. Calling the full `process_dependency` here would
+    // redundantly re-resolve the original spec (whose manifest we already have)
+    // before it checks the override and resolves the override spec.
+    let resolved = if let Some(override_spec) =
+        graph.check_override(parent, &edge.name, Some(&resolved.version))
+    {
+        match resolve_registry_dep(registry, &edge.name, &override_spec, &edge.edge_type)
+            .await
+            .map_err(|inner| chain_err(graph, parent, edge, inner))?
+        {
+            Some(overridden) => overridden,
+            None => resolved, // override failed to resolve — keep the original
+        }
+    } else {
+        resolved
+    };
+
+    receiver.on_event(BuildEvent::PackageResolved((&*resolved.manifest).into()));
+    Ok(process_dependency_with_resolved(
+        graph, parent, edge, &resolved, config,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/ruborist/src/resolver/demand/driver.rs
+++ b/crates/ruborist/src/resolver/demand/driver.rs
@@ -1,0 +1,749 @@
+//! The BFS driver loop. Walks the dependency graph level by level, drives the
+//! fetch pipeline, and feeds resolved manifests back into the graph. Owns the
+//! per-run [`ManifestState`] store and [`FetchQueues`] scheduler.
+
+use std::collections::VecDeque;
+use std::future::poll_fn;
+use std::sync::Arc;
+use std::task::Poll;
+
+use futures::stream::{FuturesUnordered, StreamExt};
+use petgraph::graph::NodeIndex;
+
+use crate::model::graph::DependencyGraph;
+use crate::model::manifest::NodeManifest;
+use crate::model::node::EdgeType;
+use crate::resolver::builder::{
+    BuildDepsConfig, ProcessResult, chain_err, handle_resolved_registry_manifest,
+    process_dependency, try_reuse_dependency,
+};
+use crate::resolver::edges::{DependencyEdgeInfo, collect_unresolved_edges};
+use crate::resolver::registry::ResolveError;
+use crate::resolver::semver::normalize_spec;
+use crate::service::ManifestProvider;
+use crate::spec::SpecStr;
+use crate::traits::progress::{BuildEvent, EventReceiver};
+
+use super::queue::{FetchDone, FetchKey};
+use super::queue::{FetchFuture, FetchQueues};
+use super::schedule::{schedule_fetch, schedule_transitive_prefetches};
+use super::select::{EdgeStep, ResolutionMode, WaitKey, select_edge};
+use super::state::{ManifestState, PackageVersions, ResolverManifestCache};
+use crate::model::node::PeerDeps;
+use crate::service::{ManifestFullData, ManifestJob, ManifestJobDone};
+use crate::traits::registry::RegistryError;
+
+/// Emit the resolution + placement events for a freshly created node.
+fn emit_created_events<E: EventReceiver>(
+    graph: &DependencyGraph,
+    receiver: &E,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    idx: NodeIndex,
+) {
+    // `Created(idx)` is the index `graph.add_node` just returned, so the node
+    // must exist — a miss is an invariant violation, not a normal absence.
+    let node = graph
+        .get_node(idx)
+        .expect("a freshly created node must exist in the graph");
+    receiver.on_event(BuildEvent::Resolved {
+        name: &edge.name,
+        version: &node.version,
+    });
+    // Only registry nodes carry a manifest to place; file/git/http nodes don't.
+    if let NodeManifest::Registry(ref manifest) = node.manifest {
+        let parent_path = graph.get_node(parent).map(|p| p.path.as_path());
+        receiver.on_event(BuildEvent::PackagePlaced {
+            package: manifest.as_ref().into(),
+            path: &node.path,
+            parent_path,
+        });
+    }
+}
+
+fn handle_processed<E: EventReceiver>(
+    graph: &DependencyGraph,
+    receiver: &E,
+    parent: NodeIndex,
+    edge: &DependencyEdgeInfo,
+    processed: &ProcessResult,
+    next_level: &mut Vec<NodeIndex>,
+) {
+    match processed {
+        ProcessResult::Created(idx) => {
+            emit_created_events(graph, receiver, parent, edge, *idx);
+            next_level.push(*idx);
+        }
+        ProcessResult::Reused(idx) => {
+            if let Some(node) = graph.get_node(*idx) {
+                receiver.on_event(BuildEvent::Reused {
+                    name: &edge.name,
+                    version: &node.version,
+                });
+            }
+        }
+        ProcessResult::Skipped => {
+            receiver.on_event(BuildEvent::Skipped {
+                name: &edge.name,
+                spec: &edge.spec,
+            });
+        }
+    }
+}
+
+/// Seed one BFS level's work from its nodes: the root's workspace children
+/// become the next level directly, and every unresolved registry edge becomes
+/// a pending edge to resolve this level.
+fn seed_level<E: EventReceiver>(
+    graph: &DependencyGraph,
+    receiver: &E,
+    current_level: &[NodeIndex],
+    root_idx: NodeIndex,
+) -> (Vec<NodeIndex>, VecDeque<WaitingEdge>) {
+    let mut next_level = Vec::new();
+    let mut level_pending = VecDeque::new();
+
+    for node_index in current_level {
+        for (_, dep) in graph.get_dependency_edges(*node_index) {
+            if dep.valid
+                && let Some(to) = dep.to
+                && let Some(n) = graph.get_node(to)
+                && n.is_workspace()
+                && *node_index == root_idx
+            {
+                next_level.push(to);
+            }
+        }
+
+        let unresolved = collect_unresolved_edges(graph, *node_index);
+        receiver.on_event(BuildEvent::DependencyCount {
+            count: unresolved.len(),
+        });
+        for edge in unresolved {
+            level_pending.push_back((*node_index, edge));
+        }
+    }
+
+    (next_level, level_pending)
+}
+
+/// Run-invariant context threaded through the demand loop's per-edge helpers:
+/// the manifest provider, the progress receiver, the build config, and whether
+/// the registry resolves semver ranges. Bundled so the helpers stay readable.
+struct DemandCtx<'a, R, E> {
+    registry: &'a R,
+    receiver: &'a E,
+    config: &'a BuildDepsConfig,
+    supports_semver: ResolutionMode,
+}
+
+impl<R, E> DemandCtx<'_, R, E>
+where
+    R: ManifestProvider,
+    R::Error: Send,
+    E: EventReceiver,
+{
+    /// Resolve one pending edge: dispatch a non-registry spec to the legacy
+    /// resolver, reuse an existing compatible node, resolve it now from a cached
+    /// manifest, skip/fail it, or park it on a pending fetch and schedule it.
+    async fn process_pending_edge(
+        &self,
+        graph: &mut DependencyGraph,
+        state: &mut ManifestState,
+        queues: &mut FetchQueues,
+        parent: NodeIndex,
+        edge: DependencyEdgeInfo,
+        next_level: &mut Vec<NodeIndex>,
+    ) -> Result<(), ResolveError<R::Error>> {
+        self.receiver
+            .on_event(BuildEvent::Resolving { name: &edge.name });
+
+        if !edge.spec.is_registry_spec() {
+            let processed = process_dependency(graph, self.registry, parent, &edge, self.config)
+                .await
+                .map_err(|inner| chain_err(graph, parent, &edge, inner))?;
+            handle_processed(graph, self.receiver, parent, &edge, &processed, next_level);
+            return Ok(());
+        }
+
+        if let Some(processed) = try_reuse_dependency(graph, parent, &edge) {
+            handle_processed(graph, self.receiver, parent, &edge, &processed, next_level);
+            return Ok(());
+        }
+
+        let (real_name, real_spec) = normalize_spec(&edge.name, &edge.spec);
+        let step =
+            select_edge::<R::Error>(state, &edge, &real_name, &real_spec, self.supports_semver)
+                .map_err(|inner| chain_err(graph, parent, &edge, inner))?;
+
+        match step {
+            EdgeStep::Resolve { manifest, alias } => {
+                if let Some((alias_name, alias_spec)) = alias {
+                    state.cache_version(alias_name, alias_spec, Arc::clone(&manifest));
+                }
+                let processed = handle_resolved_registry_manifest(
+                    graph,
+                    self.registry,
+                    self.receiver,
+                    parent,
+                    &edge,
+                    manifest,
+                    self.config,
+                )
+                .await?;
+                handle_processed(graph, self.receiver, parent, &edge, &processed, next_level);
+            }
+            EdgeStep::Skip => {
+                self.receiver.on_event(BuildEvent::Skipped {
+                    name: &edge.name,
+                    spec: &edge.spec,
+                });
+            }
+            EdgeStep::Fail(message) => {
+                if edge.edge_type == EdgeType::Optional {
+                    self.receiver.on_event(BuildEvent::Skipped {
+                        name: &edge.name,
+                        spec: &edge.spec,
+                    });
+                } else {
+                    return Err(chain_err(graph, parent, &edge, registry_error(message)));
+                }
+            }
+            EdgeStep::Park { wait, fetch } => {
+                match wait {
+                    WaitKey::Full(key) => state.park_on_package(key, (parent, edge)),
+                    WaitKey::Version(key) => state.park_on_version(key, (parent, edge)),
+                }
+                schedule_fetch(state, queues, fetch, self.supports_semver);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Last-resort path when the fetch stream drains while edges are still parked:
+    /// resolve every remaining waiter sequentially through the legacy resolver.
+    async fn resolve_waiters_sequentially(
+        &self,
+        graph: &mut DependencyGraph,
+        state: &mut ManifestState,
+        next_level: &mut Vec<NodeIndex>,
+    ) -> Result<(), ResolveError<R::Error>> {
+        for (parent, edge) in state.drain_waiters() {
+            let processed = process_dependency(graph, self.registry, parent, &edge, self.config)
+                .await
+                .map_err(|inner| chain_err(graph, parent, &edge, inner))?;
+            handle_processed(graph, self.receiver, parent, &edge, &processed, next_level);
+        }
+        Ok(())
+    }
+
+    /// Top up the in-flight fetch set from the queue up to `concurrency`, spawning
+    /// each as a provider job so independent fetch + parse run in parallel.
+    fn pump_fetches(
+        &self,
+        fetches: &mut FuturesUnordered<FetchFuture>,
+        fetch_queues: &mut FetchQueues,
+        concurrency: usize,
+    ) {
+        while fetches.len() < concurrency {
+            let Some(request) = fetch_queues.pop() else {
+                break;
+            };
+            fetches.push(fetch_registry_manifest(self.registry.clone(), request));
+        }
+    }
+}
+
+/// Demand-driven BFS resolution loop.
+///
+/// Walks the dependency graph level by level. Within a level it schedules
+/// manifest fetches as provider jobs on a `FuturesUnordered`, then drains them
+/// as they complete and feeds resolved versions back into the graph so the next
+/// level can be discovered. [`ManifestState`] owns the per-run manifest cache,
+/// waiters, and inflight de-duplication; [`FetchQueues`] prioritises on-demand
+/// fetches over speculative prefetches. Returns the warmed manifest cache so the
+/// caller can reuse it.
+pub(crate) async fn run_main_loop_bfs<R, E>(
+    graph: &mut DependencyGraph,
+    registry: &R,
+    config: &BuildDepsConfig,
+    receiver: &E,
+) -> Result<ResolverManifestCache, ResolveError<R::Error>>
+where
+    // `R` is the I/O boundary (a manifest provider); its error must be `Send`
+    // because fetch jobs are polled on a `FuturesUnordered`. `E` receives
+    // progress events as the loop advances.
+    R: ManifestProvider,
+    R::Error: Send,
+    E: EventReceiver,
+{
+    let supports_semver =
+        ResolutionMode::from_supports_semver(registry.supports_semver_resolution());
+    let concurrency = config.concurrency.max(1);
+    let ctx = DemandCtx {
+        registry,
+        receiver,
+        config,
+        supports_semver,
+    };
+
+    let mut state = ManifestState::seeded(
+        config
+            .project_cache
+            .as_ref()
+            .map(|pc| pc.resolved_manifests())
+            .unwrap_or_default(),
+    );
+    let mut queues = FetchQueues::default();
+    let mut fetches: FuturesUnordered<FetchFuture> = FuturesUnordered::new();
+
+    let root_idx = graph.root_index;
+    let mut current_level = vec![root_idx];
+
+    // Resolve the graph one BFS level at a time; each iteration discovers the
+    // next level from the edges it resolves.
+    while !current_level.is_empty() {
+        receiver.on_event(BuildEvent::LevelStart {
+            node_count: current_level.len(),
+        });
+
+        let (mut next_level, mut level_pending) =
+            seed_level(graph, receiver, &current_level, root_idx);
+
+        // Drain loop: keep the fetch pipeline saturated and process edges as
+        // their manifests arrive, until this level has nothing left in flight.
+        loop {
+            ctx.pump_fetches(&mut fetches, &mut queues, concurrency);
+
+            while let Some((parent, edge)) = level_pending.pop_front() {
+                ctx.process_pending_edge(
+                    graph,
+                    &mut state,
+                    &mut queues,
+                    parent,
+                    edge,
+                    &mut next_level,
+                )
+                .await?;
+                ctx.pump_fetches(&mut fetches, &mut queues, concurrency);
+            }
+
+            loop {
+                let ready = poll_fn(|cx| match fetches.poll_next_unpin(cx) {
+                    Poll::Ready(done) => Poll::Ready(done),
+                    Poll::Pending => Poll::Ready(None),
+                })
+                .await;
+                let Some(done) = ready else {
+                    break;
+                };
+                let done = done.map_err(|e| {
+                    registry_error::<R::Error>(format!("manifest fetch task failed: {e}"))
+                })?;
+
+                apply_fetch_result(
+                    &mut state,
+                    &mut queues,
+                    done,
+                    supports_semver,
+                    config.peer_deps,
+                    &mut level_pending,
+                );
+            }
+
+            if !level_pending.is_empty() {
+                continue;
+            }
+
+            if state.has_pending_waiters() {
+                ctx.pump_fetches(&mut fetches, &mut queues, concurrency);
+            } else {
+                break;
+            }
+
+            let Some(done) = fetches.next().await else {
+                let (full_waiters, version_waiters) = state.pending_waiter_counts();
+                tracing::warn!(
+                    full_waiters,
+                    version_waiters,
+                    "manifest fetch stream ended with pending resolver waiters; falling back to sequential resolution"
+                );
+                ctx.resolve_waiters_sequentially(graph, &mut state, &mut next_level)
+                    .await?;
+                break;
+            };
+            let done = done.map_err(|e| {
+                registry_error::<R::Error>(format!("manifest fetch task failed: {e}"))
+            })?;
+
+            apply_fetch_result(
+                &mut state,
+                &mut queues,
+                done,
+                supports_semver,
+                config.peer_deps,
+                &mut level_pending,
+            );
+        }
+
+        receiver.on_event(BuildEvent::LevelComplete {
+            next_level_count: next_level.len(),
+        });
+        current_level = next_level;
+    }
+
+    Ok(state.into_resolver_cache())
+}
+
+// ---- Orchestration: state transitions over the store + queue ----
+//
+// These tie the manifest store and the fetch scheduler together; the store and
+// the queue stay unaware of each other.
+
+/// A parked edge waiting on a pending fetch (matches `state`'s waiter payload).
+pub(super) type WaitingEdge = (NodeIndex, DependencyEdgeInfo);
+
+pub(super) fn registry_error<E: From<RegistryError>>(
+    message: impl Into<String>,
+) -> ResolveError<E> {
+    ResolveError::Registry(RegistryError(anyhow::anyhow!(message.into())).into())
+}
+
+async fn fetch_registry_manifest_inner<R: ManifestProvider>(
+    registry: R,
+    request: ManifestJob,
+) -> FetchDone {
+    let key = request.key();
+    match registry.execute_manifest_job(request).await {
+        Ok(done) => match done {
+            ManifestJobDone::Full { name, data } => FetchDone::Full {
+                name,
+                result: Ok(data),
+            },
+            ManifestJobDone::Version {
+                name,
+                spec,
+                manifest,
+            } => FetchDone::Version {
+                name,
+                spec,
+                result: Ok(manifest),
+            },
+        },
+        Err(error) => match key {
+            FetchKey::Full(name) => FetchDone::Full {
+                name,
+                result: Err(format!("{error:#}")),
+            },
+            FetchKey::Version(name, spec) => FetchDone::Version {
+                name,
+                spec,
+                result: Err(format!("{error:#}")),
+            },
+        },
+    }
+}
+
+/// Spawn a fetch job. Native runs it on the multi-threaded runtime so
+/// independent fetch + parse jobs progress in parallel; wasm has no threads, so
+/// it runs on the current local set.
+#[cfg(not(target_arch = "wasm32"))]
+fn fetch_registry_manifest<R: ManifestProvider>(registry: R, request: ManifestJob) -> FetchFuture
+where
+    R::Error: Send,
+{
+    tokio::spawn(fetch_registry_manifest_inner(registry, request))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn fetch_registry_manifest<R: ManifestProvider>(registry: R, request: ManifestJob) -> FetchFuture {
+    tokio::task::spawn_local(fetch_registry_manifest_inner(registry, request))
+}
+
+/// Apply one completed fetch to the store: cache it, wake parked edges, and
+/// schedule any transitive prefetches.
+pub(super) fn apply_fetch_result(
+    state: &mut ManifestState,
+    queues: &mut FetchQueues,
+    done: FetchDone,
+    supports_semver: ResolutionMode,
+    peer_deps: PeerDeps,
+    ready: &mut VecDeque<WaitingEdge>,
+) {
+    let done_key = done.key();
+    queues.complete(&done_key);
+
+    match done {
+        FetchDone::Full { name, result } => {
+            match result {
+                Ok(ManifestFullData::Full {
+                    manifest: full,
+                    speculative,
+                }) => {
+                    if let Some((resolved_spec, manifest)) = speculative {
+                        state.cache_version(name.clone(), resolved_spec, Arc::clone(&manifest));
+                        schedule_transitive_prefetches(
+                            state,
+                            queues,
+                            &manifest,
+                            peer_deps,
+                            supports_semver,
+                        );
+                    }
+                    state.set_package(name.clone(), PackageVersions::Full(full));
+                }
+                Ok(ManifestFullData::Versions(versions)) => {
+                    state.set_package(name.clone(), PackageVersions::List(versions));
+                }
+                Err(e) => {
+                    state.set_package(name.clone(), PackageVersions::Failed(e));
+                }
+            }
+            state.wake_package(&name, ready);
+        }
+        FetchDone::Version { name, spec, result } => {
+            match result {
+                Ok(manifest) => {
+                    state.cache_version(name.clone(), spec.clone(), Arc::clone(&manifest));
+                    schedule_transitive_prefetches(
+                        state,
+                        queues,
+                        &manifest,
+                        peer_deps,
+                        supports_semver,
+                    );
+                }
+                Err(e) => state.fail_version(&name, &spec, e),
+            }
+            state.wake_version(&name, &spec, ready);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use petgraph::graph::EdgeIndex;
+
+    use super::*;
+    use crate::model::manifest::{CoreVersionManifest, FullManifest};
+    use crate::model::package_json::PackageJson;
+    use crate::resolver::builder::resolve;
+    use crate::service::{ManifestJob, ManifestJobDone};
+    use crate::traits::registry::mock::{MockError, MockRegistryClient};
+
+    /// A parked waiter; node/edge indices are placeholders — `apply_fetch_result`
+    /// only routes the payload, it never dereferences the graph.
+    fn test_edge(name: &str, spec: &str) -> WaitingEdge {
+        (
+            NodeIndex::new(0),
+            DependencyEdgeInfo {
+                edge_id: EdgeIndex::new(0),
+                name: name.to_string(),
+                spec: spec.to_string(),
+                edge_type: EdgeType::Prod,
+            },
+        )
+    }
+
+    fn create_version_manifest(name: &str, version: &str) -> CoreVersionManifest {
+        CoreVersionManifest {
+            name: name.to_string(),
+            version: version.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn create_version_manifest_with_deps(
+        name: &str,
+        version: &str,
+        deps: Vec<(&str, &str)>,
+    ) -> CoreVersionManifest {
+        let dependencies = deps
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        CoreVersionManifest {
+            name: name.to_string(),
+            version: version.to_string(),
+            dependencies: Some(dependencies),
+            ..Default::default()
+        }
+    }
+
+    #[derive(Clone)]
+    struct CountingRegistry {
+        inner: MockRegistryClient,
+        shared_version_jobs: Arc<AtomicUsize>,
+    }
+
+    impl crate::traits::registry::RegistryClient for CountingRegistry {
+        type Error = MockError;
+
+        async fn fetch_full_manifest(&self, name: &str) -> Result<Arc<FullManifest>, Self::Error> {
+            self.inner.fetch_full_manifest(name).await
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl ManifestProvider for CountingRegistry {
+        async fn execute_manifest_job(
+            &self,
+            job: ManifestJob,
+        ) -> Result<ManifestJobDone, Self::Error> {
+            if matches!(
+                &job,
+                ManifestJob::Full { name, .. }
+                    | ManifestJob::Version { name, .. }
+                    | ManifestJob::ExtractVersion { name, .. }
+                    if name == "shared"
+            ) {
+                self.shared_version_jobs.fetch_add(1, Ordering::Relaxed);
+            }
+            self.inner.execute_manifest_job(job).await
+        }
+    }
+
+    // The `resolve` entry in `builder` still routes through the legacy
+    // `RegistryClient::fetch_version_manifest` path in this PR — the cutover
+    // that points it at the demand driver lives in the follow-up PR in this
+    // stack. Until then the `CountingRegistry`'s `ManifestProvider`-side job
+    // counter stays at zero (the legacy path bypasses it), so the
+    // single-flight assertion below has nothing to count. The cutover PR
+    // removes this `#[ignore]` alongside flipping the entry-point bounds.
+    #[ignore = "exercises the demand-driver pipeline, wired in the cutover PR"]
+    #[tokio::test]
+    async fn test_non_semver_exact_version_extract_single_flight() {
+        let mut inner = MockRegistryClient::new();
+        inner.add_package(
+            "a",
+            "1.0.0",
+            create_version_manifest_with_deps("a", "1.0.0", vec![("shared", "^1.0.0")]),
+        );
+        inner.add_package(
+            "b",
+            "1.0.0",
+            create_version_manifest_with_deps("b", "1.0.0", vec![("shared", "~1.2.0")]),
+        );
+        inner.add_package(
+            "shared",
+            "1.2.3",
+            create_version_manifest("shared", "1.2.3"),
+        );
+
+        let shared_version_jobs = Arc::new(AtomicUsize::new(0));
+        let registry = CountingRegistry {
+            inner,
+            shared_version_jobs: Arc::clone(&shared_version_jobs),
+        };
+        let pkg = PackageJson {
+            dependencies: Some(HashMap::from([
+                ("a".to_string(), "1.0.0".to_string()),
+                ("b".to_string(), "1.0.0".to_string()),
+            ])),
+            ..PackageJson::new("test-project", "1.0.0")
+        };
+
+        let lock = resolve(&pkg, &registry).await.unwrap();
+
+        assert!(lock.packages.contains_key("node_modules/shared"));
+        assert_eq!(shared_version_jobs.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn apply_version_success_caches_and_wakes_waiter() {
+        let mut state = ManifestState::seeded(Vec::new());
+        let mut queues = FetchQueues::default();
+        let mut ready = VecDeque::new();
+        state.park_on_version(
+            ("shared".to_string(), "^1.0.0".to_string()),
+            test_edge("shared", "^1.0.0"),
+        );
+
+        apply_fetch_result(
+            &mut state,
+            &mut queues,
+            FetchDone::Version {
+                name: "shared".to_string(),
+                spec: "^1.0.0".to_string(),
+                result: Ok(Arc::new(create_version_manifest("shared", "1.2.3"))),
+            },
+            ResolutionMode::Semver,
+            PeerDeps::Skip,
+            &mut ready,
+        );
+
+        // Manifest cached under the requested spec, and the parked edge is woken.
+        assert!(state.get_version_manifest("shared", "^1.0.0").is_some());
+        assert_eq!(ready.len(), 1);
+    }
+
+    #[test]
+    fn apply_version_failure_records_and_wakes_waiter() {
+        let mut state = ManifestState::seeded(Vec::new());
+        let mut queues = FetchQueues::default();
+        let mut ready = VecDeque::new();
+        state.park_on_version(
+            ("shared".to_string(), "^1.0.0".to_string()),
+            test_edge("shared", "^1.0.0"),
+        );
+
+        apply_fetch_result(
+            &mut state,
+            &mut queues,
+            FetchDone::Version {
+                name: "shared".to_string(),
+                spec: "^1.0.0".to_string(),
+                result: Err("registry exploded".to_string()),
+            },
+            ResolutionMode::Semver,
+            PeerDeps::Skip,
+            &mut ready,
+        );
+
+        // Failure recorded so the woken edge resolves to skip-or-error, not a hang.
+        assert_eq!(
+            state.get_version_failure("shared", "^1.0.0"),
+            Some("registry exploded")
+        );
+        assert_eq!(ready.len(), 1);
+    }
+
+    #[test]
+    fn apply_version_success_schedules_transitive_prefetch() {
+        let mut state = ManifestState::seeded(Vec::new());
+        let mut queues = FetchQueues::default();
+        let mut ready = VecDeque::new();
+
+        apply_fetch_result(
+            &mut state,
+            &mut queues,
+            FetchDone::Version {
+                name: "a".to_string(),
+                spec: "^1.0.0".to_string(),
+                result: Ok(Arc::new(create_version_manifest_with_deps(
+                    "a",
+                    "1.0.0",
+                    vec![("dep", "^2.0.0")],
+                ))),
+            },
+            ResolutionMode::Semver,
+            PeerDeps::Skip,
+            &mut ready,
+        );
+
+        // The resolved manifest's registry dep is queued as a speculative prefetch.
+        let job = queues
+            .pop()
+            .expect("transitive prefetch for `dep` should be queued");
+        assert_eq!(
+            job.key(),
+            FetchKey::Version("dep".to_string(), "^2.0.0".to_string())
+        );
+    }
+}

--- a/crates/ruborist/src/resolver/demand/mod.rs
+++ b/crates/ruborist/src/resolver/demand/mod.rs
@@ -3,15 +3,17 @@
 //! - [`state`] — per-run manifest store (cache, waiters, failures).
 //! - [`queue`] — fetch scheduling, single-flight de-duplication, priority.
 //! - [`select`] — per-edge resolution decision (pure; reads the store).
+//! - [`schedule`] — fetch-scheduling policy: which manifest jobs to enqueue.
+//! - [`driver`] — BFS loop: drives fetches, applies results, builds the graph.
 //!
-//! These are independent leaf concerns; the driver that coordinates them (and exposes
-//! `run_main_loop_bfs`) lands in the follow-up PR. Until then they are staged
-//! here and exercised by their own unit tests.
+//! `state`/`queue`/`select`/`schedule` are leaf concerns; the driver
+//! coordinates them.
 
-// Staged ahead of the driver: the only consumers so far are the unit tests, so
-// the driver-facing API is dead in this PR.
-#![allow(dead_code)]
-
+mod driver;
 mod queue;
+mod schedule;
 mod select;
 mod state;
+
+pub(crate) use driver::run_main_loop_bfs;
+pub(crate) use state::ResolverManifestCache;

--- a/crates/ruborist/src/resolver/demand/queue.rs
+++ b/crates/ruborist/src/resolver/demand/queue.rs
@@ -52,7 +52,10 @@ impl FetchDone {
     }
 }
 
-pub(crate) type FetchFuture = std::pin::Pin<Box<dyn std::future::Future<Output = FetchDone>>>;
+/// A spawned fetch job. On native it's a `tokio::spawn` task (multi-threaded
+/// runtime → fetch + parse for independent manifests run in parallel); on wasm
+/// it's a `spawn_local` task. Either way the driver awaits the `JoinHandle`.
+pub(crate) type FetchFuture = tokio::task::JoinHandle<FetchDone>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum FetchPriority {
@@ -127,7 +130,6 @@ impl FetchQueues {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::service::MetadataFormat;
 
     fn full(name: &str) -> ManifestJob {
         ManifestJob::Full {
@@ -145,7 +147,6 @@ mod tests {
                 name: "demand".to_string(),
                 spec: "^1.0.0".to_string(),
                 fetch_spec: "^1.0.0".to_string(),
-                format: MetadataFormat::Abbreviated,
             },
             FetchPriority::Demand,
         );

--- a/crates/ruborist/src/resolver/demand/schedule.rs
+++ b/crates/ruborist/src/resolver/demand/schedule.rs
@@ -1,0 +1,148 @@
+//! Fetch-scheduling policy for the demand resolver.
+//!
+//! Decides *what manifest jobs to enqueue* — the dual of [`super::select`],
+//! which decides what to do with an edge. Given an edge's resolution plan or a
+//! freshly resolved manifest, these helpers translate it into [`ManifestJob`]s
+//! and push them onto the [`FetchQueues`] scheduler, de-duplicating against the
+//! [`ManifestState`] store so each `(name, spec)` is fetched at most once.
+//!
+//! The driver owns the loop and the in-flight set; this module owns the
+//! "fetch next" policy it delegates to.
+
+use std::sync::Arc;
+
+use crate::model::manifest::{CoreVersionManifest, FullManifest};
+use crate::model::node::{DevDeps, PeerDeps};
+use crate::resolver::edges::DependencySource;
+use crate::resolver::semver::normalize_spec;
+use crate::service::ManifestJob;
+use crate::spec::SpecStr;
+
+use super::queue::{FetchPriority, FetchQueues};
+use super::select::{FetchPlan, ResolutionMode};
+use super::state::ManifestState;
+
+/// Collect a manifest's registry dependencies (excluding dev deps) as
+/// `(name, spec)` pairs eligible for speculative prefetch.
+fn collect_registry_prefetches(
+    manifest: &CoreVersionManifest,
+    peer_deps: PeerDeps,
+) -> Vec<(String, String)> {
+    let mut deps = Vec::new();
+    manifest.for_each_dep(peer_deps, DevDeps::Exclude, |_, name, spec| {
+        if spec.is_registry_spec() {
+            deps.push((name.to_string(), spec.to_string()));
+        }
+    });
+    deps
+}
+
+/// Schedule the fetch a parked edge is waiting on. Owns the [`FetchPlan`] →
+/// [`ManifestJob`] mapping so the driver only says "schedule this plan" — parked
+/// edges are always demand priority.
+pub(super) fn schedule_fetch(
+    state: &mut ManifestState,
+    queues: &mut FetchQueues,
+    plan: FetchPlan,
+    supports_semver: ResolutionMode,
+) {
+    match plan {
+        FetchPlan::Registry { name, spec } => schedule_registry_fetch(
+            state,
+            queues,
+            name,
+            spec,
+            supports_semver,
+            FetchPriority::Demand,
+        ),
+        FetchPlan::Extract {
+            name,
+            version,
+            full,
+        } => enqueue_version_extract(queues, name, version, full),
+        FetchPlan::VersionFetch { name, version } => enqueue_version_fetch(queues, name, version),
+    }
+}
+
+/// Queue a registry fetch for `(name, spec)` unless the store already has it.
+fn schedule_registry_fetch(
+    state: &mut ManifestState,
+    queues: &mut FetchQueues,
+    name: String,
+    spec: String,
+    supports_semver: ResolutionMode,
+    priority: FetchPriority,
+) {
+    let (real_name, real_spec) = normalize_spec(&name, &spec);
+    if matches!(supports_semver, ResolutionMode::Semver) {
+        if state.is_version_settled(&real_name, &real_spec) {
+            return;
+        }
+        queues.push(
+            ManifestJob::Version {
+                name: real_name.clone(),
+                spec: real_spec.clone(),
+                fetch_spec: real_spec,
+            },
+            priority,
+        );
+    } else {
+        if state.has_package_source(&real_name) {
+            return;
+        }
+        queues.push(
+            ManifestJob::Full {
+                name: real_name,
+                spec: Some(real_spec),
+            },
+            priority,
+        );
+    }
+}
+
+fn enqueue_version_extract(
+    queues: &mut FetchQueues,
+    name: String,
+    version: String,
+    full: Arc<FullManifest>,
+) {
+    queues.push(
+        ManifestJob::ExtractVersion {
+            name,
+            spec: version.clone(),
+            version,
+            full,
+        },
+        FetchPriority::Demand,
+    );
+}
+
+fn enqueue_version_fetch(queues: &mut FetchQueues, name: String, fetch_spec: String) {
+    queues.push(
+        ManifestJob::Version {
+            name,
+            spec: fetch_spec.clone(),
+            fetch_spec,
+        },
+        FetchPriority::Demand,
+    );
+}
+
+pub(super) fn schedule_transitive_prefetches(
+    state: &mut ManifestState,
+    queues: &mut FetchQueues,
+    manifest: &CoreVersionManifest,
+    peer_deps: PeerDeps,
+    supports_semver: ResolutionMode,
+) {
+    for (name, spec) in collect_registry_prefetches(manifest, peer_deps) {
+        schedule_registry_fetch(
+            state,
+            queues,
+            name,
+            spec,
+            supports_semver,
+            FetchPriority::Prefetch,
+        );
+    }
+}

--- a/crates/ruborist/src/resolver/demand/state.rs
+++ b/crates/ruborist/src/resolver/demand/state.rs
@@ -23,6 +23,12 @@ type WaitingEdge = (NodeIndex, DependencyEdgeInfo);
 /// adapts these to/from disk; the store itself stays format-agnostic.
 #[derive(Default)]
 pub(crate) struct ResolverManifestCache {
+    // The resolver writes this on each run via `ManifestState::into_resolver_cache`;
+    // the reader is `ProjectCacheData::from_resolved` in the cutover PR's `api.rs`
+    // edit. Staged write-only here so the driver lands ahead of the entry-point
+    // switch — see the matching `#[allow(dead_code)]` on `ProjectCacheData`'s
+    // bridges in `service/cache.rs` introduced by the preceding (provider) PR.
+    #[allow(dead_code)]
     pub(crate) entries: Vec<(String, String, Arc<CoreVersionManifest>)>,
 }
 
@@ -136,6 +142,36 @@ impl ManifestState {
     /// Park an edge waiting on `name`'s package (full/versions) fetch.
     pub(crate) fn park_on_package(&mut self, name: String, waiter: WaitingEdge) {
         self.package_waiters.entry(name).or_default().push(waiter);
+    }
+
+    /// Park an edge waiting on a `(name, spec)` version-manifest fetch.
+    pub(crate) fn park_on_version(&mut self, key: (String, String), waiter: WaitingEdge) {
+        self.version.waiters.entry(key).or_default().push(waiter);
+    }
+
+    /// Whether any edge is still parked on a pending package or version fetch.
+    pub(crate) fn has_pending_waiters(&self) -> bool {
+        !self.package_waiters.is_empty() || !self.version.waiters.is_empty()
+    }
+
+    /// Parked-edge counts as `(package, version)`, for diagnostics.
+    pub(crate) fn pending_waiter_counts(&self) -> (usize, usize) {
+        let package = self.package_waiters.values().map(Vec::len).sum();
+        let version = self.version.waiters.values().map(Vec::len).sum();
+        (package, version)
+    }
+
+    /// Drain every parked edge (package + version waiters) for last-resort
+    /// sequential resolution.
+    pub(crate) fn drain_waiters(&mut self) -> Vec<WaitingEdge> {
+        let mut all = Vec::new();
+        for (_, waiters) in self.package_waiters.drain() {
+            all.extend(waiters);
+        }
+        for (_, waiters) in self.version.waiters.drain() {
+            all.extend(waiters);
+        }
+        all
     }
 
     /// Move every edge waiting on `name`'s package fetch into `ready`.

--- a/crates/ruborist/src/service/manifest_provider.rs
+++ b/crates/ruborist/src/service/manifest_provider.rs
@@ -12,7 +12,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 
 use super::cache::VersionsInfo;
-use super::manifest::MetadataFormat;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
 use crate::traits::registry::RegistryClient;
 
@@ -48,10 +47,6 @@ pub enum ManifestJob {
         /// Registry request spec. For npmjs 304 flows this is the resolved
         /// exact version, while `spec` remains the original range key.
         fetch_spec: String,
-        /// Metadata format for the version endpoint. Semver-capable registries
-        /// accept install-v1 for range/tag queries; npmjs exact-version
-        /// fallback requires the complete metadata format.
-        format: MetadataFormat,
     },
     ExtractVersion {
         name: String,

--- a/crates/ruborist/src/service/registry/provider.rs
+++ b/crates/ruborist/src/service/registry/provider.rs
@@ -24,6 +24,18 @@ use crate::model::manifest::{CoreVersionManifest, extract_core_version_off_runti
 use crate::traits::registry::RegistryError;
 
 impl UnifiedRegistry {
+    /// Metadata format for a version-manifest fetch. Semver registries accept
+    /// the abbreviated install-v1 form for range/tag queries; non-semver (npmjs)
+    /// exact-version fetches need the complete document. Derived from the
+    /// registry's own capability, so the demand loop never has to pass it.
+    fn version_fetch_format(&self) -> manifest::MetadataFormat {
+        if self.supports_semver {
+            manifest::MetadataFormat::Abbreviated
+        } else {
+            manifest::MetadataFormat::Complete
+        }
+    }
+
     /// Persist a resolved version manifest through the host store.
     ///
     /// De-duplicated by `(name, version)`: sibling specs frequently resolve to
@@ -114,7 +126,6 @@ impl ManifestProvider for UnifiedRegistry {
                 name,
                 spec,
                 fetch_spec,
-                format,
             } => {
                 if Version::parse_from_npm(&fetch_spec).is_ok()
                     && let Some(manifest) =
@@ -133,7 +144,7 @@ impl ManifestProvider for UnifiedRegistry {
                         registry_url: &self.registry_url,
                         name: &name,
                         spec: &fetch_spec,
-                        format,
+                        format: self.version_fetch_format(),
                     })
                     .await
                     .map_err(RegistryError)?;

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -428,7 +428,6 @@ pub mod mock {
                     name,
                     spec,
                     fetch_spec,
-                    format: _,
                 } => {
                     let manifest = self.fetch_version_manifest(&name, &fetch_spec).await?;
                     Ok(ManifestJobDone::Version {


### PR DESCRIPTION
Part **2/3** of the demand-resolver rework (#3028). Stacks on #3085.

Lands the demand-driven BFS loop on top of the `ManifestProvider` trait. Still no caller from the public entry-points — dead-code-staged; the cutover (#3087) flips them over.

## Stack

```
next
 └─ #3085  provider trait + adapter
     └─ #3086  demand driver loop        ◄ this PR
         └─ #3087  entry-point cutover    (perf lands here)
```

## The demand loop

```
        run_main_loop_bfs
          │
   graph ─┤─► select_edge ──► FetchQueues ──single-flight──► spawn job
     ▲    │     (decide)      (dedup)                          │
     │    │                                                    ▼
     └────┴──◄── apply result ──◄── ManifestState ◄── ManifestProvider
                                    (cache/waiters)        (#3085)
```

Reachable only from its own module + tests in this PR; bench stays flat vs `next` (the live path still uses the legacy two-phase resolver).
