### PR TITLE
refactor(pm): make UnifiedRegistry stateless; resolve via demand provider

### DIFF
--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -31,7 +31,7 @@ use crate::resolver::registry::{ResolveError, resolve_registry_dep};
 use crate::service::{ManifestProvider, ProjectCacheData};
 use crate::spec::{Catalogs, PackageSpec, Protocol};
 use crate::traits::progress::{BuildEvent, EventReceiver, NoopReceiver};
-use crate::traits::registry::{RegistryClient, ResolvedPackage};
+use crate::traits::registry::ResolvedPackage;
 
 /// Dispatch a git/github spec to the real `gix`-backed resolver when the
 /// `native-git` feature is enabled, otherwise error with a hint.
@@ -413,7 +413,7 @@ async fn process_file_dep<E>(
 ///
 /// # Returns
 /// The result of processing (reused, created, or skipped)
-pub async fn process_dependency<R: RegistryClient>(
+pub async fn process_dependency<R: ManifestProvider>(
     graph: &mut DependencyGraph,
     registry: &R,
     node_index: NodeIndex,
@@ -893,7 +893,7 @@ pub(crate) async fn handle_resolved_registry_manifest<R, E>(
     config: &BuildDepsConfig,
 ) -> Result<ProcessResult, ResolveError<R::Error>>
 where
-    R: RegistryClient,
+    R: ManifestProvider,
     E: EventReceiver,
 {
     let resolved = ResolvedPackage {

--- a/crates/ruborist/src/resolver/demand/driver.rs
+++ b/crates/ruborist/src/resolver/demand/driver.rs
@@ -530,7 +530,7 @@ mod tests {
     use petgraph::graph::EdgeIndex;
 
     use super::*;
-    use crate::model::manifest::{CoreVersionManifest, FullManifest};
+    use crate::model::manifest::CoreVersionManifest;
     use crate::model::package_json::PackageJson;
     use crate::resolver::builder::resolve;
     use crate::service::{ManifestJob, ManifestJobDone};
@@ -583,10 +583,6 @@ mod tests {
 
     impl crate::traits::registry::RegistryClient for CountingRegistry {
         type Error = MockError;
-
-        async fn fetch_full_manifest(&self, name: &str) -> Result<Arc<FullManifest>, Self::Error> {
-            self.inner.fetch_full_manifest(name).await
-        }
     }
 
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]

--- a/crates/ruborist/src/resolver/registry.rs
+++ b/crates/ruborist/src/resolver/registry.rs
@@ -9,11 +9,12 @@
 
 use std::sync::Arc;
 
-use crate::model::manifest::FullManifest;
+use crate::model::manifest::{CoreVersionManifest, FullManifest};
 use crate::model::node::EdgeType;
 use crate::resolver::semver::normalize_spec;
 use crate::resolver::version::resolve_target_version;
-use crate::traits::registry::{RegistryClient, ResolvedPackage};
+use crate::service::{ManifestFullData, ManifestJob, ManifestJobDone, ManifestProvider};
+use crate::traits::registry::ResolvedPackage;
 
 /// Error type for package resolution.
 #[derive(Debug)]
@@ -114,20 +115,85 @@ impl<E: std::error::Error + 'static> std::error::Error for ResolveError<E> {
 /// let resolved = resolve_package(&registry, "lodash", "^4.0.0").await?;
 /// println!("Resolved to {}@{}", resolved.name, resolved.version);
 /// ```
-pub async fn resolve_package<R: RegistryClient>(
-    registry: &R,
+pub async fn resolve_package<P: ManifestProvider>(
+    provider: &P,
     name: &str,
     spec: &str,
-) -> Result<ResolvedPackage, ResolveError<R::Error>> {
-    // Normalize spec first to handle npm: alias and workspace: prefix
-    // This ensures correct behavior even if RegistryClient::resolve_package is overridden
-    // e.g., "wrap-ansi-cjs" + "npm:wrap-ansi@^7.0.0" -> fetch "wrap-ansi" @ "^7.0.0"
+) -> Result<ResolvedPackage, ResolveError<P::Error>> {
+    // Normalize spec first to handle npm: alias and workspace: prefix, e.g.
+    // "wrap-ansi-cjs" + "npm:wrap-ansi@^7.0.0" -> fetch "wrap-ansi" @ "^7.0.0".
     let (fetch_name, fetch_spec) = normalize_spec(name, spec);
 
-    registry
-        .resolve_package(&fetch_name, &fetch_spec)
+    if provider.supports_semver_resolution() {
+        // Semver registries resolve the range/tag server-side: one version job
+        // returns the matching version's manifest directly.
+        let manifest = version_manifest(provider, &fetch_name, &fetch_spec, &fetch_spec).await?;
+        return Ok(resolved_from_version(&fetch_name, manifest));
+    }
+
+    // Non-semver: fetch the full manifest, resolve the version client-side.
+    let done = provider
+        .execute_manifest_job(ManifestJob::Full {
+            name: fetch_name.clone(),
+            spec: Some(fetch_spec.clone()),
+        })
         .await
-        .map_err(ResolveError::Registry)
+        .map_err(ResolveError::Registry)?;
+    match done {
+        // The provider speculatively extracted the requested version already.
+        ManifestJobDone::Version { manifest, .. } => {
+            Ok(resolved_from_version(&fetch_name, manifest))
+        }
+        ManifestJobDone::Full { data, .. } => match data {
+            ManifestFullData::Full { manifest, .. } => {
+                let resolved = resolve_from_manifest::<P::Error>(&manifest, &fetch_spec)?;
+                Ok(ResolvedPackage {
+                    name: fetch_name,
+                    ..resolved
+                })
+            }
+            ManifestFullData::Versions(versions) => {
+                // 304 path: resolve a concrete version from the cached list, then
+                // fetch that exact version manifest.
+                let version = resolve_target_version((&*versions).into(), &fetch_spec)
+                    .map_err(|e| ResolveError::Version(format!("{name}@{fetch_spec}: {e}")))?;
+                let manifest =
+                    version_manifest(provider, &fetch_name, &version, &fetch_spec).await?;
+                Ok(resolved_from_version(&fetch_name, manifest))
+            }
+        },
+    }
+}
+
+/// Fetch a single version manifest job and unwrap it to the version manifest.
+async fn version_manifest<P: ManifestProvider>(
+    provider: &P,
+    name: &str,
+    fetch_spec: &str,
+    requested_spec: &str,
+) -> Result<Arc<CoreVersionManifest>, ResolveError<P::Error>> {
+    let done = provider
+        .execute_manifest_job(ManifestJob::Version {
+            name: name.to_string(),
+            spec: fetch_spec.to_string(),
+            fetch_spec: fetch_spec.to_string(),
+        })
+        .await
+        .map_err(ResolveError::Registry)?;
+    match done {
+        ManifestJobDone::Version { manifest, .. } => Ok(manifest),
+        ManifestJobDone::Full { .. } => Err(ResolveError::Version(format!(
+            "{name}@{requested_spec}: provider returned a full manifest for a version job"
+        ))),
+    }
+}
+
+fn resolved_from_version(name: &str, manifest: Arc<CoreVersionManifest>) -> ResolvedPackage {
+    ResolvedPackage {
+        name: name.to_string(),
+        version: manifest.version.clone(),
+        manifest,
+    }
 }
 
 /// Resolve a package from already-fetched manifest.
@@ -165,13 +231,13 @@ pub fn resolve_from_manifest<E: std::error::Error + 'static>(
 ///
 /// For optional dependencies, returns `Ok(None)` on resolution failure
 /// instead of propagating the error.
-pub async fn resolve_registry_dep<R: RegistryClient>(
-    registry: &R,
+pub async fn resolve_registry_dep<P: ManifestProvider>(
+    provider: &P,
     name: &str,
     spec: &str,
     edge_type: &EdgeType,
-) -> Result<Option<ResolvedPackage>, ResolveError<R::Error>> {
-    match resolve_package(registry, name, spec).await {
+) -> Result<Option<ResolvedPackage>, ResolveError<P::Error>> {
+    match resolve_package(provider, name, spec).await {
         Ok(resolved) => Ok(Some(resolved)),
         Err(e) => {
             if *edge_type == EdgeType::Optional {

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
-use super::cache::{PackageCache, ProjectCacheData};
+use super::cache::ProjectCacheData;
 use super::fs::Glob;
 use super::registry::UnifiedRegistry;
 use super::store::{ManifestStore, NoopStore};
@@ -203,24 +203,11 @@ where
         add_edges_from(&mut graph, workspace_index, &ws_pkg, &edge_ctx);
     }
 
-    // 7. Create in-memory package cache and pre-populate from the warm
-    // project cache (host-supplied; `None` for cold runs).
-    let package_cache = Arc::new(PackageCache::default());
-    let (cache_count, missing_count) =
-        prepopulate_warm_cache(&package_cache, project_cache.as_ref());
-    if missing_count > 0 {
-        tracing::warn!(
-            "Project cache has {missing_count} specs with missing manifests, will re-fetch from registry"
-        );
-    }
-    if cache_count > 0 {
-        tracing::debug!("Loaded {cache_count} manifests from project cache");
-    }
-
-    // 8. Create registry client with shared cache and persistence backend.
+    // 7. Create the stateless registry client (persistence backend only).
+    //    The warm `project_cache` seeds the demand resolver's manifest cache
+    //    directly via `BuildDepsConfig::project_cache` below.
     let mut builder = UnifiedRegistry::builder()
         .registry(&registry_url)
-        .cache(package_cache)
         .store(Arc::clone(&manifest_store));
     if let Some(semver) = supports_semver {
         builder = builder.supports_semver(semver);
@@ -258,32 +245,6 @@ where
         lock: PackageLock::new(&pkg.name, &pkg.version, packages),
         project_cache,
     })
-}
-
-/// Pre-populate `cache` from a warm project cache. Returns
-/// `(loaded, missing)` — `loaded` is the count of usable spec→manifest
-/// entries; `missing` counts specs whose resolved version had no manifest
-/// (corrupted cache, will be re-fetched).
-fn prepopulate_warm_cache(cache: &PackageCache, warm: Option<&ProjectCacheData>) -> (usize, usize) {
-    let Some(warm) = warm else {
-        return (0, 0);
-    };
-    let mut loaded = 0;
-    let mut missing = 0;
-    for (name, pkg_cache) in &warm.cache {
-        for (spec, version) in &pkg_cache.specs {
-            let Some(manifest) = pkg_cache.manifests.get(version) else {
-                tracing::debug!(
-                    "Project cache missing manifest: {name}@{spec} (version {version})"
-                );
-                missing += 1;
-                continue;
-            };
-            cache.set_version_manifest(name.clone(), spec.clone(), Arc::new(manifest.clone()));
-            loaded += 1;
-        }
-    }
-    (loaded, missing)
 }
 
 #[cfg(test)]

--- a/crates/ruborist/src/service/cache.rs
+++ b/crates/ruborist/src/service/cache.rs
@@ -1,47 +1,19 @@
-//! In-memory manifest cache for dependency resolution.
+//! Manifest cache data types for dependency resolution.
 //!
-//! ruborist itself only owns the memory tier; persistent storage (disk, remote
-//! KV, …) is delegated to a [`super::store::ManifestStore`] supplied by the
-//! host. The project-level cache ([`ProjectCacheData`]) is also pure data —
-//! callers load/save it themselves and pass it through `BuildDepsOptions` /
-//! `BuildDepsOutput`.
-//!
-//! # Memory Layout
-//!
-//! ```text
-//!  MemoryCache ─ Clone ─► (cheap: Arc ref-count)
-//!  │
-//!  └──► Arc<MemoryCacheInner>              single allocation
-//!       ├── DashMap<Arc<FullManifest>>      sharded, lock-free reads
-//!       ├── DashMap<Arc<VersionsInfo>>
-//!       └── DashMap<Arc<CoreVersionManifest>>
-//!                           │
-//!                           ▼
-//!                    All values Arc-wrapped → get/set is O(1) ref-count,
-//!                    no full clone of the (large) manifest payload.
-//!
-//!  Global singleton: GLOBAL_MEMORY_CACHE (LazyLock)
-//!  └── all UnifiedRegistry instances share the same cache
-//! ```
-//!
-//! # Lookup Flow
-//!
-//! ```text
-//!  resolve(name, spec)
-//!    │
-//!    ├─ 1. Memory hit?       ──yes──► Arc<CoreVersionManifest> clone → done
-//!    ├─ 2. ManifestStore hit? ──yes──► populate memory → done
-//!    └─ 3. Network            ──────► fetch JSON → store memory + fire-and-forget
-//!                                       ManifestStore::store_*
-//! ```
+//! ruborist owns no resolution-time cache state — the demand resolver holds the
+//! per-run manifest store, and persistent storage (disk, remote KV, …) is
+//! delegated to a [`super::store::ManifestStore`] supplied by the host. This
+//! module holds the shared, pure-data types: [`VersionsInfo`]/[`Versions`]
+//! (persisted by `ManifestStore` for ETag validation) and the project-level
+//! cache ([`ProjectCacheData`]) that hosts load/save and pass through
+//! `BuildDepsOptions` / `BuildDepsOutput`.
 
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
-use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 
-use crate::model::manifest::{CoreVersionManifest, FullManifest, VersionsRef};
+use crate::model::manifest::{CoreVersionManifest, VersionsRef};
 
 /// Lightweight versions info, persisted by `ManifestStore` for ETag validation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,117 +45,6 @@ impl<'a> From<&'a Versions> for VersionsRef<'a> {
         }
     }
 }
-
-// ============================================================================
-// Memory cache (lock-free reads via DashMap)
-// ============================================================================
-
-/// Thread-safe in-memory manifest cache. Uses sharded `DashMap`s so concurrent
-/// reads are lock-free across shards and writes only contend within a single
-/// shard; values are stored as `Arc<…>` so reads return cheap ref-count clones
-/// instead of cloning the full (potentially large) manifest payload.
-#[derive(Clone)]
-pub struct MemoryCache(Arc<MemoryCacheInner>);
-
-struct MemoryCacheInner {
-    full_manifests: DashMap<String, Arc<FullManifest>>,
-    versions_info: DashMap<String, Arc<VersionsInfo>>,
-    version_manifests: DashMap<String, Arc<CoreVersionManifest>>,
-}
-
-/// Global singleton. All `UnifiedRegistry` instances share the same cache.
-static GLOBAL_MEMORY_CACHE: LazyLock<MemoryCache> = LazyLock::new(|| {
-    MemoryCache(Arc::new(MemoryCacheInner {
-        full_manifests: DashMap::new(),
-        versions_info: DashMap::new(),
-        version_manifests: DashMap::new(),
-    }))
-});
-
-impl Default for MemoryCache {
-    fn default() -> Self {
-        GLOBAL_MEMORY_CACHE.clone()
-    }
-}
-
-impl MemoryCache {
-    pub fn get_full_manifest(&self, name: &str) -> Option<Arc<FullManifest>> {
-        self.0.full_manifests.get(name).map(|v| v.clone())
-    }
-
-    pub fn set_full_manifest(&self, name: String, manifest: Arc<FullManifest>) {
-        self.0.full_manifests.insert(name, manifest);
-    }
-
-    pub fn get_versions(&self, name: &str) -> Option<Arc<VersionsInfo>> {
-        self.0.versions_info.get(name).map(|v| v.clone())
-    }
-
-    pub fn set_versions(&self, name: String, info: Arc<VersionsInfo>) {
-        self.0.versions_info.insert(name, info);
-    }
-
-    pub fn get_version_manifest(
-        &self,
-        name: &str,
-        version: &str,
-    ) -> Option<Arc<CoreVersionManifest>> {
-        let key = format!("{name}@{version}");
-        self.0.version_manifests.get(&key).map(|v| v.clone())
-    }
-
-    pub fn set_version_manifest(
-        &self,
-        name: String,
-        version: String,
-        manifest: Arc<CoreVersionManifest>,
-    ) {
-        let key = format!("{name}@{version}");
-        self.0.version_manifests.insert(key, manifest);
-    }
-
-    pub fn full_manifest_count(&self) -> usize {
-        self.0.full_manifests.len()
-    }
-
-    pub fn versions_count(&self) -> usize {
-        self.0.versions_info.len()
-    }
-
-    pub fn version_manifest_count(&self) -> usize {
-        self.0.version_manifests.len()
-    }
-
-    /// Export all version manifests for persistence into a project cache.
-    pub fn export_version_manifests(&self) -> Vec<(String, Arc<CoreVersionManifest>)> {
-        self.0
-            .version_manifests
-            .iter()
-            .map(|kv| (kv.key().clone(), kv.value().clone()))
-            .collect()
-    }
-
-    /// Get cache statistics.
-    pub fn stats(&self) -> CacheStats {
-        CacheStats {
-            full_manifest_count: self.full_manifest_count(),
-            versions_count: self.versions_count(),
-            version_manifest_count: self.version_manifest_count(),
-        }
-    }
-}
-
-/// Cache statistics.
-#[derive(Debug, Clone)]
-pub struct CacheStats {
-    pub full_manifest_count: usize,
-    pub versions_count: usize,
-    pub version_manifest_count: usize,
-}
-
-/// Alias kept so call sites that pre-date the disk-cache split can continue
-/// to spell the in-memory cache as `PackageCache` without churn.
-pub type PackageCache = MemoryCache;
 
 // ============================================================================
 // Project-level cache (per-project resolved packages)
@@ -248,64 +109,5 @@ impl ProjectCacheData {
                 .or_insert_with(|| (*manifest).clone());
         }
         data
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_memory_cache_full_manifest() {
-        let cache = MemoryCache::default();
-
-        let manifest = FullManifest {
-            name: "test".to_string(),
-            ..Default::default()
-        };
-
-        cache.set_full_manifest("test".to_string(), Arc::new(manifest));
-
-        let retrieved = cache.get_full_manifest("test").unwrap();
-        assert_eq!(retrieved.name, "test");
-        assert!(cache.full_manifest_count() >= 1);
-    }
-
-    #[test]
-    fn test_memory_cache_versions() {
-        let cache = MemoryCache::default();
-
-        let info = VersionsInfo {
-            versions: Versions {
-                version_list: vec!["1.0.0".to_string()],
-                dist_tags: HashMap::new(),
-            },
-            etag: Some("abc".to_string()),
-            last_updated: 12345,
-        };
-
-        cache.set_versions("test".to_string(), Arc::new(info));
-
-        let retrieved = cache.get_versions("test").unwrap();
-        assert_eq!(retrieved.versions.version_list, vec!["1.0.0"]);
-        assert!(cache.versions_count() >= 1);
-    }
-
-    #[test]
-    fn test_memory_cache_version_manifest() {
-        let cache = MemoryCache::default();
-
-        let manifest = CoreVersionManifest {
-            name: "test".to_string(),
-            version: "1.0.0".to_string(),
-            ..Default::default()
-        };
-
-        cache.set_version_manifest("test".to_string(), "1.0.0".to_string(), Arc::new(manifest));
-
-        let retrieved = cache.get_version_manifest("test", "1.0.0").unwrap();
-        assert_eq!(retrieved.name, "test");
-        assert_eq!(retrieved.version, "1.0.0");
-        assert!(cache.version_manifest_count() >= 1);
     }
 }

--- a/crates/ruborist/src/service/mod.rs
+++ b/crates/ruborist/src/service/mod.rs
@@ -54,10 +54,7 @@ mod registry;
 mod store;
 
 pub use api::{BuildDepsOptions, BuildDepsOutput, build_deps};
-pub use cache::{
-    CacheStats, MemoryCache, PackageCache, ProjectCacheData, ProjectPackageCache, Versions,
-    VersionsInfo,
-};
+pub use cache::{ProjectCacheData, ProjectPackageCache, Versions, VersionsInfo};
 pub use fs::{Glob, NoopGlob, exists, read_to_string};
 pub use http::client_builder;
 pub use manifest::{

--- a/crates/ruborist/src/service/registry/mod.rs
+++ b/crates/ruborist/src/service/registry/mod.rs
@@ -1,26 +1,18 @@
 //! Unified registry client implementation.
 //!
-//! Provides `UnifiedRegistry` that works on both native and WASM targets.
-//! Combines HTTP fetching with in-memory caching, optional persistent storage
-//! through a [`ManifestStore`], and automatic registry capability detection
-//! (semver support).
+//! Provides `UnifiedRegistry`, a stateless [`ManifestProvider`] that works on
+//! both native and WASM targets. It owns no resolution state — version
+//! selection and de-duplication live in the demand resolver (see
+//! [`crate::resolver::demand`]); the registry only fetches and parses one
+//! manifest job at a time (see the child [`provider`] module) and persists
+//! through the injected [`ManifestStore`].
 //!
 //! For non-semver registries (npmjs.org), the persistent store doubles as the
 //! ETag source: `versions.json` carries the etag for the next conditional
 //! GET, and per-version manifests act as a warm cache for `(name, spec)`
 //! pairs.
-//!
-//! # Architecture
-//!
-//! - `manifest` module: Manifest fetching with retry (`fetch_full_manifest`, `fetch_version_manifest`)
-//! - `UnifiedRegistry`: in-memory cache + injected `ManifestStore` (host-supplied persistence)
-//!   - Memory cache (fastest)
-//!   - `ManifestStore` (host: disk / KV / no-op)
-//!   - Network (authoritative source)
 
 use std::sync::Arc;
-
-use anyhow::anyhow;
 
 /// Get current timestamp in seconds since UNIX epoch.
 /// Works on both native and WASM targets.
@@ -41,30 +33,20 @@ fn current_timestamp_secs() -> u64 {
 
 use dashmap::DashSet;
 
-use super::cache::{PackageCache, Versions, VersionsInfo};
-use super::manifest;
 use super::store::{ManifestStore, NoopStore};
-use crate::model::manifest::{CoreVersionManifest, FullManifest, extract_core_version_off_runtime};
-use crate::resolver::semver::normalize_spec;
-use crate::resolver::version::resolve_target_version;
-use crate::traits::registry::{RegistryClient, RegistryError, ResolvedPackage, is_npm_registry};
-use crate::util::OnceMap;
+use crate::traits::registry::{RegistryClient, RegistryError, is_npm_registry};
 
 /// `ManifestProvider` implementation for the demand BFS resolver. A child
 /// module so it can reach `UnifiedRegistry`'s private fields without widening
 /// their visibility.
 mod provider;
 
-/// Unified registry client that works on both native and WASM.
+/// Stateless registry client that works on both native and WASM.
 ///
-/// Cache lookup order:
-/// 1. In-memory `PackageCache` (fastest, lost on restart)
-/// 2. Host-provided `ManifestStore` (persistent; disk on native, no-op on WASM by default)
-/// 3. Network (slowest, always authoritative)
-///
-/// For non-semver registries (npmjs.org), uses ETag validation to avoid
-/// re-downloading unchanged manifests; the etag is sourced from
-/// `ManifestStore::load_versions`.
+/// Resolution order per fetch: host-provided `ManifestStore` (persistent;
+/// disk on native, no-op on WASM by default) → network. For non-semver
+/// registries (npmjs.org), uses ETag validation to avoid re-downloading
+/// unchanged manifests; the etag is sourced from `ManifestStore::load_versions`.
 ///
 /// # Example
 ///
@@ -77,33 +59,19 @@ mod provider;
 /// ```
 pub struct UnifiedRegistry {
     registry_url: String,
-    cache: Arc<PackageCache>,
     store: Arc<dyn ManifestStore>,
     supports_semver: bool,
-    /// Single-flight gate for full-manifest fetches keyed by package name.
-    /// **Gate-only**: the entry value is `()`; the canonical
-    /// `Arc<FullManifest>` lives in `PackageCache`. Concurrent resolves for
-    /// the same name share one network + parse round-trip; the
-    /// 200/304 outcome is recovered by inspecting cache state after the
-    /// gate releases.
-    inflight_full: Arc<OnceMap<String, ()>>,
-    /// Single-flight gate for version-manifest fetches keyed by
-    /// `(name, spec)`. Same gate-only pattern: the canonical `Arc<…>`
-    /// lives in `PackageCache.version_manifests`; the gate stores `()`.
-    inflight_version: Arc<OnceMap<(String, String), ()>>,
     /// Dedup set for `store_version_manifest` disk writes keyed by
-    /// `(name, resolved_version)`. `inflight_version` is keyed by
-    /// `(name, spec)`, so sibling specs (e.g. `^1.0.0` and `^1.2.0`)
-    /// resolving to the same version each fire the gate independently
-    /// and would otherwise issue duplicate writes for the same path.
-    /// First insert wins; subsequent specs skip the redundant write.
+    /// `(name, resolved_version)`. Sibling specs (e.g. `^1.0.0` and `^1.2.0`)
+    /// resolving to the same version would otherwise issue duplicate writes
+    /// for the same path. First insert wins; later specs skip the redundant
+    /// write.
     stored_version: Arc<DashSet<(String, String)>>,
 }
 
 /// Builder for `UnifiedRegistry`.
 pub struct UnifiedRegistryBuilder {
     registry_url: Option<String>,
-    cache: Option<Arc<PackageCache>>,
     store: Option<Arc<dyn ManifestStore>>,
     supports_semver: Option<bool>,
 }
@@ -113,7 +81,6 @@ impl UnifiedRegistryBuilder {
     pub fn new() -> Self {
         Self {
             registry_url: None,
-            cache: None,
             store: None,
             supports_semver: None,
         }
@@ -128,12 +95,6 @@ impl UnifiedRegistryBuilder {
     /// Set the persistence backend. Defaults to [`NoopStore`].
     pub fn store(mut self, store: Arc<dyn ManifestStore>) -> Self {
         self.store = Some(store);
-        self
-    }
-
-    /// Set a shared in-memory cache instance.
-    pub fn cache(mut self, cache: Arc<PackageCache>) -> Self {
-        self.cache = Some(cache);
         self
     }
 
@@ -154,18 +115,12 @@ impl UnifiedRegistryBuilder {
             .supports_semver
             .unwrap_or_else(|| !is_npm_registry(&registry_url));
 
-        let cache = self
-            .cache
-            .unwrap_or_else(|| Arc::new(PackageCache::default()));
         let store = self.store.unwrap_or_else(|| Arc::new(NoopStore));
 
         UnifiedRegistry {
             registry_url,
-            cache,
             store,
             supports_semver,
-            inflight_full: Arc::new(OnceMap::new()),
-            inflight_version: Arc::new(OnceMap::new()),
             stored_version: Arc::new(DashSet::new()),
         }
     }
@@ -181,27 +136,11 @@ impl Clone for UnifiedRegistry {
     fn clone(&self) -> Self {
         Self {
             registry_url: self.registry_url.clone(),
-            cache: Arc::clone(&self.cache),
             store: Arc::clone(&self.store),
             supports_semver: self.supports_semver,
-            inflight_full: Arc::clone(&self.inflight_full),
-            inflight_version: Arc::clone(&self.inflight_version),
             stored_version: Arc::clone(&self.stored_version),
         }
     }
-}
-
-/// Result of `resolve_full_manifest`.
-///
-/// Separates the 200 (full data) and 304 (use cache) cases at the type level,
-/// so callers can pattern-match instead of string-matching error messages.
-enum FullManifestResult {
-    /// Fresh manifest fetched from the network (HTTP 200).
-    Full(Arc<FullManifest>),
-    /// ETag matched, versions cache is valid (HTTP 304).
-    /// Caller should resolve from the in-memory versions cache and
-    /// fetch individual version manifests as needed.
-    NotModified,
 }
 
 impl UnifiedRegistry {
@@ -219,292 +158,6 @@ impl UnifiedRegistry {
     pub fn supports_semver(&self) -> bool {
         self.supports_semver
     }
-
-    /// Get the underlying in-memory cache.
-    pub fn cache(&self) -> &PackageCache {
-        &self.cache
-    }
-
-    /// Resolve full manifest through memory → store → network with ETag validation.
-    ///
-    /// Single-flight cache flow:
-    /// 1. Memory cache hit on `full_manifests` → return immediately (Arc bump).
-    /// 2. Otherwise, acquire the gate-only `inflight_full<name>`. The worker
-    ///    closure populates `PackageCache` as a side effect: writes
-    ///    `full_manifests` on 200, writes only `versions_info` on 304.
-    /// 3. After the gate releases, recover the outcome by inspecting cache
-    ///    state — `full_manifests` populated → 200, only `versions_info`
-    ///    populated → 304.
-    async fn resolve_full_manifest(&self, name: &str) -> Result<FullManifestResult, RegistryError> {
-        if let Some(manifest) = self.cache.get_full_manifest(name) {
-            return Ok(FullManifestResult::Full(manifest));
-        }
-
-        self.inflight_full
-            .get_or_try_init::<RegistryError, _, _>(name.to_string(), || async {
-                // Re-check inside the worker — a previous winner may have
-                // populated the cache while we queued on the OnceMap shard.
-                if self.cache.get_full_manifest(name).is_some() {
-                    return Ok(());
-                }
-
-                let store_versions = self.store.load_versions(name).await.map(Arc::new);
-                let etag = store_versions.as_ref().and_then(|v| v.etag.clone());
-
-                match manifest::fetch_full_manifest(manifest::FetchManifestOptions {
-                    registry_url: &self.registry_url,
-                    name,
-                    format: manifest::MetadataFormat::Abbreviated,
-                    etag: etag.as_deref(),
-                })
-                .await
-                .map_err(RegistryError)?
-                {
-                    manifest::FetchManifestResult::Ok(manifest, new_etag) => {
-                        // Build a `VersionsInfo` strictly for the disk-persist
-                        // task. We do NOT also fill the in-memory
-                        // `versions_info` cache slot on the 200 path: readers
-                        // (`resolve_via_full_manifest::Full`) now go through
-                        // `VersionsRef::from(&Arc<FullManifest>)` for this
-                        // case, so the `full_manifests` slot is the single
-                        // source of truth in memory. The `versions_info` slot
-                        // is reserved for the 304 path (or disk-loaded warm
-                        // cache from a previous run).
-                        let versions_info = Arc::new(VersionsInfo {
-                            versions: Versions {
-                                version_list: manifest.versions.clone(),
-                                dist_tags: manifest.dist_tags.clone(),
-                            },
-                            etag: new_etag,
-                            last_updated: current_timestamp_secs(),
-                        });
-                        self.cache
-                            .set_full_manifest(name.to_string(), Arc::new(manifest));
-                        // Fire-and-forget: store may spawn its own task.
-                        self.store.store_versions(name, versions_info);
-                    }
-                    manifest::FetchManifestResult::NotModified => {
-                        if let Some(versions_info) = store_versions {
-                            // Only populate `versions_info`; absence of
-                            // `full_manifests` after the gate is the 304
-                            // signal.
-                            self.cache.set_versions(name.to_string(), versions_info);
-                        } else {
-                            // Persistent store corrupted/missing, fetch fresh (without etag).
-                            let (manifest, new_etag) = manifest::fetch_full_manifest_fresh(
-                                &self.registry_url,
-                                name,
-                                manifest::MetadataFormat::Abbreviated,
-                            )
-                            .await
-                            .map_err(RegistryError)?;
-
-                            // Same shape as the 200 branch: only the
-                            // canonical `full_manifests` slot is filled in
-                            // memory; the disk-persist task gets its own
-                            // `Arc<VersionsInfo>`.
-                            let versions_info = Arc::new(VersionsInfo {
-                                versions: Versions {
-                                    version_list: manifest.versions.clone(),
-                                    dist_tags: manifest.dist_tags.clone(),
-                                },
-                                etag: new_etag,
-                                last_updated: current_timestamp_secs(),
-                            });
-                            self.cache
-                                .set_full_manifest(name.to_string(), Arc::new(manifest));
-                            self.store.store_versions(name, versions_info);
-                        }
-                    }
-                }
-                Ok(())
-            })
-            .await?;
-
-        // Cache state is the discriminator: `full_manifests` populated → 200;
-        // only `versions_info` populated → 304; neither → cache eviction race.
-        if let Some(manifest) = self.cache.get_full_manifest(name) {
-            Ok(FullManifestResult::Full(manifest))
-        } else if self.cache.get_versions(name).is_some() {
-            Ok(FullManifestResult::NotModified)
-        } else {
-            Err(RegistryError(anyhow!(
-                "manifest for {name} vanished from cache after fetch"
-            )))
-        }
-    }
-
-    /// Resolve version manifest through memory → store → network.
-    ///
-    /// Cache key is `name@spec` (e.g., `lodash@^4.17.0`), so the same spec
-    /// requested multiple times shares one fetch.
-    ///
-    /// Non-semver registries resolve the spec by extracting the matching
-    /// version from the full manifest (the latter is itself single-flight
-    /// gated by `inflight_full`). Semver registries query the version
-    /// manifest directly. Either way the work for one `(name, spec)` runs
-    /// once; concurrent callers for the same key share the result.
-    async fn resolve_version_manifest(
-        &self,
-        name: &str,
-        spec: &str,
-    ) -> Result<Arc<CoreVersionManifest>, RegistryError> {
-        if let Some(manifest) = self.cache.get_version_manifest(name, spec) {
-            return Ok(manifest);
-        }
-
-        self.inflight_version
-            .get_or_try_init::<RegistryError, _, _>(
-                (name.to_string(), spec.to_string()),
-                || async {
-                    // Re-check inside the worker (covers the brief window
-                    // between fast-path miss and OnceMap shard-lock acquire).
-                    if self.cache.get_version_manifest(name, spec).is_some() {
-                        return Ok(());
-                    }
-
-                    // Store keys are *resolved* versions — only do this lookup
-                    // when the caller already has an exact version. Range/tag
-                    // specs would always miss (and on Windows, range chars
-                    // like `*` / `>` aren't even valid filenames).
-                    if !self.supports_semver
-                        && deno_semver::Version::parse_from_npm(spec).is_ok()
-                        && let Some(manifest) = self.store.load_version_manifest(name, spec).await
-                    {
-                        // Populate memory cache ourselves — store knows nothing about it.
-                        self.cache.set_version_manifest(
-                            name.to_string(),
-                            spec.to_string(),
-                            Arc::new(manifest),
-                        );
-                        return Ok(());
-                    }
-
-                    if !self.supports_semver {
-                        // Non-semver: resolve the spec by extracting the matching
-                        // version from the full manifest. `resolve_full_manifest`
-                        // is itself inflight-gated, so concurrent specs for the
-                        // same name share one full-manifest fetch.
-                        let (resolved_version, arc) =
-                            self.resolve_via_full_manifest(name, spec).await?;
-                        self.cache.set_version_manifest(
-                            name.to_string(),
-                            spec.to_string(),
-                            Arc::clone(&arc),
-                        );
-                        if resolved_version != spec {
-                            self.cache.set_version_manifest(
-                                name.to_string(),
-                                resolved_version.clone(),
-                                Arc::clone(&arc),
-                            );
-                        }
-                        if self
-                            .stored_version
-                            .insert((name.to_string(), resolved_version.clone()))
-                        {
-                            self.store.store_version_manifest(
-                                name,
-                                &resolved_version,
-                                Arc::clone(&arc),
-                            );
-                        }
-                        return Ok(());
-                    }
-
-                    let manifest =
-                        manifest::fetch_version_manifest(manifest::FetchVersionManifestOptions {
-                            registry_url: &self.registry_url,
-                            name,
-                            spec,
-                            format: manifest::MetadataFormat::Abbreviated,
-                        })
-                        .await
-                        .map_err(RegistryError)?;
-
-                    self.cache.set_version_manifest(
-                        name.to_string(),
-                        spec.to_string(),
-                        Arc::new(manifest),
-                    );
-                    Ok(())
-                },
-            )
-            .await?;
-
-        // Gate released — populated either by us, a prior waiter, or a previous
-        // run that hit memory/disk cache. Missing only on cache eviction race.
-        self.cache.get_version_manifest(name, spec).ok_or_else(|| {
-            RegistryError(anyhow!(
-                "version manifest for {name}@{spec} vanished from cache after fetch"
-            ))
-        })
-    }
-
-    /// Resolve `(name, spec)` for non-semver registries by reading the full
-    /// manifest and extracting the matching version.
-    ///
-    /// Handles the 304 (NotModified) case by falling back to the in-memory
-    /// versions cache for resolution and a single-version network fetch for
-    /// the manifest itself. The caller is responsible for caching the
-    /// extracted manifest; this helper does not touch `PackageCache`.
-    async fn resolve_via_full_manifest(
-        &self,
-        name: &str,
-        spec: &str,
-    ) -> Result<(String, Arc<CoreVersionManifest>), RegistryError> {
-        match self.resolve_full_manifest(name).await? {
-            FullManifestResult::Full(full) => {
-                if full.versions.is_empty() {
-                    return Err(RegistryError(anyhow!("No versions available for {}", name)));
-                }
-                let resolved_version = resolve_target_version((&*full).into(), spec)
-                    .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
-                // Race window: while we awaited `resolve_full_manifest` (gated
-                // by `inflight_full<name>`), a sibling spec for the same
-                // package may have resolved to this same version and populated
-                // `version_manifests` cache (writer at line 373-387 stores
-                // both `(name, spec)` and `(name, resolved_version)` keys).
-                // Reuse the Arc instead of paying the off-runtime reparse.
-                if let Some(cached) = self.cache.get_version_manifest(name, &resolved_version) {
-                    return Ok((resolved_version, cached));
-                }
-                let (resolved_version, core) =
-                    extract_core_version_off_runtime(full, resolved_version).await;
-                let core = core.ok_or_else(|| {
-                    RegistryError(anyhow!(
-                        "Version {} not found in manifest for {}",
-                        resolved_version,
-                        name
-                    ))
-                })?;
-                Ok((resolved_version, core))
-            }
-            FullManifestResult::NotModified => {
-                // 304 fallback: ETag matched, full payload not refetched.
-                // Resolve via the lightweight versions cache, then hit the
-                // network for the single requested version. Direct call into
-                // `manifest::fetch_version_manifest` (not `self.resolve_version_manifest`)
-                // to avoid re-entering the inflight_version gate; the outer
-                // `inflight_version<(name, spec)>` already serializes us.
-                let versions_info = self.cache.get_versions(name).ok_or_else(|| {
-                    RegistryError(anyhow!("Versions cache not found for {}", name))
-                })?;
-                let resolved_version = resolve_target_version((&*versions_info).into(), spec)
-                    .map_err(|e| RegistryError(anyhow!("{}@{}: {}", name, spec, e)))?;
-                let manifest =
-                    manifest::fetch_version_manifest(manifest::FetchVersionManifestOptions {
-                        registry_url: &self.registry_url,
-                        name,
-                        spec: &resolved_version,
-                        format: manifest::MetadataFormat::Complete,
-                    })
-                    .await
-                    .map_err(RegistryError)?;
-                Ok((resolved_version, Arc::new(manifest)))
-            }
-        }
-    }
 }
 
 impl RegistryClient for UnifiedRegistry {
@@ -512,61 +165,6 @@ impl RegistryClient for UnifiedRegistry {
 
     fn supports_semver_resolution(&self) -> bool {
         self.supports_semver
-    }
-
-    async fn fetch_full_manifest(&self, name: &str) -> Result<Arc<FullManifest>, Self::Error> {
-        match self.resolve_full_manifest(name).await? {
-            FullManifestResult::Full(manifest) => Ok(manifest),
-            FullManifestResult::NotModified => {
-                // 304 in trait context: caller doesn't have versions cache access,
-                // so we return an error indicating the manifest is unchanged.
-                Err(RegistryError(anyhow!(
-                    "No versions available for {} (304 Not Modified but no full manifest cached)",
-                    name
-                )))
-            }
-        }
-    }
-
-    async fn fetch_version_manifest(
-        &self,
-        name: &str,
-        spec: &str,
-    ) -> Result<Arc<CoreVersionManifest>, Self::Error> {
-        // Delegates to `resolve_version_manifest` so the inflight dedup +
-        // memory/store cache logic lives in one place.
-        self.resolve_version_manifest(name, spec).await
-    }
-
-    async fn resolve_package(
-        &self,
-        name: &str,
-        spec: &str,
-    ) -> Result<ResolvedPackage, Self::Error> {
-        // Normalize spec (handles npm: alias and workspace: prefix)
-        let (fetch_name, fetch_spec) = normalize_spec(name, spec);
-        if fetch_name != name || fetch_spec != spec {
-            tracing::debug!(
-                "Normalized {}@{} -> {}@{}",
-                name,
-                spec,
-                fetch_name,
-                fetch_spec
-            );
-        }
-
-        // Single entry point: `resolve_version_manifest` covers both semver
-        // (direct version-manifest fetch) and non-semver (full-manifest +
-        // extract) paths, with `inflight_version<(name, spec)>` ensuring one
-        // fetch+extraction per `(name, spec)` regardless of registry type.
-        let manifest = self
-            .resolve_version_manifest(&fetch_name, &fetch_spec)
-            .await?;
-        Ok(ResolvedPackage {
-            name: name.to_string(),
-            version: manifest.version.clone(),
-            manifest,
-        })
     }
 }
 
@@ -623,23 +221,5 @@ mod tests {
             .registry("https://registry.npmmirror.com")
             .build();
         assert!(registry.supports_semver());
-    }
-
-    #[test]
-    fn test_unified_registry_with_shared_cache() {
-        let shared_cache = Arc::new(PackageCache::default());
-
-        let registry1 = UnifiedRegistry::builder()
-            .registry("https://registry.npmmirror.com")
-            .cache(Arc::clone(&shared_cache))
-            .build();
-
-        let registry2 = UnifiedRegistry::builder()
-            .registry("https://registry.npmmirror.com")
-            .cache(Arc::clone(&shared_cache))
-            .build();
-
-        // Both registries share the same cache
-        assert!(Arc::ptr_eq(&registry1.cache, &registry2.cache));
     }
 }

--- a/crates/ruborist/src/traits/registry.rs
+++ b/crates/ruborist/src/traits/registry.rs
@@ -1,11 +1,12 @@
 //! Registry client trait for dependency resolution.
 
 use std::collections::HashMap;
-use std::future::Future;
 use std::sync::Arc;
 
-use crate::model::manifest::{CoreVersionManifest, FullManifest};
-use crate::resolver::semver::normalize_spec;
+use crate::model::manifest::CoreVersionManifest;
+#[cfg(test)]
+use crate::model::manifest::FullManifest;
+#[cfg(test)]
 use crate::resolver::version::resolve_target_version;
 
 /// Check if a registry URL is the official npm registry.
@@ -132,149 +133,6 @@ pub trait RegistryClient {
     fn supports_semver_resolution(&self) -> bool {
         false
     }
-
-    /// Fetch full package manifest from registry.
-    ///
-    /// Returns the complete package manifest with all versions, wrapped in
-    /// an `Arc` so callers share the (potentially large) payload without
-    /// cloning.
-    fn fetch_full_manifest(
-        &self,
-        name: &str,
-    ) -> impl Future<Output = Result<Arc<FullManifest>, Self::Error>>;
-
-    /// Fetch specific version manifest from registry.
-    ///
-    /// For semver-supporting registries, this can directly query `registry/name/spec`.
-    /// The `spec` can be a semver range (^1.0.0), dist-tag (latest), or exact version.
-    ///
-    /// Default implementation fetches full manifest and resolves locally.
-    /// Override this for semver-supporting registries for better performance.
-    fn fetch_version_manifest(
-        &self,
-        name: &str,
-        spec: &str,
-    ) -> impl Future<Output = Result<Arc<CoreVersionManifest>, Self::Error>> {
-        async move {
-            let manifest = self.fetch_full_manifest(name).await?;
-
-            // Resolve version using shared logic
-            let resolved_version = resolve_target_version((&*manifest).into(), spec)
-                .map_err(|e| RegistryError(anyhow::anyhow!("{}@{}: {}", name, spec, e)))?;
-
-            manifest
-                .get_core_version(&resolved_version)
-                .map(Arc::new)
-                .ok_or_else(|| {
-                    RegistryError(anyhow::anyhow!(
-                        "Version {} not found in manifest for {}",
-                        resolved_version,
-                        name
-                    ))
-                    .into()
-                })
-        }
-    }
-
-    /// Resolve a package by name and version spec.
-    ///
-    /// This is the main entry point for package resolution. It automatically
-    /// chooses the best strategy based on registry capabilities:
-    ///
-    /// - If `supports_semver_resolution()` is true, uses `fetch_version_manifest` directly
-    /// - Otherwise, fetches full manifest and resolves locally
-    ///
-    /// Handles npm alias specs like `npm:package@version` by fetching the aliased package.
-    ///
-    /// # Arguments
-    /// * `name` - Package name (used as the alias name in the result)
-    /// * `spec` - Version specification (semver range, dist-tag, exact version, or npm alias)
-    fn resolve_package(
-        &self,
-        name: &str,
-        spec: &str,
-    ) -> impl Future<Output = Result<ResolvedPackage, Self::Error>> {
-        async move {
-            // Normalize spec (handles npm: alias and workspace: prefix)
-            let (fetch_name, fetch_spec) = normalize_spec(name, spec);
-            if fetch_name != name || fetch_spec != spec {
-                tracing::debug!(
-                    "Normalized {}@{} -> {}@{}",
-                    name,
-                    spec,
-                    fetch_name,
-                    fetch_spec
-                );
-            }
-
-            if self.supports_semver_resolution() {
-                // Semver-supporting registry: direct query
-                tracing::debug!("Using semver resolution for {}@{}", fetch_name, fetch_spec);
-                let manifest = self
-                    .fetch_version_manifest(&fetch_name, &fetch_spec)
-                    .await?;
-                Ok(ResolvedPackage {
-                    name: name.to_string(), // Keep original name as the dependency name
-                    version: manifest.version.clone(),
-                    manifest,
-                })
-            } else {
-                // Traditional registry: fetch full manifest and resolve locally
-                tracing::debug!(
-                    "Using full manifest resolution for {}@{}",
-                    fetch_name,
-                    fetch_spec
-                );
-                let full_manifest = self.fetch_full_manifest(&fetch_name).await?;
-
-                if full_manifest.versions.is_empty() {
-                    return Err(RegistryError(anyhow::anyhow!(
-                        "No versions available for {}",
-                        fetch_name
-                    ))
-                    .into());
-                }
-
-                let resolved_version =
-                    resolve_target_version((&*full_manifest).into(), &fetch_spec)
-                        .map_err(|e| RegistryError(anyhow::anyhow!("{}@{}: {}", name, spec, e)))?;
-
-                let version_manifest = full_manifest
-                    .get_core_version(&resolved_version)
-                    .map(Arc::new)
-                    .ok_or_else(|| {
-                        RegistryError(anyhow::anyhow!(
-                            "Version {} not found in manifest for {}",
-                            resolved_version,
-                            fetch_name
-                        ))
-                    })?;
-
-                Ok(ResolvedPackage {
-                    name: name.to_string(), // Keep original name as the dependency name
-                    version: resolved_version,
-                    manifest: version_manifest,
-                })
-            }
-        }
-    }
-
-    /// Fetch only versions info (lightweight, without full manifests).
-    ///
-    /// Default implementation calls `fetch_full_manifest` and extracts version info.
-    /// Override for more efficient implementation if the registry supports it.
-    fn fetch_versions_info(
-        &self,
-        name: &str,
-    ) -> impl Future<Output = Result<VersionsInfo, Self::Error>> {
-        async move {
-            let manifest = self.fetch_full_manifest(name).await?;
-            Ok(VersionsInfo {
-                version_list: manifest.versions.clone(),
-                dist_tags: manifest.dist_tags.clone(),
-            })
-        }
-    }
 }
 
 /// A simple in-memory registry client for testing.
@@ -356,8 +214,10 @@ pub mod mock {
 
     impl RegistryClient for MockRegistryClient {
         type Error = MockError;
+    }
 
-        async fn fetch_full_manifest(&self, name: &str) -> Result<Arc<FullManifest>, Self::Error> {
+    impl MockRegistryClient {
+        async fn fetch_full_manifest(&self, name: &str) -> Result<Arc<FullManifest>, MockError> {
             let pkg = self
                 .packages
                 .get(name)
@@ -378,6 +238,24 @@ pub mod mock {
                 raw: bytes::Bytes::from(raw),
                 ..Default::default()
             }))
+        }
+
+        async fn fetch_version_manifest(
+            &self,
+            name: &str,
+            spec: &str,
+        ) -> Result<Arc<CoreVersionManifest>, MockError> {
+            let manifest = self.fetch_full_manifest(name).await?;
+            let resolved_version = resolve_target_version((&*manifest).into(), spec)
+                .map_err(|e| MockError(format!("{name}@{spec}: {e}")))?;
+            manifest
+                .get_core_version(&resolved_version)
+                .map(Arc::new)
+                .ok_or_else(|| {
+                    MockError(format!(
+                        "Version {resolved_version} not found in manifest for {name}"
+                    ))
+                })
         }
     }
 


### PR DESCRIPTION
Stacked on #3087 (demand-resolver cutover). Makes `UnifiedRegistry` a stateless `ManifestProvider` so single-package resolution (`utoo add`, global install) and the demand BFS share one manifest path — the registry owns no resolution state.

### What changed
- **`resolver::registry::resolve_package` / `resolve_registry_dep`** now bound on `ManifestProvider`, resolving via `execute_manifest_job` (semver → version job; non-semver → full job + client-side version select, including the 304/`Versions` path).
- **`builder::process_dependency` / `handle_resolved_registry_manifest`** bound flipped `RegistryClient → ManifestProvider`.
- **`RegistryClient` trait slimmed** to `{ Error; supports_semver_resolution }`. Removed `fetch_full_manifest` / `fetch_version_manifest` / `resolve_package` / `fetch_versions_info`. `MockRegistryClient` keeps them as inherent test helpers.
- **`UnifiedRegistry` is now `{ registry_url, store, supports_semver, stored_version }`** — dropped the `cache` / `inflight_full` / `inflight_version` fields, the `resolve_*` methods, and the builder `cache` option.
- **Removed the now-dead `MemoryCache` / `PackageCache` / `CacheStats`** and `api.rs`'s `prepopulate_warm_cache` (the demand resolver seeds from `project_cache` directly).

### Why
The legacy `RegistryClient` path duplicated the demand provider's fetch/parse logic and carried per-instance cache + single-flight state that single-package CLI resolves never benefited from (one package, no concurrency; `Context::registry()` never even set the cache). Unifying on the provider removes ~720 lines and the parallel resolution layer.

### Verification
- ruborist + pm `clippy --all-targets` clean (default + `http-tarball,native-git`).
- 177 (ruborist) + 259 (pm) tests pass.
- Net **+141 / −861** across 8 files; `utoo-wasm` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
