### PR TITLE
fix(pm): publish prerelease binaries with npm tag

### DIFF
--- a/.github/workflows/pm-release.yml
+++ b/.github/workflows/pm-release.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/utoo/utoo
 
-      - name: Get version from release
+      - name: Get version and npm tag from release
         id: get_version
         run: |
           if [[ "$GITHUB_REF" == refs/tags/utoo-v* ]]; then
@@ -109,6 +109,17 @@ jobs:
             echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
             echo "Using version: $VERSION"
           fi
+
+          if [[ "$VERSION" == *"-"* ]]; then
+            PRERELEASE="${VERSION#*-}"
+            NPM_TAG="${PRERELEASE%%.*}"
+          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" == "true" ]]; then
+            NPM_TAG="beta"
+          else
+            NPM_TAG="latest"
+          fi
+          echo "NPM_TAG=$NPM_TAG" >> $GITHUB_OUTPUT
+          echo "Using npm tag: $NPM_TAG"
 
       - name: Update Cargo.toml version
         env:
@@ -183,6 +194,7 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
+          NPM_TAG: ${{ steps.get_version.outputs.NPM_TAG }}
         run: |
           cd vendor/scripts
 
@@ -196,7 +208,7 @@ jobs:
               BINARY_PATH="../../target/${{ matrix.target }}/release/${BIN}"
             fi
 
-            ./npm-binary.sh "$PACKAGE_NAME" "$VERSION" "$BINARY_PATH" "${{ matrix.platform_os }}" "${{ matrix.platform_cpu }}" --dry-run
+            ./npm-binary.sh "$PACKAGE_NAME" "$VERSION" "$BINARY_PATH" "${{ matrix.platform_os }}" "${{ matrix.platform_cpu }}" "$NPM_TAG" --dry-run
           done
 
       - name: Upload Release Asset
@@ -213,6 +225,7 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
+          NPM_TAG: ${{ steps.get_version.outputs.NPM_TAG }}
         run: |
           set -e
           cd vendor/scripts
@@ -227,7 +240,7 @@ jobs:
               BINARY_PATH="../../target/${{ matrix.target }}/release/${BIN}"
             fi
 
-            ./npm-binary.sh "$PACKAGE_NAME" "$VERSION" "$BINARY_PATH" "${{ matrix.platform_os }}" "${{ matrix.platform_cpu }}"
+            ./npm-binary.sh "$PACKAGE_NAME" "$VERSION" "$BINARY_PATH" "${{ matrix.platform_os }}" "${{ matrix.platform_cpu }}" "$NPM_TAG"
           done
 
   publish-main:
@@ -248,8 +261,14 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/utoo-v}"
             echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
