### PR TITLE
perf(pack): derive HTML initial assets from endpoint output paths

### DIFF
--- a/crates/pack-api/src/app.rs
+++ b/crates/pack-api/src/app.rs
@@ -42,6 +42,7 @@ use turbopack_core::{
 
 use crate::{
     endpoint::{Endpoint, EndpointOutput, EndpointOutputPaths},
+    paths::initial_paths_in_root,
     project::Project,
 };
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
@@ -501,12 +502,18 @@ impl Endpoint for AppEndpoint {
                 None
             };
 
-            let dist_root = this.project.dist_root().await?;
+            let dist_root_vc = this.project.dist_root();
+            let dist_root = dist_root_vc.await?;
+            let client_paths = initial_paths_in_root(output_assets, dist_root_vc)
+                .await?
+                .iter()
+                .cloned()
+                .collect();
 
             let written_endpoint = EndpointOutputPaths::NodeJs {
                 server_entry_path: dist_root.path.clone(),
                 server_paths: vec![],
-                client_paths: vec![],
+                client_paths,
             };
 
             let mut output_assets = output_assets;

--- a/crates/pack-api/src/library.rs
+++ b/crates/pack-api/src/library.rs
@@ -38,6 +38,7 @@ use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
 use crate::{
     endpoint::{Endpoint, EndpointOutput, EndpointOutputPaths},
+    paths::initial_paths_in_root,
     project::Project,
 };
 
@@ -369,13 +370,19 @@ impl Endpoint for LibraryEndpoint {
             let output_assets = self.output_assets();
             let output_assets = output_assets.concatenate(self.project().copy_output_assets());
 
-            let dist_root = self.project().dist_root().await?;
+            let dist_root_vc = self.project().dist_root();
+            let dist_root = dist_root_vc.await?;
+            let client_paths = initial_paths_in_root(output_assets, dist_root_vc)
+                .await?
+                .iter()
+                .cloned()
+                .collect();
 
             let written_endpoint = EndpointOutputPaths::NodeJs {
                 // FIXME: No server path when bundling library
                 server_entry_path: dist_root.path.clone(),
                 server_paths: vec![],
-                client_paths: vec![],
+                client_paths,
             };
 
             Ok(EndpointOutput {

--- a/crates/pack-api/src/paths.rs
+++ b/crates/pack-api/src/paths.rs
@@ -4,11 +4,15 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ReadRef, ResolvedVc, TryFlatJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::HashAlgorithm;
+use turbopack_browser::ecmascript::{EcmascriptBrowserEvaluateChunk, EcmascriptDevChunkList};
 use turbopack_core::{
     asset::Asset,
     output::{OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
 };
+use turbopack_nodejs::EcmascriptBuildNodeEntryChunk;
+
+use pack_core::library::ecmascript::EcmascriptLibraryEvaluateChunk;
 
 /// A reference to a server file with content hash for change detection
 #[turbo_tasks::value]
@@ -74,6 +78,91 @@ pub async fn all_paths_in_root(
     Ok(Vc::cell(
         get_paths_from_root(root, all_assets, |_| true).await?,
     ))
+}
+
+/// Return the initial asset paths required to start entry chunks without
+/// collecting full webpack stats.
+///
+/// Evaluate chunks load their referenced JavaScript chunks through the
+/// Turbopack runtime. HTML only needs to include non-JS referenced assets
+/// eagerly, plus the evaluate chunk itself.
+#[turbo_tasks::function]
+pub async fn initial_paths_in_root(
+    assets: Vc<OutputAssets>,
+    root: Vc<FileSystemPath>,
+) -> Result<Vc<Vec<RcStr>>> {
+    let assets = assets.await?;
+    let root = root.await?;
+    let mut paths = Vec::new();
+
+    for asset in assets.iter().copied() {
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBrowserEvaluateChunk>(asset)
+        {
+            push_non_js_chunks_data_paths(&mut paths, chunk.chunks_data().await?).await?;
+            let path = chunk.path().await?;
+            push_asset_path(&mut paths, &root, &path);
+            continue;
+        }
+
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBuildNodeEntryChunk>(asset) {
+            push_non_js_chunks_data_paths(&mut paths, chunk.chunks_data().await?).await?;
+            let path = chunk.path().await?;
+            push_asset_path(&mut paths, &root, &path);
+            continue;
+        }
+
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptLibraryEvaluateChunk>(asset)
+        {
+            push_non_js_chunks_data_paths(&mut paths, chunk.chunks_data().await?).await?;
+            let path = chunk.path().await?;
+            push_asset_path(&mut paths, &root, &path);
+            continue;
+        }
+
+        if let Some(chunk_list) = ResolvedVc::try_downcast_type::<EcmascriptDevChunkList>(asset) {
+            let path = chunk_list.path().await?;
+            push_asset_path(&mut paths, &root, &path);
+        }
+    }
+
+    Ok(Vc::cell(paths))
+}
+
+async fn push_non_js_chunks_data_paths(
+    paths: &mut Vec<RcStr>,
+    chunks_data: ReadRef<turbopack_core::chunk::ChunksData>,
+) -> Result<()> {
+    for chunk_data in chunks_data.iter() {
+        let chunk_data = chunk_data.await?;
+        let path = chunk_data.path.as_str();
+        if !is_js_path(path) {
+            push_unique_path(paths, path.into());
+        }
+    }
+
+    Ok(())
+}
+
+fn is_js_path(path: &str) -> bool {
+    path.ends_with(".js")
+}
+
+fn push_asset_path(paths: &mut Vec<RcStr>, root: &FileSystemPath, path: &FileSystemPath) {
+    let relative = root
+        .get_relative_path_to(path)
+        .unwrap_or_else(|| path.path.clone());
+    let relative = relative
+        .strip_prefix("./")
+        .map(|path| path.into())
+        .unwrap_or(relative);
+
+    push_unique_path(paths, relative);
+}
+
+fn push_unique_path(paths: &mut Vec<RcStr>, path: RcStr) {
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
 }
 
 pub(crate) async fn get_paths_from_root(

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -7,8 +7,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::pack_api::turbopack_ctx::{
-    NapiTurbopackCallbacks, NapiTurbopackCallbacksJsObject, RootTask, TurbopackContext,
+use crate::pack_api::{
+    endpoint::NapiWrittenEndpoint,
+    turbopack_ctx::{
+        NapiTurbopackCallbacks, NapiTurbopackCallbacksJsObject, RootTask, TurbopackContext,
+    },
 };
 use anyhow::{Context, Result, anyhow, bail};
 use bincode::{Decode, Encode};
@@ -19,6 +22,7 @@ use napi::{
     threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
 use pack_api::{
+    endpoint::{Endpoint, EndpointOutputPaths, OptionEndpoint},
     entrypoint::{
         EntrypointsWithIssues, get_all_written_entrypoints_with_issues_operation,
         get_entrypoints_with_issues_operation,
@@ -41,7 +45,7 @@ use tracing_subscriber::{
 };
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    NonLocalValue, OperationValue, PrettyPrintError, ReadRef, ResolvedVc, TaskInput,
+    NonLocalValue, OperationValue, OperationVc, PrettyPrintError, ReadRef, ResolvedVc, TaskInput,
     TransientInstance, TurboTasksApi, UpdateInfo, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileContent, FileSystem, util::uri_from_file};
@@ -467,6 +471,8 @@ pub async fn project_shutdown(
 pub struct NapiEntrypoints {
     pub apps: Option<Vec<External<ExternalEndpoint>>>,
     pub libraries: Option<Vec<External<ExternalEndpoint>>>,
+    pub app_paths: Option<Vec<NapiWrittenEndpoint>>,
+    pub library_paths: Option<Vec<NapiWrittenEndpoint>>,
 }
 
 impl NapiEntrypoints {
@@ -493,8 +499,30 @@ impl NapiEntrypoints {
                     .map(make_endpoint)
                     .collect(),
             ),
+            app_paths: None,
+            library_paths: None,
         })
     }
+}
+
+async fn collect_endpoint_output_paths(
+    endpoints: &[OperationVc<OptionEndpoint>],
+) -> Result<Vec<EndpointOutputPaths>> {
+    let mut paths = Vec::with_capacity(endpoints.len());
+
+    for endpoint in endpoints {
+        let endpoint = endpoint.connect().await?;
+        let output_paths = if let Some(endpoint) = *endpoint {
+            let output = endpoint.output().await?;
+            let output_paths = output.output_paths.await?;
+            ReadRef::into_owned(output_paths)
+        } else {
+            EndpointOutputPaths::NotFound
+        };
+        paths.push(output_paths);
+    }
+
+    Ok(paths)
 }
 
 #[tracing::instrument(level = "info", name = "write all entrypoints to disk", skip_all)]
@@ -507,7 +535,7 @@ pub async fn project_write_all_entrypoints_to_disk(
     let container = project.container;
     let tt = ctx.turbo_tasks();
 
-    let (entrypoints, issues) = tt
+    let (entrypoints, app_paths, library_paths, issues) = tt
         .run(async move {
             let entrypoints_with_issues_op =
                 get_all_written_entrypoints_with_issues_operation(container);
@@ -521,9 +549,13 @@ pub async fn project_write_all_entrypoints_to_disk(
                 .await?;
             // Apply phase side effects. Asset emission is performed once at the end.
             effects.apply().await?;
+            let app_paths = collect_endpoint_output_paths(&entrypoints.apps).await?;
+            let library_paths = collect_endpoint_output_paths(&entrypoints.libraries).await?;
 
             Ok((
                 entrypoints.clone(),
+                app_paths,
+                library_paths,
                 issues.iter().cloned().collect::<Vec<_>>(),
             ))
         })
@@ -532,8 +564,20 @@ pub async fn project_write_all_entrypoints_to_disk(
 
     tracing::info!("All project entrypoints wrote to disk.");
 
-    let napi_entrypoints =
+    let mut napi_entrypoints =
         NapiEntrypoints::from_entrypoints_op(&entrypoints, &project.turbopack_ctx)?;
+    napi_entrypoints.app_paths = Some(
+        app_paths
+            .into_iter()
+            .map(|path| NapiWrittenEndpoint::from(Some(path)))
+            .collect(),
+    );
+    napi_entrypoints.library_paths = Some(
+        library_paths
+            .into_iter()
+            .map(|path| NapiWrittenEndpoint::from(Some(path)))
+            .collect(),
+    );
 
     tracing::info!("Compile done in {:?}", start.elapsed());
 

--- a/examples/with-antd/utoopack.json
+++ b/examples/with-antd/utoopack.json
@@ -28,6 +28,5 @@
         "maxMergeChunkSize": 200000
       }
     }
-  },
-  "stats": true
+  }
 }

--- a/packages/pack/src/__test__/getInitialAssets.test.ts
+++ b/packages/pack/src/__test__/getInitialAssets.test.ts
@@ -1,0 +1,71 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getInitialAssetsFromEndpointPaths,
+  getInitialAssetsFromStats,
+} from "../utils/getInitialAssets";
+
+let tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "utoo-assets-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+  tempDirs = [];
+});
+
+describe("initial asset discovery", () => {
+  it("deduplicates entry assets from webpack stats", () => {
+    const outputDir = createTempDir();
+    fs.writeFileSync(
+      path.join(outputDir, "stats.json"),
+      JSON.stringify({
+        entrypoints: {
+          main: {
+            assets: [
+              { name: "index.js" },
+              { name: "index.js" },
+              { name: "index.css" },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(getInitialAssetsFromStats(outputDir)).toEqual({
+      js: ["index.js"],
+      css: ["index.css"],
+    });
+  });
+
+  it("uses endpoint client paths for html assets without stats", () => {
+    expect(
+      getInitialAssetsFromEndpointPaths([
+        {
+          type: "nodejs",
+          entryPath: "dist",
+          clientPaths: [
+            "static/runtime.js",
+            "static/runtime.js",
+            "static/runtime.js.map",
+            "static/runtime.js.LICENSE.txt",
+            "static/app.css",
+          ],
+          serverPaths: [],
+          config: {},
+        },
+      ]),
+    ).toEqual({
+      js: ["static/runtime.js"],
+      css: ["static/app.css"],
+    });
+  });
+});

--- a/packages/pack/src/__test__/serveStats.test.ts
+++ b/packages/pack/src/__test__/serveStats.test.ts
@@ -73,7 +73,7 @@ function runServeStatsFixture() {
 }
 
 describe("serve stats", () => {
-  it("writes webpack stats.json in dev mode for top-level html config", async () => {
+  it("writes webpack stats.json in dev mode when stats are enabled", async () => {
     await expect(runServeStatsFixture()).resolves.toMatchInlineSnapshot(`
       {
         "assets": [

--- a/packages/pack/src/__test__/serveStatsChild.ts
+++ b/packages/pack/src/__test__/serveStatsChild.ts
@@ -78,6 +78,7 @@ async function main() {
         entry: [{ import: "./src/index.js", name: "main" }],
         html: { title: "Serve Stats Snapshot" },
         output: { path: "./dist", clean: true },
+        stats: true,
       },
     },
     projectPath,

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -146,6 +146,8 @@ export declare function projectShutdown(project: { __napiType: "Project" }): Pro
 export interface NapiEntrypoints {
   apps?: Array<ExternalObject<ExternalEndpoint>>
   libraries?: Array<ExternalObject<ExternalEndpoint>>
+  appPaths?: Array<NapiWrittenEndpoint>
+  libraryPaths?: Array<NapiWrittenEndpoint>
 }
 export declare function projectWriteAllEntrypointsToDisk(project: { __napiType: "Project" }): Promise<TurbopackResult>
 export declare function projectEntrypointsSubscribe(project: { __napiType: "Project" }, func: (...args: any[]) => any): { __napiType: "RootTask" }

--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -10,7 +10,7 @@ import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
 import { blockStdout, getPackPath } from "../utils/common";
 import { findRootDir } from "../utils/findRoot";
-import { getInitialAssetsFromStats } from "../utils/getInitialAssets";
+import { getInitialAssetsFromEndpointPaths } from "../utils/getInitialAssets";
 import { processHtmlEntry } from "../utils/htmlEntry";
 import { acquirePersistentCacheLock } from "../utils/lockfile";
 import { normalizePath } from "../utils/normalizePath";
@@ -46,6 +46,8 @@ async function buildInternal(
   const resolvedProjectPath = projectPath || process.cwd();
   const resolvedRootPath = rootPath || projectPath || process.cwd();
   const persistentCaching = bundleOptions.config.persistentCaching ?? false;
+  const shouldCreateWebpackStats =
+    Boolean(process.env.ANALYZE) || Boolean(bundleOptions.config.stats);
   processHtmlEntry(bundleOptions.config, resolvedProjectPath);
   validateEntryPaths(bundleOptions.config, resolvedProjectPath);
   await cleanOutput(bundleOptions.config, resolvedProjectPath);
@@ -72,10 +74,7 @@ async function buildInternal(
         tracing: bundleOptions.tracing ?? true,
         config: {
           ...bundleOptions.config,
-          stats:
-            Boolean(process.env.ANALYZE) ||
-            bundleOptions.config.stats ||
-            bundleOptions.config.entry.some((e: EntryOptions) => !!e.html),
+          stats: shouldCreateWebpackStats,
           pluginRuntimeStrategy:
             bundleOptions?.config?.pluginRuntimeStrategy ??
             (useWorkerThreads() ? "workerThreads" : "childProcesses"),
@@ -89,7 +88,6 @@ async function buildInternal(
         // Build mode is a short-lived, one-shot compilation, so avoid paying
         // dependency graph bookkeeping cost unless the persistent cache needs it.
         dependencyTracking: persistentCaching,
-        isShortSession: true,
       },
     );
 
@@ -109,18 +107,15 @@ async function buildInternal(
     ];
 
     if (htmlConfigs.length > 0) {
-      const assets = { js: [] as string[], css: [] as string[] };
+      const assets = getInitialAssetsFromEndpointPaths([
+        ...(entrypoints.appPaths ?? []),
+        ...(entrypoints.libraryPaths ?? []),
+      ]);
 
       const outputDir = getOutputPath(
         bundleOptions.config,
         resolvedProjectPath,
       );
-
-      if (assets.js.length === 0 && assets.css.length === 0) {
-        const discovered = getInitialAssetsFromStats(outputDir);
-        assets.js.push(...discovered.js);
-        assets.css.push(...discovered.css);
-      }
 
       const publicPath = bundleOptions.config.output?.publicPath;
 

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -14,11 +14,12 @@ import { nanoid } from "nanoid";
 import type { Socket } from "net";
 import { Duplex } from "stream";
 import { WebSocketServer } from "ws";
+import type { NapiWrittenEndpoint } from "../binding";
 import { BundleOptions } from "../config/types";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
 import { debounce, getPackPath, processIssues } from "../utils/common";
-import { getInitialAssetsFromStats } from "../utils/getInitialAssets";
+import { getInitialAssetsFromEndpointPaths } from "../utils/getInitialAssets";
 import { processHtmlEntry } from "../utils/htmlEntry";
 import { acquirePersistentCacheLock } from "../utils/lockfile";
 import { normalizePath } from "../utils/normalizePath";
@@ -181,9 +182,7 @@ export async function createHotReloader(
       .map((e: EntryOptions) => e.html!),
   ];
   const shouldCreateWebpackStats =
-    Boolean(process.env.ANALYZE) ||
-    bundleOptions.config.stats ||
-    htmlConfigs.length > 0;
+    Boolean(process.env.ANALYZE) || Boolean(bundleOptions.config.stats);
 
   let project: Project;
   try {
@@ -294,6 +293,24 @@ export async function createHotReloader(
     sendEnqueuedMessagesDebounce();
   }
 
+  const writtenEndpointPaths = new Map<Endpoint, NapiWrittenEndpoint>();
+
+  function updateWrittenEndpointPaths(
+    endpoints: Endpoint[] | undefined,
+    paths: NapiWrittenEndpoint[] | undefined,
+  ) {
+    if (!endpoints || !paths) {
+      return;
+    }
+
+    endpoints.forEach((endpoint, index) => {
+      const written = paths[index];
+      if (written) {
+        writtenEndpointPaths.set(endpoint, written);
+      }
+    });
+  }
+
   async function regenerateHtml() {
     if (htmlConfigs.length === 0) {
       return;
@@ -301,7 +318,9 @@ export async function createHotReloader(
 
     const outputDir = getOutputPath(bundleOptions.config, resolvedProjectPath);
     const publicPath = bundleOptions.config.output?.publicPath;
-    const assets = getInitialAssetsFromStats(outputDir);
+    const assets = getInitialAssetsFromEndpointPaths([
+      ...writtenEndpointPaths.values(),
+    ]);
 
     for (const config of htmlConfigs) {
       const plugin = new HtmlPlugin(config);
@@ -312,12 +331,15 @@ export async function createHotReloader(
   async function writeAllEntrypointsToDisk() {
     const result = await project.writeAllEntrypointsToDisk();
     processIssues(result, true, true);
+    updateWrittenEndpointPaths(result.apps, result.appPaths);
+    updateWrittenEndpointPaths(result.libraries, result.libraryPaths);
     await regenerateHtml();
   }
 
   async function writeEntrypointToDisk(entrypoint: Endpoint) {
     const result = await entrypoint.writeToDisk();
     processIssues(result, true, true);
+    writtenEndpointPaths.set(entrypoint, result);
     await regenerateHtml();
   }
 

--- a/packages/pack/src/core/project.ts
+++ b/packages/pack/src/core/project.ts
@@ -654,11 +654,15 @@ export function projectFactory() {
     entrypoints: TurbopackResult<{
       apps?: { __napiType: "Endpoint" }[];
       libraries?: { __napiType: "Endpoint" }[];
+      appPaths?: NapiWrittenEndpoint[];
+      libraryPaths?: NapiWrittenEndpoint[];
     }>,
   ) {
     return {
       apps: (entrypoints.apps || []).map((e) => new EndpointImpl(e)),
       libraries: (entrypoints.libraries || []).map((e) => new EndpointImpl(e)),
+      appPaths: entrypoints.appPaths,
+      libraryPaths: entrypoints.libraryPaths,
       issues: entrypoints.issues,
     };
   }

--- a/packages/pack/src/core/types.ts
+++ b/packages/pack/src/core/types.ts
@@ -94,6 +94,8 @@ export interface Project {
 export interface RawEntrypoints {
   apps?: Endpoint[];
   libraries?: Endpoint[];
+  appPaths?: NapiWrittenEndpoint[];
+  libraryPaths?: NapiWrittenEndpoint[];
 }
 
 export interface Endpoint {

--- a/packages/pack/src/utils/getInitialAssets.ts
+++ b/packages/pack/src/utils/getInitialAssets.ts
@@ -1,9 +1,24 @@
 import fs from "fs";
 import path from "path";
+import type { NapiWrittenEndpoint } from "../binding";
 
 export interface Assets {
   js: string[];
   css: string[];
+}
+
+function addUniqueAsset(assets: string[], file: string) {
+  if (!assets.includes(file)) {
+    assets.push(file);
+  }
+}
+
+function isJavascriptAsset(file: string): boolean {
+  return (
+    file.endsWith(".js") &&
+    !file.endsWith(".LICENSE.txt") &&
+    !file.endsWith(".map")
+  );
 }
 
 export function getInitialAssetsFromStats(outputDir: string): Assets {
@@ -15,14 +30,11 @@ export function getInitialAssetsFromStats(outputDir: string): Assets {
       if (stats.entrypoints) {
         Object.values(stats.entrypoints).forEach((entrypoint: any) => {
           entrypoint.assets?.forEach((asset: any) => {
-            if (asset.name.endsWith(".js") && !assets.js.includes(asset.name)) {
-              assets.js.push(asset.name);
+            if (asset.name.endsWith(".js")) {
+              addUniqueAsset(assets.js, asset.name);
             }
-            if (
-              asset.name.endsWith(".css") &&
-              !assets.css.includes(asset.name)
-            ) {
-              assets.css.push(asset.name);
+            if (asset.name.endsWith(".css")) {
+              addUniqueAsset(assets.css, asset.name);
             }
           });
         });
@@ -31,5 +43,24 @@ export function getInitialAssetsFromStats(outputDir: string): Assets {
       console.warn("Failed to read stats.json for assets discovery", e);
     }
   }
+  return assets;
+}
+
+export function getInitialAssetsFromEndpointPaths(
+  endpoints: NapiWrittenEndpoint[],
+): Assets {
+  const assets = { js: [] as string[], css: [] as string[] };
+
+  endpoints.forEach((endpoint) => {
+    endpoint.clientPaths.forEach((file) => {
+      if (isJavascriptAsset(file)) {
+        addUniqueAsset(assets.js, file);
+      }
+      if (file.endsWith(".css")) {
+        addUniqueAsset(assets.css, file);
+      }
+    });
+  });
+
   return assets;
 }


### PR DESCRIPTION


## Summary

drop stats.json generate when enable html template, we can just get the entry chunk from output assets(it will save generate time in some case).


## Test Plan

add unit test
