### PR TITLE
perf(pack): optimize transform setup

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -245,13 +245,18 @@ pub async fn get_client_module_options_context(
         SourceMapsType::None
     };
     let postcss_config_content = (*config.postcss_config_content().await?).clone();
-    let postcss_package_mapping = get_postcss_package_mapping().to_resolved().await?;
-    let postcss_transform_options = Some(PostCssTransformOptions {
-        postcss_package: Some(postcss_package_mapping),
-        config_location: PostCssConfigLocation::ProjectPathOrLocalPath,
-        config_content: postcss_config_content,
-        ..Default::default()
-    });
+    let postcss_package_mapping = if postcss_config_content.is_some() {
+        Some(get_postcss_package_mapping().to_resolved().await?)
+    } else {
+        None
+    };
+    let postcss_transform_options =
+        postcss_config_content.map(|postcss_config_content| PostCssTransformOptions {
+            postcss_package: postcss_package_mapping,
+            config_location: PostCssConfigLocation::ProjectPathOrLocalPath,
+            config_content: Some(postcss_config_content),
+            ..Default::default()
+        });
 
     let postcss_foreign_transform_options =
         postcss_transform_options
@@ -263,12 +268,12 @@ pub async fn get_client_module_options_context(
                 ..postcss_transform_options.clone()
             });
 
-    let postcss_import_map = postcss_import_map(*postcss_package_mapping);
+    let postcss_import_map = postcss_package_mapping.map(|mapping| postcss_import_map(*mapping));
     let create_inline_postcss_transform = |options: &PostCssTransformOptions| {
         PostCssTransform::new(
             node_evaluate_asset_context(
                 *execution_context,
-                Some(postcss_import_map),
+                postcss_import_map,
                 None,
                 Layer::new(rcstr!("webpack_loaders")),
                 cfg!(all(target_family = "wasm", target_os = "unknown")),

--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -203,13 +203,16 @@ pub async fn get_server_module_options_context(
     }
 
     let postcss_config_content = (*config.postcss_config_content().await?).clone();
-
-    let postcss_transform_options = Some(PostCssTransformOptions {
-        postcss_package: Some(get_postcss_package_mapping().to_resolved().await?),
-        config_location: PostCssConfigLocation::ProjectPathOrLocalPath,
-        config_content: postcss_config_content,
-        ..Default::default()
-    });
+    let postcss_transform_options = if let Some(postcss_config_content) = postcss_config_content {
+        Some(PostCssTransformOptions {
+            postcss_package: Some(get_postcss_package_mapping().to_resolved().await?),
+            config_location: PostCssConfigLocation::ProjectPathOrLocalPath,
+            config_content: Some(postcss_config_content),
+            ..Default::default()
+        })
+    } else {
+        None
+    };
 
     let postcss_foreign_transform_options =
         postcss_transform_options

--- a/crates/pack-core/src/shared/transforms/webpack_public_path.rs
+++ b/crates/pack-core/src/shared/transforms/webpack_public_path.rs
@@ -5,7 +5,7 @@ use swc_core::{
     common::SyntaxContext,
     ecma::{
         ast::*,
-        visit::{VisitMut, VisitMutWith},
+        visit::{Visit, VisitMut, VisitMutWith, VisitWith},
     },
 };
 use turbopack::module_options::ModuleRule;
@@ -31,8 +31,60 @@ impl CustomTransformer for WebpackPublicPathTransformer {
     #[tracing::instrument(level = "trace", name = "webpack_public_path", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         let unresolved_ctxt = SyntaxContext::empty().apply_mark(ctx.unresolved_mark);
+        let mut checker = WebpackPublicPathChecker {
+            unresolved_ctxt,
+            should_work: false,
+        };
+        program.visit_with(&mut checker);
+        if !checker.should_work {
+            return Ok(());
+        }
+
         program.visit_mut_with(&mut WebpackPublicPathVisitor { unresolved_ctxt });
         Ok(())
+    }
+}
+
+struct WebpackPublicPathChecker {
+    unresolved_ctxt: SyntaxContext,
+    should_work: bool,
+}
+
+impl WebpackPublicPathChecker {
+    fn is_webpack_public_path(&self, ident: &Ident) -> bool {
+        ident.sym == atom!("__webpack_public_path__") && ident.ctxt == self.unresolved_ctxt
+    }
+}
+
+impl Visit for WebpackPublicPathChecker {
+    fn visit_ident(&mut self, ident: &Ident) {
+        if self.is_webpack_public_path(ident) {
+            self.should_work = true;
+        }
+    }
+
+    fn visit_program(&mut self, program: &Program) {
+        if !self.should_work {
+            program.visit_children_with(self);
+        }
+    }
+
+    fn visit_module_item(&mut self, item: &ModuleItem) {
+        if !self.should_work {
+            item.visit_children_with(self);
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if !self.should_work {
+            stmt.visit_children_with(self);
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        if !self.should_work {
+            expr.visit_children_with(self);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR trims a couple of fixed setup costs in Utoopack's module option setup:

- Skip constructing PostCSS package mappings, import maps, and transform options when there is no inline `styles.postcss` config.
- Add a cheap pre-check before running the `__webpack_public_path__` mutating AST transform, so ordinary modules without that global return early.

## Impact

Projects that do not configure PostCSS avoid paying the PostCSS transform setup cost during client/server context construction. Projects that do use inline `styles.postcss` continue to take the existing path.

The webpack public path transform still runs for modules that reference unresolved `__webpack_public_path__`; modules that do not reference it avoid the mutating visitor.

## Validation

- `cargo fmt --check`
- `cargo check -p pack-core`
- `cargo test -p pack-tests --test snapshot test_tests__snapshot__public_path__runtime -- --exact`
- `cargo test -p pack-tests --test snapshot test_tests__snapshot__style__inline_css_postcss -- --exact`