### PR TITLE
fix(wasm): restore web dependency install

### DIFF
--- a/crates/ruborist/src/resolver/demand/driver.rs
+++ b/crates/ruborist/src/resolver/demand/driver.rs
@@ -491,20 +491,29 @@ async fn fetch_registry_manifest_inner<R: ManifestProvider>(
     }
 }
 
-/// Spawn a fetch job. Native runs it on the multi-threaded runtime so
-/// independent fetch + parse jobs progress in parallel; wasm has no threads, so
-/// it runs on the current local set.
+/// Create a fetch job. Native runs it on the multi-threaded runtime so
+/// independent fetch + parse jobs progress in parallel; wasm has no Tokio
+/// `LocalSet`, so it stays as a local future driven by `FuturesUnordered`.
 #[cfg(not(target_arch = "wasm32"))]
 fn fetch_registry_manifest<R: ManifestProvider>(registry: R, request: ManifestJob) -> FetchFuture
 where
     R::Error: Send,
 {
-    tokio::spawn(fetch_registry_manifest_inner(registry, request))
+    Box::pin(async move {
+        tokio::spawn(fetch_registry_manifest_inner(registry, request))
+            .await
+            .map_err(|error| {
+                if error.is_panic() {
+                    std::panic::resume_unwind(error.into_panic());
+                }
+                error.to_string()
+            })
+    })
 }
 
 #[cfg(target_arch = "wasm32")]
 fn fetch_registry_manifest<R: ManifestProvider>(registry: R, request: ManifestJob) -> FetchFuture {
-    tokio::task::spawn_local(fetch_registry_manifest_inner(registry, request))
+    Box::pin(async move { Ok(fetch_registry_manifest_inner(registry, request).await) })
 }
 
 /// Apply one completed fetch to the store: cache it, wake parked edges, and

--- a/crates/ruborist/src/resolver/demand/queue.rs
+++ b/crates/ruborist/src/resolver/demand/queue.rs
@@ -7,6 +7,8 @@
 //! and does not depend on it.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::model::manifest::CoreVersionManifest;
@@ -52,10 +54,11 @@ impl FetchDone {
     }
 }
 
-/// A spawned fetch job. On native it's a `tokio::spawn` task (multi-threaded
-/// runtime → fetch + parse for independent manifests run in parallel); on wasm
-/// it's a `spawn_local` task. Either way the driver awaits the `JoinHandle`.
-pub(crate) type FetchFuture = tokio::task::JoinHandle<FetchDone>;
+/// A fetch job owned by the demand driver. Native wraps a `tokio::spawn`
+/// handle so independent fetch + parse jobs progress on the multi-threaded
+/// runtime; wasm keeps the provider future local and lets `FuturesUnordered`
+/// poll browser-backed I/O without requiring a Tokio `LocalSet`.
+pub(crate) type FetchFuture = Pin<Box<dyn Future<Output = Result<FetchDone, String>>>>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum FetchPriority {


### PR DESCRIPTION
## Summary
- avoid `tokio::task::spawn_local` in the ruborist wasm resolver path by polling local fetch futures directly
- keep native resolver fetches on `tokio::spawn`, while preserving panic propagation for native `JoinError`s

## Verification
- cargo fmt
- cargo test -p utoo-ruborist
- cargo check -p utoo-wasm --target wasm32-unknown-unknown -Z build-std=panic_abort,std
- cargo clippy --all-targets -- -D warnings --no-deps
- ut build:local --workspace @utoo/web
- ut start --workspace utooweb-demo, cleared same-origin browser storage including OPFS (`opfsBefore: [utooweb-demo, stores]`, `opfsAfter: []`, usage 0), reloaded http://localhost:8081 from the empty OPFS state, and the initial install restored the Project controls with no console errors/panic/RuntimeError
- clicked Update in the browser to force `project.deps()` + `project.install()`; the UI returned from `Updating...` to `Update` with no console errors/panic/RuntimeError