### PR TITLE
chore(web): update opfs-project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5700,9 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "opfs-project"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c6f83474d2f7ca98f9f419568db611e171775fc59a524f1fd64574a868737f"
+checksum = "19f4b0a6ec3fd978d540b890175c062731b7a72dc68a99770fcabb935205ad06"
 dependencies = [
  "anyhow",
  "bytes",

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -16,7 +16,7 @@ flate2                   = "1.1.5"
 futures                  = { workspace = true }
 js-sys                   = "0.3.83"
 oneshot                  = "0.1.11"
-opfs-project             = "0.2.8"
+opfs-project             = "0.2.9"
 petgraph                 = "0.6"
 reqwest                  = { version = "0.12.22", default-features = false, features = ["json"] }
 rustc-hash               = { workspace = true }


### PR DESCRIPTION
## Summary
- update `opfs-project` from `0.2.8` to `0.2.9` for `utoo-wasm`
- refresh `Cargo.lock` checksum for the new crates.io release

## Verification
- `CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang RUSTC=/Users/elr/.rustup/toolchains/nightly-2026-04-02-aarch64-apple-darwin/bin/rustc /Users/elr/.rustup/toolchains/nightly-2026-04-02-aarch64-apple-darwin/bin/cargo check -p utoo-wasm --target wasm32-unknown-unknown --lib`

Note: local pre-push hook failed only because `typos` is not installed on this machine; formatting/biome checks in the hook passed before that.