### PR TITLE
fix(pack): remove antd from default package imports

### DIFF
--- a/packages/pack/src/__test__/project.test.ts
+++ b/packages/pack/src/__test__/project.test.ts
@@ -11,7 +11,7 @@ describe("serializeConfig", () => {
     const serialized = JSON.parse(await serializeConfig(baseConfig, false));
 
     expect(serialized.optimization.packageImports).toContain("lodash-es");
-    expect(serialized.optimization.packageImports).toContain("antd");
+    expect(serialized.optimization.packageImports).not.toContain("antd");
     expect(serialized.optimization.packageImports).toContain("react-icons/fa");
     expect(serialized.optimization.packageImports).toContain(
       "@effect/platform-node",

--- a/packages/pack/src/core/project.ts
+++ b/packages/pack/src/core/project.ts
@@ -109,7 +109,6 @@ const DEFAULT_OPTIMIZE_PACKAGE_IMPORTS = [
   "date-fns",
   "lodash-es",
   "ramda",
-  "antd",
   "react-bootstrap",
   "ahooks",
   "@ant-design/icons",


### PR DESCRIPTION
## Summary

Remove `antd` from `DEFAULT_OPTIMIZE_PACKAGE_IMPORTS` in `@utoo/pack`.

antd has style side-effect import chains, especially in v4 less-based usage. Enabling package import optimization by default for `antd` can change the module graph enough that required component styles are no longer attached to the initial entry CSS in Umi/Bigfish applications.

Users can still opt into AntD package import optimization explicitly via `optimization.packageImports` when their application is compatible.

## Verification

```bash
vitest run packages/pack/src/__test__/project.test.ts
```

Passed: 3 tests.

Note: the test was run from a clean worktree using the existing local repo test dependencies and native binding.