### PR TITLE
feat(pm): resolve workspace:/catalog: protocols in packed manifests

### DIFF
--- a/crates/pm/src/service/mod.rs
+++ b/crates/pm/src/service/mod.rs
@@ -11,6 +11,7 @@ pub mod package;
 pub mod package_management;
 pub mod pm_pack;
 pub mod publish;
+pub mod publish_manifest;
 pub mod rebuild;
 pub mod script;
 pub mod update;

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -12,7 +12,8 @@ use crate::model::package::PackageInfo;
 use crate::service::publish_manifest::normalize_publish_manifest;
 use crate::service::script::{ScriptOutput, ScriptService};
 use crate::util::integrity::compute_integrity;
-use crate::util::user_config::get_or_load_package_json;
+use crate::util::json::load_package_json;
+use crate::util::user_config::{get_or_load_package_json, set_package_json};
 
 #[derive(Default)]
 pub struct PackResult {
@@ -49,14 +50,21 @@ pub async fn pack(package_root: &Path) -> Result<PackResult> {
         anyhow::bail!("Missing 'version' field in package.json");
     }
 
+    ScriptService::execute_script(&package_info, LifecycleHook::Prepack, ScriptOutput::Verbose)
+        .await?;
+
+    // Re-read the manifest after `prepack`: the script may have rewritten
+    // package.json (version bumps, stripped fields), and npm/pnpm pack the
+    // post-`prepack` manifest. `get_or_load_package_json` is cached from before
+    // the script ran, so read fresh and refresh the cache write-through.
+    let pkg = load_package_json::<PackageJson>(package_root).await?;
+    set_package_json(package_root, pkg.clone());
+
     // Rewrite `workspace:`/`catalog:` specifiers so the packed manifest is
     // installable outside the workspace. `None` means there was nothing to
     // rewrite, in which case the on-disk package.json is packed verbatim.
     let normalized = normalize_publish_manifest(package_root, &pkg).await?;
     let pkg_json_override = normalized.as_ref().map(serialize_manifest).transpose()?;
-
-    ScriptService::execute_script(&package_info, LifecycleHook::Prepack, ScriptOutput::Verbose)
-        .await?;
 
     // collect_pack_files uses ignore::WalkBuilder which does synchronous I/O.
     // Run on a blocking thread to avoid stalling the tokio runtime.

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -2,9 +2,10 @@ use anyhow::{Context, Result};
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use ignore::WalkBuilder;
-use std::io::Write;
+use std::fs;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
-use tar::Builder;
+use tar::{Builder, EntryType, Header};
 use utoo_ruborist::manifest::PackageJson;
 
 use crate::model::package::LifecycleHook;
@@ -173,19 +174,19 @@ fn append_override<W: Write>(
     archive_path: &Path,
     bytes: &[u8],
 ) -> Result<()> {
-    let mut header = tar::Header::new_gnu();
-    match std::fs::metadata(package_root.join("package.json")) {
+    let mut header = Header::new_gnu();
+    match fs::metadata(package_root.join("package.json")) {
         Ok(meta) => header.set_metadata(&meta),
         // The manifest was just read, so a missing file here only means it was
         // racily removed — fall back to defaults. Surface any other error
         // (e.g. permissions) rather than masking it.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        Err(e) if e.kind() == ErrorKind::NotFound => {
             header.set_mode(0o644);
             header.set_mtime(0);
         }
         Err(e) => return Err(e).context("Failed to stat package.json for tarball header"),
     }
-    header.set_entry_type(tar::EntryType::file());
+    header.set_entry_type(EntryType::file());
     header.set_size(bytes.len() as u64);
     header.set_cksum();
     builder

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -2,11 +2,14 @@ use anyhow::{Context, Result};
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use ignore::WalkBuilder;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use tar::Builder;
+use utoo_ruborist::manifest::PackageJson;
 
 use crate::model::package::LifecycleHook;
 use crate::model::package::PackageInfo;
+use crate::service::publish_manifest::normalize_publish_manifest;
 use crate::service::script::{ScriptOutput, ScriptService};
 use crate::util::integrity::compute_integrity;
 use crate::util::user_config::get_or_load_package_json;
@@ -20,6 +23,10 @@ pub struct PackResult {
     pub integrity: String,
     pub unpacked_size: u64,
     pub packed_size: u64,
+    /// The manifest as written into the tarball — with `workspace:`/`catalog:`
+    /// specifiers rewritten to concrete versions. Reused to build the publish
+    /// payload so the registry metadata matches the packed `package.json`.
+    pub manifest: PackageJson,
 }
 
 impl PackResult {
@@ -42,6 +49,12 @@ pub async fn pack(package_root: &Path) -> Result<PackResult> {
         anyhow::bail!("Missing 'version' field in package.json");
     }
 
+    // Rewrite `workspace:`/`catalog:` specifiers so the packed manifest is
+    // installable outside the workspace. `None` means there was nothing to
+    // rewrite, in which case the on-disk package.json is packed verbatim.
+    let normalized = normalize_publish_manifest(package_root, &pkg).await?;
+    let pkg_json_override = normalized.as_ref().map(serialize_manifest).transpose()?;
+
     ScriptService::execute_script(&package_info, LifecycleHook::Prepack, ScriptOutput::Verbose)
         .await?;
 
@@ -55,16 +68,26 @@ pub async fn pack(package_root: &Path) -> Result<PackResult> {
     })
     .await??;
 
-    let unpacked_size: u64 = collected.iter().map(|(_, size)| size).sum();
+    // When package.json is rewritten, account for the rewritten byte length
+    // instead of the on-disk size in the reported stats.
+    let effective_size = |path: &Path, on_disk: u64| match &pkg_json_override {
+        Some(bytes) if is_root_manifest(path) => bytes.len() as u64,
+        _ => on_disk,
+    };
+    let unpacked_size: u64 = collected
+        .iter()
+        .map(|(path, size)| effective_size(path, *size))
+        .sum();
     let file_paths: Vec<(String, u64)> = collected
         .iter()
-        .map(|(p, size)| (p.to_string_lossy().into_owned(), *size))
+        .map(|(p, size)| (p.to_string_lossy().into_owned(), effective_size(p, *size)))
         .collect();
 
     // create_tarball reads each file via std::fs — also blocking I/O.
-    let tar_data =
-        tokio::task::spawn_blocking(move || create_tarball(&package_root_owned, &collected))
-            .await??;
+    let tar_data = tokio::task::spawn_blocking(move || {
+        create_tarball(&package_root_owned, &collected, pkg_json_override)
+    })
+    .await??;
     let integrity = compute_integrity(&tar_data);
     let packed_size = tar_data.len() as u64;
 
@@ -83,7 +106,24 @@ pub async fn pack(package_root: &Path) -> Result<PackResult> {
         integrity,
         unpacked_size,
         packed_size,
+        manifest: normalized.unwrap_or(pkg),
     })
+}
+
+/// Whether `path` is the root-level `package.json` (the only manifest the
+/// `workspace:`/`catalog:` rewrite substitutes — nested `package.json` files
+/// are packed verbatim).
+fn is_root_manifest(path: &Path) -> bool {
+    path == Path::new("package.json")
+}
+
+/// Serialize a manifest to pretty 2-space JSON with a trailing newline, the
+/// formatting npm writes into packed tarballs.
+fn serialize_manifest(pkg: &PackageJson) -> Result<Vec<u8>> {
+    let mut bytes =
+        serde_json::to_vec_pretty(pkg).context("Failed to serialize rewritten package.json")?;
+    bytes.push(b'\n');
+    Ok(bytes)
 }
 
 /// Create a gzip-compressed tarball from the collected file list.
