### PR TITLE
fix(web): harden loader worker dependency loading

### DIFF
--- a/packages/utoo-web/src/webpackLoaders/loaderWorkerPool.ts
+++ b/packages/utoo-web/src/webpackLoaders/loaderWorkerPool.ts
@@ -4,7 +4,6 @@ import {
   registerWorkerScheduler,
   WebWorkerCreation,
   WebWorkerTermination,
-  workerCreated,
 } from "../utoo";
 import { createWorkerFromDataUri } from "../workers/inline";
 import { LoaderRunnerMeta } from "./types";
@@ -79,8 +78,6 @@ export const runLoaderWorkerPool = async (
       const workers =
         loaderWorkers[filename] || (loaderWorkers[filename] = new Map());
       workers.set(workerId, worker);
-
-      workerCreated(workerId);
     },
     (termination: WebWorkerTermination) => {
       const { workerId, options } = termination;


### PR DESCRIPTION
This pull request makes a minor cleanup to the `loaderWorkerPool.ts` file by removing the unused `workerCreated` import and its corresponding call. It should be called at https://github.com/utooland/next.js/blob/b78a0616eadc10bda9260873b73a7847bfb90102/turbopack/crates/turbopack-node/js/src/web_worker/evaluate.ts#L17, if called earlier, maybe cause loaders assets in `.turbopack/*` not found.