### PR TITLE
perf(pm): install hot-path pass + verdict-first bench CI

### DIFF
--- a/.github/actions/install-bench-tools/action.yml
+++ b/.github/actions/install-bench-tools/action.yml
@@ -12,7 +12,16 @@ runs:
     - name: Install bench tools (linux)
       if: inputs.platform == 'linux'
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y hyperfine time
+      # Pinned hyperfine .deb straight from GitHub releases: skips the slow,
+      # occasionally flaky `apt-get update`, and pins the JSON schema the
+      # comment renderer parses. GNU time still comes from apt (tiny, and
+      # `apt-get install` without `update` resolves from the baked index).
+      run: |
+        curl -fsSL --retry 3 -o /tmp/hyperfine.deb \
+          https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine_1.19.0_amd64.deb
+        sudo dpkg -i /tmp/hyperfine.deb
+        /usr/bin/time --version >/dev/null 2>&1 || sudo apt-get install -y time \
+          || { sudo apt-get update && sudo apt-get install -y time; }
     - name: Install bench tools (mac)
       if: inputs.platform == 'mac'
       shell: bash

--- a/.github/actions/post-bench-phases-comment/action.yml
+++ b/.github/actions/post-bench-phases-comment/action.yml
@@ -8,6 +8,10 @@ inputs:
   os:
     description: Runner OS string (ubuntu-latest / macos-latest) — shown in the comment title
     required: true
+  project:
+    description: Project the bench ran against (matches the bench script's PROJECT env)
+    required: false
+    default: ant-design
   github-token:
     description: GitHub token for `gh` CLI lookups + sticky-comment posting
     required: true
@@ -17,6 +21,8 @@ runs:
   steps:
     - name: Build PR comment body
       shell: bash
+      env:
+        PROJECT: ${{ inputs.project }}
       run: bash .github/scripts/render-bench-phases-comment.sh ${{ inputs.platform }} ${{ inputs.os }}
     - name: Find Current PR
       id: findPr

--- a/.github/scripts/render-bench-phases-comment.mjs
+++ b/.github/scripts/render-bench-phases-comment.mjs
@@ -26,9 +26,10 @@ const PHASES = [
   ["p3_cold_install", "p3 · cold install"],
   ["p4_warm_link", "p4 · warm link"],
 ];
-const PM_ORDER = ["utoo", "utoo-next", "utoo-npm", "bun"];
+const PM_ORDER = ["utoo", "utoo-alt", "utoo-next", "utoo-npm", "bun"];
 const PM_LABEL = {
   utoo: "utoo (PR)",
+  "utoo-alt": "utoo-alt (PR + alt env)",
   "utoo-next": "utoo-next (baseline)",
   "utoo-npm": "utoo-npm (published)",
   bun: "bun",

--- a/.github/scripts/render-bench-phases-comment.mjs
+++ b/.github/scripts/render-bench-phases-comment.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+// Render the pm-bench-phases sticky PR comment from the raw per-cell JSON
+// exported by bench/pm-bench-phases.sh (BENCH_OUT_DIR/results-<registry>/),
+// instead of awk-scraping fixed-width log tables.
+//
+// The headline is the verdict: utoo (PR build) vs utoo-next (baseline) per
+// phase, with a significance gate so registry weather doesn't read as a
+// regression. Raw numbers stay available below; resources fold into
+// <details>.
+//
+// Usage: render-bench-phases-comment.mjs <platform> <os>
+// Env:   PROJECT (default ant-design), OUT_DIR (default /tmp/pm-bench-output),
+//        GITHUB_SHA / GITHUB_REPOSITORY / GITHUB_SERVER_URL / GITHUB_RUN_ID,
+//        GITHUB_STEP_SUMMARY (appended when set).
+
+import fs from "node:fs";
+import path from "node:path";
+
+const [platform = "linux", os = "ubuntu-latest"] = process.argv.slice(2);
+const PROJECT = process.env.PROJECT || "ant-design";
+const OUT_DIR = process.env.OUT_DIR || "/tmp/pm-bench-output";
+
+const PHASES = [
+  ["p0_full_cold", "p0 · full cold install"],
+  ["p1_resolve", "p1 · resolve"],
+  ["p3_cold_install", "p3 · cold install"],
+  ["p4_warm_link", "p4 · warm link"],
+];
+const PM_ORDER = ["utoo", "utoo-next", "utoo-npm", "bun"];
+const PM_LABEL = {
+  utoo: "utoo (PR)",
+  "utoo-next": "utoo-next (baseline)",
+  "utoo-npm": "utoo-npm (published)",
+  bun: "bun",
+};
+
+// Relative delta below this is never flagged, whatever the sigmas say.
+const FLAG_THRESHOLD = 0.05;
+
+const parseKey = (file, suffix) => {
+  const base = file.slice(0, -suffix.length);
+  for (const [phase] of PHASES) {
+    const idx = base.indexOf(`_${phase}_`);
+    if (idx === -1) continue;
+    return { phase, pm: base.slice(idx + phase.length + 2) };
+  }
+  return null;
+};
+
+const readJson = (p) => {
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+};
+
+// registry label -> phase -> pm -> cell
+const registries = new Map();
+const cell = (reg, phase, pm) => {
+  if (!registries.has(reg)) registries.set(reg, {});
+  const phases = registries.get(reg);
+  return ((phases[phase] ??= {})[pm] ??= {});
+};
+
+const resultDirs = fs.existsSync(OUT_DIR)
+  ? fs
+      .readdirSync(OUT_DIR)
+      .filter((d) => d.startsWith("results-"))
+      .map((d) => ({ reg: d.slice("results-".length), dir: path.join(OUT_DIR, d) }))
+  : [];
+
+for (const { reg, dir } of resultDirs) {
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.startsWith(`${PROJECT}_`)) continue;
+    const full = path.join(dir, f);
+    if (f.endsWith("_failed.json")) {
+      const key = parseKey(f, "_failed.json");
+      if (key) cell(reg, key.phase, key.pm).failed = readJson(full)?.failed || "failed";
+    } else if (f.endsWith("_metrics.jsonl")) {
+      const key = parseKey(f, "_metrics.jsonl");
+      if (!key) continue;
+      const rows = fs
+        .readFileSync(full, "utf8")
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => {
+          try {
+            return JSON.parse(l);
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean);
+      if (!rows.length) continue;
+      const avg = {};
+      for (const k of Object.keys(rows[0])) {
+        avg[k] = rows.reduce((s, r) => s + Number(r[k] || 0), 0) / rows.length;
+      }
+      cell(reg, key.phase, key.pm).metrics = avg;
+    } else if (f.endsWith("_footprint.json")) {
+      const key = parseKey(f, "_footprint.json");
+      if (key) cell(reg, key.phase, key.pm).footprint = readJson(full);
+    } else if (f.endsWith(".json")) {
+      const key = parseKey(f, ".json");
+      if (!key) continue;
+      const r = readJson(full)?.results?.[0];
+      if (!r) continue;
+      cell(reg, key.phase, key.pm).timing = {
+        mean: r.mean,
+        stddev: r.stddev ?? 0,
+        min: r.min,
+        max: r.max,
+        runs: r.times?.length ?? 0,
+      };
+    }
+  }
+}
+
+const fmtS = (s) => (s >= 10 ? s.toFixed(1) : s.toFixed(2)) + "s";
+const fmtB = (b) =>
+  b >= 1 << 30
+    ? (b / (1 << 30)).toFixed(2) + "G"
+    : b >= 1 << 20
+      ? (b / (1 << 20)).toFixed(0) + "M"
+      : b >= 1 << 10
+        ? (b / (1 << 10)).toFixed(0) + "K"
+        : Math.round(b) + "B";
+const fmtPct = (d) => (d > 0 ? "+" : "") + (d * 100).toFixed(1) + "%";
+
+// Welch-style 2-sigma gate on the difference of means; with 3-7 runs this is
+// a coarse filter, which is exactly the point — only flag what the sample
+// can actually support.
+function compare(utoo, next) {
+  if (!utoo?.timing || !next?.timing) return null;
+  const a = utoo.timing;
+  const b = next.timing;
+  if (!b.mean) return null;
+  const delta = (a.mean - b.mean) / b.mean;
+  const se = Math.sqrt(
+    (a.stddev * a.stddev) / Math.max(a.runs, 1) + (b.stddev * b.stddev) / Math.max(b.runs, 1),
+  );
+  const significant = Math.abs(delta) > FLAG_THRESHOLD && Math.abs(a.mean - b.mean) > 2 * se;
+  const verdict = !significant ? "✅" : delta < 0 ? "🚀" : "⚠️";
+  return { delta, significant, verdict };
+}
+
+const sha = (process.env.GITHUB_SHA || "").slice(0, 7);
+const runUrl = `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${process.env.GITHUB_REPOSITORY || ""}/actions/runs/${process.env.GITHUB_RUN_ID || ""}`;
+
+const lines = [];
+lines.push(`## 📊 pm-bench-phases · \`${sha}\` · ${platform} (\`${os}\`)`);
+lines.push("");
+lines.push(`[Workflow run](${runUrl}) — ${PROJECT}`);
+lines.push("");
+
+if (!resultDirs.length) {
+  lines.push("_No bench results captured (bench aborted before export?). See the workflow log._");
+} else {
+  for (const { reg } of resultDirs) {
+    const phases = registries.get(reg) || {};
+
+    // Headline: utoo vs utoo-next per phase.
+    const verdicts = [];
+    for (const [phase, label] of PHASES) {
+      const pms = phases[phase];
+      if (!pms) continue;
+      const cmp = compare(pms["utoo"], pms["utoo-next"]);
+      if (cmp) verdicts.push(`${cmp.verdict} ${label.split(" · ")[0]} ${fmtPct(cmp.delta)}`);
+    }
+    lines.push(`### ${reg}`);
+    lines.push("");
+    if (verdicts.length) {
+      lines.push(`**utoo (PR) vs utoo-next (baseline):** ${verdicts.join(" · ")}`);
+      lines.push("");
+      lines.push(
+        "_✅ within noise · 🚀 faster · ⚠️ slower (|Δ| > 5% and beyond 2σ of the run spread)_",
+      );
+      lines.push("");
+    }
+
+    for (const [phase, label] of PHASES) {
+      const pms = phases[phase];
+      if (!pms) continue;
+      const present = PM_ORDER.filter((pm) => pms[pm]);
+      if (!present.length) continue;
+
+      lines.push(`#### ${label}`);
+      lines.push("");
+      lines.push("| PM | wall (mean ± σ) | min | user | sys | RSS | Δ vs baseline |");
+      lines.push("|---|---|---|---|---|---|---|");
+      for (const pm of present) {
+        const c = pms[pm];
+        if (c.failed) {
+          lines.push(`| ${PM_LABEL[pm] ?? pm} | — ${c.failed} failed | | | | | |`);
+          continue;
+        }
+        const t = c.timing;
+        const m = c.metrics || {};
+        const cmp = pm === "utoo-next" ? null : compare(c, pms["utoo-next"]);
+        lines.push(
+          `| ${PM_LABEL[pm] ?? pm} | ${t ? `${fmtS(t.mean)} ± ${fmtS(t.stddev)}` : "—"} | ${t ? fmtS(t.min) : "—"} | ${m.user_s != null ? fmtS(m.user_s) : "—"} | ${m.sys_s != null ? fmtS(m.sys_s) : "—"} | ${m.rss ? fmtB(m.rss) : "—"} | ${cmp ? `${fmtPct(cmp.delta)} ${cmp.verdict}` : "—"} |`,
+        );
+      }
+      lines.push("");
+    }
+
+    // Resources fold.
+    lines.push("<details><summary>Resources & footprint</summary>");
+    lines.push("");
+    for (const [phase, label] of PHASES) {
+      const pms = phases[phase];
+      if (!pms) continue;
+      const present = PM_ORDER.filter((pm) => pms[pm] && !pms[pm].failed);
+      if (!present.length) continue;
+      lines.push(`**${label}**`);
+      lines.push("");
+      lines.push("| PM | vCtx | iCtx | netRX | netTX | cache | node_modules | lock |");
+      lines.push("|---|---|---|---|---|---|---|---|");
+      for (const pm of present) {
+        const m = pms[pm].metrics || {};
+        const fp = pms[pm].footprint || {};
+        lines.push(
+          `| ${pm} | ${Math.round(m.vol_ctx || 0)} | ${Math.round(m.invol_ctx || 0)} | ${fmtB(m.net_rx || 0)} | ${fmtB(m.net_tx || 0)} | ${fmtB(fp.cache || 0)} | ${fmtB(fp.node_modules || 0)} | ${fmtB(fp.lockfile || 0)} |`,
+        );
+      }
+      lines.push("");
+    }
+    lines.push("</details>");
+    lines.push("");
+  }
+}
+
+const body = lines.join("\n");
+fs.mkdirSync(OUT_DIR, { recursive: true });
+fs.writeFileSync(path.join(OUT_DIR, "pr_comment.md"), body);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, body + "\n");
+}
+console.log(body);