@@ -91,14 +131,25 @@ pub async fn pack(package_root: &Path) -> Result<PackResult> {
 /// Each file is archived under a `package/` prefix (npm tarball convention).
 /// Pre-allocates the output buffer based on file sizes to reduce reallocation:
 /// each tar entry has a 512-byte header, and compressed output is typically ~50% of raw size.
-fn create_tarball(package_root: &Path, files: &[(PathBuf, u64)]) -> Result<Vec<u8>> {
+fn create_tarball(
+    package_root: &Path,
+    files: &[(PathBuf, u64)],
+    pkg_json_override: Option<Vec<u8>>,
+) -> Result<Vec<u8>> {
     let raw_estimate: usize = files.iter().map(|(_, size)| *size as usize + 512).sum();
     let mut encoder = GzEncoder::new(Vec::with_capacity(raw_estimate / 2), Compression::default());
     {
         let mut builder = Builder::new(&mut encoder);
         for (file_path, _) in files {
-            let full_path = package_root.join(file_path);
             let archive_path = Path::new("package").join(file_path);
+            // Substitute the rewritten manifest for the on-disk package.json.
+            if is_root_manifest(file_path)
+                && let Some(bytes) = &pkg_json_override
+            {
+                append_override(&mut builder, package_root, &archive_path, bytes)?;
+                continue;
+            }
+            let full_path = package_root.join(file_path);
             builder
                 .append_path_with_name(&full_path, &archive_path)
                 .with_context(|| format!("Failed to add {} to tarball", file_path.display()))?;
@@ -106,6 +157,31 @@ fn create_tarball(package_root: &Path, files: &[(PathBuf, u64)]) -> Result<Vec<u
         builder.finish()?;
     }
     Ok(encoder.finish()?)
+}
+
+/// Append in-memory bytes (the rewritten package.json) as a tarball entry,
+/// preserving the original file's mode/mtime where available.
+fn append_override<W: Write>(
+    builder: &mut Builder<W>,
+    package_root: &Path,
+    archive_path: &Path,
+    bytes: &[u8],
+) -> Result<()> {
+    let mut header = tar::Header::new_gnu();
+    match std::fs::metadata(package_root.join("package.json")) {
+        Ok(meta) => header.set_metadata(&meta),
+        Err(_) => {
+            header.set_mode(0o644);
+            header.set_mtime(0);
+        }
+    }
+    header.set_entry_type(tar::EntryType::file());
+    header.set_size(bytes.len() as u64);
+    header.set_cksum();
+    builder
+        .append_data(&mut header, archive_path, bytes)
+        .context("Failed to add rewritten package.json to tarball")?;
+    Ok(())
 }
 
 /// Collect files to include in a pack tarball, returning `(relative_path, size)` pairs.

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -13,7 +13,7 @@ use crate::service::publish_manifest::normalize_publish_manifest;
 use crate::service::script::{ScriptOutput, ScriptService};
 use crate::util::integrity::compute_integrity;
 use crate::util::json::load_package_json;
-use crate::util::user_config::{get_or_load_package_json, set_package_json};
+use crate::util::user_config::get_or_load_package_json;
 
 #[derive(Default)]
 pub struct PackResult {
@@ -53,12 +53,10 @@ pub async fn pack(package_root: &Path) -> Result<PackResult> {
     ScriptService::execute_script(&package_info, LifecycleHook::Prepack, ScriptOutput::Verbose)
         .await?;
 
-    // Re-read the manifest after `prepack`: the script may have rewritten
-    // package.json (version bumps, stripped fields), and npm/pnpm pack the
-    // post-`prepack` manifest. `get_or_load_package_json` is cached from before
-    // the script ran, so read fresh and refresh the cache write-through.
-    let pkg = load_package_json::<PackageJson>(package_root).await?;
-    set_package_json(package_root, pkg.clone());
+    // npm/pnpm pack the post-`prepack` manifest, and the script may have
+    // rewritten package.json (version bump, stripped fields). The `pkg` above
+    // is cached from before the script ran, so read the current file from disk.
+    let pkg: PackageJson = load_package_json(package_root).await?;
 
     // Rewrite `workspace:`/`catalog:` specifiers so the packed manifest is
     // installable outside the workspace. `None` means there was nothing to

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -178,10 +178,14 @@ fn append_override<W: Write>(
     let mut header = tar::Header::new_gnu();
     match std::fs::metadata(package_root.join("package.json")) {
         Ok(meta) => header.set_metadata(&meta),
-        Err(_) => {
+        // The manifest was just read, so a missing file here only means it was
+        // racily removed — fall back to defaults. Surface any other error
+        // (e.g. permissions) rather than masking it.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             header.set_mode(0o644);
             header.set_mtime(0);
         }
+        Err(e) => return Err(e).context("Failed to stat package.json for tarball header"),
     }
     header.set_entry_type(tar::EntryType::file());
     header.set_size(bytes.len() as u64);

--- a/crates/pm/src/service/publish.rs
+++ b/crates/pm/src/service/publish.rs
@@ -35,7 +35,6 @@ use crate::service::pm_pack;
 use crate::service::script::{ScriptOutput, ScriptService};
 use crate::util::format_print::print_pack_details;
 use crate::util::integrity::compute_shasum;
-use crate::util::user_config::get_or_load_package_json;
 
 /// Options for publishing a package, resolved by the cmd layer.
 pub struct PublishOptions<'a> {
@@ -80,10 +79,10 @@ pub async fn publish(opts: &PublishOptions<'_>) -> Result<PublishResult> {
 
     let token = auth::require_token(opts.registry).await?;
 
-    // Load package.json for version metadata in the publish payload
-    let pkg = get_or_load_package_json(&opts.package_info.path).await?;
+    // Reuse the manifest packed into the tarball (with `workspace:`/`catalog:`
+    // already rewritten) so the registry metadata matches the tarball contents.
     let payload = PublishPayload::new(&PublishPayloadInput {
-        package_json: &pkg,
+        package_json: &pack_result.manifest,
         name: &pack_result.name,
         version: &pack_result.version,
         tag: opts.tag,

--- a/crates/pm/src/service/publish_manifest.rs
+++ b/crates/pm/src/service/publish_manifest.rs
@@ -20,13 +20,10 @@ use std::path::Path;
 
 use anyhow::{Context as _, Result, bail};
 use utoo_ruborist::manifest::PackageJson;
-use utoo_ruborist::spec::{Catalogs, resolve_catalog_spec, resolve_workspace_spec};
+use utoo_ruborist::spec::{Catalogs, Protocol, resolve_catalog_spec, resolve_workspace_spec};
 
 use crate::helper::ruborist_context::Context;
 use crate::util::config_file::Config;
-
-const WORKSPACE_PREFIX: &str = "workspace:";
-const CATALOG_PREFIX: &str = "catalog:";
 
 /// Return a normalized clone of `pkg` with `workspace:`/`catalog:` dependency
 /// specifiers rewritten to concrete version ranges, or `Ok(None)` when there is
@@ -38,8 +35,8 @@ pub(crate) async fn normalize_publish_manifest(
     package_root: &Path,
     pkg: &PackageJson,
 ) -> Result<Option<PackageJson>> {
-    let needs_workspace = has_spec_with_prefix(pkg, WORKSPACE_PREFIX);
-    let needs_catalog = has_spec_with_prefix(pkg, CATALOG_PREFIX);
+    let needs_workspace = has_protocol(pkg, Protocol::Workspace);
+    let needs_catalog = has_protocol(pkg, Protocol::Catalog);
     if !needs_workspace && !needs_catalog {
         return Ok(None);
     }
@@ -64,7 +61,7 @@ pub(crate) async fn normalize_publish_manifest(
         HashMap::new()
     };
     let catalogs = if needs_catalog {
-        load_catalogs(&root).await
+        load_catalogs(&root).await?
     } else {
         Catalogs::new()
     };
@@ -91,23 +88,27 @@ fn rewrite_dep_specs(
     ];
     for map in maps.into_iter().flatten() {
         for (name, spec) in map.iter_mut() {
-            if spec.starts_with(WORKSPACE_PREFIX) {
-                let version = workspace_versions.get(name).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "cannot resolve workspace dependency `{name}` (\"{spec}\"): \
-                         no workspace package named `{name}` with a version was found"
-                    )
-                })?;
-                *spec = resolve_workspace_spec(spec, version)
-                    .expect("spec starts with workspace: prefix");
-            } else if spec.starts_with(CATALOG_PREFIX) {
-                let resolved = resolve_catalog_spec(name, spec, catalogs).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "cannot resolve catalog dependency `{name}` (\"{spec}\"): \
-                         no matching catalog entry (check `pnpm-workspace.yaml` / `.utoo.toml`)"
-                    )
-                })?;
-                *spec = resolved.to_string();
+            match Protocol::strip_prefix(spec) {
+                Some((Protocol::Workspace, _)) => {
+                    let version = workspace_versions.get(name).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "cannot resolve workspace dependency `{name}` (\"{spec}\"): \
+                             no workspace package named `{name}` with a version was found"
+                        )
+                    })?;
+                    *spec = resolve_workspace_spec(spec, version)
+                        .expect("spec starts with workspace: prefix");
+                }
+                Some((Protocol::Catalog, _)) => {
+                    let resolved = resolve_catalog_spec(name, spec, catalogs).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "cannot resolve catalog dependency `{name}` (\"{spec}\"): \
+                             no matching catalog entry (check `pnpm-workspace.yaml` / `.utoo.toml`)"
+                        )
+                    })?;
+                    *spec = resolved.to_string();
+                }
+                _ => {}
             }
         }
     }
