### PR TITLE
fix(pm): compute dep types in one pass after the tree is built

### DIFF
--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -14,6 +14,7 @@
 
 use petgraph::graph::NodeIndex;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -317,6 +318,71 @@ pub fn update_node_type_from_edge(
     }
 }
 
+/// Assign dependency types (prod/dev/optional/peer) across the whole graph.
+///
+/// This is the single source of truth for node types: the BFS only builds graph
+/// structure and never touches types, so this pass — run once after the tree is
+/// complete — cannot observe a half-built tree and therefore can't leave stale
+/// `dev` marks on the subtree of a node that turns out to be prod (the bug that
+/// motivated centralizing it here).
+///
+/// It applies the per-edge propagation rules ([`update_node_type_from_edge`])
+/// over every resolved edge, starting from the importer roots (whose
+/// `is_root`/edge type seeds their direct deps) and re-queuing a node's children
+/// whenever its flags change, until nothing changes.
+///
+/// Termination relies on the type lattice being monotone: each node's flags only
+/// move "up" (dev/optional/peer may be set once, then `is_prod` is absorbing —
+/// once set it clears the others and the `!is_prod` guards freeze the node), so
+/// every node changes O(1) times.
+pub fn compute_node_types(graph: &mut DependencyGraph) {
+    use std::collections::VecDeque;
+
+    // Seed only the importers (root + workspace members); their edge types seed
+    // their direct deps, and the fixpoint re-queues every changed node's
+    // children, so the whole reachable graph is covered without visiting leaves
+    // that have nothing to propagate.
+    let mut queued: HashSet<NodeIndex> = graph
+        .graph
+        .node_indices()
+        .filter(|&i| {
+            graph
+                .get_node(i)
+                .is_some_and(|n| n.is_root() || n.is_workspace())
+        })
+        .collect();
+    let mut worklist: VecDeque<NodeIndex> = queued.iter().copied().collect();
+
+    while let Some(src) = worklist.pop_front() {
+        queued.remove(&src);
+
+        // Snapshot resolved out-edges so we can mutate targets while iterating.
+        let edges: Vec<(NodeIndex, EdgeType)> = graph
+            .get_dependency_edges(src)
+            .into_iter()
+            .filter_map(|(_, edge)| {
+                edge.to
+                    .filter(|_| edge.valid)
+                    .map(|to| (to, edge.edge_type))
+            })
+            .collect();
+
+        for (to, edge_type) in edges {
+            let before = graph
+                .get_node(to)
+                .map(|n| (n.is_prod, n.is_dev, n.is_optional, n.is_peer));
+            update_node_type_from_edge(graph, src, to, &edge_type);
+            let after = graph
+                .get_node(to)
+                .map(|n| (n.is_prod, n.is_dev, n.is_optional, n.is_peer));
+
+            if before != after && queued.insert(to) {
+                worklist.push_back(to);
+            }
+        }
+    }
+}
+
 /// Result of processing a single dependency.
 #[derive(Debug)]
 pub enum ProcessResult {
@@ -393,7 +459,6 @@ async fn process_file_dep<E>(
         let idx = graph.add_node(PackageNode::link_from_package_json(abs, pkg));
         graph.add_physical_edge(conflict_parent, idx);
         graph.mark_dependency_resolved(edge.edge_id, idx);
-        update_node_type_from_edge(graph, node_index, idx, &edge.edge_type);
         return Ok(ControlFlow::Break(ProcessResult::Created(idx)));
     }
 
@@ -452,11 +517,9 @@ pub async fn process_dependency<R: ManifestProvider>(
     // Find installation location
     match graph.find_compatible_node(node_index, &edge_info.name, &edge_info.spec) {
         FindResult::Reuse(existing_index) => {
-            // Mark edge as resolved
+            // Mark edge as resolved. Node types are assigned in a single pass
+            // after the tree is built (see `compute_node_types`).
             graph.mark_dependency_resolved(edge_info.edge_id, existing_index);
-
-            // Update target node type
-            update_node_type_from_edge(graph, node_index, existing_index, &edge_info.edge_type);
 
             Ok(ProcessResult::Reused(existing_index))
         }
@@ -627,9 +690,6 @@ pub async fn process_dependency<R: ManifestProvider>(
             // Mark dependency as resolved
             graph.mark_dependency_resolved(edge_info.edge_id, new_index);
 
-            // Update node type
-            update_node_type_from_edge(graph, node_index, new_index, &edge_info.edge_type);
-
             // Add dependencies of the new node
             add_edges_from(
                 graph,
@@ -754,6 +814,10 @@ where
 
     let manifest_cache = run_main_loop_bfs(graph, registry, &config, receiver).await?;
 
+    // The BFS only builds graph structure; assign all node types in one pass now
+    // that the tree is complete, so prod-ness reaches every transitive dep.
+    compute_node_types(graph);
+
     receiver.on_event(BuildEvent::Complete {
         total_nodes: graph.graph.node_count(),
     });
@@ -841,19 +905,17 @@ fn graph_to_package_lock(
 
 // ---- demand-resolver graph building (moved from demand::driver) ----
 
-/// Resolve `edge` onto an already-present compatible node: mark the edge
-/// resolved and update that node's type from the edge. Shared by the pre-fetch
-/// reuse probe ([`try_reuse_dependency`]) and the post-resolution placement
-/// ([`process_dependency_with_resolved`]), whose `FindResult::Reuse` arms are
-/// otherwise identical.
+/// Resolve `edge` onto an already-present compatible node by marking the edge
+/// resolved. Shared by the pre-fetch reuse probe ([`try_reuse_dependency`]) and
+/// the post-resolution placement ([`process_dependency_with_resolved`]), whose
+/// `FindResult::Reuse` arms are otherwise identical. Node types are assigned in
+/// a single pass after the tree is built (see [`compute_node_types`]).
 fn reuse_existing_node(
     graph: &mut DependencyGraph,
-    parent: NodeIndex,
     edge: &DependencyEdgeInfo,
     existing_index: NodeIndex,
 ) -> ProcessResult {
     graph.mark_dependency_resolved(edge.edge_id, existing_index);
-    update_node_type_from_edge(graph, parent, existing_index, &edge.edge_type);
     ProcessResult::Reused(existing_index)
 }
 
@@ -863,9 +925,7 @@ pub(crate) fn try_reuse_dependency(
     edge: &DependencyEdgeInfo,
 ) -> Option<ProcessResult> {
     match graph.find_compatible_node(parent, &edge.name, &edge.spec) {
-        FindResult::Reuse(existing_index) => {
-            Some(reuse_existing_node(graph, parent, edge, existing_index))
-        }
+        FindResult::Reuse(existing_index) => Some(reuse_existing_node(graph, edge, existing_index)),
         FindResult::Conflict(_) | FindResult::New(_) => None,
     }
 }
@@ -878,15 +938,12 @@ pub fn process_dependency_with_resolved(
     config: &BuildDepsConfig,
 ) -> ProcessResult {
     match graph.find_compatible_node(node_index, &edge_info.name, &edge_info.spec) {
-        FindResult::Reuse(existing_index) => {
-            reuse_existing_node(graph, node_index, edge_info, existing_index)
-        }
+        FindResult::Reuse(existing_index) => reuse_existing_node(graph, edge_info, existing_index),
         FindResult::Conflict(conflict_parent) | FindResult::New(conflict_parent) => {
             let new_node = create_package_node(&edge_info.name, resolved, conflict_parent, graph);
             let new_index = graph.add_node(new_node);
             graph.add_physical_edge(conflict_parent, new_index);
             graph.mark_dependency_resolved(edge_info.edge_id, new_index);
-            update_node_type_from_edge(graph, node_index, new_index, &edge_info.edge_type);
             add_edges_from(
                 graph,
                 new_index,

--- a/crates/ruborist/src/resolver/demand/driver.rs
+++ b/crates/ruborist/src/resolver/demand/driver.rs
@@ -689,6 +689,153 @@ mod tests {
         assert_eq!(shared_version_jobs.load(Ordering::Relaxed), 1);
     }
 
+    #[tokio::test]
+    async fn prod_flip_propagates_through_already_resolved_subtree() {
+        // root.devDeps: shared (shallow dev path) -> leaf
+        // root.deps: prod1 -> prod2 -> prod3 -> shared (deep prod path)
+        // `shared` is created dev first; its edge shared->leaf is resolved while
+        // shared is still dev (=> leaf dev). The deep prod path later flips
+        // `shared` to prod; the finalize fixpoint must re-propagate prod-ness so
+        // `leaf` (shared's prod child) is no longer marked dev, matching npm.
+        let mut inner = MockRegistryClient::new();
+        inner.add_package(
+            "prod1",
+            "1.0.0",
+            create_version_manifest_with_deps("prod1", "1.0.0", vec![("prod2", "^1.0.0")]),
+        );
+        inner.add_package(
+            "prod2",
+            "1.0.0",
+            create_version_manifest_with_deps("prod2", "1.0.0", vec![("prod3", "^1.0.0")]),
+        );
+        inner.add_package(
+            "prod3",
+            "1.0.0",
+            create_version_manifest_with_deps("prod3", "1.0.0", vec![("shared", "^1.0.0")]),
+        );
+        inner.add_package(
+            "shared",
+            "1.0.0",
+            create_version_manifest_with_deps("shared", "1.0.0", vec![("leaf", "^1.0.0")]),
+        );
+        inner.add_package("leaf", "1.0.0", create_version_manifest("leaf", "1.0.0"));
+
+        let registry = inner;
+        let pkg = PackageJson {
+            dependencies: Some(HashMap::from([("prod1".to_string(), "1.0.0".to_string())])),
+            dev_dependencies: Some(HashMap::from([("shared".to_string(), "1.0.0".to_string())])),
+            ..PackageJson::new("test-project", "1.0.0")
+        };
+
+        let lock = resolve(&pkg, &registry).await.unwrap();
+        let shared = lock
+            .packages
+            .get("node_modules/shared")
+            .expect("shared present");
+        let leaf = lock
+            .packages
+            .get("node_modules/leaf")
+            .expect("leaf present");
+        assert_ne!(
+            shared.dev,
+            Some(true),
+            "shared reached via prod, must not be dev"
+        );
+        assert_ne!(
+            leaf.dev,
+            Some(true),
+            "leaf is prod child of prod shared, must not be dev"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_prod_chain_overrides_root_dev_mark() {
+        // root.devDeps: shared (shallow dev via the root importer => shared.is_dev),
+        //               rdev   (pure dev leaf, sanity check)
+        // workspace `app`.deps: mid -> deep -> shared (deep prod via a workspace)
+        // `shared` is reachable through a workspace's prod chain, so it must be
+        // prod, not dev — the cross-workspace analog of the resolve-order bug.
+        use crate::model::graph::DependencyGraph;
+        use crate::model::node::DevDeps;
+        use crate::resolver::builder::{
+            BuildDepsConfig, add_edges_from, add_workspace_member, build_deps_with_config_output,
+        };
+        use crate::resolver::edges::EdgeContext;
+        use crate::traits::progress::NoopReceiver;
+        use std::path::PathBuf;
+
+        let mut inner = MockRegistryClient::new();
+        inner.add_package(
+            "mid",
+            "1.0.0",
+            create_version_manifest_with_deps("mid", "1.0.0", vec![("deep", "^1.0.0")]),
+        );
+        inner.add_package(
+            "deep",
+            "1.0.0",
+            create_version_manifest_with_deps("deep", "1.0.0", vec![("shared", "^1.0.0")]),
+        );
+        inner.add_package(
+            "shared",
+            "1.0.0",
+            create_version_manifest("shared", "1.0.0"),
+        );
+        inner.add_package("rdev", "1.0.0", create_version_manifest("rdev", "1.0.0"));
+        let registry = inner;
+
+        let root_pkg = PackageJson {
+            dev_dependencies: Some(HashMap::from([
+                ("shared".to_string(), "^1.0.0".to_string()),
+                ("rdev".to_string(), "^1.0.0".to_string()),
+            ])),
+            ..PackageJson::new("root", "1.0.0")
+        };
+        let mut graph = DependencyGraph::from_package_json(PathBuf::from("."), root_pkg.clone());
+        let root_index = graph.root_index;
+        let edge_ctx = EdgeContext::new(PeerDeps::Skip, DevDeps::Include);
+        add_edges_from(&mut graph, root_index, &root_pkg, &edge_ctx);
+
+        let app = PackageJson {
+            dependencies: Some(HashMap::from([("mid".to_string(), "^1.0.0".to_string())])),
+            ..PackageJson::new("app", "1.0.0")
+        };
+        add_workspace_member(
+            &mut graph,
+            root_index,
+            "app",
+            PathBuf::from("packages/app"),
+            &app,
+            &edge_ctx,
+        );
+
+        let config = BuildDepsConfig::default().with_peer_deps(PeerDeps::Skip);
+        build_deps_with_config_output(&mut graph, &registry, config, &NoopReceiver)
+            .await
+            .unwrap();
+        let (packages, _) = graph.serialize_to_packages(&PathBuf::from("."));
+
+        let dev_of = |k: &str| packages.get(k).unwrap_or_else(|| panic!("{k} present")).dev;
+        // workspace prod subtree is prod
+        assert_ne!(dev_of("node_modules/mid"), Some(true), "workspace prod dep");
+        assert_ne!(
+            dev_of("node_modules/deep"),
+            Some(true),
+            "workspace prod transitive"
+        );
+        // shared: dev via root, but prod via the workspace chain => prod wins
+        assert_ne!(
+            dev_of("node_modules/shared"),
+            Some(true),
+            "shared reached via workspace prod chain must not be dev"
+        );
+        // sanity: a pure root devDep leaf is still dev
+        assert_eq!(
+            dev_of("node_modules/rdev"),
+            Some(true),
+            "pure dev leaf stays dev"
+        );
+    }
+
     #[test]
     fn apply_version_success_caches_and_wakes_waiter() {
         let mut state = ManifestState::seeded(Vec::new());

--- a/e2e/pm/dev-prod-dedup/package.json
+++ b/e2e/pm/dev-prod-dedup/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dev-prod-dedup",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Regression fixture: a package that is both a root devDependency and a transitive prod dependency must be marked prod, not dev.",
+  "dependencies": {
+    "sdk-base": "4.2.1"
+  },
+  "devDependencies": {
+    "p-timeout": "^4.1.0"
+  }
+}

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -1216,4 +1216,33 @@ utoo add -g cowsay --registry=https://registry.npmjs.org \
 which cowsay >/dev/null 2>&1 || { echo -e "${RED}FAIL: cowsay not in PATH after global add${NC}"; exit 1; }
 echo -e "${GREEN}  ✓ PASS: utoo add -g works${NC}"
 
+# ═══════════════════════════════════════════════════════════════
+# Case: prod-reachable devDependency must not be marked `dev`
+# ═══════════════════════════════════════════════════════════════
+# `p-timeout` is declared as a root devDependency (shallow dev path) but is
+# also a prod dependency of `sdk-base` (a root prod dependency). Since it is
+# reachable through a prod chain it must be a prod node — no `"dev": true` —
+# matching npm. Regression test for the demand resolver leaving stale dev marks
+# on prod-reachable transitive deps.
+echo -e "${YELLOW}Case: prod-reachable devDependency is not marked dev${NC}"
+cd e2e/pm/dev-prod-dedup
+rm -rf node_modules package-lock.json
+rm -rf ~/.cache/nm
+utoo install --ignore-scripts --registry=https://registry.npmjs.org \
+  || { echo -e "${RED}FAIL: utoo install failed for dev-prod-dedup${NC}"; exit 1; }
+node -e '
+const lock = require("./package-lock.json");
+const sdkBase = lock.packages["node_modules/sdk-base"];
+const pTimeout = lock.packages["node_modules/p-timeout"];
+if (!sdkBase) { console.error("sdk-base missing from lockfile"); process.exit(1); }
+if (!pTimeout) { console.error("p-timeout missing from lockfile"); process.exit(1); }
+if (sdkBase.dev === true) { console.error("sdk-base wrongly marked dev"); process.exit(1); }
+if (pTimeout.dev === true) {
+  console.error("REGRESSION: p-timeout is prod-reachable via sdk-base but marked dev:true");
+  process.exit(1);
+}
+' || { echo -e "${RED}FAIL: prod-reachable dep marked dev in lockfile${NC}"; exit 1; }
+echo -e "${GREEN}PASS: prod-reachable devDependency correctly not marked dev${NC}"
+cd ../../../
+
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"


### PR DESCRIPTION
## Problem

`utoo deps` produces lockfiles where a **prod** package can have a `"dev": true` transitive dependency — an inconsistency npm never emits.

Real-world case (`pickpansys`): top-level `node_modules/sdk-base@4.2.1` is a prod package whose prod dependency `p-timeout: ^4.1.0` resolves to top-level `node_modules/p-timeout@4.1.0`, which is marked `"dev": true`. Reproduced with a release build.

## Root cause

The demand resolver assigned dependency types (prod/dev/optional/peer) **incrementally** as it resolved each edge:

1. A shared node is first reached via a **shallow dev path** → created `dev`, and its out-edge is `mark_dependency_resolved` while it is still `dev` → its child is marked `dev`.
2. A **deeper prod path** later reaches the shared node and flips it to prod.
3. But the node's already-resolved subtree is **never revisited**, so the child stays `dev`.

## Fix

Node types are **write-only until serialization** — the BFS never reads them to make resolution decisions (those use the *edge* type). So rather than scattering `update_node_type_from_edge` across the resolution paths and patching up staleness, this PR:

- **Removes** all inline type updates from the resolution paths — the BFS now only builds graph *structure*.
- **Computes all types in a single pass** (`compute_node_types`) once the tree is complete. This is now the single source of truth for node types, so a half-built tree can never be observed.

The pass applies the existing per-edge propagation rules from the importer roots outward, re-queuing a node's children whenever its flags change. It **terminates** because the lattice is monotone: prod is absorbing (once set it clears the others and the `!is_prod` guards freeze the node), so each node changes O(1) times → ~O(V+E).

## Tests

- New regression test `prod_flip_propagates_through_already_resolved_subtree` (deep prod path + shallow dev path sharing a node) — fails before, passes after.
- Full `utoo-ruborist` suite green (181 lib tests) — confirms the unified computation is behavior-preserving for all existing dev/optional/peer cases while fixing the bug; `cargo fmt` / `cargo clippy -D warnings` clean; `utoo-pm` and `utoo-wasm` compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)