--- a/.github/scripts/render-bench-phases-comment.sh
+++ b/.github/scripts/render-bench-phases-comment.sh
@@ -29,6 +29,14 @@ OUT=/tmp/pm-bench-output/pr_comment.md
 SHA="${GITHUB_SHA:0:7}"
 RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
+# Preferred path: the bench script exported raw per-cell JSON
+# (results-<registry>/ dirs). The node renderer computes Δ% vs utoo-next
+# with significance flags instead of scraping fixed-width log text. The awk
+# path below stays as a fallback for runs that died before the export step.
+if compgen -G "/tmp/pm-bench-output/results-*" > /dev/null; then
+  exec node "$(dirname "$0")/render-bench-phases-comment.mjs" "$PLATFORM" "$OS"
+fi
+
 mkdir -p /tmp/pm-bench-output
 {
   echo "## 📊 pm-bench-phases · \`$SHA\` · ${PLATFORM} (\`${OS}\`)"

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -526,7 +526,11 @@ jobs:
       - uses: ./.github/actions/install-bench-tools
         with:
           platform: linux
-      - uses: ./.github/actions/install-utoo-npm-baseline
+      # utoo-npm (last published release) only changes on releases — bench it
+      # on manual dispatch only; label-triggered PR runs compare against
+      # utoo-next, which is the signal that can actually change per PR.
+      - if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/install-utoo-npm-baseline
       # The utoo-next binary is built upstream by build-linux's
       # "Build next branch utoo (bench baseline)" step. Just download.
       - name: Download utoo-next binary
@@ -544,7 +548,7 @@ jobs:
         run: |
           hyperfine --version
           utoo --version
-          "$UTOO_NPM_BIN" --version
+          if [ -n "${UTOO_NPM_BIN:-}" ]; then "$UTOO_NPM_BIN" --version; fi
           "$UTOO_NEXT_BIN" --version
           bun --version
       - name: Define cache wipe function
@@ -565,7 +569,11 @@ jobs:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
-          PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
+          # p1/p4 cells finish in seconds — extra runs there sharpen the
+          # significance gate of the PR comment at negligible cost.
+          BENCH_RUNS_CHEAP: '5'
+          BENCH_OUT_DIR: '/tmp/pm-bench-output'
+          PM_LIST: ${{ github.event_name == 'workflow_dispatch' && 'utoo,utoo-next,utoo-npm,bun' || 'utoo,utoo-next,bun' }}
         run: |
           chmod +x bench/pm-bench-phases.sh
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmjs.log
@@ -585,6 +593,8 @@ jobs:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS_CHEAP: '5'
+          BENCH_OUT_DIR: '/tmp/pm-bench-output'
           PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
         run: |
           mkdir -p /tmp/pm-bench-output
@@ -601,6 +611,7 @@ jobs:
         with:
           platform: linux
           os: ubuntu-latest
+          project: ${{ github.event.inputs.project || 'ant-design' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   bench-phases-mac:
@@ -654,6 +665,8 @@ jobs:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS_CHEAP: '5'
+          BENCH_OUT_DIR: '/tmp/pm-bench-output'
           PM_LIST: 'utoo,utoo-npm,bun'
         run: |
           chmod +x bench/pm-bench-phases.sh
@@ -670,6 +683,8 @@ jobs:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
+          BENCH_RUNS_CHEAP: '5'
+          BENCH_OUT_DIR: '/tmp/pm-bench-output'
           PM_LIST: 'utoo,utoo-npm,bun'
         run: |
           mkdir -p /tmp/pm-bench-output
@@ -686,6 +701,7 @@ jobs:
         with:
           platform: mac
           os: macos-latest
+          project: ${{ github.event.inputs.project || 'ant-design' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # ============================================================

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -75,6 +75,11 @@ on:
         required: false
         default: '3'
         type: string
+      utoo_alt_env:
+        description: '[phases] Extra env for a second utoo variant (ablation A/B), e.g. "UTOO_TARBALL_HTTP=h2" or "UTOO_CLONE_CONCURRENCY=8"'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -557,7 +562,7 @@ jobs:
           #!/usr/bin/env bash
           rm -rf /tmp/pm-bench /tmp/pm-bench-results /tmp/pm-bench-output \
                  /tmp/utoo-bench-cache /tmp/utoo-npm-bench-cache \
-                 /tmp/utoo-next-bench-cache /tmp/bun-bench-cache \
+                 /tmp/utoo-next-bench-cache /tmp/utoo-alt-bench-cache /tmp/bun-bench-cache \
                  ~/.bun/install/cache ~/.cache/nm 2>/dev/null || true
           mkdir -p /tmp/pm-bench-output
           WIPE
@@ -572,6 +577,7 @@ jobs:
           # p1/p4 cells finish in seconds — extra runs there sharpen the
           # significance gate of the PR comment at negligible cost.
           BENCH_RUNS_CHEAP: '5'
+          UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
           BENCH_OUT_DIR: '/tmp/pm-bench-output'
           PM_LIST: ${{ github.event_name == 'workflow_dispatch' && 'utoo,utoo-next,utoo-npm,bun' || 'utoo,utoo-next,bun' }}
         run: |
@@ -594,6 +600,7 @@ jobs:
           REGISTRY: 'https://registry.npmmirror.com'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
           BENCH_RUNS_CHEAP: '5'
+          UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
           BENCH_OUT_DIR: '/tmp/pm-bench-output'
           PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
         run: |
@@ -653,7 +660,7 @@ jobs:
           cat > /tmp/wipe-bench-state.sh <<'WIPE'
           #!/usr/bin/env bash
           rm -rf /tmp/pm-bench /tmp/pm-bench-results /tmp/pm-bench-output \
-                 /tmp/utoo-bench-cache /tmp/utoo-npm-bench-cache /tmp/bun-bench-cache \
+                 /tmp/utoo-bench-cache /tmp/utoo-npm-bench-cache /tmp/utoo-alt-bench-cache /tmp/bun-bench-cache \
                  ~/.bun/install/cache ~/.cache/nm 2>/dev/null || true
           mkdir -p /tmp/pm-bench-output
           WIPE
@@ -666,6 +673,7 @@ jobs:
           REGISTRY: 'https://registry.npmjs.org'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
           BENCH_RUNS_CHEAP: '5'
+          UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
           BENCH_OUT_DIR: '/tmp/pm-bench-output'
           PM_LIST: 'utoo,utoo-npm,bun'
         run: |
@@ -684,6 +692,7 @@ jobs:
           REGISTRY: 'https://registry.npmmirror.com'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
           BENCH_RUNS_CHEAP: '5'
+          UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
           BENCH_OUT_DIR: '/tmp/pm-bench-output'
           PM_LIST: 'utoo,utoo-npm,bun'
         run: |

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -80,6 +80,22 @@ on:
         required: false
         default: ''
         type: string
+      phases:
+        description: '[phases] Comma-separated phase filter (p0,p1,p3,p4) - ablations can run just the relevant phases'
+        required: false
+        default: 'p0,p1,p3,p4'
+        type: string
+      phases_pm_list:
+        description: '[phases] PMs to bench - an utoo vs utoo-alt ablation only needs "utoo"'
+        required: false
+        default: 'utoo,utoo-next,utoo-npm,bun'
+        type: string
+      phases_registry:
+        description: '[phases] Registry leg(s) to run'
+        required: false
+        default: 'both'
+        type: choice
+        options: [both, npmjs, npmmirror]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -570,6 +586,7 @@ jobs:
       - name: Wipe bench state before npmjs
         run: bash /tmp/wipe-bench-state.sh
       - name: Run phase-isolated benchmark · npmjs
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.phases_registry != 'npmmirror'
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
@@ -578,15 +595,16 @@ jobs:
           # significance gate of the PR comment at negligible cost.
           BENCH_RUNS_CHEAP: '5'
           UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
+          PHASES: ${{ github.event.inputs.phases || 'p0,p1,p3,p4' }}
           BENCH_OUT_DIR: '/tmp/pm-bench-output'
-          PM_LIST: ${{ github.event_name == 'workflow_dispatch' && 'utoo,utoo-next,utoo-npm,bun' || 'utoo,utoo-next,bun' }}
+          PM_LIST: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.phases_pm_list || 'utoo,utoo-next,utoo-npm,bun') || 'utoo,utoo-next,bun' }}
         run: |
           chmod +x bench/pm-bench-phases.sh
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmjs.log
       # npmmirror only runs on manual dispatch — label-triggered runs stick to
       # the npmjs leg to keep PR feedback loops short.
       - name: Stash npmjs logs and wipe state before npmmirror
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.phases_registry != 'npmjs'
         run: |
           mkdir -p /tmp/bench-logs-stash
           cp -r /tmp/pm-bench-output/. /tmp/bench-logs-stash/ 2>/dev/null || true
@@ -594,15 +612,16 @@ jobs:
           mkdir -p /tmp/pm-bench-output
           cp -r /tmp/bench-logs-stash/. /tmp/pm-bench-output/ 2>/dev/null || true
       - name: Run phase-isolated benchmark · npmmirror
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.phases_registry != 'npmjs'
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
           BENCH_RUNS_CHEAP: '5'
           UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
+          PHASES: ${{ github.event.inputs.phases || 'p0,p1,p3,p4' }}
           BENCH_OUT_DIR: '/tmp/pm-bench-output'
-          PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
+          PM_LIST: ${{ github.event.inputs.phases_pm_list || 'utoo,utoo-next,utoo-npm,bun' }}
         run: |
           mkdir -p /tmp/pm-bench-output
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmmirror.log
@@ -668,18 +687,21 @@ jobs:
       - name: Wipe bench state before npmjs
         run: bash /tmp/wipe-bench-state.sh
       - name: Run phase-isolated benchmark · npmjs
+        if: github.event.inputs.phases_registry != 'npmmirror'
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
           BENCH_RUNS_CHEAP: '5'
           UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
+          PHASES: ${{ github.event.inputs.phases || 'p0,p1,p3,p4' }}
           BENCH_OUT_DIR: '/tmp/pm-bench-output'
-          PM_LIST: 'utoo,utoo-npm,bun'
+          PM_LIST: ${{ github.event.inputs.phases_pm_list || 'utoo,utoo-npm,bun' }}
         run: |
           chmod +x bench/pm-bench-phases.sh
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmjs.log
       - name: Stash npmjs logs and wipe state before npmmirror
+        if: github.event.inputs.phases_registry != 'npmjs'
         run: |
           mkdir -p /tmp/bench-logs-stash
           cp -r /tmp/pm-bench-output/. /tmp/bench-logs-stash/ 2>/dev/null || true
@@ -687,14 +709,16 @@ jobs:
           mkdir -p /tmp/pm-bench-output
           cp -r /tmp/bench-logs-stash/. /tmp/pm-bench-output/ 2>/dev/null || true
       - name: Run phase-isolated benchmark · npmmirror
+        if: github.event.inputs.phases_registry != 'npmjs'
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
           BENCH_RUNS_CHEAP: '5'
           UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
+          PHASES: ${{ github.event.inputs.phases || 'p0,p1,p3,p4' }}
           BENCH_OUT_DIR: '/tmp/pm-bench-output'
-          PM_LIST: 'utoo,utoo-npm,bun'
+          PM_LIST: ${{ github.event.inputs.phases_pm_list || 'utoo,utoo-npm,bun' }}
         run: |
           mkdir -p /tmp/pm-bench-output
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmmirror.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11381,6 +11381,7 @@ dependencies = [
  "indicatif",
  "libc",
  "libdeflater",
+ "mimalloc",
  "mockito",
  "once_cell",
  "open",

--- a/bench/pm-bench-phases.sh
+++ b/bench/pm-bench-phases.sh
@@ -10,6 +10,15 @@ RUNS=${BENCH_RUNS:-3}
 # Cheap phases (p1 resolve / p4 warm link) finish in seconds; more runs there
 # buys statistical power exactly where it's affordable.
 RUNS_CHEAP=${BENCH_RUNS_CHEAP:-$RUNS}
+# Ablation variant: `utoo-alt` runs the SAME utoo binary with the extra env
+# from UTOO_ALT_ENV (e.g. "UTOO_TARBALL_HTTP=h2" or
+# "UTOO_CLONE_CONCURRENCY=8") and its own cache dir. Benching utoo vs
+# utoo-alt on one runner isolates a single knob from network/runner weather
+# — the way to validate protocol/concurrency choices instead of trusting
+# cross-run deltas. Auto-appended to PM_LIST when UTOO_ALT_ENV is set.
+if [ -n "${UTOO_ALT_ENV:-}" ] && [[ ",${PM_LIST:-}," != *",utoo-alt,"* ]]; then
+  PM_LIST="${PM_LIST:+$PM_LIST,}utoo-alt"
+fi
 IFS=',' read -ra PACKAGE_MANAGERS <<< "${PM_LIST:-utoo,bun}"
 
 BENCH_DIR=${BENCH_DIR:-/tmp/pm-bench}
@@ -22,6 +31,7 @@ mkdir -p "$BENCH_DIR" "$RESULTS_DIR"
 UTOO_CACHE="${UTOO_CACHE:-/tmp/utoo-bench-cache}"
 UTOO_NPM_CACHE="${UTOO_NPM_CACHE:-/tmp/utoo-npm-bench-cache}"
 UTOO_NEXT_CACHE="${UTOO_NEXT_CACHE:-/tmp/utoo-next-bench-cache}"
+UTOO_ALT_CACHE="${UTOO_ALT_CACHE:-/tmp/utoo-alt-bench-cache}"
 BUN_CACHE="${BUN_CACHE:-/tmp/bun-bench-cache}"
 export BUN_INSTALL_CACHE_DIR="$BUN_CACHE"
 
@@ -41,6 +51,12 @@ for pm in "${PACKAGE_MANAGERS[@]}"; do
     utoo-next)
       if [ -z "${UTOO_NEXT_BIN:-}" ]; then
         echo "skip utoo-next: UTOO_NEXT_BIN not set" >&2
+        continue
+      fi
+      ;;
+    utoo-alt)
+      if [ -z "${UTOO_ALT_ENV:-}" ]; then
+        echo "skip utoo-alt: UTOO_ALT_ENV not set" >&2
         continue
       fi
       ;;
@@ -152,6 +168,7 @@ capture_footprint() {
     utoo)      cache=$UTOO_CACHE ;;
     utoo-npm)  cache=$UTOO_NPM_CACHE ;;
     utoo-next) cache=$UTOO_NEXT_CACHE ;;
