### PR TITLE
feat(pm): OIDC trusted publishing for ut publish

### DIFF
--- a/crates/pm/src/service/auth.rs
+++ b/crates/pm/src/service/auth.rs
@@ -54,19 +54,26 @@ pub async fn cached_token() -> Option<String> {
         .clone()
 }
 
+/// Parse a registry/URL that may be configured as a bare host (no scheme, e.g.
+/// `registry.npmjs.org` or `localhost:4873`), defaulting to `https://`.
+///
+/// Detect a scheme by the `://` separator rather than `Url::parse(..).is_ok()`:
+/// a bare `host:port` parses "successfully" with the host read as the scheme
+/// (`localhost:4873` → scheme `localhost`), which would misclassify it.
+pub(crate) fn parse_registry(registry: &str) -> Option<Url> {
+    if registry.contains("://") {
+        Url::parse(registry).ok()
+    } else {
+        Url::parse(&format!("https://{registry}")).ok()
+    }
+}
+
 /// Whether `url` targets the same host as `registry`. The leak guard for
 /// attaching a token to a tarball download: credentials go to the registry
 /// host only, never to a third-party CDN a manifest's `dist.tarball` points at.
 fn same_host(url: &str, registry: &str) -> bool {
     fn host(s: &str) -> Option<String> {
-        // The registry may be configured as a bare host (no scheme), e.g.
-        // `registry.npmjs.org` or `localhost:4873`; give it one so it parses.
-        let parsed = if s.contains("://") {
-            Url::parse(s)
-        } else {
-            Url::parse(&format!("https://{s}"))
-        };
-        parsed.ok()?.host_str().map(str::to_ascii_lowercase)
+        parse_registry(s)?.host_str().map(str::to_ascii_lowercase)
     }
     matches!((host(url), host(registry)), (Some(a), Some(b)) if a == b)
 }

--- a/crates/pm/src/service/mod.rs
+++ b/crates/pm/src/service/mod.rs
@@ -7,6 +7,7 @@ pub mod execute;
 pub mod init;
 pub mod install;
 pub mod install_scheduler;
+pub mod oidc;
 pub mod package;
 pub mod package_management;
 pub mod pm_pack;

