### PR TITLE
test(pack): cover svg css url loader handling

### DIFF
--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/config.json
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/config.json
@@ -1,0 +1,25 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "./input/index.js",
+        "name": "main"
+      }
+    ],
+    "module": {
+      "rules": {
+        "*.svg": {
+          "loaders": [
+            "test-file-loader"
+          ],
+          "as": "*.js"
+        }
+      }
+    },
+    "optimization": {
+      "minify": false,
+      "moduleIds": "named"
+    },
+    "sourceMaps": false
+  }
+}

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/input/bg.img.svg
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/input/bg.img.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" fill="#0f766e" />
+  <circle cx="60" cy="60" r="32" fill="#facc15" />
+</svg>

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/input/font.css
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/input/font.css
@@ -1,0 +1,15 @@
+@font-face {
+  font-family: 'UtooSvgFont';
+  src: url('./font.svg') format('svg');
+}
+
+.icon {
+  font-family: 'UtooSvgFont';
+}
+
+.backgroundImg {
+  background: url('./bg.img.svg');
+  background-repeat: no-repeat;
+  background-size: cover;
+  height: 120px;
+}

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/input/font.svg
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/input/font.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <font id="UtooSvgFont" horiz-adv-x="512">
+      <font-face font-family="UtooSvgFont" units-per-em="512" />
+      <glyph unicode="a" d="M0 0h512v512H0z" />
+    </font>
+  </defs>
+</svg>

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/input/index.js
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/input/index.js
@@ -1,0 +1,3 @@
+import './font.css';
+
+console.log('svg font url');

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/output/bg.img.461d9747.svg
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/output/bg.img.461d9747.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" fill="#0f766e" />
+  <circle cx="60" cy="60" r="32" fill="#facc15" />
+</svg>

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/output/font.b4e2fe96.svg
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/output/font.b4e2fe96.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <font id="UtooSvgFont" horiz-adv-x="512">
+      <font-face font-family="UtooSvgFont" units-per-em="512" />
+      <glyph unicode="a" d="M0 0h512v512H0z" />
+    </font>
+  </defs>
+</svg>

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/output/input_font_bfe74ff9.css
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/output/input_font_bfe74ff9.css
@@ -1,0 +1,14 @@
+/* [project]/style/url_svg_font/input/font.css [client] (css) */
+@font-face {
+  font-family: UtooSvgFont;
+  src: url("./font.b4e2fe96.svg") format("svg");
+}
+
+.icon {
+  font-family: UtooSvgFont;
+}
+
+.backgroundImg {
+  background: url("./bg.img.461d9747.svg") 0 0 / cover no-repeat;
+  height: 120px;
+}

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/output/input_index_f3db01c9.js
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/output/input_index_f3db01c9.js
@@ -1,0 +1,9 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/style/url_svg_font/input/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+;
+console.log('svg font url');
+__turbopack_context__.s([]);
+}),
+]);

--- a/crates/pack-tests/tests/snapshot/style/url_svg_font/output/main.js
+++ b/crates/pack-tests/tests/snapshot/style/url_svg_font/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_font_bfe74ff9.css","input_index_f3db01c9.js"],"runtimeModuleIds":["[project]/style/url_svg_font/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime


### PR DESCRIPTION
## Summary

- update the `next.js` submodule to the merged Turbopack fix from utooland/next.js#156 (`6670817a33b1765d14510eeebfb48769e48ac9b5`)
- add a pack snapshot covering CSS SVG URLs when a `*.svg` webpack loader rule with `as: "*.js"` is configured
- cover both `@font-face src: url('./font.svg')` and normal `background: url('./bg.img.svg')`
- verify CSS SVG URLs remain static asset URLs instead of being transformed by the SVG loader

## Related

- Turbopack fix: https://github.com/utooland/next.js/pull/156

## Tests

Run locally with `next.js` checked out at the merged `origin/utoo` commit `6670817a33b1765d14510eeebfb48769e48ac9b5`:

- `UPDATE=1 cargo test -p pack-tests url_svg_font -- --nocapture`
- `cargo test -p pack-tests url_svg_font -- --nocapture`

Earlier regression coverage also passed against the same fix:

- `cargo test -p pack-tests custom_loader -- --nocapture`
- `cargo test -p pack-tests module_type -- --nocapture`
- `cargo test -p pack-tests less -- --nocapture`
- `cargo test -p pack-tests global_css -- --nocapture`
- `git diff --check`