+    utoo-alt)  cache=$UTOO_ALT_CACHE ;;
     bun)       cache=$BUN_CACHE ;;
   esac
   printf '{"cache":%d,"node_modules":%d,"lockfile":%d}\n' \
@@ -179,6 +196,7 @@ write_prepare() {
     utoo)      cache=$UTOO_CACHE ;;
     utoo-npm)  cache=$UTOO_NPM_CACHE ;;
     utoo-next) cache=$UTOO_NEXT_CACHE ;;
+    utoo-alt)  cache=$UTOO_ALT_CACHE ;;
     bun)       cache=$BUN_CACHE ;;
   esac
 
@@ -201,7 +219,7 @@ EOF
       # Phase 0: full cold install — nothing reused. Lockfile + all caches wiped.
       cat >> "$path" <<EOF
 rm -f package-lock.json bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_CACHE" "$UTOO_NPM_CACHE" "$UTOO_NEXT_CACHE" "$BUN_CACHE"
+rm -rf "$UTOO_CACHE" "$UTOO_NPM_CACHE" "$UTOO_NEXT_CACHE" "$UTOO_ALT_CACHE" "$BUN_CACHE"
 echo "[prep] phase 0 $pm: full cold (lockfile + caches + node_modules wiped)"
 EOF
       ;;
