### PR TITLE
fix(pack): enable default cli optimizations

### DIFF
--- a/packages/pack-cli/src/utils/common.ts
+++ b/packages/pack-cli/src/utils/common.ts
@@ -22,6 +22,33 @@ function resolveOptionalPath(
   return typeof value === "string" ? path.resolve(baseDir, value) : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function applyCliConfigDefaults(
+  config: Record<string, unknown>,
+  dev: unknown,
+): Record<string, unknown> {
+  const isProduction = config.mode !== "development" && dev !== true;
+  const optimization = isRecord(config.optimization) ? config.optimization : {};
+
+  return {
+    ...config,
+    persistentCaching: config.persistentCaching ?? true,
+    ...(isProduction
+      ? {
+          optimization: {
+            ...optimization,
+            concatenateModules: optimization.concatenateModules ?? true,
+            removeUnusedExports: optimization.removeUnusedExports ?? true,
+            removeUnusedImports: optimization.removeUnusedImports ?? true,
+          },
+        }
+      : {}),
+  };
+}
+
 export async function resolveFromConfigFile(
   configDir: string,
 ): Promise<Record<string, unknown>> {
@@ -95,7 +122,7 @@ export async function resolveBuildOptions(flags: {
     rootPath = rootPath || resolveOptionalPath(configDir, configRootPath);
 
     projectOptions = {
-      config,
+      config: applyCliConfigDefaults(config, dev),
       processEnv,
       watch,
       dev,

--- a/packages/pack-shared/src/webpackCompat.ts
+++ b/packages/pack-shared/src/webpackCompat.ts
@@ -150,18 +150,19 @@ export function compatOptionsFromWebpack(
   if (outputCompat && copy) {
     (outputCompat as any).copy = copy;
   }
+  const modeCompat = compatMode(mode);
 
   return {
     config: {
       entry: compatEntry(entry, html),
-      mode: compatMode(mode),
+      mode: modeCompat,
       module: compatModule(module),
       resolve: compatResolve(resolve),
       externals: compatExternals(externals, externalsType),
       output: outputCompat,
       target: compatTarget(target),
       sourceMaps: compatSourceMaps(devtool),
-      optimization: compatOptimization(optimization),
+      optimization: compatOptimization(optimization, modeCompat),
       define: compatFromWebpackPlugin(plugins, compatDefine),
       provider: compatFromWebpackPlugin(plugins, compatProvider),
       stats: compatStats(stats),
@@ -710,8 +711,18 @@ function compatSourceMaps(
 
 function compatOptimization(
   webpackOptimization: WebpackOptimization | undefined,
+  mode: ConfigComplete["mode"],
 ): ConfigComplete["optimization"] {
+  const productionDefault = mode === "production" ? true : undefined;
+
   if (!webpackOptimization) {
+    if (mode === "production") {
+      return {
+        concatenateModules: true,
+        removeUnusedExports: true,
+        removeUnusedImports: true,
+      };
+    }
     return;
   }
   const { moduleIds, minimize, concatenateModules, usedExports } =
@@ -727,10 +738,10 @@ function compatOptimization(
           : undefined,
     noMangling: webpackOptimization.mangleExports === false,
     minify: minimize,
-    concatenateModules,
+    concatenateModules: concatenateModules ?? productionDefault,
     treeShaking: false,
-    removeUnusedExports: enableWebpackUsedExports,
-    removeUnusedImports: enableWebpackUsedExports,
+    removeUnusedExports: enableWebpackUsedExports ?? productionDefault,
+    removeUnusedImports: enableWebpackUsedExports ?? productionDefault,
   };
 }
 

--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -45,7 +45,7 @@ async function buildInternal(
 
   const resolvedProjectPath = projectPath || process.cwd();
   const resolvedRootPath = rootPath || projectPath || process.cwd();
-  const persistentCaching = bundleOptions.config.persistentCaching ?? false;
+  const persistentCaching = bundleOptions.config.persistentCaching ?? true;
   const shouldCreateWebpackStats =
     Boolean(process.env.ANALYZE) || Boolean(bundleOptions.config.stats);
   processHtmlEntry(bundleOptions.config, resolvedProjectPath);

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -164,7 +164,7 @@ export async function createHotReloader(
   await cleanOutput(bundleOptions.config, resolvedProjectPath);
 
   const createProject = projectFactory();
-  const persistentCaching = bundleOptions.config.persistentCaching ?? false;
+  const persistentCaching = bundleOptions.config.persistentCaching ?? true;
   const persistentCacheLock = await acquirePersistentCacheLock(
     resolvedProjectPath,
     "utoo pack dev",


### PR DESCRIPTION
## Summary

- Enable persistent caching by default for utoopack build and dev while preserving explicit `persistentCaching: false`.
- Apply production CLI defaults for `concatenateModules`, `removeUnusedExports`, and `removeUnusedImports` without overriding explicit `false` values.
- Align the webpack compatibility path with the same production optimization defaults.

## Impact

Production utoopack CLI builds now get module concatenation and unused import/export pruning defaults, and both build/dev paths use the persistent Turbopack cache unless users opt out.

## Validation

- `npx tsc -p packages/pack-shared/tsconfig.json --noEmit`
- `npx tsc -p packages/pack-cli/tsconfig.json --noEmit`
- `npx tsc -p packages/pack/tsconfig.json --noEmit`
- `npx biome check packages/pack-shared/src/webpackCompat.ts packages/pack-cli/src/utils/common.ts packages/pack/src/commands/build.ts packages/pack/src/core/hmr.ts`
- pre-push hook Biome check