--- a/crates/pm/src/service/oidc.rs
+++ b/crates/pm/src/service/oidc.rs
@@ -1,0 +1,220 @@
+//! OIDC trusted publishing.
+//!
+//! Mints a short-lived registry token from a CI OIDC id_token so `ut publish`
+//! in CI needs no long-lived npm token. Compatible with npm's trusted-publishing
+//! flow (npm 11.5.1+):
+//!
+//! 1. Obtain a CI OIDC id_token whose audience is `npm:<registry-host>`:
+//!    - **GitHub Actions**: `GET $ACTIONS_ID_TOKEN_REQUEST_URL&audience=…` with
+//!      `Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN` → `{ value }`.
+//!    - **GitLab CI / CircleCI**: read the pre-supplied `$NPM_ID_TOKEN`.
+//! 2. Exchange it at
+//!    `POST {registry}/-/npm/v1/oidc/token/exchange/package/{escapedName}`
+//!    (`Authorization: Bearer <id_token>`) → `{ token }`.
+//!
+//! Best-effort: returns `None` when not in an OIDC-capable CI or when the
+//! exchange fails, so the caller falls back to a configured token.
+
+use std::env;
+
+use anyhow::{Context, Result};
+use reqwest::Url;
+use serde_json::Value;
+
+use crate::util::http::client;
+
+/// Try to mint a publish token via OIDC trusted publishing.
+///
+/// `None` means "not available / fell back" — the caller should resolve a
+/// configured token instead. Never errors: a misconfigured or unsupported
+/// registry simply yields `None`.
+pub async fn try_mint_publish_token(registry: &str, package_name: &str) -> Option<String> {
+    let id_token = ci_id_token(registry).await?;
+    match exchange(registry, package_name, &id_token).await {
+        Ok(token) => {
+            tracing::info!(
+                "OIDC trusted publishing: minted a short-lived token for {package_name}"
+            );
+            Some(token)
+        }
+        Err(e) => {
+            tracing::warn!("OIDC token exchange failed, falling back to configured token: {e:#}");
+            None
+        }
+    }
+}
+
+/// The OIDC audience for `registry`, e.g. `npm:registry.npmjs.org`. Matches
+/// npm's `npm:${new URL(registry).hostname}` (host only, no port or path).
+fn audience(registry: &str) -> Option<String> {
+    let host = Url::parse(registry).ok()?.host_str()?.to_owned();
+    Some(format!("npm:{host}"))
+}
+
+/// Obtain a CI OIDC id_token for the registry audience, or `None` when not in a
+/// supported CI with OIDC enabled.
+async fn ci_id_token(registry: &str) -> Option<String> {
+    let audience = audience(registry)?;
+
+    // GitHub Actions: request an id_token from the runner's token service.
+    // Both vars are present only when the workflow grants `id-token: write`.
+    if let (Ok(req_url), Ok(req_token)) = (
+        env::var("ACTIONS_ID_TOKEN_REQUEST_URL"),
+        env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+    ) && !req_url.is_empty()
+        && !req_token.is_empty()
+    {
+        return github_actions_id_token(&req_url, &req_token, &audience).await;
+    }
+
+    // GitLab CI / CircleCI supply the id_token directly via `id_tokens`.
+    match env::var("NPM_ID_TOKEN") {
+        Ok(token) if !token.is_empty() => Some(token),
+        _ => None,
+    }
+}
+
+/// Fetch an id_token from the GitHub Actions runner token service.
+async fn github_actions_id_token(req_url: &str, req_token: &str, audience: &str) -> Option<String> {
+    let mut url = Url::parse(req_url).ok()?;
+    url.query_pairs_mut().append_pair("audience", audience);
+
+    let resp = client()
+        .get(url)
+        .header("Accept", "application/json")
+        .bearer_auth(req_token)
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        tracing::warn!(
+            "GitHub Actions OIDC token request failed: HTTP {}",
+            resp.status()
+        );
+        return None;
+    }
+    let body: Value = resp.json().await.ok()?;
+    body["value"].as_str().map(str::to_owned)
+}
+
+/// Exchange a CI OIDC id_token for a short-lived registry publish token.
+async fn exchange(registry: &str, package_name: &str, id_token: &str) -> Result<String> {
+    let url = format!(
+        "{}/-/npm/v1/oidc/token/exchange/package/{}",
+        registry.trim_end_matches('/'),
+        escaped_name(package_name),
+    );
+
+    let resp = client()
+        .post(&url)
+        .bearer_auth(id_token)
+        .send()
+        .await
+        .context("OIDC token exchange request failed")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("OIDC token exchange returned HTTP {status}: {body}");
+    }
+
+    let body: Value = resp
+        .json()
+        .await
+        .context("Invalid OIDC token exchange response")?;
+    body["token"]
+        .as_str()
+        .map(str::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("OIDC token exchange response missing `token`"))
+}
+
+/// npm `escapedName`: only the `/` in a scoped name is percent-encoded, so
+/// `@scope/name` → `@scope%2fname` and `pkg` stays `pkg`.
+fn escaped_name(package_name: &str) -> String {
+    package_name.replace('/', "%2f")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_audience() {
+        assert_eq!(
+            audience("https://registry.npmjs.org").as_deref(),
+            Some("npm:registry.npmjs.org")
+        );
+        // Path and port are dropped — host only.
+        assert_eq!(
+            audience("https://packages.example.com:8443/org/npm-registry/").as_deref(),
+            Some("npm:packages.example.com")
+        );
+        assert_eq!(audience("not a url"), None);
+    }
+
+    #[test]
+    fn test_escaped_name() {
+        assert_eq!(escaped_name("lodash"), "lodash");
+        assert_eq!(escaped_name("@scope/pkg"), "@scope%2fpkg");
+    }
+
+    #[tokio::test]
+    async fn test_github_actions_id_token() {
+        use mockito::Matcher;
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/token")
+            .match_query(Matcher::UrlEncoded(
+                "audience".into(),
+                "npm:registry.npmjs.org".into(),
+            ))
+            .match_header("authorization", "Bearer req-token")
+            .match_header("accept", "application/json")
+            .with_status(200)
+            .with_body(r#"{"value":"the.id.token"}"#)
+            .create_async()
+            .await;
+
+        let req_url = format!("{}/token", server.url());
+        let token = github_actions_id_token(&req_url, "req-token", "npm:registry.npmjs.org").await;
+
+        mock.assert_async().await;
+        assert_eq!(token.as_deref(), Some("the.id.token"));
+    }
+
+    #[tokio::test]
+    async fn test_exchange_mints_token() {
+        let mut server = mockito::Server::new_async().await;
+        // Scoped name escaping: `@scope/pkg` → `@scope%2fpkg` in the path.
+        let mock = server
+            .mock("POST", "/-/npm/v1/oidc/token/exchange/package/@scope%2fpkg")
+            .match_header("authorization", "Bearer the.id.token")
+            .with_status(200)
+            .with_body(r#"{"token":"npm_minted_publish_token"}"#)
+            .create_async()
+            .await;
+
+        let token = exchange(&server.url(), "@scope/pkg", "the.id.token")
+            .await
+            .unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(token, "npm_minted_publish_token");
+    }
+
+    #[tokio::test]
+    async fn test_exchange_non_success_errors() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/-/npm/v1/oidc/token/exchange/package/pkg")
+            .with_status(404)
+            .with_body("no trusted publisher configured")
+            .create_async()
+            .await;
+
+        let err = exchange(&server.url(), "pkg", "the.id.token")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+}

--- a/crates/pm/src/service/oidc.rs
+++ b/crates/pm/src/service/oidc.rs
@@ -21,6 +21,7 @@ use anyhow::{Context, Result};
 use reqwest::Url;
 use serde_json::Value;
 
+use crate::service::auth;
 use crate::util::http::client;
 
 /// Try to mint a publish token via OIDC trusted publishing.
@@ -29,6 +30,10 @@ use crate::util::http::client;
 /// configured token instead. Never errors: a misconfigured or unsupported
 /// registry simply yields `None`.
 pub async fn try_mint_publish_token(registry: &str, package_name: &str) -> Option<String> {
+    // Normalize a bare-host registry to a scheme'd URL once, so audience
+    // derivation and the exchange endpoint both parse.
+    let registry = auth::parse_registry(registry)?;
+    let registry = registry.as_str();
     let id_token = ci_id_token(registry).await?;
     match exchange(registry, package_name, &id_token).await {
         Ok(token) => {
@@ -47,7 +52,7 @@ pub async fn try_mint_publish_token(registry: &str, package_name: &str) -> Optio
 /// The OIDC audience for `registry`, e.g. `npm:registry.npmjs.org`. Matches
 /// npm's `npm:${new URL(registry).hostname}` (host only, no port or path).
 fn audience(registry: &str) -> Option<String> {
-    let host = Url::parse(registry).ok()?.host_str()?.to_owned();
+    let host = auth::parse_registry(registry)?.host_str()?.to_owned();
     Some(format!("npm:{host}"))
 }
 
@@ -144,6 +149,12 @@ mod tests {
             audience("https://registry.npmjs.org").as_deref(),
             Some("npm:registry.npmjs.org")
         );
+        // Bare host (no scheme) is normalized before parsing.
+        assert_eq!(
+            audience("registry.npmjs.org").as_deref(),
+            Some("npm:registry.npmjs.org")
+        );
+        assert_eq!(audience("localhost:4873").as_deref(), Some("npm:localhost"));
         // Path and port are dropped — host only.
         assert_eq!(
             audience("https://packages.example.com:8443/org/npm-registry/").as_deref(),

--- a/crates/pm/src/service/publish.rs
+++ b/crates/pm/src/service/publish.rs
@@ -31,6 +31,7 @@ use crate::model::package::LifecycleHook;
 use crate::model::package::PackageInfo;
 use crate::model::publish_payload::{PublishPayload, PublishPayloadInput};
 use crate::service::auth;
+use crate::service::oidc;
 use crate::service::pm_pack;
 use crate::service::script::{ScriptOutput, ScriptService};
 use crate::util::format_print::print_pack_details;
@@ -77,7 +78,12 @@ pub async fn publish(opts: &PublishOptions<'_>) -> Result<PublishResult> {
         });
     }
 
-    let token = auth::require_token(opts.registry).await?;
+    // Prefer OIDC trusted publishing when running in a supported CI (no
+    // long-lived token needed); fall back to a configured token otherwise.
+    let token = match oidc::try_mint_publish_token(opts.registry, &pack_result.name).await {
+        Some(token) => token,
+        None => auth::require_token(opts.registry).await?,
+    };
 
     // Reuse the manifest packed into the tarball (with `workspace:`/`catalog:`
     // already rewritten) so the registry metadata matches the tarball contents.


### PR DESCRIPTION
## Summary

`ut publish` in CI required a long-lived npm token. This adds **OIDC trusted publishing** (compatible with npm 11.5.1+): mint a short-lived registry token from a CI OIDC id_token, so no stored secret is needed — the same mechanism utoo's own `pm-release.yml` uses via npm.

## Flow (`crates/pm/src/service/oidc.rs`)

1. Obtain a CI OIDC id_token with audience `npm:<registry-host>`:
   - **GitHub Actions**: `GET $ACTIONS_ID_TOKEN_REQUEST_URL&audience=…` with `Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN` → `{ value }`
   - **GitLab CI / CircleCI**: read the pre-supplied `$NPM_ID_TOKEN`
2. Exchange at `POST {registry}/-/npm/v1/oidc/token/exchange/package/{escapedName}` (`Authorization: Bearer <id_token>`) → `{ token }`
3. Use the minted token for the publish `PUT`.

`publish` tries OIDC first and **falls back to a configured token** (`NPM_TOKEN` / config) when not in an OIDC-capable CI or the exchange fails — existing token-based publishing is unchanged, and non-CI / dry-run paths are no-ops.

## Scope

- OIDC publish **auth** only. Provenance attestation (Sigstore/Fulcio) is a separate, larger feature and is **not** included.
- Single configured registry; mirrors npm's `escapedName` (`@scope/name` → `@scope%2fname`) and `audience` derivation (`npm:${new URL(registry).hostname}`, host only).

## Test plan

- Unit: `audience` (host-only, path/port dropped, unparsable→None), `escaped_name`.
- mockito integration (the protocol — the risky part):
  - id_token fetch: GET with `audience` query + `Bearer` request-token → `{value}`.
  - exchange: POST to `/-/npm/v1/oidc/token/exchange/package/@scope%2fpkg` with `Bearer id_token` → `{token}`.
  - exchange non-200 → error → caller falls back.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `typos` clean; full pm suite green.
- ⚠️ **Not** verifiable locally end-to-end: real OIDC needs a GitHub Actions run with `id-token: write` against a registry that has a trusted publisher configured for the package. Recommend validating in a CI dry-run before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)