@@ -209,37 +227,25 @@ EOF
       # Phase 1: cold resolve — wipe lockfiles AND caches so nothing can be reused.
       cat >> "$path" <<EOF
 rm -f package-lock.json bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_CACHE" "$UTOO_NPM_CACHE" "$UTOO_NEXT_CACHE" "$BUN_CACHE"
+rm -rf "$UTOO_CACHE" "$UTOO_NPM_CACHE" "$UTOO_NEXT_CACHE" "$UTOO_ALT_CACHE" "$BUN_CACHE"
 echo "[prep] phase 1 $pm: cleaned lockfiles + caches + node_modules"
 EOF
       ;;
     p3_*)
-      # Phase 3: cold install — keep THIS pm's lockfile, wipe THIS pm's cache.
-      # Delete the other pm's lockfile so bun doesn't try to migrate utoo's
-      # package-lock.json (and vice versa).
+      # Phase 3: cold install — keep THIS pm's lockfile, wipe THIS pm's cache
+      # (the $cache resolved above). Delete the other pm's lockfile so bun
+      # doesn't try to migrate utoo's package-lock.json (and vice versa).
       case "$pm" in
-        utoo) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_CACHE"
-echo "[prep] phase 3 utoo: kept package-lock.json, wiped $UTOO_CACHE"
-EOF
-          ;;
-        utoo-npm) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_NPM_CACHE"
-echo "[prep] phase 3 utoo-npm: kept package-lock.json, wiped $UTOO_NPM_CACHE"
-EOF
-          ;;
-        utoo-next) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_NEXT_CACHE"
-echo "[prep] phase 3 utoo-next: kept package-lock.json, wiped $UTOO_NEXT_CACHE"
-EOF
-          ;;
         bun) cat >> "$path" <<EOF
 rm -f package-lock.json yarn.lock pnpm-lock.yaml
 rm -rf "$BUN_CACHE"
 echo "[prep] phase 3 bun: kept bun.lock, wiped $BUN_CACHE"
+EOF
+          ;;
+        *) cat >> "$path" <<EOF
+rm -f bun.lock yarn.lock pnpm-lock.yaml
+rm -rf "$cache"
+echo "[prep] phase 3 $pm: kept package-lock.json, wiped $cache"
 EOF
           ;;
       esac
@@ -247,24 +253,14 @@ EOF
     p4_*)
       # Phase 4: warm link — keep lockfile AND cache, only drop node_modules.
       case "$pm" in
-        utoo) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-echo "[prep] phase 4 utoo: kept package-lock.json + cache"
-EOF
-          ;;
-        utoo-npm) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-echo "[prep] phase 4 utoo-npm: kept package-lock.json + cache"
-EOF
-          ;;
-        utoo-next) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-echo "[prep] phase 4 utoo-next: kept package-lock.json + cache"
-EOF
-          ;;
         bun) cat >> "$path" <<EOF
 rm -f package-lock.json yarn.lock pnpm-lock.yaml
 echo "[prep] phase 4 bun: kept bun.lock + cache"
+EOF
+          ;;
+        *) cat >> "$path" <<EOF
+rm -f bun.lock yarn.lock pnpm-lock.yaml
+echo "[prep] phase 4 $pm: kept package-lock.json + cache"
 EOF
           ;;
       esac
@@ -293,6 +289,7 @@ seed_lockfile_cmd() {
     utoo)      echo "utoo deps --registry=$REGISTRY --cache-dir=$UTOO_CACHE" ;;
     utoo-npm)  echo "$UTOO_NPM_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NPM_CACHE" ;;
     utoo-next) echo "$UTOO_NEXT_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE" ;;
+    utoo-alt)  echo "env $UTOO_ALT_ENV utoo deps --registry=$REGISTRY --cache-dir=$UTOO_ALT_CACHE" ;;
   esac
 }
 
@@ -301,7 +298,7 @@ seed_for_phase() {
   local seed_log="$RESULTS_DIR/seed_${phase}_${pm}.log"
   cd "$PROJECT_DIR"
   case "$phase:$pm" in
-    p3_*:utoo|p4_*:utoo|p3_*:utoo-npm|p4_*:utoo-npm|p3_*:utoo-next|p4_*:utoo-next)
+    p3_*:utoo|p4_*:utoo|p3_*:utoo-npm|p4_*:utoo-npm|p3_*:utoo-next|p4_*:utoo-next|p3_*:utoo-alt|p4_*:utoo-alt)
       if [ ! -f package-lock.json ]; then
         echo -e "  ${CYAN}seed: generating package-lock.json (baseline-pinned when available)${NC}"
         retry 3 bash -c "$(seed_lockfile_cmd "$pm") >> '$seed_log' 2>&1" || return 1
@@ -322,6 +319,7 @@ seed_for_phase() {
       utoo)      cache=$UTOO_CACHE ;;
       utoo-npm)  cache=$UTOO_NPM_CACHE ;;
       utoo-next) cache=$UTOO_NEXT_CACHE ;;
+      utoo-alt)  cache=$UTOO_ALT_CACHE ;;
       bun)       cache=$BUN_CACHE ;;
     esac
     if [ ! -d "$cache" ] || [ -z "$(ls -A "$cache" 2>/dev/null)" ]; then
@@ -338,6 +336,7 @@ install_cmd() {
     utoo)      echo "utoo install --ignore-scripts --registry=$REGISTRY --cache-dir=$UTOO_CACHE" ;;
     utoo-npm)  echo "$UTOO_NPM_BIN install --ignore-scripts --registry=$REGISTRY --cache-dir=$UTOO_NPM_CACHE" ;;
     utoo-next) echo "$UTOO_NEXT_BIN install --ignore-scripts --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE" ;;
+    utoo-alt)  echo "env $UTOO_ALT_ENV utoo install --ignore-scripts --registry=$REGISTRY --cache-dir=$UTOO_ALT_CACHE" ;;
     bun)       echo "bun install --ignore-scripts --registry=$REGISTRY" ;;
   esac
 }
@@ -347,6 +346,7 @@ resolve_cmd() {
     utoo)      echo "utoo deps --registry=$REGISTRY --cache-dir=$UTOO_CACHE" ;;
     utoo-npm)  echo "$UTOO_NPM_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NPM_CACHE" ;;
     utoo-next) echo "$UTOO_NEXT_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE" ;;
+    utoo-alt)  echo "env $UTOO_ALT_ENV utoo deps --registry=$REGISTRY --cache-dir=$UTOO_ALT_CACHE" ;;
     bun)       echo "bun install --lockfile-only --registry=$REGISTRY" ;;
   esac
 }

--- a/bench/pm-bench-phases.sh
+++ b/bench/pm-bench-phases.sh
@@ -7,6 +7,9 @@ set -eo pipefail
 PROJECT=${PROJECT:-ant-design}
 REGISTRY=${REGISTRY:-https://registry.npmjs.org}
 RUNS=${BENCH_RUNS:-3}
+# Cheap phases (p1 resolve / p4 warm link) finish in seconds; more runs there
+# buys statistical power exactly where it's affordable.
+RUNS_CHEAP=${BENCH_RUNS_CHEAP:-$RUNS}
 IFS=',' read -ra PACKAGE_MANAGERS <<< "${PM_LIST:-utoo,bun}"
 
 BENCH_DIR=${BENCH_DIR:-/tmp/pm-bench}
@@ -53,6 +56,20 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 banner() { echo -e "${YELLOW}=== $* ===${NC}"; }
+
+# Retry a command a few times with a short pause — registry/network hiccups
+# during the (untimed) seed installs were the dominant CI flake mode, and a
+# single blip used to abort the whole bench via `set -e`.
+retry() {
+  local attempts=$1 i
+  shift
+  for ((i = 1; i <= attempts; i++)); do
+    "$@" && return 0
+    echo -e "  ${RED}attempt $i/$attempts failed:${NC} $*" >&2
+    [ "$i" -lt "$attempts" ] && sleep 5
+  done
+  return 1
+}
 
 # --- metrics wrapper ---
 # Keeps the hot path fast: only /usr/bin/time + counter snapshots inside the
@@ -148,7 +165,7 @@ capture_footprint() {
 banner "Preparing $PROJECT"
 cd "$BENCH_DIR"
 if [ ! -d "$PROJECT" ]; then
-  git clone --depth=1 "https://github.com/ant-design/${PROJECT}.git" "$PROJECT"
+  retry 3 git clone --depth=1 "https://github.com/ant-design/${PROJECT}.git" "$PROJECT"
 fi
 PROJECT_DIR="$BENCH_DIR/$PROJECT"
 
@@ -258,34 +275,43 @@ EOF
 }
 
 # Seed PM-specific state before a phase runs (lockfile + cache where needed).
-# This runs ONCE before hyperfine starts, not per-iteration.
+# This runs ONCE before hyperfine starts, not per-iteration. Returns non-zero
+# on terminal seed failure so run_phase can skip just that (phase, pm) cell
+# instead of aborting the whole bench.
+#
+# Lockfile provenance: all utoo variants install from one package-lock.json.
+# Generate it with the *baseline* binary (utoo-next) when wired up, so a PR
+# that changes resolution/lockfile shape can never perturb the input the
+# baseline is measured against — p3/p4 compare install speed on equal input.
+seed_lockfile_cmd() {
+  local pm=$1
+  if [ -n "${UTOO_NEXT_BIN:-}" ]; then
+    echo "$UTOO_NEXT_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE"
+    return
+  fi
+  case "$pm" in
+    utoo)      echo "utoo deps --registry=$REGISTRY --cache-dir=$UTOO_CACHE" ;;
+    utoo-npm)  echo "$UTOO_NPM_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NPM_CACHE" ;;
+    utoo-next) echo "$UTOO_NEXT_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE" ;;
+  esac
+}
+
 seed_for_phase() {
   local phase=$1 pm=$2
+  local seed_log="$RESULTS_DIR/seed_${phase}_${pm}.log"
   cd "$PROJECT_DIR"
   case "$phase:$pm" in
-    p3_*:utoo|p4_*:utoo)
+    p3_*:utoo|p4_*:utoo|p3_*:utoo-npm|p4_*:utoo-npm|p3_*:utoo-next|p4_*:utoo-next)
       if [ ! -f package-lock.json ]; then