-            # Determine npm tag based on GitHub Release prerelease flag
-            if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            # Derive the npm tag from the semver prerelease first; fall back to
+            # the GitHub Release prerelease flag for manually marked releases.
+            if [[ "$VERSION" == *"-"* ]]; then
+              PRERELEASE="${VERSION#*-}"
+              NPM_TAG="${PRERELEASE%%.*}"
+              echo "NPM_TAG=$NPM_TAG" >> $GITHUB_OUTPUT
+              echo "Version is prerelease, will publish to '$NPM_TAG' tag"
+            elif [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
               echo "NPM_TAG=beta" >> $GITHUB_OUTPUT
               echo "GitHub Release marked as prerelease, will publish to 'beta' tag"
             else

--- a/vendor/scripts/npm-binary.sh
+++ b/vendor/scripts/npm-binary.sh
@@ -3,8 +3,9 @@
 set -euo pipefail
 
 # args check
-if [ "$#" -lt 5 ] || [ "$#" -gt 6 ]; then
-    echo "Usage: $0 <package-name> <version> <binary-path> <os> <cpu> [--dry-run]"
+if [ "$#" -lt 5 ] || [ "$#" -gt 7 ]; then
+    echo "Usage: $0 <package-name> <version> <binary-path> <os> <cpu> [tag] [--dry-run]"
+    echo "  tag: npm dist-tag (default: latest, or prerelease identifier for prerelease versions)"
     exit 1
 fi
 
@@ -13,7 +14,33 @@ VERSION=$2
 BINARY=$3
 OS=$4
 CPU=$5
-DRY_RUN=${6:-""}
+NPM_TAG=""
+DRY_RUN=""
+
+default_npm_tag() {
+  local version=$1
+  if [[ "$version" == *"-"* ]]; then
+    local prerelease="${version#*-}"
+    echo "${prerelease%%.*}"
+  else
+    echo "latest"
+  fi
+}
+
+for ARG in "${@:6}"; do
+  if [ "$ARG" = "--dry-run" ]; then
+    DRY_RUN="--dry-run"
+  elif [ -z "$NPM_TAG" ]; then
+    NPM_TAG="$ARG"
+  else
+    echo "Unexpected argument: $ARG" >&2
+    exit 1
+  fi
+done
+
+if [ -z "$NPM_TAG" ]; then
+  NPM_TAG=$(default_npm_tag "$VERSION")
+fi
 
 # create temporary dir
 WORK_DIR=$(mktemp -d)
@@ -45,10 +72,11 @@ chmod +x "$PLATFORM_DIR/bin/$NAME"
 
 # do publish; pass --dry-run for verification without publishing
 cd "$PLATFORM_DIR"
+echo "Publishing @utoo/$NAME-$OS-$CPU@$VERSION with tag: $NPM_TAG"
 if [ "$DRY_RUN" = "--dry-run" ]; then
-  npm publish --provenance --access public --dry-run
+  npm publish --provenance --access public --tag "$NPM_TAG" --dry-run
 else
-  npm publish --provenance --access public
+  npm publish --provenance --access public --tag "$NPM_TAG"
 fi
 cat package.json
 

--- a/vendor/scripts/npm-utoo.sh
+++ b/vendor/scripts/npm-utoo.sh
@@ -6,12 +6,23 @@ set -euo pipefail
 if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
     echo "Usage: $0 <version> [tag]"
     echo "  version: npm package version (e.g., 1.0.0, 1.0.0-beta)"
-    echo "  tag: npm dist-tag (default: latest)"
+    echo "  tag: npm dist-tag (default: latest, or prerelease identifier for prerelease versions)"
     exit 1
 fi
 
 VERSION=$1
-NPM_TAG=${2:-latest}
+
+default_npm_tag() {
+  local version=$1
+  if [[ "$version" == *"-"* ]]; then
+    local prerelease="${version#*-}"
+    echo "${prerelease%%.*}"
+  else
+    echo "latest"
+  fi
+}
+
+NPM_TAG=${2:-$(default_npm_tag "$VERSION")}
 
 # create temp dir
 WORK_DIR=$(mktemp -d)

--- a/vendor/templates/binary.package.json.template
+++ b/vendor/templates/binary.package.json.template
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/utooland/utoo"
+    "url": "git+https://github.com/utooland/utoo.git"
   },
   "os": "{{os}}",
   "cpu": "{{cpu}}"

--- a/vendor/templates/utoo.package.json.template
+++ b/vendor/templates/utoo.package.json.template
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/utooland/utoo"
+    "url": "git+https://github.com/utooland/utoo.git"
   },
   "optionalDependencies": {
     "@utoo/utoo-linux-x64": "{{version}}",


### PR DESCRIPTION
## Summary

- derive an npm dist-tag for pm release binary jobs and pass it to both dry-run and publish
- make `npm-binary.sh` and `npm-utoo.sh` default prerelease versions such as `1.1.0-beta` to `--tag beta`
- normalize generated package `repository.url` values to `git+https://github.com/utooland/utoo.git` for npm trusted publishing/provenance checks

## Verification

- `bash -n vendor/scripts/npm-binary.sh`
- `bash -n vendor/scripts/npm-utoo.sh`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pm-release.yml"); puts "yaml ok"'`
- fake-npm script checks for prerelease binary/main publishes using `--tag beta` and stable binary publish using `--tag latest`

Fixes the release failure from https://github.com/utooland/utoo/actions/runs/27060953424.
