### PR TITLE
chore(web): update opfs-project to 0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5700,9 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "opfs-project"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f4b0a6ec3fd978d540b890175c062731b7a72dc68a99770fcabb935205ad06"
+checksum = "c4a2d62fde0aad91700c1724f6cfefb4ef30ea7150db82cbd383da8264c57324"
 dependencies = [
  "anyhow",
  "bytes",

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -16,7 +16,7 @@ flate2                   = "1.1.5"
 futures                  = { workspace = true }
 js-sys                   = "0.3.83"
 oneshot                  = "0.1.11"
-opfs-project             = "0.2.9"
+opfs-project             = "0.2.10"
 petgraph                 = "0.6"
 reqwest                  = { version = "0.12.22", default-features = false, features = ["json"] }
 rustc-hash               = { workspace = true }


### PR DESCRIPTION
## Summary
- Update utoo-wasm's opfs-project dependency to 0.2.10 for the ensure_tgz fix.
- Refresh Cargo.lock for opfs-project 0.2.10.

## Tests
- cargo fmt
- cargo clippy --all-targets -- -D warnings --no-deps