@@ -143,17 +144,21 @@ async fn discover_workspace_versions(root: &Path) -> Result<HashMap<String, Stri
 }
 
 /// Load catalog definitions from the workspace root's `.utoo.toml` (written by
-/// `ut install --from pnpm` from `pnpm-workspace.yaml`). Missing config yields
-/// an empty catalog, which surfaces as a clear per-dependency error later.
-async fn load_catalogs(root: &Path) -> Catalogs {
-    Config::load_from_path(&root.join(".utoo.toml"))
+/// `ut install --from pnpm` from `pnpm-workspace.yaml`).
+///
+/// `Config::load_from_path` already treats a missing file as an empty config,
+/// so only a malformed or unreadable `.utoo.toml` surfaces an error here — and
+/// that should fail loudly rather than silently yield an empty catalog (which
+/// would later read as a confusing "no matching catalog entry").
+async fn load_catalogs(root: &Path) -> Result<Catalogs> {
+    Ok(Config::load_from_path(&root.join(".utoo.toml"))
         .await
-        .map(|c| c.catalogs())
-        .unwrap_or_default()
+        .context("failed to load catalog config from .utoo.toml")?
+        .catalogs())
 }
 
-/// Whether any dependency map contains a spec starting with `prefix`.
-fn has_spec_with_prefix(pkg: &PackageJson, prefix: &str) -> bool {
+/// Whether any dependency map contains a spec using `protocol`.
+fn has_protocol(pkg: &PackageJson, protocol: Protocol) -> bool {
     [
         &pkg.dependencies,
         &pkg.dev_dependencies,
@@ -163,7 +168,7 @@ fn has_spec_with_prefix(pkg: &PackageJson, prefix: &str) -> bool {
     .into_iter()
     .flatten()
     .flat_map(|m| m.values())
-    .any(|spec| spec.starts_with(prefix))
+    .any(|spec| Protocol::strip_prefix(spec).is_some_and(|(p, _)| p == protocol))
 }
 
 #[cfg(test)]
@@ -273,13 +278,17 @@ mod tests {
     }
 
     #[test]
-    fn has_spec_with_prefix_detects_protocols() {
+    fn has_protocol_detects_protocols() {
         let ws = pkg_with_deps(&[("a", "workspace:*")]);
-        assert!(has_spec_with_prefix(&ws, WORKSPACE_PREFIX));
-        assert!(!has_spec_with_prefix(&ws, CATALOG_PREFIX));
+        assert!(has_protocol(&ws, Protocol::Workspace));
+        assert!(!has_protocol(&ws, Protocol::Catalog));
+
+        let cat = pkg_with_deps(&[("a", "catalog:")]);
+        assert!(has_protocol(&cat, Protocol::Catalog));
+        assert!(!has_protocol(&cat, Protocol::Workspace));
 
         let plain = pkg_with_deps(&[("a", "^1.0.0")]);
-        assert!(!has_spec_with_prefix(&plain, WORKSPACE_PREFIX));
-        assert!(!has_spec_with_prefix(&plain, CATALOG_PREFIX));
+        assert!(!has_protocol(&plain, Protocol::Workspace));
+        assert!(!has_protocol(&plain, Protocol::Catalog));
     }
 }

--- a/crates/pm/src/service/publish_manifest.rs
+++ b/crates/pm/src/service/publish_manifest.rs
@@ -1,0 +1,285 @@
+//! Normalize a package's manifest for publishing/packing.
+//!
+//! npm consumers cannot understand the `workspace:` and `catalog:` dependency
+//! protocols — installing a tarball whose `package.json` still contains them
+//! fails with `EUNSUPPORTEDPROTOCOL`. pnpm/bun rewrite these specifiers to
+//! concrete semver ranges when they pack or publish; utoo must do the same.
+//!
+//! [`normalize_publish_manifest`] rewrites:
+//!
+//! - `workspace:*` / `workspace:^` / `workspace:~` / `workspace:<range>` →
+//!   the linked workspace package's version (see [`resolve_workspace_spec`])
+//! - `catalog:` / `catalog:<name>` → the version pinned in the catalog
+//!   (`pnpm-workspace.yaml` → `.utoo.toml`, see [`resolve_catalog_spec`])
+//!
+//! It is a no-op (returns `None`) when the manifest contains neither protocol,
+//! so standalone packages keep their on-disk `package.json` byte-for-byte.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{Context as _, Result, bail};
+use utoo_ruborist::manifest::PackageJson;
+use utoo_ruborist::spec::{Catalogs, resolve_catalog_spec, resolve_workspace_spec};
+
+use crate::helper::ruborist_context::Context;
+use crate::util::config_file::Config;
+
+const WORKSPACE_PREFIX: &str = "workspace:";
+const CATALOG_PREFIX: &str = "catalog:";
+
+/// Return a normalized clone of `pkg` with `workspace:`/`catalog:` dependency
+/// specifiers rewritten to concrete version ranges, or `Ok(None)` when there is
+/// nothing to rewrite.
+///
+/// `package_root` is the directory of the package being packed; it is used to
+/// locate the surrounding workspace when resolving `workspace:` specifiers.
+pub(crate) async fn normalize_publish_manifest(
+    package_root: &Path,
+    pkg: &PackageJson,
+) -> Result<Option<PackageJson>> {
+    let needs_workspace = has_spec_with_prefix(pkg, WORKSPACE_PREFIX);
+    let needs_catalog = has_spec_with_prefix(pkg, CATALOG_PREFIX);
+    if !needs_workspace && !needs_catalog {
+        return Ok(None);
+    }
+
+    // Both protocols resolve against the surrounding workspace root: sibling
+    // members supply `workspace:` versions, and the root `.utoo.toml` holds the
+    // catalog definitions (migrated from `pnpm-workspace.yaml`). `pm-pack` runs
+    // inside a member dir, so we must look up the root rather than the cwd.
+    let root = Context::discovery()
+        .find_root_path(package_root)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to locate the workspace root for {}",
+                package_root.display()
+            )
+        })?;
+
+    let workspace_versions = if needs_workspace {
+        discover_workspace_versions(&root).await?
+    } else {
+        HashMap::new()
+    };
+    let catalogs = if needs_catalog {
+        load_catalogs(&root).await
+    } else {
+        Catalogs::new()
+    };
+
+    let mut normalized = pkg.clone();
+    rewrite_dep_specs(&mut normalized, &workspace_versions, &catalogs)?;
+    Ok(Some(normalized))
+}
+
+/// Rewrite every `workspace:`/`catalog:` specifier across all dependency maps
+/// in place. Bails with a descriptive error if a specifier cannot be resolved
+/// — leaving it in place would only defer the failure to the consumer's
+/// `npm install`.
+fn rewrite_dep_specs(
+    pkg: &mut PackageJson,
+    workspace_versions: &HashMap<String, String>,
+    catalogs: &Catalogs,
+) -> Result<()> {
+    let maps = [
+        &mut pkg.dependencies,
+        &mut pkg.dev_dependencies,
+        &mut pkg.peer_dependencies,
+        &mut pkg.optional_dependencies,
+    ];
+    for map in maps.into_iter().flatten() {
+        for (name, spec) in map.iter_mut() {
+            if spec.starts_with(WORKSPACE_PREFIX) {
+                let version = workspace_versions.get(name).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "cannot resolve workspace dependency `{name}` (\"{spec}\"): \
+                         no workspace package named `{name}` with a version was found"
+                    )
+                })?;
+                *spec = resolve_workspace_spec(spec, version)
+                    .expect("spec starts with workspace: prefix");
+            } else if spec.starts_with(CATALOG_PREFIX) {
+                let resolved = resolve_catalog_spec(name, spec, catalogs).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "cannot resolve catalog dependency `{name}` (\"{spec}\"): \
+                         no matching catalog entry (check `pnpm-workspace.yaml` / `.utoo.toml`)"
+                    )
+                })?;
+                *spec = resolved.to_string();
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build a `name -> version` map of every package in the workspace rooted at
+/// `root`, used to resolve `workspace:` specifiers.
+async fn discover_workspace_versions(root: &Path) -> Result<HashMap<String, String>> {
+    let members = Context::discovery()
+        .find_workspaces(root)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to enumerate workspace packages under {}",
+                root.display()
+            )
+        })?;
+
+    if members.is_empty() {
+        bail!(
+            "manifest uses `workspace:` dependencies but no workspace packages \
+             were discovered from root {}",
+            root.display(),
+        );
+    }
+
+    Ok(members
+        .into_iter()
+        .filter(|m| !m.package_json.version.is_empty())
+        .map(|m| (m.name, m.package_json.version))
+        .collect())
+}
+
+/// Load catalog definitions from the workspace root's `.utoo.toml` (written by
+/// `ut install --from pnpm` from `pnpm-workspace.yaml`). Missing config yields
+/// an empty catalog, which surfaces as a clear per-dependency error later.
+async fn load_catalogs(root: &Path) -> Catalogs {
+    Config::load_from_path(&root.join(".utoo.toml"))
+        .await
+        .map(|c| c.catalogs())
+        .unwrap_or_default()
+}
+
+/// Whether any dependency map contains a spec starting with `prefix`.
+fn has_spec_with_prefix(pkg: &PackageJson, prefix: &str) -> bool {
+    [
+        &pkg.dependencies,
+        &pkg.dev_dependencies,
+        &pkg.peer_dependencies,
+        &pkg.optional_dependencies,
+    ]
+    .into_iter()
+    .flatten()
+    .flat_map(|m| m.values())
+    .any(|spec| spec.starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg_with_deps(deps: &[(&str, &str)]) -> PackageJson {
+        let map: HashMap<String, String> = deps
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        PackageJson {
+            name: "host".to_string(),
+            version: "1.0.0".to_string(),
+            dependencies: Some(map),
+            ..Default::default()
+        }
+    }
+
+    fn workspace_versions(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn catalogs(pairs: &[(&str, &str)]) -> Catalogs {
+        let default: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Catalogs::from([(String::new(), default)])
+    }
+
+    #[test]
+    fn rewrites_workspace_and_catalog_specs() {
+        let mut pkg = pkg_with_deps(&[
+            ("@scope/star", "workspace:*"),
+            ("@scope/caret", "workspace:^"),
+            ("@scope/range", "workspace:^2.0.0"),
+            ("lodash", "catalog:"),
+            ("react", "^18.0.0"),
+        ]);
+        let ws = workspace_versions(&[
+            ("@scope/star", "1.5.0"),
+            ("@scope/caret", "3.1.0"),
+            ("@scope/range", "2.4.0"),
+        ]);
+        let cat = catalogs(&[("lodash", "^4.17.21")]);
+
+        rewrite_dep_specs(&mut pkg, &ws, &cat).unwrap();
+
+        let deps = pkg.dependencies.unwrap();
+        assert_eq!(deps["@scope/star"], "1.5.0");
+        assert_eq!(deps["@scope/caret"], "^3.1.0");
+        assert_eq!(deps["@scope/range"], "^2.0.0");
+        assert_eq!(deps["lodash"], "^4.17.21");
+        // Untouched: a normal registry range.
+        assert_eq!(deps["react"], "^18.0.0");
+    }
+
+    #[test]
+    fn rewrites_across_all_dependency_kinds() {
+        let mut pkg = PackageJson {
+            name: "host".to_string(),
+            version: "1.0.0".to_string(),
+            dev_dependencies: Some(HashMap::from([(
+                "dev-pkg".to_string(),
+                "workspace:~".to_string(),
+            )])),
+            peer_dependencies: Some(HashMap::from([(
+                "peer-pkg".to_string(),
+                "workspace:*".to_string(),
+            )])),
+            optional_dependencies: Some(HashMap::from([(
+                "opt-pkg".to_string(),
+                "catalog:legacy".to_string(),
+            )])),
+            ..Default::default()
+        };
+        let ws = workspace_versions(&[("dev-pkg", "0.2.0"), ("peer-pkg", "5.0.0")]);
+        let mut cat = Catalogs::new();
+        cat.insert(
+            "legacy".to_string(),
+            HashMap::from([("opt-pkg".to_string(), "^1.0.0".to_string())]),
+        );
+
+        rewrite_dep_specs(&mut pkg, &ws, &cat).unwrap();
+
+        assert_eq!(pkg.dev_dependencies.unwrap()["dev-pkg"], "~0.2.0");
+        assert_eq!(pkg.peer_dependencies.unwrap()["peer-pkg"], "5.0.0");
+        assert_eq!(pkg.optional_dependencies.unwrap()["opt-pkg"], "^1.0.0");
+    }
+
+    #[test]
+    fn errors_on_unresolvable_workspace_dep() {
+        let mut pkg = pkg_with_deps(&[("missing", "workspace:*")]);
+        let err = rewrite_dep_specs(&mut pkg, &HashMap::new(), &Catalogs::new()).unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn errors_on_unresolvable_catalog_dep() {
+        let mut pkg = pkg_with_deps(&[("missing", "catalog:")]);
+        let err = rewrite_dep_specs(&mut pkg, &HashMap::new(), &Catalogs::new()).unwrap_err();
+        assert!(err.to_string().contains("catalog"));
+    }
+
+    #[test]
+    fn has_spec_with_prefix_detects_protocols() {
+        let ws = pkg_with_deps(&[("a", "workspace:*")]);
+        assert!(has_spec_with_prefix(&ws, WORKSPACE_PREFIX));
+        assert!(!has_spec_with_prefix(&ws, CATALOG_PREFIX));
+
+        let plain = pkg_with_deps(&[("a", "^1.0.0")]);
+        assert!(!has_spec_with_prefix(&plain, WORKSPACE_PREFIX));
+        assert!(!has_spec_with_prefix(&plain, CATALOG_PREFIX));
+    }
+}

--- a/crates/pm/src/service/publish_manifest.rs
+++ b/crates/pm/src/service/publish_manifest.rs
@@ -86,31 +86,40 @@ fn rewrite_dep_specs(
         &mut pkg.peer_dependencies,
         &mut pkg.optional_dependencies,
     ];
-    for map in maps.into_iter().flatten() {
-        for (name, spec) in map.iter_mut() {
-            match Protocol::strip_prefix(spec) {
-                Some((Protocol::Workspace, _)) => {
-                    let version = workspace_versions.get(name).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "cannot resolve workspace dependency `{name}` (\"{spec}\"): \
-                             no workspace package named `{name}` with a version was found"
-                        )
-                    })?;
-                    *spec = resolve_workspace_spec(spec, version)
-                        .expect("spec starts with workspace: prefix");
-                }
-                Some((Protocol::Catalog, _)) => {
-                    let resolved = resolve_catalog_spec(name, spec, catalogs).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "cannot resolve catalog dependency `{name}` (\"{spec}\"): \
-                             no matching catalog entry (check `pnpm-workspace.yaml` / `.utoo.toml`)"
-                        )
-                    })?;
-                    *spec = resolved.to_string();
-                }
-                _ => {}
-            }
+    for (name, spec) in maps.into_iter().flatten().flat_map(|m| m.iter_mut()) {
+        rewrite_spec(name, spec, workspace_versions, catalogs)?;
+    }
+    Ok(())
+}
+
+/// Rewrite a single dependency `spec` in place if it uses the `workspace:` or
+/// `catalog:` protocol; leave any other spec untouched.
+fn rewrite_spec(
+    name: &str,
+    spec: &mut String,
+    workspace_versions: &HashMap<String, String>,
+    catalogs: &Catalogs,
+) -> Result<()> {
+    match Protocol::strip_prefix(spec) {
+        Some((Protocol::Workspace, _)) => {
+            let version = workspace_versions.get(name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "cannot resolve workspace dependency `{name}` (\"{spec}\"): \
+                     no workspace package named `{name}` with a version was found"
+                )
+            })?;
+            *spec = resolve_workspace_spec(spec, version).expect("spec has workspace: prefix");
         }
