### PR TITLE
fix(ci): disable setup-node package manager cache

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -110,6 +110,7 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: 22.14.0
+          package-manager-cache: false
       - name: Install
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}
@@ -141,6 +142,8 @@ jobs:
         run: utoo install
       - name: Setup node x86
         uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
       - name: Build in docker
         if: ${{ matrix.settings.docker }}
         run: |
@@ -182,6 +185,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.14.0
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
       - name: Setup Utoo
         uses: utooland/setup-utoo@v1

--- a/.github/workflows/pm-release.yml
+++ b/.github/workflows/pm-release.yml
@@ -201,6 +201,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.14.0
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
 
       - name: Bump npm CLI for OIDC trusted publisher
@@ -264,6 +265,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.14.0
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
 
       - name: Bump npm CLI for OIDC trusted publisher

--- a/.github/workflows/utooweb-release.yml
+++ b/.github/workflows/utooweb-release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.14.0
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What changed

- Disabled `actions/setup-node@v6` automatic package manager caching in release workflows.
- Covered `pack-release`, `pm-release`, and `utooweb-release`, which all use `setup-node@v6` on `origin/next`.

## Why

`package.json` declares `packageManager: "npm@11.6.2"`, but `package-lock.json` is intentionally ignored and not present in GitHub Actions checkouts. `setup-node@v6` enables npm caching automatically from that field, then fails during setup because no supported lockfile is present.

Failed job: https://github.com/utooland/utoo/actions/runs/27003743478/job/79691665753

The workflows install dependencies with `utoo install`, so the npm lockfile-based cache is not needed here.

## Validation

- Parsed the changed workflow YAML files with Ruby's YAML parser.
- Confirmed the diff only adds `package-manager-cache: false` to existing `setup-node@v6` steps.