-        echo -e "  ${CYAN}seed: running \`utoo deps\` to generate package-lock.json${NC}"
-        utoo deps --registry="$REGISTRY" --cache-dir="$UTOO_CACHE" > "$RESULTS_DIR/seed_${phase}_${pm}.log" 2>&1
-      fi
-      ;;
-    p3_*:utoo-npm|p4_*:utoo-npm)
-      if [ ! -f package-lock.json ]; then
-        echo -e "  ${CYAN}seed: running \`utoo-npm deps\` to generate package-lock.json${NC}"
-        "$UTOO_NPM_BIN" deps --registry="$REGISTRY" --cache-dir="$UTOO_NPM_CACHE" > "$RESULTS_DIR/seed_${phase}_${pm}.log" 2>&1
-      fi
-      ;;
-    p3_*:utoo-next|p4_*:utoo-next)
-      if [ ! -f package-lock.json ]; then
-        echo -e "  ${CYAN}seed: running \`utoo-next deps\` to generate package-lock.json${NC}"
-        "$UTOO_NEXT_BIN" deps --registry="$REGISTRY" --cache-dir="$UTOO_NEXT_CACHE" > "$RESULTS_DIR/seed_${phase}_${pm}.log" 2>&1
+        echo -e "  ${CYAN}seed: generating package-lock.json (baseline-pinned when available)${NC}"
+        retry 3 bash -c "$(seed_lockfile_cmd "$pm") >> '$seed_log' 2>&1" || return 1
       fi
       ;;
     p3_*:bun|p4_*:bun)
       if [ ! -f bun.lock ]; then
         echo -e "  ${CYAN}seed: running \`bun install --lockfile-only\` to generate bun.lock${NC}"
         rm -f package-lock.json
-        bun install --lockfile-only --registry="$REGISTRY" > "$RESULTS_DIR/seed_${phase}_${pm}.log" 2>&1
+        retry 3 bash -c "bun install --lockfile-only --registry='$REGISTRY' >> '$seed_log' 2>&1" || return 1
       fi
       ;;
   esac
@@ -301,12 +327,7 @@ seed_for_phase() {
     if [ ! -d "$cache" ] || [ -z "$(ls -A "$cache" 2>/dev/null)" ]; then
       echo -e "  ${CYAN}seed: warming $pm cache via full install${NC}"
       rm -rf node_modules
-      case "$pm" in
-        utoo)      utoo install --ignore-scripts --registry="$REGISTRY" --cache-dir="$UTOO_CACHE" > "$RESULTS_DIR/seed_warmup_${pm}.log" 2>&1 ;;
-        utoo-npm)  "$UTOO_NPM_BIN" install --ignore-scripts --registry="$REGISTRY" --cache-dir="$UTOO_NPM_CACHE" > "$RESULTS_DIR/seed_warmup_${pm}.log" 2>&1 ;;
-        utoo-next) "$UTOO_NEXT_BIN" install --ignore-scripts --registry="$REGISTRY" --cache-dir="$UTOO_NEXT_CACHE" > "$RESULTS_DIR/seed_warmup_${pm}.log" 2>&1 ;;
-        bun)       bun  install --ignore-scripts --registry="$REGISTRY" > "$RESULTS_DIR/seed_warmup_${pm}.log" 2>&1 ;;
-      esac
+      retry 3 bash -c "$(install_cmd "$pm") >> '$RESULTS_DIR/seed_warmup_${pm}.log' 2>&1" || return 1
       rm -rf node_modules
     fi
   fi
@@ -337,7 +358,17 @@ run_phase() {
   local prep_script="$RESULTS_DIR/prep_${phase}_${pm}.sh"
   local cmd_script="$RESULTS_DIR/cmd_${phase}_${pm}.sh"
 
-  seed_for_phase "$phase" "$pm"
+  # Cheap phases get more runs (see RUNS_CHEAP).
+  local runs=$RUNS
+  case "$phase" in
+    p1_* | p4_*) runs=$RUNS_CHEAP ;;
+  esac
+
+  if ! seed_for_phase "$phase" "$pm"; then
+    echo -e "  ${RED}$pm $phase seed failed after retries — skipping this cell${NC}"
+    printf '{"failed":"seed"}\n' > "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_failed.json"
+    return 0
+  fi
   write_prepare "$prep_script" "$phase" "$pm"
 
   # Reset metrics file; wrap the bench command so /usr/bin/time can measure it.
@@ -498,5 +529,16 @@ RESULTS_DIR="$RESULTS_DIR" node -e "
     }
   }
 "
+
+# Export raw per-cell results (hyperfine JSON, metrics, footprint, failure
+# markers) for the CI comment renderer — keyed by registry host so multi-leg
+# runs (npmjs + npmmirror) don't clobber each other across state wipes.
+if [ -n "${BENCH_OUT_DIR:-}" ]; then
+  REG_LABEL=$(echo "$REGISTRY" | sed -E 's|^https?://||; s|/.*$||')
+  EXPORT_DIR="$BENCH_OUT_DIR/results-$REG_LABEL"
+  mkdir -p "$EXPORT_DIR"
+  cp "$RESULTS_DIR/$PROJECT"_* "$EXPORT_DIR/" 2>/dev/null || true
+  echo -e "${GREEN}Exported raw results to $EXPORT_DIR${NC}"
+fi
 
 echo -e "${GREEN}Done. Raw results in $RESULTS_DIR${NC}"

--- a/bench/pm-bench-phases.sh
+++ b/bench/pm-bench-phases.sh
@@ -402,31 +402,45 @@ run_phase() {
   capture_footprint "$phase" "$pm" "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_footprint.json"
 }
 
+# Optional phase filter: PHASES="p3,p4" runs only those phases — ablation
+# runs targeting one subsystem (e.g. clone concurrency) don't need the full
+# matrix. Default runs everything.
+PHASES=${PHASES:-p0,p1,p3,p4}
+phase_enabled() { [[ ",$PHASES," == *",$1,"* ]]; }
+
 # === PHASE 0: full cold install (clean slate + full install) ===
 # Matches the end-to-end user scenario: no lockfile, no cache, no node_modules.
 # Directly comparable to `bun install` / `utoo install` on a freshly cloned repo.
-banner "Phase 0 · full cold install (lockfile + cache + node_modules all wiped)"
-for pm in "${PACKAGE_MANAGERS[@]}"; do
-  run_phase "p0_full_cold" "$pm" "$(install_cmd "$pm")"
-done
+if phase_enabled p0; then
+  banner "Phase 0 · full cold install (lockfile + cache + node_modules all wiped)"
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    run_phase "p0_full_cold" "$pm" "$(install_cmd "$pm")"
+  done
+fi
 
 # === PHASE 1: resolve only (clean slate) ===
-banner "Phase 1 · resolve (lockfile only, cold cache)"
-for pm in "${PACKAGE_MANAGERS[@]}"; do
-  run_phase "p1_resolve" "$pm" "$(resolve_cmd "$pm")"
-done
+if phase_enabled p1; then
+  banner "Phase 1 · resolve (lockfile only, cold cache)"
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    run_phase "p1_resolve" "$pm" "$(resolve_cmd "$pm")"
+  done
+fi
 
 # === PHASE 3: cold install (lockfile exists, cache empty) ===
-banner "Phase 3 · cold install (lockfile present, empty cache, empty node_modules)"
-for pm in "${PACKAGE_MANAGERS[@]}"; do
-  run_phase "p3_cold_install" "$pm" "$(install_cmd "$pm")"
-done
+if phase_enabled p3; then
+  banner "Phase 3 · cold install (lockfile present, empty cache, empty node_modules)"
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    run_phase "p3_cold_install" "$pm" "$(install_cmd "$pm")"
+  done
+fi
 
 # === PHASE 4: warm link (cache populated, lockfile exists) ===
-banner "Phase 4 · warm link (lockfile present, populated cache, empty node_modules)"
-for pm in "${PACKAGE_MANAGERS[@]}"; do
-  run_phase "p4_warm_link" "$pm" "$(install_cmd "$pm")"
-done
+if phase_enabled p4; then
+  banner "Phase 4 · warm link (lockfile present, populated cache, empty node_modules)"
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    run_phase "p4_warm_link" "$pm" "$(install_cmd "$pm")"
+  done
+fi
 
 # === SUMMARY ===
 banner "Summary"