+        Some((Protocol::Catalog, _)) => {
+            let resolved = resolve_catalog_spec(name, spec, catalogs).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "cannot resolve catalog dependency `{name}` (\"{spec}\"): \
+                     no matching catalog entry (check `pnpm-workspace.yaml` / `.utoo.toml`)"
+                )
+            })?;
+            *spec = resolved.to_string();
+        }
+        _ => {}
     }
     Ok(())
 }

--- a/crates/ruborist/src/spec/mod.rs
+++ b/crates/ruborist/src/spec/mod.rs
@@ -26,6 +26,7 @@
 //! | `npm:`          | `Registry`          | Alias: `npm:lodash@^4`          |
 //! | (semver)        | `Registry`          | Resolved by registry            |
 
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use crate::model::util::{PackageNameStr, parse_package_spec};
@@ -303,8 +304,6 @@ impl SpecStr for str {
 // Catalog protocol
 // ---------------------------------------------------------------------------
 
-use std::collections::HashMap;
-
 /// Catalog definitions for the `catalog:` dependency protocol.
 ///
 /// Maps catalog name to (package_name -> version_spec).
@@ -325,6 +324,33 @@ pub fn resolve_catalog_spec<'a>(
         .get(catalog_name)
         .and_then(|c| c.get(pkg_name))
         .map(|s| s.as_str())
+}
+
+/// Resolve a `workspace:` spec to the version range that should appear in a
+/// **published** manifest, given the concrete `version` of the linked
+/// workspace package. Mirrors pnpm / bun pack behavior:
+///
+/// | Spec                | Result (version = `1.2.3`) |
+/// |---------------------|----------------------------|
+/// | `workspace:*`       | `1.2.3`                    |
+/// | `workspace:~`       | `~1.2.3`                   |
+/// | `workspace:^`       | `^1.2.3`                   |
+/// | `workspace:^1.2.0`  | `^1.2.0` (prefix stripped) |
+/// | `workspace:./path`  | `1.2.3` (path → version)   |
+///
+/// Returns `None` if `spec` is not a `workspace:` spec.
+pub fn resolve_workspace_spec(spec: &str, version: &str) -> Option<String> {
+    let rest = spec.strip_prefix("workspace:")?;
+    Some(match rest {
+        "" | "*" => version.to_string(),
+        "~" => format!("~{version}"),
+        "^" => format!("^{version}"),
+        // Path-based workspace deps (`workspace:./pkg`) publish as the concrete
+        // version, since the relative path is meaningless outside the monorepo.
+        p if p.starts_with('.') || p.starts_with('/') => version.to_string(),
+        // Explicit range/version: strip the prefix and keep it verbatim.
+        other => other.to_string(),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -707,6 +733,35 @@ mod tests {
                 path: "legacy".to_string(),
             }
         );
+    }
+
+    // -- resolve_workspace_spec --
+
+    #[test]
+    fn test_resolve_workspace_spec() {
+        let v = "1.2.3";
+        assert_eq!(resolve_workspace_spec("workspace:*", v).unwrap(), "1.2.3");
+        assert_eq!(resolve_workspace_spec("workspace:~", v).unwrap(), "~1.2.3");
+        assert_eq!(resolve_workspace_spec("workspace:^", v).unwrap(), "^1.2.3");
+        // Bare `workspace:` behaves like `workspace:*`.
+        assert_eq!(resolve_workspace_spec("workspace:", v).unwrap(), "1.2.3");
+        // Explicit ranges keep their text, only the prefix is dropped.
+        assert_eq!(
+            resolve_workspace_spec("workspace:^1.2.0", v).unwrap(),
+            "^1.2.0"
+        );
+        assert_eq!(
+            resolve_workspace_spec("workspace:>=1.0.0", v).unwrap(),
+            ">=1.0.0"
+        );
+        // Path-based workspace deps publish as the concrete version.
+        assert_eq!(
+            resolve_workspace_spec("workspace:./pkgs/foo", v).unwrap(),
+            "1.2.3"
+        );
+        // Non-workspace specs are left untouched.
+        assert!(resolve_workspace_spec("^1.0.0", v).is_none());
+        assert!(resolve_workspace_spec("catalog:", v).is_none());
     }
 
     // -- PackageSpec: npm alias --

--- a/e2e/pm/pack-protocols/.utoo.toml
+++ b/e2e/pm/pack-protocols/.utoo.toml
@@ -1,0 +1,2 @@
+[catalog]
+lodash = "^4.17.21"

--- a/e2e/pm/pack-protocols/package.json
+++ b/e2e/pm/pack-protocols/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pack-protocols",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/e2e/pm/pack-protocols/packages/bar/package.json
+++ b/e2e/pm/pack-protocols/packages/bar/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pack-protocols/bar",
+  "version": "2.4.1"
+}

