### PR TITLE
fix(pack): flush dev cache on shutdown

### DIFF
--- a/packages/pack/src/commands/dev.ts
+++ b/packages/pack/src/commands/dev.ts
@@ -349,8 +349,20 @@ async function runDev(
     printServerInfo(scheme, displayHost, serveOptsBase.port);
   }
 
-  const cleanup = () => {
-    hotReloader.close();
+  let cleanupStarted = false;
+  const cleanup = async () => {
+    if (cleanupStarted) {
+      return;
+    }
+    cleanupStarted = true;
+
+    try {
+      await hotReloader.close();
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    }
+
     // We always create HTTP/1.1 server (http or https), so closeAllConnections exists; Hono's
     // ServerType union includes HTTP/2, so TS does not narrow. Use runtime check to satisfy types.
     if (

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -84,7 +84,7 @@ export interface HotReloaderInterface {
   /** Handle a message from a client (JSON string). */
   handleClientMessage(ws: WSLike, data: string): void;
   buildFallbackError(): Promise<void>;
-  close(): void;
+  close(): Promise<void>;
 }
 
 export type ChangeSubscriptions = Map<
@@ -759,11 +759,14 @@ export async function createHotReloader(
       // Not implemented yet.
     },
 
-    close() {
+    async close() {
       closed = true;
-      void disposeBackgroundWatchSubscriptions();
-      closePromise ??= project
-        .onExit()
+      const disposePromise = disposeBackgroundWatchSubscriptions();
+      closePromise ??= (
+        bundleOptions.config.persistentCaching
+          ? project.shutdown()
+          : project.onExit()
+      )
         .catch((err) => {
           console.error(err);
         })
@@ -775,6 +778,8 @@ export async function createHotReloader(
         wsClient.close();
       }
       clients.clear();
+
+      await Promise.all([disposePromise, closePromise]);
     },
   };
 


### PR DESCRIPTION
## Summary

- await `HotReloader.close()` during dev server cleanup
- keep the default dev shutdown path aligned with `project.onExit()` when persistent caching is disabled
- use `project.shutdown()` only when `persistentCaching` is enabled, so filesystem cache can be fully persisted before process exit
- guard cleanup so repeated signals do not race the shutdown path

## Root cause

The dev server cleanup path called `hotReloader.close()` synchronously and then exited the process. `HotReloader.close()` triggered `project.onExit()` in the background, so `process.exit(0)` could run before Turbopack had a chance to finish the dev cleanup path. This made persistent dev cache look ineffective in the startup-with-cache benchmark.

`project.onExit()` alone matches the fast dev-exit behavior, but it is best-effort for filesystem cache persistence. When `persistentCaching` is enabled, this PR uses `project.shutdown()` to run `project_on_exit` and wait for turbo-tasks graceful shutdown, matching the binding's complete persistence semantics while limiting the extra shutdown cost to persistent-cache users.

## Validation

- `npm run build:cjs --workspace=@utoo/pack`
- `npm run build:esm --workspace=@utoo/pack`
- copied the patched `@utoo/pack` output into `build-tools-performance` and ran:
  - `CASE=react-1k TOOLS=utoo WARMUP_TIMES=0 RUN_TIMES=1 TURBO_ENGINE_IGNORE_DIRTY=1 pnpm benchmark`
  - `project.onExit()`-only variant: Startup with cache `3086ms` (still ineffective)
  - conditional `persistentCaching ? shutdown() : onExit()` variant: Startup with cache `1932ms`, then `1582ms` on rerun

Note: `TURBO_ENGINE_IGNORE_DIRTY=1` was used because dirty git worktrees disable the filesystem cache by default.