### PR TITLE
feat(pm): private npm registry auth for install/view

### DIFF
--- a/crates/pm/src/cmd/view.rs
+++ b/crates/pm/src/cmd/view.rs
@@ -23,8 +23,10 @@ async fn view_with_registry(package_spec: &str, registry_url: &str) -> Result<()
 
     tracing::debug!("Resolved package: {name} (spec: {version_spec})");
 
-    // Fetch full manifest directly from registry (Complete format for display, no ETag)
-    let token = auth::cached_token().await;
+    // Fetch full manifest directly from registry (Complete format for display, no ETag).
+    // token_for_url applies the leak guard: a token only when registry_url is
+    // the configured registry host.
+    let token = auth::token_for_url(registry_url).await;
     let (full_manifest, _etag) = fetch_full_manifest_fresh(
         registry_url,
         name,

--- a/crates/pm/src/cmd/view.rs
+++ b/crates/pm/src/cmd/view.rs
@@ -5,6 +5,7 @@ use utoo_ruborist::manifest::{FullManifest, VersionManifest};
 use utoo_ruborist::service::{MetadataFormat, fetch_full_manifest_fresh};
 use utoo_ruborist::util::parse_package_spec;
 
+use crate::service::auth;
 use crate::util::format_print::print_grid;
 use crate::util::user_config::get_registry;
 
@@ -23,10 +24,15 @@ async fn view_with_registry(package_spec: &str, registry_url: &str) -> Result<()
     tracing::debug!("Resolved package: {name} (spec: {version_spec})");
 
     // Fetch full manifest directly from registry (Complete format for display, no ETag)
-    let (full_manifest, _etag) =
-        fetch_full_manifest_fresh(registry_url, name, MetadataFormat::Complete)
-            .await
-            .map_err(|e| anyhow!("Failed to fetch package info for {}: {}", package_spec, e))?;
+    let token = auth::cached_token().await;
+    let (full_manifest, _etag) = fetch_full_manifest_fresh(
+        registry_url,
+        name,
+        MetadataFormat::Complete,
+        token.as_deref(),
+    )
+    .await
+    .map_err(|e| anyhow!("Failed to fetch package info for {}: {}", package_spec, e))?;
 
     tracing::debug!("Fetched package info: {full_manifest:?}");
 

--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -191,7 +191,7 @@ pub async fn resolve_package_spec(spec: &str) -> Result<(String, String, String)
     let parsed = PackageSpec::from(spec);
     match parsed {
         PackageSpec::Registry { name, version_spec } => {
-            let resolved = resolve_package(&Context::registry(), &name, &version_spec)
+            let resolved = resolve_package(&Context::registry().await, &name, &version_spec)
                 .await
                 .context("Failed to resolve package")?;
             Ok((name, resolved.version, version_spec))

--- a/crates/pm/src/helper/ruborist_context.rs
+++ b/crates/pm/src/helper/ruborist_context.rs
@@ -7,6 +7,7 @@ use utoo_ruborist::service::{
     BuildDepsOptions, BuildDepsOutput, Glob, ManifestStore, UnifiedRegistry,
 };
 
+use crate::service::auth;
 use crate::service::install_scheduler::{InstallEventReceiver, InstallScheduler};
 use crate::util::cache::get_cache_dir;
 use crate::util::logger::ProgressReceiver;
@@ -54,15 +55,13 @@ impl Context {
         let project_cache = Some(project_cache::load(&cwd).await);
         BuildDepsOptions {
             cwd,
-            registry_url: get_registry(),
+            registry: Self::registry().await,
             cache_dir: Some(get_cache_dir()),
-            manifest_store: Self::manifest_store(),
             project_cache,
             concurrency: get_manifests_concurrency_limit().await,
             peer_deps: get_peer_deps().await,
             glob: TokioGlob,
             receiver,
-            supports_semver: get_supports_semver(),
             catalogs,
         }
     }
@@ -88,10 +87,14 @@ impl Context {
         Ok(output)
     }
 
-    /// Create a UnifiedRegistry with standard configuration.
-    pub fn registry() -> Registry {
+    /// Create a UnifiedRegistry with standard configuration, including the
+    /// private-registry auth token (resolved once, cached). This is the single
+    /// place registry config + credentials are assembled; `deps_options` reuses
+    /// it so install and `resolve_package` share one authenticated client.
+    pub async fn registry() -> Registry {
         let mut builder = UnifiedRegistry::builder()
             .registry(get_registry())
+            .auth_token(auth::cached_token().await)
             .store(Self::manifest_store());
         if let Some(semver) = get_supports_semver() {
             builder = builder.supports_semver(semver);

--- a/crates/pm/src/service/auth.rs
+++ b/crates/pm/src/service/auth.rs
@@ -59,7 +59,14 @@ pub async fn cached_token() -> Option<String> {
 /// host only, never to a third-party CDN a manifest's `dist.tarball` points at.
 fn same_host(url: &str, registry: &str) -> bool {
     fn host(s: &str) -> Option<String> {
-        Url::parse(s).ok()?.host_str().map(str::to_ascii_lowercase)
+        // The registry may be configured as a bare host (no scheme), e.g.
+        // `registry.npmjs.org` or `localhost:4873`; give it one so it parses.
+        let parsed = if s.contains("://") {
+            Url::parse(s)
+        } else {
+            Url::parse(&format!("https://{s}"))
+        };
+        parsed.ok()?.host_str().map(str::to_ascii_lowercase)
     }
     matches!((host(url), host(registry)), (Some(a), Some(b)) if a == b)
 }
@@ -260,6 +267,16 @@ mod tests {
         assert!(same_host(
             "http://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
             registry
+        ));
+        // Registry configured as a bare host (no scheme) → still matches.
+        assert!(same_host(
+            "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
+            "registry.npmjs.org"
+        ));
+        // Bare host with a port (e.g. a local Verdaccio) → matches by host.
+        assert!(same_host(
+            "http://localhost:4873/pkg/-/pkg-1.0.0.tgz",
+            "localhost:4873"
         ));
         // Host case is normalized.
         assert!(same_host("https://REGISTRY.npmjs.org/pkg.tgz", registry));

--- a/crates/pm/src/service/auth.rs
+++ b/crates/pm/src/service/auth.rs
@@ -1,4 +1,6 @@
 use anyhow::{Context, Result, bail};
+use reqwest::Url;
+use tokio::sync::OnceCell;
 
 use crate::util::cli_enum::ConfigScope;
 use crate::util::config_file::Config;
@@ -37,6 +39,41 @@ pub async fn resolve_token(registry: &str) -> Option<String> {
     let config = Config::load(ConfigScope::Global).await.ok()?;
     let token = config.get(&token_key(registry)).ok().flatten()?;
     if token.is_empty() { None } else { Some(token) }
+}
+
+/// Token for the configured registry, resolved once and cached for the process.
+///
+/// Install decides per request whether to attach auth; resolving env/config on
+/// every fetch would be wasteful, so the lookup runs at most once (npm/bun both
+/// load credentials once at startup, then do in-memory lookups).
+pub async fn cached_token() -> Option<String> {
+    static CACHED_TOKEN: OnceCell<Option<String>> = OnceCell::const_new();
+    CACHED_TOKEN
+        .get_or_init(|| async { resolve_token(&crate::util::user_config::get_registry()).await })
+        .await
+        .clone()
+}
+
+/// Whether `url` targets the same host as `registry`. The leak guard for
+/// attaching a token to a tarball download: credentials go to the registry
+/// host only, never to a third-party CDN a manifest's `dist.tarball` points at.
+fn same_host(url: &str, registry: &str) -> bool {
+    fn host(s: &str) -> Option<String> {
+        Url::parse(s).ok()?.host_str().map(str::to_ascii_lowercase)
+    }
+    matches!((host(url), host(registry)), (Some(a), Some(b)) if a == b)
+}
+
+/// The Bearer token to attach when fetching `url`, or `None` when there is no
+/// configured token or `url` does not target the registry host (leak guard).
+/// Use for downloads whose host is not guaranteed to be the registry (e.g. a
+/// tarball URL that a manifest may point at a CDN).
+pub async fn token_for_url(url: &str) -> Option<String> {
+    if same_host(url, &crate::util::user_config::get_registry()) {
+        cached_token().await
+    } else {
+        None
+    }
 }
 
 /// Resolve token or bail with a login hint.
@@ -209,6 +246,32 @@ mod tests {
             registry_host("https://registry.npmjs.org/"),
             "registry.npmjs.org"
         );
+    }
+
+    #[test]
+    fn test_same_host_leak_guard() {
+        let registry = "https://registry.npmjs.org";
+        // A tarball served by the registry itself → attach token.
+        assert!(same_host(
+            "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            registry
+        ));
+        // Scheme differs but host matches → still the registry.
+        assert!(same_host(
+            "http://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
+            registry
+        ));
+        // Host case is normalized.
+        assert!(same_host("https://REGISTRY.npmjs.org/pkg.tgz", registry));
+        // A third-party CDN → never leak the token.
+        assert!(!same_host(
+            "https://cdn.jsdelivr.net/npm/pkg/-/pkg-1.0.0.tgz",
+            registry
+        ));
+        // A sibling subdomain is still a different host.
+        assert!(!same_host("https://cdn.npmjs.org/pkg.tgz", registry));
+        // Unparsable URLs are treated as non-matching (fail closed).
+        assert!(!same_host("not a url", registry));
     }
 
     #[test]

--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -1,4 +1,5 @@
 use crate::fs;
+use crate::service::auth;
 use crate::util::http::client;
 use crate::util::json::read_json_file;
 use crate::util::user_config::get_registry;
@@ -20,8 +21,11 @@ async fn load_config() -> Result<&'static Value> {
         .get_or_try_init(|| async {
             let registry = get_registry();
             let url = format!("{registry}/binary-mirror-config/latest");
-            let response = client()
-                .get(&url)
+            let mut request = client().get(&url);
+            if let Some(token) = auth::token_for_url(&url).await {
+                request = request.bearer_auth(token);
+            }
+            let response = request
                 .send()
                 .await
                 .context("Failed to fetch binary mirror config")?;
@@ -238,7 +242,16 @@ pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
         return Ok(());
     }
 
-    let config = load_config().await?;
+    // A missing/unreachable binary-mirror-config (e.g. a private registry that
+    // doesn't host it) must not fail the install — the china-mirror rewrite is
+    // an optimization. Skip gracefully, matching `get_envs`.
+    let config = match load_config().await {
+        Ok(config) => config,
+        Err(e) => {
+            tracing::debug!("Binary mirror config unavailable, skipping: {e}");
+            return Ok(());
+        }
+    };
 
     let mirrors = config["mirrors"]["china"]
         .as_object()

--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -1,6 +1,5 @@
 use crate::fs;
-use crate::service::auth;
-use crate::util::http::client;
+use crate::helper::ruborist_context::Context as RuboristContext;
 use crate::util::json::read_json_file;
 use crate::util::user_config::get_registry;
 use anyhow::{Context, Result};
@@ -19,25 +18,16 @@ static SKIP_BINARY_MIRROR: OnceLock<bool> = OnceLock::new();
 async fn load_config() -> Result<&'static Value> {
     CONFIG
         .get_or_try_init(|| async {
-            let registry = get_registry();
-            let url = format!("{registry}/binary-mirror-config/latest");
-            let mut request = client().get(&url);
-            if let Some(token) = auth::token_for_url(&url).await {
-                request = request.bearer_auth(token);
-            }
-            let response = request
-                .send()
+            // Go through the registry client so URL construction and private-
+            // registry auth are handled in one place rather than hand-rolled.
+            // `binary-mirror-config@latest` is a normal version manifest whose
+            // `mirrors` field carries the config.
+            let bytes = RuboristContext::registry()
+                .await
+                .fetch_version_manifest_bytes("binary-mirror-config", "latest")
                 .await
                 .context("Failed to fetch binary mirror config")?;
-
-            if !response.status().is_success() {
-                return Err(anyhow::anyhow!("HTTP status: {}", response.status()));
-            }
-
-            response
-                .json()
-                .await
-                .context("Failed to parse binary mirror config")
+            serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")
         })
         .await
 }

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -7,6 +7,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use utoo_ruborist::progress::{BuildEvent, EventReceiver, PackageTarballInfo};
 
+use crate::service::auth;
 use crate::util::cloner::{PackageClone, clone_package_sync};
 use crate::util::downloader::{download_bytes, is_registry_tarball_url};
 use crate::util::package_cache::{
@@ -446,10 +447,13 @@ impl SchedulerState {
             self.async_ops.push(tokio::spawn(async move {
                 let result = match registry_cache_lookup(&package.name, &package.version).await {
                     Ok(Some(cache_path)) => Ok(DownloadOutcome::Cached(cache_path)),
-                    Ok(None) => download_bytes(&package.tarball_url)
-                        .await
-                        .map(DownloadOutcome::Bytes)
-                        .map_err(|e| format!("{e:#}")),
+                    Ok(None) => {
+                        let token = auth::token_for_url(&package.tarball_url).await;
+                        download_bytes(&package.tarball_url, token.as_deref())
+                            .await
+                            .map(DownloadOutcome::Bytes)
+                            .map_err(|e| format!("{e:#}"))
+                    }
                     Err(e) => Err(format!("{e:#}")),
                 };
                 StageReport::Download { package, result }

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -24,15 +24,22 @@ pub fn is_registry_tarball_url(url: &str) -> bool {
 }
 
 /// Download tarball bytes with retries (network phase only).
-pub async fn download_bytes(url: &str) -> Result<Bytes> {
+///
+/// `auth_token` is attached as a Bearer header when present; callers are
+/// responsible for the leak guard (only pass a token for registry-host URLs —
+/// see [`crate::service::auth::token_for_url`]).
+pub async fn download_bytes(url: &str, auth_token: Option<&str>) -> Result<Bytes> {
     let retry_count = AtomicU32::new(0);
     RetryIf::spawn(
         create_retry_strategy(),
         || async {
             let attempt = retry_count.fetch_add(1, Ordering::Relaxed);
 
-            let response = DOWNLOADER_CLIENT
-                .get(url)
+            let mut request = DOWNLOADER_CLIENT.get(url);
+            if let Some(token) = auth_token {
+                request = request.bearer_auth(token);
+            }
+            let response = request
                 .send()
                 .await
                 .map_err(|e| RetryableError::Temporary(format!("Network error: {e}")))?;

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -21,14 +21,12 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use anyhow::Result;
 
 use super::cache::ProjectCacheData;
 use super::fs::Glob;
 use super::registry::UnifiedRegistry;
-use super::store::{ManifestStore, NoopStore};
 use crate::model::graph::DependencyGraph;
 use crate::model::package_json::PackageJson;
 use crate::model::package_lock::PackageLock;
@@ -45,14 +43,14 @@ use crate::traits::progress::EventReceiver;
 pub struct BuildDepsOptions<G, R> {
     /// Current working directory (contains package.json)
     pub cwd: PathBuf,
-    /// Registry URL (e.g., "https://registry.npmmirror.com")
-    pub registry_url: String,
+    /// Pre-built registry client. The host (pm) constructs this with the
+    /// registry URL, manifest store, semver capability, and any private-registry
+    /// auth token — keeping all registry configuration (and credential
+    /// resolution) on the host side, out of ruborist.
+    pub registry: UnifiedRegistry,
     /// Tarball cache directory passed through to non-registry resolvers
     /// (http/tarball, native-git). Unrelated to manifest disk cache.
     pub cache_dir: Option<PathBuf>,
-    /// Persistence backend for manifest cache. Defaults to `NoopStore`
-    /// (everything is in-memory).
-    pub manifest_store: Arc<dyn ManifestStore>,
     /// Project-level warm cache pre-loaded by the host. Seeds the demand
     /// resolver's manifest cache so a warm install skips re-fetching.
     pub project_cache: Option<ProjectCacheData>,
@@ -64,8 +62,6 @@ pub struct BuildDepsOptions<G, R> {
     pub glob: G,
     /// Progress event receiver
     pub receiver: R,
-    /// Explicit semver support override (None = auto-detect from registry URL)
-    pub supports_semver: Option<bool>,
     /// Catalog definitions for the `catalog:` dependency protocol.
     /// Key `""` = default catalog, other keys = named catalogs.
     pub catalogs: Catalogs,
@@ -80,15 +76,15 @@ impl<G, R> BuildDepsOptions<G, R> {
     {
         Self {
             cwd,
-            registry_url: "https://registry.npmmirror.com".to_string(),
+            registry: UnifiedRegistry::builder()
+                .registry("https://registry.npmmirror.com")
+                .build(),
             cache_dir: None,
-            manifest_store: Arc::new(NoopStore),
             project_cache: None,
             concurrency: 20,
             peer_deps: PeerDeps::Skip,
             glob,
             receiver,
-            supports_semver: None,
             catalogs: HashMap::new(),
         }
     }
@@ -125,15 +121,13 @@ where
 {
     let BuildDepsOptions {
         cwd: root_path,
-        registry_url,
+        registry,
         cache_dir,
-        manifest_store,
         project_cache,
         concurrency,
         peer_deps,
         glob,
         receiver,
-        supports_semver,
         catalogs,
     } = options;
 
@@ -178,17 +172,9 @@ where
         );
     }
 
-    // 4. Create the stateless registry client (persistence backend only).
-    //    The warm `project_cache` seeds the demand resolver's manifest cache
-    //    directly via `BuildDepsConfig::project_cache` below.
-    let mut builder = UnifiedRegistry::builder()
-        .registry(&registry_url)
-        .store(Arc::clone(&manifest_store));
-    if let Some(semver) = supports_semver {
-        builder = builder.supports_semver(semver);
-    }
-    let registry = builder.build();
-
+    // 4. The host supplies the stateless registry client (URL, store, semver,
+    //    auth) pre-built. The warm `project_cache` seeds the demand resolver's
+    //    manifest cache directly via `BuildDepsConfig::project_cache` below.
     tracing::debug!(
         "Using registry: {} (semver: {})",
         registry.registry_url(),
@@ -253,21 +239,24 @@ mod tests {
     async fn test_build_deps_options_creation() {
         let options: BuildDepsOptions<NoopGlob, NoopReceiver> = BuildDepsOptions {
             cwd: PathBuf::from("."),
-            registry_url: "https://registry.npmmirror.com".to_string(),
+            registry: UnifiedRegistry::builder()
+                .registry("https://registry.npmmirror.com")
+                .build(),
             cache_dir: None,
-            manifest_store: Arc::new(NoopStore),
             project_cache: None,
             concurrency: 20,
             peer_deps: PeerDeps::Skip,
             glob: NoopGlob,
             receiver: NoopReceiver,
-            supports_semver: None,
             catalogs: HashMap::new(),
         };
 
         assert_eq!(options.concurrency, 20);
         assert_eq!(options.peer_deps, PeerDeps::Skip);
-        assert!(options.supports_semver.is_none());
+        assert_eq!(
+            options.registry.registry_url(),
+            "https://registry.npmmirror.com"
+        );
     }
 
     /// `build_deps` resolves an **in-memory** synthetic root (no disk
@@ -278,15 +267,15 @@ mod tests {
     async fn test_build_deps_in_memory_root_no_deps() {
         let options: BuildDepsOptions<NoopGlob, NoopReceiver> = BuildDepsOptions {
             cwd: PathBuf::from("/synthetic-root"),
-            registry_url: "https://registry.npmmirror.com".to_string(),
+            registry: UnifiedRegistry::builder()
+                .registry("https://registry.npmmirror.com")
+                .build(),
             cache_dir: None,
-            manifest_store: Arc::new(NoopStore),
             project_cache: None,
             concurrency: 20,
             peer_deps: PeerDeps::Skip,
             glob: NoopGlob,
             receiver: NoopReceiver,
-            supports_semver: None,
             catalogs: HashMap::new(),
         };
         let mut pkg = PackageJson::new("utoo-global", "0.0.0");

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -160,6 +160,9 @@ pub struct FetchManifestOptions<'a> {
     pub name: &'a str,
     pub format: MetadataFormat,
     pub etag: Option<&'a str>,
+    /// Bearer token for a private registry. Attached only to requests against
+    /// `registry_url`, which these manifest URLs are by construction.
+    pub auth_token: Option<&'a str>,
 }
 
 /// Fetch full manifest bytes with retry and ETag support, without parsing.
@@ -168,6 +171,7 @@ pub async fn fetch_full_manifest_bytes(
 ) -> Result<FetchManifestBytesResult> {
     let url = format!("{}/{}", opts.registry_url, opts.name);
     let etag_owned = opts.etag.map(|s| s.to_string());
+    let auth_owned = opts.auth_token.map(|s| s.to_string());
     let accept = match opts.format {
         MetadataFormat::Abbreviated => "application/vnd.npm.install-v1+json",
         MetadataFormat::Complete => "application/json",
@@ -178,6 +182,7 @@ pub async fn fetch_full_manifest_bytes(
         || {
             let url = url.clone();
             let etag = etag_owned.clone();
+            let auth = auth_owned.clone();
             async move {
                 let mut request = get_client()
                     .map_err(FetchError::Permanent)?
@@ -185,6 +190,9 @@ pub async fn fetch_full_manifest_bytes(
                     .header("Accept", accept);
                 if let Some(etag_value) = &etag {
                     request = request.header("If-None-Match", etag_value);
+                }
+                if let Some(token) = &auth {
+                    request = request.bearer_auth(token);
                 }
 
                 let response = request.send().await.map_err(classify_reqwest_error)?;
@@ -245,12 +253,14 @@ pub async fn fetch_full_manifest_fresh(
     registry_url: &str,
     name: &str,
     format: MetadataFormat,
+    auth_token: Option<&str>,
 ) -> Result<(FullManifest, Option<String>)> {
     match fetch_full_manifest(FetchManifestOptions {
         registry_url,
         name,
         format,
         etag: None,
+        auth_token,
     })
     .await?
     {
@@ -291,6 +301,9 @@ pub struct FetchVersionManifestOptions<'a> {
     pub name: &'a str,
     pub spec: &'a str,
     pub format: MetadataFormat,
+    /// Bearer token for a private registry. Attached only to requests against
+    /// `registry_url`, which these manifest URLs are by construction.
+    pub auth_token: Option<&'a str>,
 }
 
 /// Fetch version manifest into a mutable parse buffer with retry.
@@ -302,6 +315,7 @@ pub(crate) async fn fetch_version_manifest_vec(
     opts: FetchVersionManifestOptions<'_>,
 ) -> Result<Vec<u8>> {
     let url = format!("{}/{}/{}", opts.registry_url, opts.name, opts.spec);
+    let auth_owned = opts.auth_token.map(|s| s.to_string());
 
     let accept = match opts.format {
         MetadataFormat::Abbreviated => "application/vnd.npm.install-v1+json",
@@ -312,14 +326,16 @@ pub(crate) async fn fetch_version_manifest_vec(
         retry_strategy(),
         || {
             let url = url.clone();
+            let auth = auth_owned.clone();
             async move {
-                let response = get_client()
+                let mut request = get_client()
                     .map_err(FetchError::Permanent)?
                     .get(&url)
-                    .header("Accept", accept)
-                    .send()
-                    .await
-                    .map_err(classify_reqwest_error)?;
+                    .header("Accept", accept);
+                if let Some(token) = &auth {
+                    request = request.bearer_auth(token);
+                }
+                let response = request.send().await.map_err(classify_reqwest_error)?;
 
                 if response.status().is_success() {
                     read_body_vec(response).await

--- a/crates/ruborist/src/service/registry/mod.rs
+++ b/crates/ruborist/src/service/registry/mod.rs
@@ -59,6 +59,9 @@ mod provider;
 /// ```
 pub struct UnifiedRegistry {
     registry_url: String,
+    /// Bearer token for a private registry, attached to manifest requests
+    /// against `registry_url`. `None` for public registries.
+    auth_token: Option<String>,
     store: Arc<dyn ManifestStore>,
     supports_semver: bool,
     /// Dedup set for `store_version_manifest` disk writes keyed by
@@ -72,6 +75,7 @@ pub struct UnifiedRegistry {
 /// Builder for `UnifiedRegistry`.
 pub struct UnifiedRegistryBuilder {
     registry_url: Option<String>,
+    auth_token: Option<String>,
     store: Option<Arc<dyn ManifestStore>>,
     supports_semver: Option<bool>,
 }
@@ -81,6 +85,7 @@ impl UnifiedRegistryBuilder {
     pub fn new() -> Self {
         Self {
             registry_url: None,
+            auth_token: None,
             store: None,
             supports_semver: None,
         }
@@ -89,6 +94,14 @@ impl UnifiedRegistryBuilder {
     /// Set the registry URL.
     pub fn registry(mut self, url: impl Into<String>) -> Self {
         self.registry_url = Some(url.into());
+        self
+    }
+
+    /// Set the Bearer token for a private registry. `None` leaves requests
+    /// unauthenticated. ruborist never resolves the token itself — the host
+    /// (pm) reads it from env/config and injects it here.
+    pub fn auth_token(mut self, token: Option<String>) -> Self {
+        self.auth_token = token;
         self
     }
 
@@ -119,6 +132,7 @@ impl UnifiedRegistryBuilder {
 
         UnifiedRegistry {
             registry_url,
+            auth_token: self.auth_token,
             store,
             supports_semver,
             stored_version: Arc::new(DashSet::new()),
@@ -136,6 +150,7 @@ impl Clone for UnifiedRegistry {
     fn clone(&self) -> Self {
         Self {
             registry_url: self.registry_url.clone(),
+            auth_token: self.auth_token.clone(),
             store: Arc::clone(&self.store),
             supports_semver: self.supports_semver,
             stored_version: Arc::clone(&self.stored_version),

--- a/crates/ruborist/src/service/registry/mod.rs
+++ b/crates/ruborist/src/service/registry/mod.rs
@@ -33,6 +33,7 @@ fn current_timestamp_secs() -> u64 {
 
 use dashmap::DashSet;
 
+use super::manifest;
 use super::store::{ManifestStore, NoopStore};
 use crate::traits::registry::{RegistryClient, RegistryError, is_npm_registry};
 
@@ -172,6 +173,25 @@ impl UnifiedRegistry {
     /// Check if this registry supports semver resolution.
     pub fn supports_semver(&self) -> bool {
         self.supports_semver
+    }
+
+    /// Fetch the raw version-manifest JSON for `name@spec` through this
+    /// registry — URL construction and auth are applied here, not by the
+    /// caller. Returns the complete document so custom fields the typed model
+    /// omits are preserved (e.g. `binary-mirror-config`'s `mirrors`).
+    pub async fn fetch_version_manifest_bytes(
+        &self,
+        name: &str,
+        spec: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        manifest::fetch_version_manifest_vec(manifest::FetchVersionManifestOptions {
+            registry_url: &self.registry_url,
+            name,
+            spec,
+            format: manifest::MetadataFormat::Complete,
+            auth_token: self.auth_token.as_deref(),
+        })
+        .await
     }
 }
 

--- a/crates/ruborist/src/service/registry/provider.rs
+++ b/crates/ruborist/src/service/registry/provider.rs
@@ -65,6 +65,7 @@ impl UnifiedRegistry {
             name,
             format: manifest::MetadataFormat::Abbreviated,
             etag: etag.as_deref(),
+            auth_token: self.auth_token.as_deref(),
         })
         .await
         .map_err(RegistryError)?
@@ -149,6 +150,7 @@ impl ManifestProvider for UnifiedRegistry {
                         name: &name,
                         spec: &fetch_spec,
                         format: self.version_fetch_format(),
+                        auth_token: self.auth_token.as_deref(),
                     })
                     .await
                     .map_err(RegistryError)?;

--- a/crates/utoo-wasm/src/deps.rs
+++ b/crates/utoo-wasm/src/deps.rs
@@ -8,7 +8,9 @@ use anyhow::Result;
 use utoo_ruborist::builder::PeerDeps;
 use utoo_ruborist::lock::PackageLock;
 use utoo_ruborist::progress::NoopReceiver;
-use utoo_ruborist::service::{build_deps, read_root_manifest, BuildDepsOptions, NoopStore};
+use utoo_ruborist::service::{
+    build_deps, read_root_manifest, BuildDepsOptions, NoopStore, UnifiedRegistry,
+};
 
 use crate::fs::OpfsGlob;
 
@@ -35,17 +37,20 @@ pub async fn build_deps_from_file(
 ) -> Result<PackageLock> {
     // Resolve the workspace root + read its manifest from OPFS, then resolve.
     let (root_path, pkg) = read_root_manifest(cwd, OpfsGlob).await?;
+    // Browser builds have no private-registry auth (no env/config token source),
+    // so the registry is constructed without a token.
     let options = BuildDepsOptions {
         cwd: root_path,
-        registry_url: registry_url.unwrap_or(DEFAULT_REGISTRY).to_string(),
+        registry: UnifiedRegistry::builder()
+            .registry(registry_url.unwrap_or(DEFAULT_REGISTRY))
+            .store(Arc::new(NoopStore))
+            .build(),
         cache_dir: None,
-        manifest_store: Arc::new(NoopStore),
         project_cache: None,
         concurrency: concurrency.unwrap_or(DEFAULT_CONCURRENCY),
         peer_deps: PeerDeps::Skip,
         glob: OpfsGlob,
         receiver: NoopReceiver,
-        supports_semver: None,
         catalogs: std::collections::HashMap::new(),
     };
 


### PR DESCRIPTION
## Summary

`ut install` / `ut view` / `utoo add` against a **private registry** returned 401 — the install path (manifest fetch in ruborist, tarball download in pm) carried no credentials. This resolves a Bearer token once and attaches it, scoped to the registry host.

Supersedes #2758 (that branch predates the demand-resolver rework and the `service::auth` infrastructure; rebuilt fresh on current `next`).

## Design

**Credentials live on the registry, resolution lives on the host.**

- **ruborist** — `UnifiedRegistry` gains an `auth_token`. The provider attaches it to manifest requests (always the registry host by construction). ruborist never reads env/config — the token is *injected*.
- **`BuildDepsOptions` consolidation** — previously carried `registry_url` + `manifest_store` + `supports_semver`, and `build_deps` rebuilt the registry internally, duplicating what `Context::registry()` already assembled. Replaced those three fields with a pre-built `registry: UnifiedRegistry` the host supplies. One place builds the registry (URL + store + semver + auth); install and `resolve_package` share it.
- **pm** —
  - `auth::cached_token()` resolves the token **once** at startup (env `NPM_TOKEN`/`NODE_AUTH_TOKEN` → `~/.utoo/config.toml`), then in-memory. Matches how npm/bun load credentials once and do per-request in-memory lookups — no per-fetch disk reads.
  - `auth::token_for_url()` is the **leak guard**: a token is attached to a tarball download only when the URL host matches the registry host (npm nerf-dart semantics). bun omits this check and can leak the token to a third-party CDN that a manifest's `dist.tarball` points at — we don't.
- **wasm** — browser builds have no token source, so the registry is unauthenticated (native-only token resolution).

## Scope

Single-registry model (utoo's current `get_registry()`). Out of scope: per-scope registries (`@scope:registry=...`), npmrc `:_authToken` parsing, and basic-auth (`_auth` / user:pass) — follow-ups.

## Test plan

- Unit: `same_host` leak guard — registry tarball ✓, scheme-agnostic ✓, case-normalized ✓, third-party CDN ✗, sibling subdomain ✗, unparsable URL ✗ (fail closed).
- Existing ruborist (181) + pm (249) suites green; `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `typos` clean; wasm target compiles.
- Manual (private registry): `NPM_TOKEN=… ut install` a private scoped pkg; `utoo login` + install reads config token; public registry install still works tokenless; a CDN tarball receives **no** `Authorization` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)