--- a/e2e/pm/pack-protocols/packages/foo/index.js
+++ b/e2e/pm/pack-protocols/packages/foo/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/e2e/pm/pack-protocols/packages/foo/package.json
+++ b/e2e/pm/pack-protocols/packages/foo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@pack-protocols/foo",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pack-protocols/bar": "workspace:^",
+    "lodash": "catalog:"
+  },
+  "peerDependencies": {
+    "@pack-protocols/bar": "workspace:~"
+  },
+  "devDependencies": {
+    "@pack-protocols/bar": "workspace:*"
+  }
+}

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -401,6 +401,37 @@ echo -e "${GREEN}PASS: catalog update flow successful${NC}"
 mv .utoo.toml.bak .utoo.toml
 cd ../../..
 
+# Case 10c: pm-pack rewrites workspace:/catalog: protocols in the packed manifest (#3094)
+# A workspace member depends on a sibling via workspace: and on a catalog: entry.
+# `utoo pm-pack` must emit a tarball whose package.json carries concrete versions,
+# otherwise downstream `npm install` of the tgz fails with EUNSUPPORTEDPROTOCOL.
+echo -e "${YELLOW}Case 10c: pm-pack workspace:/catalog: rewrite${NC}"
+cd e2e/pm/pack-protocols/packages/foo
+rm -f ./*.tgz
+utoo pm-pack || { echo -e "${RED}FAIL: utoo pm-pack failed${NC}"; cd ../../../../..; exit 1; }
+PACK_TGZ=$(ls ./*.tgz)
+PACKED_PKG=$(tar -xzOf "$PACK_TGZ" package/package.json)
+echo "$PACKED_PKG"
+# workspace:^ -> ^2.4.1 (dependencies), workspace:~ -> ~2.4.1 (peerDependencies),
+# workspace:* -> 2.4.1 (devDependencies), catalog: -> ^4.17.21
+echo "$PACKED_PKG" | grep -q '"@pack-protocols/bar": "\^2.4.1"' \
+  || { echo -e "${RED}FAIL: workspace:^ not rewritten to ^2.4.1${NC}"; cd ../../../../..; exit 1; }
+echo "$PACKED_PKG" | grep -q '"@pack-protocols/bar": "~2.4.1"' \
+  || { echo -e "${RED}FAIL: workspace:~ not rewritten to ~2.4.1${NC}"; cd ../../../../..; exit 1; }
+echo "$PACKED_PKG" | grep -q '"@pack-protocols/bar": "2.4.1"' \
+  || { echo -e "${RED}FAIL: workspace:* not rewritten to 2.4.1${NC}"; cd ../../../../..; exit 1; }
+echo "$PACKED_PKG" | grep -q '"lodash": "\^4.17.21"' \
+  || { echo -e "${RED}FAIL: catalog: not rewritten to ^4.17.21${NC}"; cd ../../../../..; exit 1; }
+if echo "$PACKED_PKG" | grep -qE 'workspace:|catalog:'; then
+    echo -e "${RED}FAIL: raw workspace:/catalog: protocol left in packed manifest${NC}"; cd ../../../../..; exit 1
+fi
+# The on-disk source manifest must be left untouched (still uses the protocols).
+grep -q 'workspace:' package.json \
+  || { echo -e "${RED}FAIL: source package.json was mutated by pack${NC}"; cd ../../../../..; exit 1; }
+rm -f "$PACK_TGZ"
+cd ../../../../..
+echo -e "${GREEN}PASS: pm-pack workspace:/catalog: rewrite successful${NC}"
+
 # Case 11: npm alias (npm: prefix) install
 echo -e "${YELLOW}Case 11: npm alias install${NC}"
 cd e2e/pm/npm-alias


### PR DESCRIPTION
## Summary

Closes #3094.

`ut pm-pack` / `utoo publish` emitted tarballs whose `package.json` kept the literal `workspace:*` and `catalog:` specifiers. Any downstream `npm install` of such a tarball fails immediately with `EUNSUPPORTEDPROTOCOL`, which forced monorepos migrating to utoo (e.g. [eggjs/egg#5959](https://github.com/eggjs/egg/pull/5959)) to keep `pnpm` around **just** for the pack step.

This rewrites both protocols at pack/publish time the way pnpm/bun do:

| spec | result (member version `1.2.3`) |
|---|---|
| `workspace:*` / `workspace:` | `1.2.3` |
| `workspace:~` | `~1.2.3` |
| `workspace:^` | `^1.2.3` |
| `workspace:^1.2.0` | `^1.2.0` (prefix stripped) |
| `workspace:./path` | `1.2.3` |
| `catalog:` / `catalog:<name>` | version pinned in the catalog |

## Design

- **New** `resolve_workspace_spec` in `crates/ruborist/src/spec/mod.rs`, symmetric to the existing `resolve_catalog_spec`.
- **New** `crates/pm/src/service/publish_manifest.rs` orchestrates the rewrite:
  - No-op (returns `None`) when the manifest has neither protocol, so standalone packages are packed byte-for-byte.
  - Resolves against the **discovered workspace root** — `pm-pack` runs inside a member dir, so `workspace:` versions come from sibling members and `catalog:` from the root `.utoo.toml` (migrated from `pnpm-workspace.yaml`), not the cwd.
  - Unresolvable specifiers `bail` with an actionable message rather than shipping a broken tarball.
- `pm_pack::pack` substitutes the rewritten manifest into the tarball entry (`append_override`); the **on-disk `package.json` is never mutated** (pnpm parity).
- `publish` now builds the payload from `pack_result.manifest`, so registry metadata and tarball contents can't drift.

## Test plan

- Unit: `resolve_workspace_spec` (all forms), `rewrite_dep_specs` across all four dependency kinds, unresolvable workspace/catalog errors, protocol detection. — pm `publish_manifest` (5) + ruborist `spec` pass.
- Existing `pm_pack` (11) and full `utoo-pm` (248) suites green; `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.
- Manual E2E: a 2-member workspace with `workspace:^`/`workspace:*` + `catalog:` → tarball `package.json` rewritten to concrete ranges, unknown fields (`repository`/`keywords`) preserved, source manifest unchanged.

## Follow-ups (out of scope)

- `workspace:<name>@<range>` aliasing (`npm:` rewrite) — rare; not handled yet.
- `ut pm-pack -r` / `--pack-destination` are tracked separately (#3095 / #3096).

🤖 Generated with [Claude Code](https://claude.com/claude-code)