### PR TITLE
fix(pm): keep cache on same device as node_modules to avoid copy fallback

### DIFF
--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -49,7 +49,9 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "macos")]
 use libc::clonefile;
 
-#[cfg(not(target_os = "macos"))]
+/// Hardlink-first directory clone with a copy fallback. Used directly on
+/// Linux/Windows, and on macOS as the fallback when `clonefile` can't run
+/// (non-APFS volume or cross-device).
 mod hardlink_clone {
     use std::collections::HashSet;
     use std::path::{Path, PathBuf};
@@ -164,8 +166,9 @@ mod hardlink_clone {
 
     /// Async wrapper around [`clone_dir_sync`] for the dir-clone tests. The
     /// production path calls `clone_dir_sync` directly (in a blocking pool via
-    /// the scheduler), so this wrapper is test-only.
-    #[cfg(test)]
+    /// the scheduler), so this wrapper is test-only. The tests that use it are
+    /// macOS-excluded, so gate it the same way to avoid a dead-code warning.
+    #[cfg(all(test, not(target_os = "macos")))]
     pub async fn clone_dir(src: &Path, dst: &Path) -> Result<()> {
         let src = src.to_path_buf();
         let dst = dst.to_path_buf();
@@ -230,9 +233,10 @@ fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
                 last_error = Some(err);
                 // ENOTSUP (non-APFS volume) and EXDEV (cross-device) are
                 // permanent: clonefile can never succeed here, so retrying only
-                // adds delay to every clone. Stop and surface the error.
+                // adds delay to every clone. Fall back to hardlink/copy, which
+                // hardlinks within a device and copies across one.
                 if raw == Some(libc::ENOTSUP) || raw == Some(libc::EXDEV) {
-                    break;
+                    return hardlink_clone::clone_dir_sync(real_src, dst);
                 }
             }
         }

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -230,6 +230,15 @@ fn hardlink_clone_retry(real_src: &Path, dst: &Path) -> Result<()> {
         match hardlink_clone::clone_dir_sync(real_src, dst) {
             Ok(()) => return Ok(()),
             Err(e) => {
+                // TEMP PROBE: is the concurrency-race retry still needed after
+                // #3093's lock-authoritative clone rework? Logged at error! so
+                // it surfaces in e2e/bench output. If this never fires across a
+                // full concurrent install, the retry is stale defensive code.
+                tracing::error!(
+                    "RETRY-PROBE hardlink_clone_retry: clone_dir_sync failed {} -> {}: {e:#}",
+                    real_src.display(),
+                    dst.display()
+                );
                 let _ = std::fs::remove_dir_all(dst);
                 last_error = Some(e);
             }

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -1,4 +1,7 @@
+use std::iter::once;
 use std::path::{Path, PathBuf};
+use std::thread::sleep;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
@@ -220,9 +223,9 @@ fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
 /// as the macOS fallback when `clonefile` can't run.
 fn hardlink_clone_retry(real_src: &Path, dst: &Path) -> Result<()> {
     let mut last_error = None;
-    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+    for delay in once(Duration::ZERO).chain(create_retry_strategy()) {
         if !delay.is_zero() {
-            std::thread::sleep(delay);
+            sleep(delay);
         }
         match hardlink_clone::clone_dir_sync(real_src, dst) {
             Ok(()) => return Ok(()),
@@ -247,9 +250,9 @@ fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
     let dst_c = CString::new(dst.as_os_str().as_bytes())?;
     let mut last_error = None;
 
-    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+    for delay in once(Duration::ZERO).chain(create_retry_strategy()) {
         if !delay.is_zero() {
-            std::thread::sleep(delay);
+            sleep(delay);
         }
 
         match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -213,51 +213,12 @@ fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
     None
 }
 
-#[cfg(target_os = "macos")]
-fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
-    let src_c = CString::new(real_src.as_os_str().as_bytes())?;
-    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
-    let mut last_error = None;
-
-    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
-        if !delay.is_zero() {
-            std::thread::sleep(delay);
-        }
-
-        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
-            0 => return Ok(()),
-            _ => {
-                let err = std::io::Error::last_os_error();
-                let _ = std::fs::remove_dir_all(dst);
-                let raw = err.raw_os_error();
-                last_error = Some(err);
-                // ENOTSUP (non-APFS volume) and EXDEV (cross-device) are
-                // permanent: clonefile can never succeed here, so retrying only
-                // adds delay to every clone. Fall back to hardlink/copy, which
-                // hardlinks within a device and copies across one.
-                if raw == Some(libc::ENOTSUP) || raw == Some(libc::EXDEV) {
-                    return hardlink_clone::clone_dir_sync(real_src, dst);
-                }
-            }
-        }
-    }
-
-    Err(anyhow::anyhow!(
-        "clonefile {} -> {}: {}",
-        real_src.display(),
-        dst.display(),
-        last_error
-            .map(|e| e.to_string())
-            .unwrap_or_else(|| "unknown error".to_string())
-    ))
-}
-
-#[cfg(not(target_os = "macos"))]
-fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
-    // Retry with backoff like the macOS arm: concurrent installs race on
-    // create_dir_all/remove_dir_all of shared parents and can hit transient
-    // EAGAIN/ENOENT during the hardlink walk. origin/next retried on all
-    // platforms; the sync rewrite must keep that for Linux/Windows too.
+/// Hardlink/copy clone with retry+backoff. Concurrent installs race on
+/// create_dir_all/remove_dir_all of shared parents and can hit transient
+/// EAGAIN/ENOENT during the hardlink walk, so a failed attempt is retried after
+/// clearing the partial destination. Used as the Linux/Windows clone path and
+/// as the macOS fallback when `clonefile` can't run.
+fn hardlink_clone_retry(real_src: &Path, dst: &Path) -> Result<()> {
     let mut last_error = None;
     for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
         if !delay.is_zero() {
@@ -278,6 +239,51 @@ fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
             real_src.display(),
             dst.display()
         )))
+}
+
+#[cfg(target_os = "macos")]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    let src_c = CString::new(real_src.as_os_str().as_bytes())?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
+    let mut last_error = None;
+
+    for delay in std::iter::once(std::time::Duration::ZERO).chain(create_retry_strategy()) {
+        if !delay.is_zero() {
+            std::thread::sleep(delay);
+        }
+
+        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
+            0 => return Ok(()),
+            _ => {
+                let err = std::io::Error::last_os_error();
+                let _ = std::fs::remove_dir_all(dst);
+                let raw = err.raw_os_error();
+                last_error = Some(err);
+                // ENOTSUP (non-APFS volume) and EXDEV (cross-device) are
+                // permanent: clonefile can never succeed here, so retrying it
+                // only adds delay. Fall back to the hardlink/copy path (which
+                // hardlinks within a device and copies across one), keeping the
+                // same retry-on-transient behavior as Linux/Windows.
+                if raw == Some(libc::ENOTSUP) || raw == Some(libc::EXDEV) {
+                    return hardlink_clone_retry(real_src, dst);
+                }
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "clonefile {} -> {}: {}",
+        real_src.display(),
+        dst.display(),
+        last_error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string())
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
+    hardlink_clone_retry(real_src, dst)
 }
 
 fn clone_sync(src: &Path, dst: &Path, layout: CacheLayout) -> Result<()> {

--- a/crates/pm/src/util/cloner.rs
+++ b/crates/pm/src/util/cloner.rs
@@ -1,14 +1,10 @@
-use std::iter::once;
 use std::path::{Path, PathBuf};
-use std::thread::sleep;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
 use utoo_ruborist::manifest::IdentityView;
 
 use super::downloader::is_git_url;
-use super::retry::create_retry_strategy;
 
 /// How a cached package's real contents are laid out under its cache dir.
 /// Derived from the resolved tarball URL so callers never pass a bare bool.
@@ -216,86 +212,39 @@ fn find_real_src_sync(src: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Hardlink/copy clone with retry+backoff. Concurrent installs race on
-/// create_dir_all/remove_dir_all of shared parents and can hit transient
-/// EAGAIN/ENOENT during the hardlink walk, so a failed attempt is retried after
-/// clearing the partial destination. Used as the Linux/Windows clone path and
-/// as the macOS fallback when `clonefile` can't run.
-fn hardlink_clone_retry(real_src: &Path, dst: &Path) -> Result<()> {
-    let mut last_error = None;
-    for delay in once(Duration::ZERO).chain(create_retry_strategy()) {
-        if !delay.is_zero() {
-            sleep(delay);
-        }
-        match hardlink_clone::clone_dir_sync(real_src, dst) {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                // TEMP PROBE: is the concurrency-race retry still needed after
-                // #3093's lock-authoritative clone rework? Logged at error! so
-                // it surfaces in e2e/bench output. If this never fires across a
-                // full concurrent install, the retry is stale defensive code.
-                tracing::error!(
-                    "RETRY-PROBE hardlink_clone_retry: clone_dir_sync failed {} -> {}: {e:#}",
-                    real_src.display(),
-                    dst.display()
-                );
-                let _ = std::fs::remove_dir_all(dst);
-                last_error = Some(e);
-            }
-        }
-    }
-    Err(last_error
-        .unwrap_or_else(|| anyhow::anyhow!("clone_dir failed without error"))
-        .context(format!(
-            "clone_dir {} -> {}",
-            real_src.display(),
-            dst.display()
-        )))
-}
-
 #[cfg(target_os = "macos")]
 fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
     let src_c = CString::new(real_src.as_os_str().as_bytes())?;
     let dst_c = CString::new(dst.as_os_str().as_bytes())?;
-    let mut last_error = None;
 
-    for delay in once(Duration::ZERO).chain(create_retry_strategy()) {
-        if !delay.is_zero() {
-            sleep(delay);
-        }
-
-        match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
-            0 => return Ok(()),
-            _ => {
-                let err = std::io::Error::last_os_error();
-                let _ = std::fs::remove_dir_all(dst);
-                let raw = err.raw_os_error();
-                last_error = Some(err);
-                // ENOTSUP (non-APFS volume) and EXDEV (cross-device) are
-                // permanent: clonefile can never succeed here, so retrying it
-                // only adds delay. Fall back to the hardlink/copy path (which
-                // hardlinks within a device and copies across one), keeping the
-                // same retry-on-transient behavior as Linux/Windows.
-                if raw == Some(libc::ENOTSUP) || raw == Some(libc::EXDEV) {
-                    return hardlink_clone_retry(real_src, dst);
+    match unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) } {
+        0 => Ok(()),
+        _ => {
+            let err = std::io::Error::last_os_error();
+            // ENOTSUP (non-APFS volume) / EXDEV (cross-device): clonefile can
+            // never succeed here, so fall back to the hardlink/copy path (which
+            // hardlinks within a device and copies across one). Any other error
+            // is a real failure and is propagated as-is, not swallowed or
+            // worked around by mutating the destination.
+            match err.raw_os_error() {
+                Some(libc::ENOTSUP) | Some(libc::EXDEV) => {
+                    hardlink_clone::clone_dir_sync(real_src, dst)
                 }
+                _ => Err(anyhow::anyhow!(
+                    "clonefile {} -> {}: {}",
+                    real_src.display(),
+                    dst.display(),
+                    err
+                )),
             }
         }
     }
-
-    Err(anyhow::anyhow!(
-        "clonefile {} -> {}: {}",
-        real_src.display(),
-        dst.display(),
-        last_error
-            .map(|e| e.to_string())
-            .unwrap_or_else(|| "unknown error".to_string())
-    ))
 }
 
 #[cfg(not(target_os = "macos"))]
 fn clone_dir_native_sync(real_src: &Path, dst: &Path) -> Result<()> {
-    hardlink_clone_retry(real_src, dst)
+    hardlink_clone::clone_dir_sync(real_src, dst)
+        .with_context(|| format!("clone_dir {} -> {}", real_src.display(), dst.display()))
 }
 
 fn clone_sync(src: &Path, dst: &Path, layout: CacheLayout) -> Result<()> {

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -270,14 +270,6 @@ fn nearest_device(path: &Path) -> Option<u64> {
     None
 }
 
-/// A project-local cache on the same device as `node_modules`. Lives under
-/// `node_modules` so it is gitignored by convention and stays on the project's
-/// filesystem.
-#[cfg(unix)]
-fn relocated_cache_dir(project: &Path) -> PathBuf {
-    project.join("node_modules/.cache/nm")
-}
-
 #[cfg(windows)]
 fn is_cross_device(cache: &Path, project: &Path) -> bool {
     use super::platform_const::drive_root;
@@ -287,16 +279,13 @@ fn is_cross_device(cache: &Path, project: &Path) -> bool {
     }
 }
 
-/// On Windows, hardlinks cannot cross drive boundaries (e.g. cache on C:,
-/// project on D:). Put the cache at the project drive's root so it stays on the
-/// same drive and is reusable across projects on that drive.
-#[cfg(windows)]
+/// A project-local cache on the same device/drive as `node_modules`. Lives under
+/// `node_modules` (rather than the project root) so it is gitignored by
+/// convention, doesn't pollute the working tree, and stays on the project's
+/// filesystem. Same target on every platform — on Windows `node_modules` is on
+/// the project's drive, so hardlinks still work.
 fn relocated_cache_dir(project: &Path) -> PathBuf {
-    project
-        .ancestors()
-        .last()
-        .unwrap_or(project)
-        .join(".cache/nm")
+    project.join("node_modules/.cache/nm")
 }
 
 pub fn get_cache_dir() -> PathBuf {

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -22,13 +22,19 @@ static LEGACY_PEER_DEPS: LazyLock<ConfigValue<bool>> =
     LazyLock::new(|| ConfigValue::new("legacy-peer-deps", true));
 
 static CACHE_DIR: LazyLock<ConfigValue<String>> = LazyLock::new(|| {
-    let default_cache = dirs::home_dir()
+    ConfigValue::new(
+        "cache-dir",
+        default_cache_dir().to_string_lossy().to_string(),
+    )
+});
+
+/// The built-in default cache location (`~/.cache/nm`), used when no
+/// `--cache-dir`/`UTOO_CACHE_DIR`/config value is set.
+fn default_cache_dir() -> PathBuf {
+    dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".cache/nm")
-        .to_string_lossy()
-        .to_string();
-    ConfigValue::new("cache-dir", default_cache)
-});
+}
 
 pub async fn init_registry(registry: Option<String>) {
     // Priority: CLI argument > UTOO_REGISTRY env > config > auto-select
@@ -157,8 +163,11 @@ pub fn get_manifests_concurrency_limit_sync() -> usize {
 }
 
 pub async fn set_cache_dir(cache_dir: Option<String>) {
-    // Priority: CLI argument > UTOO_CACHE_DIR env > config > default
-    let final_cache_dir = if let Some(dir) = cache_dir {
+    // Priority: CLI argument > UTOO_CACHE_DIR env > config > default.
+    // `Some` means the user picked the cache dir explicitly; `None` means we
+    // fall back to the built-in default. The distinction drives how a
+    // cross-device cache is handled (see `resolve_cache_dir`).
+    let explicit = if let Some(dir) = cache_dir {
         Some(dir)
     } else if let Ok(env_dir) = std::env::var("UTOO_CACHE_DIR")
         && !env_dir.is_empty()
@@ -172,22 +181,122 @@ pub async fn set_cache_dir(cache_dir: Option<String>) {
             .and_then(|config| config.get("cache-dir").ok().flatten())
     };
 
-    CACHE_DIR.set(final_cache_dir);
+    let resolved = match std::env::current_dir() {
+        Ok(project) => resolve_cache_dir(explicit, &project),
+        Err(_) => explicit,
+    };
+    CACHE_DIR.set(resolved);
+}
+
+/// Resolve the cache dir, accounting for the case where it lands on a different
+/// filesystem/drive than the project (where `node_modules` is created).
+/// Hardlink/clonefile cannot cross devices, so a cross-device cache forces the
+/// cloner to fall back to copying every file.
+///
+/// This only covers the common "one cache, one project volume" case — it picks
+/// a good cache location up front. It is *not* a substitute for the cloner's
+/// per-package cross-device detection: in a multi-volume layout (e.g. monorepo
+/// members on different mounts) some targets can still be cross-device with the
+/// resolved cache, and the cloner must keep falling back to copy per package.
+///
+/// - default cache on a different device → relocate to a project-local cache so
+///   linking keeps working (logged at INFO).
+/// - explicitly configured cache on a different device → keep the user's choice
+///   but WARN that installs will fall back to copying.
+///
+/// `explicit` is `Some` when the user set the cache dir, `None` for the default.
+/// Returning `None` keeps the lazy built-in default.
+fn resolve_cache_dir(explicit: Option<String>, project: &Path) -> Option<String> {
+    let effective = explicit
+        .clone()
+        .map(PathBuf::from)
+        .unwrap_or_else(default_cache_dir);
+
+    if !is_cross_device(&effective, project) {
+        return explicit;
+    }
+
+    if explicit.is_some() {
+        tracing::warn!(
+            "configured cache-dir {} is on a different filesystem than the project at {}; \
+             installs will fall back to copying files instead of hardlink/clone. Point \
+             cache-dir/UTOO_CACHE_DIR at a path on the same filesystem to avoid the copy.",
+            effective.display(),
+            project.display(),
+        );
+        return explicit;
+    }
+
+    let relocated = relocated_cache_dir(project);
+    tracing::info!(
+        "default cache dir {} is on a different filesystem than the project at {}; \
+         relocating cache to {} so packages can be hardlinked/cloned instead of copied. \
+         Set cache-dir/UTOO_CACHE_DIR to override.",
+        effective.display(),
+        project.display(),
+        relocated.display(),
+    );
+    Some(relocated.to_string_lossy().to_string())
+}
+
+/// Whether `cache` and `project` live on different filesystems, so links
+/// between them are impossible. Defaults to `false` (assume same device) when
+/// the device can't be determined, to avoid relocating on transient errors.
+#[cfg(unix)]
+fn is_cross_device(cache: &Path, project: &Path) -> bool {
+    match (nearest_device(cache), nearest_device(project)) {
+        (Some(a), Some(b)) => a != b,
+        _ => false,
+    }
+}
+
+/// `st_dev` of `path`, walking up to the nearest existing ancestor since the
+/// cache dir itself may not exist yet.
+#[cfg(unix)]
+fn nearest_device(path: &Path) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+    let mut current = Some(path);
+    while let Some(p) = current {
+        if let Ok(meta) = std::fs::metadata(p) {
+            return Some(meta.dev());
+        }
+        current = p.parent();
+    }
+    None
+}
+
+/// A project-local cache on the same device as `node_modules`. Lives under
+/// `node_modules` so it is gitignored by convention and stays on the project's
+/// filesystem.
+#[cfg(unix)]
+fn relocated_cache_dir(project: &Path) -> PathBuf {
+    project.join("node_modules/.cache/nm")
+}
+
+#[cfg(windows)]
+fn is_cross_device(cache: &Path, project: &Path) -> bool {
+    use super::platform_const::drive_root;
+    match (drive_root(cache), drive_root(project)) {
+        (Some(a), Some(b)) => a != b,
+        _ => false,
+    }
+}
+
+/// On Windows, hardlinks cannot cross drive boundaries (e.g. cache on C:,
+/// project on D:). Put the cache at the project drive's root so it stays on the
+/// same drive and is reusable across projects on that drive.
+#[cfg(windows)]
+fn relocated_cache_dir(project: &Path) -> PathBuf {
+    project
+        .ancestors()
+        .last()
+        .unwrap_or(project)
+        .join(".cache/nm")
 }
 
 pub fn get_cache_dir() -> PathBuf {
-    let cache = PathBuf::from(CACHE_DIR.get_sync());
-
-    // On Windows, hardlinks cannot cross drive boundaries (e.g. cache on C:, project on D:).
-    // Fall back to a cache dir on the project's drive.
-    #[cfg(windows)]
-    if let Ok(cwd) = std::env::current_dir()
-        && super::platform_const::drive_root(&cache) != super::platform_const::drive_root(&cwd)
-    {
-        return cwd.ancestors().last().unwrap_or(&cwd).join(".cache/nm");
-    }
-
-    cache
+    // Cross-device relocation is resolved once in `set_cache_dir`.
+    PathBuf::from(CACHE_DIR.get_sync())
 }
 
 // Package.json cache — keyed by directory path, covers root + workspace members.
@@ -386,5 +495,43 @@ cache-dir = "{}"
 
         assert_eq!(cache_dir, custom_path);
         Ok(())
+    }
+
+    // Two paths under the same temp dir share a device, so the resolver must
+    // treat them as same-device regardless of platform.
+    #[test]
+    fn test_resolve_cache_dir_same_device_passthrough() -> Result<()> {
+        let temp = TempDir::new()?;
+        let project = temp.path().join("project");
+        std::fs::create_dir_all(&project)?;
+        let cache = temp.path().join("cache").to_string_lossy().to_string();
+
+        // Explicit, same device → returned unchanged.
+        assert_eq!(
+            resolve_cache_dir(Some(cache.clone()), &project),
+            Some(cache)
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nearest_device_walks_to_existing_ancestor() -> Result<()> {
+        let temp = TempDir::new()?;
+        // A not-yet-created nested cache path resolves to its existing ancestor's device.
+        let missing = temp.path().join("a/b/c/nm");
+        assert_eq!(nearest_device(&missing), nearest_device(temp.path()));
+        assert!(!is_cross_device(&missing, temp.path()));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_relocated_cache_dir_is_project_local() {
+        let project = PathBuf::from("/work/repo");
+        assert_eq!(
+            relocated_cache_dir(&project),
+            PathBuf::from("/work/repo/node_modules/.cache/nm")
+        );
     }
 }

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -183,7 +183,12 @@ pub async fn set_cache_dir(cache_dir: Option<String>) {
 
     let resolved = match std::env::current_dir() {
         Ok(project) => resolve_cache_dir(explicit, &project),
-        Err(_) => explicit,
+        Err(e) => {
+            // Without the project dir we can't compare devices; skip relocation.
+            // Log it so a silent cross-device copy-mode install is diagnosable.
+            tracing::debug!("cannot resolve current dir for cache relocation: {e}");
+            explicit
+        }
     };
     CACHE_DIR.set(resolved);
 }

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -212,10 +212,11 @@ pub async fn set_cache_dir(cache_dir: Option<String>) {
 /// `explicit` is `Some` when the user set the cache dir, `None` for the default.
 /// Returning `None` keeps the lazy built-in default.
 fn resolve_cache_dir(explicit: Option<String>, project: &Path) -> Option<String> {
-    let effective = explicit
-        .clone()
-        .map(PathBuf::from)
-        .unwrap_or_else(default_cache_dir);
+    // Borrow to derive the effective path; `explicit` is still returned by value below.
+    let effective = match explicit.as_deref() {
+        Some(dir) => PathBuf::from(dir),
+        None => default_cache_dir(),
+    };
 
     if !is_cross_device(&effective, project) {
         return explicit;

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -302,6 +302,49 @@ if (!deps.abbrev || !deps.ini) {
 echo -e "${GREEN}PASS: stale lockfile detected + regenerated${NC}"
 cd ../../..
 
+# Case 8.7: cross-device cache handling (Linux only).
+# /dev/shm is tmpfs — a separate device from the workspace disk, writable
+# without sudo — so it forces a genuine cross-filesystem cache/node_modules
+# split (EXDEV). Covers both paths: an explicitly configured cross-device cache
+# must still install (copy fallback), and the default cache must relocate next
+# to node_modules so packages can be hardlinked.
+echo -e "${YELLOW}Case 8.7: cross-device cache (Linux tmpfs)${NC}"
+if [ "$(uname -s)" = "Linux" ] && [ -d /dev/shm ]; then
+  XDEV_SHM="/dev/shm/utoo-xdev-$$"
+  XDEV_DISK="$(mktemp -d)"
+  xdev_cleanup() { rm -rf "$XDEV_SHM" "$XDEV_DISK" 2>/dev/null || true; }
+
+  # 8.7a: explicit cross-device cache-dir (cache on tmpfs, project on disk) ->
+  # respected with a WARN, install falls back to copy and still succeeds.
+  mkdir -p "$XDEV_DISK/proj"
+  printf '{"name":"xdev-explicit","version":"1.0.0","dependencies":{"is-odd":"3.0.1"}}\n' \
+    > "$XDEV_DISK/proj/package.json"
+  ( cd "$XDEV_DISK/proj" && UTOO_CACHE_DIR="$XDEV_SHM/cache" utoo install ) \
+    || { echo -e "${RED}FAIL: explicit cross-device cache install failed${NC}"; xdev_cleanup; exit 1; }
+  [ -d "$XDEV_DISK/proj/node_modules/is-odd" ] \
+    || { echo -e "${RED}FAIL: is-odd missing (explicit xdev)${NC}"; xdev_cleanup; exit 1; }
+  [ -d "$XDEV_SHM/cache" ] \
+    || { echo -e "${RED}FAIL: explicit cache dir not used at $XDEV_SHM/cache${NC}"; xdev_cleanup; exit 1; }
+  echo -e "${GREEN}PASS: explicit cross-device cache copies, install OK${NC}"
+
+  # 8.7b: default cache (~/.cache/nm on disk) cross-device with a project on
+  # tmpfs -> cache is relocated under the project's node_modules so links work.
+  mkdir -p "$XDEV_SHM/proj"
+  printf '{"name":"xdev-default","version":"1.0.0","dependencies":{"is-odd":"3.0.1"}}\n' \
+    > "$XDEV_SHM/proj/package.json"
+  ( cd "$XDEV_SHM/proj" && env -u UTOO_CACHE_DIR utoo install ) \
+    || { echo -e "${RED}FAIL: default cross-device cache install failed${NC}"; xdev_cleanup; exit 1; }
+  [ -d "$XDEV_SHM/proj/node_modules/is-odd" ] \
+    || { echo -e "${RED}FAIL: is-odd missing (default xdev)${NC}"; xdev_cleanup; exit 1; }
+  [ -d "$XDEV_SHM/proj/node_modules/.cache/nm" ] \
+    || { echo -e "${RED}FAIL: default cache not relocated to project node_modules/.cache/nm${NC}"; xdev_cleanup; exit 1; }
+  echo -e "${GREEN}PASS: default cross-device cache relocated to project, install OK${NC}"
+
+  xdev_cleanup
+else
+  echo -e "${YELLOW}SKIP: cross-device cache case (non-Linux or no /dev/shm)${NC}"
+fi
+
 # Case 9: reinstall ant-design by npmjs.org
 echo -e "${YELLOW}Case 9: reinstall ant-design${NC} by npmjs.org"
 cd e2e/pm/ant-design/ant-design


### PR DESCRIPTION
## What

When the cache dir and the project's `node_modules` live on **different filesystems**, `hardlink`/`clonefile` can't cross the device boundary, so the cloner copies every file — no disk savings, just slower (the `WARN cross-device hardlink ... Invalid cross-device link (os error 18); falling back to copy` case).

## Changes

- **`set_cache_dir` (startup, common case):** when the **default** cache (`~/.cache/nm`) lands on a different device than the project, relocate it to a project-local cache (`node_modules/.cache/nm`) so links keep working (logged at **INFO**). An **explicitly** configured cross-device `cache-dir`/`UTOO_CACHE_DIR` is **respected** but **WARN**s that installs will copy. Generalizes the existing Windows-only drive-boundary relocation to Unix (`st_dev`) and unifies both platforms.
- **`cloner` (macOS, correctness):** `clonefile` `EXDEV`/`ENOTSUP` now falls back to hardlink/copy instead of erroring, so multi-volume layouts still install. Per-package cross-device detection stays — **no global latch** (a latch would wrongly force copy on same-device targets in a multi-volume layout).
- **e2e:** Case 8.7 forces a real cross-device split via `/dev/shm` (tmpfs, Linux only) and asserts both the **copy fallback** (explicit cache) and the **relocation** (default cache).

## Why not auto-pick a same-device cache globally

Matches bun/pnpm/npm: a single global cache maximizes cross-project reuse; fragmenting it per mount point breaks that and can't cover monorepo members spread across volumes. So: relocate only the *default* when cross-device, respect explicit config (warn), and keep the cloner's per-package copy fallback as the multi-volume safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)