--- a/crates/pm/Cargo.toml
+++ b/crates/pm/Cargo.toml
@@ -76,4 +76,9 @@ utoo-ruborist      = { path = "../ruborist", version = "0.1.0", features = ["htt
 mockito = "1.7.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["full"] }
+# Allocation-heavy workload (multi-MB JSON parses, graph build, per-file
+# clone bookkeeping) — mimalloc measurably beats the system allocator here,
+# matching what the pack crates already do via TurboMalloc. Resolved through
+# the workspace [patch.crates-io] to the utooland fork.
+mimalloc = "0.1"
+tokio    = { workspace = true, features = ["full"] }

--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -16,7 +16,7 @@ use super::workspace::find_workspace_path;
 use crate::fs;
 use crate::util::cli_enum::{PackageAction, SaveType};
 use crate::util::git_resolver::{resolve_git_spec, resolve_github_spec};
-use crate::util::json::{load_package_lock_json_from_path, read_json_file};
+use crate::util::json::read_json_file;
 use crate::util::user_config::{
     get_catalogs, get_or_load_package_json, get_peer_deps, set_package_json,
 };
@@ -59,33 +59,35 @@ pub async fn ensure_package_lock(root_path: &Path) -> Result<PackageLock> {
         return Err(anyhow!("package.json not found"));
     }
 
-    // Check if we need to regenerate package-lock.json
-    let needs_regenerate = fs::metadata(root_path.join("package-lock.json"))
+    // Reuse the lockfile when it exists and is up to date; the freshness
+    // check already parsed it, so a fresh result is the loaded lock itself.
+    let fresh_lock = if fs::metadata(root_path.join("package-lock.json"))
         .await
-        .is_err()
-        || is_pkg_lock_outdated(root_path).await?;
+        .is_ok()
+    {
+        load_package_lock_if_fresh(root_path).await?
+    } else {
+        None
+    };
 
-    if needs_regenerate {
-        tracing::debug!("Resolving dependencies");
-        let output = Context::build_deps(root_path.to_path_buf()).await?;
-
-        // Write to disk asynchronously in background
-        let path = root_path.to_path_buf();
-        let lock_clone = output.lock.clone();
-        tokio::spawn(async move {
-            if let Err(e) = save_package_lock(&path, &lock_clone).await {
-                tracing::warn!("Failed to save package-lock.json: {e}");
-            }
-        });
-
-        return Ok(output.lock);
+    if let Some(package_lock) = fresh_lock {
+        tracing::debug!("Loading package-lock.json from current project");
+        return Ok(package_lock);
     }
 
-    // Load existing package-lock.json only when it's valid and up-to-date
-    tracing::debug!("Loading package-lock.json from current project");
-    let package_lock: PackageLock = load_package_lock_json_from_path(root_path).await?;
+    tracing::debug!("Resolving dependencies");
+    let output = Context::build_deps(root_path.to_path_buf()).await?;
 
-    Ok(package_lock)
+    // Write to disk asynchronously in background
+    let path = root_path.to_path_buf();
+    let lock_clone = output.lock.clone();
+    tokio::spawn(async move {
+        if let Err(e) = save_package_lock(&path, &lock_clone).await {
+            tracing::warn!("Failed to save package-lock.json: {e}");
+        }
+    });
+
+    Ok(output.lock)
 }
 
 /// Batch update package.json for multiple package specifications to reduce file I/O operations
@@ -260,7 +262,11 @@ fn root_optional_with_runtime(path: &str, pkg: &PackageJson) -> Option<HashMap<S
     Some(merged)
 }
 
-pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
+/// Freshness-check package-lock.json and return the parsed [`PackageLock`]
+/// when it is up to date — `Ok(None)` means outdated. Multi-MB lockfiles cost
+/// a full serde parse, so callers that go on to install from a fresh lock
+/// should consume this instead of re-reading the file after a boolean check.
+pub async fn load_package_lock_if_fresh(root_path: &Path) -> Result<Option<PackageLock>> {
     // Root package.json is served from the in-process cache. The cache
     // stays consistent with disk across the full `ut install` lifetime
     // because `update_package_json` calls `set_package_json` write-through
@@ -311,7 +317,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
             None => {
                 let name = if path.is_empty() { "root" } else { path };
                 tracing::warn!("package-lock.json is outdated, new workspace {name} not found");
-                return Ok(true);
+                return Ok(None);
             }
         };
 
@@ -319,7 +325,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
 
         if !deps_match(pkg.dependencies.as_ref(), lock.dependencies.as_ref()) {
             tracing::warn!("package-lock.json is outdated, {name} dependencies changed");
-            return Ok(true);
+            return Ok(None);
         }
 
         // `Context::build_deps` folds synthetic `node-bin-*` runtime deps into
@@ -332,7 +338,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
 
         if !deps_match(expected_optional, lock.optional_dependencies.as_ref()) {
             tracing::warn!("package-lock.json is outdated, {name} optionalDependencies changed");
-            return Ok(true);
+            return Ok(None);
         }
 
         if !deps_match(
@@ -340,7 +346,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
             lock.dev_dependencies.as_ref(),
         ) {
             tracing::warn!("package-lock.json is outdated, {name} devDependencies changed");
-            return Ok(true);
+            return Ok(None);
         }
 
         if peer_deps == PeerDeps::Include
@@ -350,7 +356,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
             )
         {
             tracing::warn!("package-lock.json is outdated, {name} peerDependencies changed");
-            return Ok(true);
+            return Ok(None);
         }
     }
 
@@ -369,10 +375,10 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
 
     if !engines_match {
         tracing::warn!("package-lock.json is outdated, engines changed");
-        return Ok(true);
+        return Ok(None);
     }
 
-    Ok(false)
+    Ok(Some(lock_file))
 }
 
 /// Save PackageLock to disk synchronously
@@ -515,7 +521,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            is_pkg_lock_outdated(temp_path).await.unwrap(),
+            load_package_lock_if_fresh(temp_path)
+                .await
+                .unwrap()
+                .is_none(),
             expected,
             "package.json:\n{pkg_json}"
         );
@@ -615,7 +624,12 @@ mod tests {
         });
         fs::write(temp_path.join("package.json"), pkg_json.to_string()).unwrap();
         fs::write(temp_path.join("package-lock.json"), pkg_lock.to_string()).unwrap();
-        assert!(!is_pkg_lock_outdated(temp_path).await.unwrap());
+        assert!(
+            load_package_lock_if_fresh(temp_path)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -704,7 +718,12 @@ mod tests {
         fs::write(temp_path.join("package-lock.json"), pkg_lock.to_string()).unwrap();
 
         // Test that empty object and missing field are treated as equal
-        assert!(!is_pkg_lock_outdated(temp_path).await.unwrap());
+        assert!(
+            load_package_lock_if_fresh(temp_path)
+                .await
+                .unwrap()
+                .is_some()
+        );
 
         // Test reverse case: package.json has no dependencies field, package-lock.json has empty dependencies
         let pkg_json_no_deps = json!({
@@ -735,7 +754,12 @@ mod tests {
         .unwrap();
 
         // Test that missing field and empty object are treated as equal
-        assert!(!is_pkg_lock_outdated(temp_path).await.unwrap());
+        assert!(
+            load_package_lock_if_fresh(temp_path)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -2,6 +2,10 @@ use std::process;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand};
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 use cmd::config::{handle_config_get, handle_config_list, handle_config_set};
 use cmd::deps::build_deps;
 use cmd::execute::execute;

--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -18,8 +18,9 @@ static SKIP_BINARY_MIRROR: OnceLock<bool> = OnceLock::new();
 /// On-disk cache TTL for `binary-mirror-config`. The config changes rarely;
 /// without this cache every warm install on a non-npmjs registry pays a
 /// network round trip (TLS + manifest fetch) before the first mirror-matched
-/// package can finish cloning.
-const DISK_CACHE_TTL_SECS: u64 = 86400; // 24 hours
+/// package can finish cloning. 6h keeps worst-case staleness of a new mirror
+/// entry within the same workday.
+const DISK_CACHE_TTL_SECS: u64 = 21600; // 6 hours
 
 fn disk_cache_path() -> std::path::PathBuf {
     crate::util::cache::get_cache_dir().join("_binary-mirror-config.json")

--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -15,9 +15,70 @@ static CONFIG: OnceCell<Value> = OnceCell::const_new();
 /// Cached result of whether we should skip binary mirror envs
 static SKIP_BINARY_MIRROR: OnceLock<bool> = OnceLock::new();
 
+/// On-disk cache TTL for `binary-mirror-config`. The config changes rarely;
+/// without this cache every warm install on a non-npmjs registry pays a
+/// network round trip (TLS + manifest fetch) before the first mirror-matched
+/// package can finish cloning.
+const DISK_CACHE_TTL_SECS: u64 = 86400; // 24 hours
+
+fn disk_cache_path() -> std::path::PathBuf {
+    crate::util::cache::get_cache_dir().join("_binary-mirror-config.json")
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn read_disk_cache() -> Option<Value> {
+    let raw = std::fs::read(disk_cache_path()).ok()?;
+    let cached: Value = serde_json::from_slice(&raw).ok()?;
+    let fetched_at = cached.get("fetched_at")?.as_u64()?;
+    if now_secs().saturating_sub(fetched_at) > DISK_CACHE_TTL_SECS {
+        return None;
+    }
+    cached.get("config").cloned()
+}
+
+fn write_disk_cache(config: &Value) {
+    let entry = serde_json::json!({ "fetched_at": now_secs(), "config": config });
+    let path = disk_cache_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Err(e) = crate::util::json::write_compact_sync(&path, &entry) {
+        tracing::debug!("Failed to write binary mirror config cache: {e}");
+    }
+}
+
+/// Kick off the config fetch in the background so it overlaps the install
+/// pipeline instead of stalling the first mirror-matched package (the
+/// `OnceCell` dedupes against the eventual in-line caller).
+pub fn warm_binary_mirror_config() {
+    if should_skip_binary_mirror() {
+        return;
+    }
+    tokio::spawn(async {
+        if let Err(e) = load_config().await {
+            tracing::debug!("Binary mirror config warmup failed: {e}");
+        }
+    });
+}
+
 async fn load_config() -> Result<&'static Value> {
     CONFIG
         .get_or_try_init(|| async {
+            // Serve from the on-disk cache while fresh — a fully warm install
+            // must not touch the network for a config that changes rarely.
+            if let Some(config) = tokio::task::spawn_blocking(read_disk_cache)
+                .await
+                .ok()
+                .flatten()
+            {
+                return Ok(config);
+            }
             // Go through the registry client so URL construction and private-
             // registry auth are handled in one place rather than hand-rolled.
             // `binary-mirror-config@latest` is a normal version manifest whose
@@ -27,7 +88,11 @@ async fn load_config() -> Result<&'static Value> {
                 .fetch_version_manifest_bytes("binary-mirror-config", "latest")
                 .await
                 .context("Failed to fetch binary mirror config")?;
-            serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")
+            let config: Value =
+                serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")?;
+            let to_cache = config.clone();
+            tokio::task::spawn_blocking(move || write_disk_cache(&to_cache));
+            Ok(config)
         })
         .await
 }

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -10,7 +10,7 @@ use crate::fs;
 use crate::helper::global_bin::{get_global_bin_dir, get_global_package_dir};
 use crate::helper::lock::{
     Package, UpdatePackageJsonOptions, extract_package_name, format_save_spec, group_by_depth,
-    is_pkg_lock_outdated, resolve_package_spec, save_package_lock, update_package_json,
+    load_package_lock_if_fresh, resolve_package_spec, save_package_lock, update_package_json,
 };
 use crate::helper::ruborist_context::{Context, spawn_save_project_cache};
 use crate::helper::workspace::init_project_root;
@@ -18,7 +18,6 @@ use crate::model::package::PackageInfo;
 use crate::service::package::PackageService;
 use crate::service::rebuild::RebuildService;
 use crate::util::cli_enum::{OmitType, PackageAction, SaveType};
-use crate::util::json::load_package_lock_json_from_path;
 use crate::util::linker::link;
 use crate::util::logger::{
     PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
@@ -267,23 +266,24 @@ impl InstallService {
         root_path: &Path,
         omit: &HashSet<OmitType>,
     ) -> Result<()> {
+        // Overlap the binary-mirror-config fetch (non-npmjs registries only)
+        // with the whole pipeline; awaited lazily per mirror-matched package.
+        super::binary::warm_binary_mirror_config();
         let lock_path = root_path.join("package-lock.json");
         // Treat a failing freshness check as stale: regenerate rather than
-        // install from a lockfile we couldn't validate. `is_pkg_lock_outdated`
-        // itself emits a `tracing::warn` with the specific mismatch reason.
-        let use_fresh_lock = fs::try_exists(&lock_path).await.unwrap_or(false)
-            && !is_pkg_lock_outdated(root_path).await.unwrap_or(true);
+        // install from a lockfile we couldn't validate. The check parses the
+        // lockfile, so a fresh result is the loaded lock itself — no second
+        // multi-MB parse. `load_package_lock_if_fresh` emits a
+        // `tracing::warn` with the specific mismatch reason when outdated.
+        let fresh_lock = if fs::try_exists(&lock_path).await.unwrap_or(false) {
+            load_package_lock_if_fresh(root_path).await.unwrap_or(None)
+        } else {
+            None
+        };
         let scheduler_handle = super::install_scheduler::InstallSchedulerHandle::start();
         let scheduler = scheduler_handle.scheduler();
 
-        let (package_lock, events_prefetched) = if use_fresh_lock {
-            let lock = match load_package_lock_json_from_path(root_path).await {
-                Ok(lock) => lock,
-                Err(e) => {
-                    scheduler_handle.shutdown().await;
-                    return Err(e);
-                }
-            };
+        let (package_lock, events_prefetched) = if let Some(lock) = fresh_lock {
             (lock, false)
         } else {
             start_progress_bar();

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -642,7 +642,16 @@ impl SchedulerState {
     }
 }
 
+/// Numeric override from env — lets CI A/B concurrency settings with one
+/// binary (e.g. `UTOO_CLONE_CONCURRENCY=8` to replay the old effective limit).
+fn env_limit(name: &str) -> Option<usize> {
+    std::env::var(name).ok()?.parse().ok()
+}
+
 fn clone_concurrency_limit() -> usize {
+    if let Some(n) = env_limit("UTOO_CLONE_CONCURRENCY") {
+        return n.max(1);
+    }
     // Clone jobs are kernel-blocked metadata syscalls (hardlink farms), not
     // CPU work, and they run on tokio's blocking pool — wider than cores is
     // what keeps a 4-vCPU CI runner's disk queue fed. One serial walk per
@@ -653,6 +662,9 @@ fn clone_concurrency_limit() -> usize {
 }
 
 fn extract_concurrency_limit() -> usize {
+    if let Some(n) = env_limit("UTOO_EXTRACT_CONCURRENCY") {
+        return n.max(1);
+    }
     std::thread::available_parallelism()
         .map(|n| n.get().clamp(2, 8))
         .unwrap_or(4)

--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -390,6 +390,18 @@ impl SchedulerState {
             return;
         }
 
+        // Fast path: a registry-style tarball whose download stage already
+        // completed (on warm installs the prefetch pass proves the cache for
+        // every package) goes straight to the clone queue. This skips the
+        // seeded-slot lookup task — a tokio spawn + URL sha256 + a stat of an
+        // `_http_` slot that only ever exists for non-registry tarballs.
+        if is_registry_tarball_url(&spec.package.tarball_url)
+            && let Some(cache_path) = self.download_done.get(&spec.package.key()).cloned()
+        {
+            self.clone_queue.push_back(ReadyClone { spec, cache_path });
+            return;
+        }
+
         self.resolve_cache_for_clone(spec);
     }
 
@@ -499,7 +511,12 @@ impl SchedulerState {
         );
         for (job, target) in admitted {
             let clone_done_tx = self.clone_done_tx.clone();
-            rayon::spawn(move || {
+            // Cloning is hardlink/copy syscalls that block in the kernel, not
+            // CPU work — run it on tokio's blocking pool instead of rayon's
+            // ncpu-sized pool, where it would (a) cap effective parallelism at
+            // ncpu regardless of `clone_limit` and (b) steal workers from
+            // libdeflater extraction during cold installs.
+            tokio::task::spawn_blocking(move || {
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     clone_package_sync(&PackageClone {
                         name: &job.spec.package.name,
@@ -626,9 +643,13 @@ impl SchedulerState {
 }
 
 fn clone_concurrency_limit() -> usize {
+    // Clone jobs are kernel-blocked metadata syscalls (hardlink farms), not
+    // CPU work, and they run on tokio's blocking pool — wider than cores is
+    // what keeps a 4-vCPU CI runner's disk queue fed. One serial walk per
+    // package means a single huge package still holds one slot either way.
     std::thread::available_parallelism()
-        .map(|n| (n.get() * 2).clamp(4, 16))
-        .unwrap_or(8)
+        .map(|n| (n.get() * 4).clamp(8, 32))
+        .unwrap_or(16)
 }
 
 fn extract_concurrency_limit() -> usize {

--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -3,7 +3,7 @@ use crate::model::package::{LifecycleHook, LifecycleScripts, PackageInfo};
 use crate::util::cli_enum::ScriptPolicy;
 use crate::util::logger::{PROGRESS_BAR, finish_progress_bar, log_progress, start_progress_bar};
 use anyhow::{Context, Result};
-use futures;
+use futures::{self, StreamExt as _};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -151,6 +151,8 @@ impl PackageService {
             .collect();
 
         let mut packages = Vec::new();
+        // (index into `packages`, lock path, is_link) for deferred script reads.
+        let mut pending_script_reads: Vec<(usize, String, bool)> = Vec::new();
         for (path, lock_package) in &package_lock.packages {
             if path.is_empty() {
                 continue;
@@ -219,44 +221,69 @@ impl PackageService {
                 continue;
             }
 
-            // Read lifecycle scripts from package.json only if needed. A
-            // workspace link contributes bin linking only — leave its scripts
-            // empty so `create_execution_queues` never queues them (owned by
+            // Read lifecycle scripts from package.json only when they can end
+            // up in an execution queue: the queues only consume
+            // preinstall/install/postinstall under `ScriptPolicy::Run`, and the
+            // lock's `hasInstallScript` marker covers exactly those three hooks
+            // — the same marker the early filter above already trusts. So a
+            // bin-only package (no marker) and the whole `Ignore` policy skip
+            // the read; a link's scripts are decided from disk. A workspace
+            // link contributes bin linking only — its scripts stay empty so
+            // `create_execution_queues` never queues them (owned by
             // `process_workspace_install_hooks`).
-            let lifecycle_scripts =
-                if !is_workspace_link && (has_scripts || scripts == ScriptPolicy::Run) {
-                    match Self::read_lifecycle_scripts(&package_path).await {
-                        Ok(s) => s,
-                        // A `file:` link can resolve to a missing or degenerate
-                        // `package.json` (e.g. a conflict artifact keyed
-                        // `node_modules/` with an empty name). Treat that as "no
-                        // scripts" rather than failing the whole install; a real
-                        // dependency with an unreadable manifest still errors.
-                        Err(_) if is_link => LifecycleScripts::default(),
-                        Err(e) => {
-                            return Err(e).with_context(|| {
-                                format!("Failed to read scripts for package: {path}")
-                            });
-                        }
-                    }
-                } else {
-                    LifecycleScripts::default()
-                };
+            let needs_script_read =
+                scripts == ScriptPolicy::Run && !is_workspace_link && (has_scripts || is_link);
 
             // Check if this package is an optional dependency (based on edge type)
             let is_optional =
                 lock_package.optional == Some(true) || lock_package.dev_optional == Some(true);
 
+            if needs_script_read {
+                pending_script_reads.push((packages.len(), path.clone(), is_link));
+            }
+
             let package_info = PackageInfo {
                 path: package_path,
                 bin_files,
                 scripts: Default::default(),
-                lifecycle_scripts,
+                lifecycle_scripts: LifecycleScripts::default(),
                 name: package_name,
             };
 
             packages.push((package_info, is_optional));
         }
+
+        // The reads are independent point lookups; run them concurrently
+        // instead of one awaited syscall+parse at a time.
+        let read_results = futures::stream::iter(pending_script_reads.into_iter().map(
+            |(idx, path, is_link)| {
+                let package_path = packages[idx].0.path.clone();
+                async move {
+                    let result = Self::read_lifecycle_scripts(&package_path).await;
+                    (idx, path, is_link, result)
+                }
+            },
+        ))
+        .buffer_unordered(32)
+        .collect::<Vec<_>>()
+        .await;
+
+        for (idx, path, is_link, result) in read_results {
+            match result {
+                Ok(s) => packages[idx].0.lifecycle_scripts = s,
+                // A `file:` link can resolve to a missing or degenerate
+                // `package.json` (e.g. a conflict artifact keyed
+                // `node_modules/` with an empty name). Treat that as "no
+                // scripts" rather than failing the whole install; a real
+                // dependency with an unreadable manifest still errors.
+                Err(_) if is_link => {}
+                Err(e) => {
+                    return Err(e)
+                        .with_context(|| format!("Failed to read scripts for package: {path}"));
+                }
+            }
+        }
+
         Ok(packages)
     }
 

--- a/crates/pm/src/util/json.rs
+++ b/crates/pm/src/util/json.rs
@@ -79,12 +79,6 @@ pub async fn load_package_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
     }
 }
 
-pub async fn load_package_lock_json_from_path(
-    path: &Path,
-) -> Result<utoo_ruborist::lock::PackageLock> {
-    read_json_file(&path.join("package-lock.json")).await
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/pm/src/util/retry.rs
+++ b/crates/pm/src/util/retry.rs
@@ -28,6 +28,15 @@ pub fn build_dns_cached_client() -> reqwest::Client {
     client_builder()
         .connect_timeout(std::time::Duration::from_secs(5)) // TLS + TCP handshake
         .read_timeout(std::time::Duration::from_secs(30)) // Timeout for individual read operations
+        // HTTP/1.1 so each in-flight tarball gets its own TCP connection.
+        // With ALPN h2 the registry CDN multiplexes every stream over one
+        // connection (single congestion window + flow-control cap, loss on
+        // one stream stalls siblings) — same rationale as the manifest
+        // client in ruborist/src/service/http.rs.
+        .http1_only()
+        // Tarballs are already gzip; don't invite a second Content-Encoding
+        // layer that would just burn CPU on decode.
+        .no_gzip()
         // No total timeout - large files (e.g. node binary ~100MB) need longer download time
         // No pool_max_idle_per_host - let reqwest manage connections freely
         // Concurrency is bounded by the resolver's in-flight fetch cap

--- a/crates/pm/src/util/retry.rs
+++ b/crates/pm/src/util/retry.rs
@@ -25,18 +25,23 @@ impl std::error::Error for RetryableError {}
 /// Build a reqwest::Client with timeout config.
 /// Connection pool is unlimited - concurrency is controlled by semaphore instead.
 pub fn build_dns_cached_client() -> reqwest::Client {
-    client_builder()
+    let mut builder = client_builder()
         .connect_timeout(std::time::Duration::from_secs(5)) // TLS + TCP handshake
         .read_timeout(std::time::Duration::from_secs(30)) // Timeout for individual read operations
-        // HTTP/1.1 so each in-flight tarball gets its own TCP connection.
-        // With ALPN h2 the registry CDN multiplexes every stream over one
-        // connection (single congestion window + flow-control cap, loss on
-        // one stream stalls siblings) — same rationale as the manifest
-        // client in ruborist/src/service/http.rs.
-        .http1_only()
         // Tarballs are already gzip; don't invite a second Content-Encoding
         // layer that would just burn CPU on decode.
-        .no_gzip()
+        .no_gzip();
+    // HTTP/1.1 by default so each in-flight tarball gets its own TCP
+    // connection. With ALPN h2 the registry CDN multiplexes every stream
+    // over one connection (single congestion window + flow-control cap,
+    // loss on one stream stalls siblings) — same rationale as the manifest
+    // client in ruborist/src/service/http.rs. `UTOO_TARBALL_HTTP=h2` keeps
+    // ALPN negotiation so CI can A/B the protocols with one binary.
+    let h2 = std::env::var("UTOO_TARBALL_HTTP").is_ok_and(|v| v.eq_ignore_ascii_case("h2"));
+    if !h2 {
+        builder = builder.http1_only();
+    }
+    builder
         // No total timeout - large files (e.g. node binary ~100MB) need longer download time
         // No pool_max_idle_per_host - let reqwest manage connections freely
         // Concurrency is bounded by the resolver's in-flight fetch cap

--- a/crates/ruborist/Cargo.toml
+++ b/crates/ruborist/Cargo.toml
@@ -53,8 +53,11 @@ workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 # Native (non-macOS) targets: reqwest's default rustls + ring.
+# `gzip` lets the manifest client send Accept-Encoding and transparently
+# decompress packuments (~2.5x smaller on registry.npmjs.org); brotli is
+# only ~1% smaller than gzip there but decodes slower, so it stays off.
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "macos")))'.dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["gzip", "rustls-tls-native-roots"] }
 
 # Native-only dependencies (not compiled for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -73,7 +76,10 @@ js-sys = "0.3"
 # resolves on M-series ARM. CI bench-phases regresses on Linux/x86_64
 # with this provider, so it's gated to macOS only. See service/http.rs.
 [target.'cfg(target_os = "macos")'.dependencies]
-reqwest             = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots-no-provider"] }
+reqwest             = { version = "0.12", default-features = false, features = [
+  "gzip",
+  "rustls-tls-native-roots-no-provider"
+] }
 rustls              = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
 rustls-native-certs = "0.8"
 


### PR DESCRIPTION
## What

Hot-path performance pass over the v1.1.1 demand-resolver install flow, targeting all four bench phases (p0 full cold / p1 resolve / p3 cold install / p4 warm link), plus a rework of the bench-phases CI feedback loop.

### Rust perf changes (`perf(pm)` commit)

| # | Change | Phase | Rationale |
|---|--------|-------|-----------|
| 1 | gzip on the manifest HTTP client (native targets) | p0/p1 | abbreviated packuments transfer ~2.5x smaller from npmjs (react: 2.8MB → 1.14MB); brotli is only ~1% smaller but decodes slower, left off |
| 2 | tarball downloader forces HTTP/1.1 + `no_gzip` | p0/p3 | all tarball bytes were multiplexing one h2 connection (single congestion window, HoL blocking) — same pcap-backed rationale as the manifest client in `ruborist/service/http.rs` |
| 3 | `package-lock.json` parsed once per install | p3/p4 | the freshness check now returns the parsed lock; previously two full multi-MB serde parses before any work started |
| 4 | rebuild collect trusts the lock's `hasInstallScript` marker; remaining reads `buffer_unordered(32)` | p3/p4 | the execution queues only consume preinstall/install/postinstall — exactly what the marker covers; bin-only packages and `--ignore-scripts` runs no longer read N package.json files sequentially |
| 5 | registry tarballs proven by prefetch skip the seeded-slot lookup task | p3/p4 | was a tokio spawn + URL sha256 + guaranteed-miss `_http_` stat per package |
| 6 | clone stage moves rayon → tokio blocking pool, admission limit 2x→4x cores (8..32) | p3/p4 | hardlink farms are kernel-blocked syscalls, not CPU; on a 4-vCPU runner the rayon pool capped effective parallelism at 4 and fought libdeflater extraction for workers |
| 7 | `binary-mirror-config` cached on disk (24h TTL) + background warmup | p4 | fully-warm installs on non-npmjs registries paid a TLS round trip before the first mirror-matched package could finish |
| 8 | mimalloc as global allocator | all | allocation-heavy workload; matches the pack crates' TurboMalloc |

### Bench CI changes (`ci(pm-bench)` commit)

- PR comment is now rendered from raw hyperfine JSON with a **verdict headline**: utoo (PR) vs utoo-next per phase, Δ% with a significance gate (|Δ| > 5% and beyond 2σ) → ✅ / 🚀 / ⚠️
- seeds retry 3x and terminal failures skip only their (phase, pm) cell instead of killing the whole bench
- lockfile for p3/p4 is generated by the **baseline** binary, so a PR can't perturb the baseline's input
- label runs drop `utoo-npm` (~25% faster feedback); p1/p4 run 5 iterations for tighter σ
- hyperfine pinned from GitHub releases (no `apt-get update`)

## Local A/B (404-package tree, npmmirror, M-series mac)

- **p4 warm link: 773ms ±368 → 395ms ±11** (mean −49%, user CPU 260ms → 30ms, σ down 30x)
- p1 resolve: means 4.41s → 1.89s but baseline σ was network-dominated; mins equal — no local regression, the gzip win needs the npmjs CI leg to show

## Verification

- `cargo test -p utoo-pm` 264 passed, `-p utoo-ruborist` 10 passed
- `cargo fmt --check` / `clippy -D warnings` / `tombi` / `biome ci` / `typos` clean
- renderer smoke-tested against real hyperfine JSON (verdict gate behaves correctly on high-σ data)

The `benchmark` label on this PR exercises the new bench pipeline end-to-end and should quantify the p0/p1/p3/p4 deltas on the npmjs leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
