### PR TITLE
ci(pm-bench): verdict-first comments, ablation tooling, faster runs

### DIFF
--- a/.github/actions/install-bench-tools/action.yml
+++ b/.github/actions/install-bench-tools/action.yml
@@ -12,7 +12,16 @@ runs:
     - name: Install bench tools (linux)
       if: inputs.platform == 'linux'
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y hyperfine time
+      # Pinned hyperfine .deb straight from GitHub releases: skips the slow,
+      # occasionally flaky `apt-get update`, and pins the JSON schema the
+      # comment renderer parses. GNU time still comes from apt (tiny, and
+      # `apt-get install` without `update` resolves from the baked index).
+      run: |
+        curl -fsSL --retry 3 -o /tmp/hyperfine.deb \
+          https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine_1.19.0_amd64.deb
+        sudo dpkg -i /tmp/hyperfine.deb
+        /usr/bin/time --version >/dev/null 2>&1 || sudo apt-get install -y time \
+          || { sudo apt-get update && sudo apt-get install -y time; }
     - name: Install bench tools (mac)
       if: inputs.platform == 'mac'
       shell: bash

--- a/.github/actions/post-bench-phases-comment/action.yml
+++ b/.github/actions/post-bench-phases-comment/action.yml
@@ -8,6 +8,10 @@ inputs:
   os:
     description: Runner OS string (ubuntu-latest / macos-latest) — shown in the comment title
     required: true
+  project:
+    description: Project the bench ran against (matches the bench script's PROJECT env)
+    required: false
+    default: ant-design
   github-token:
     description: GitHub token for `gh` CLI lookups + sticky-comment posting
     required: true
@@ -17,6 +21,8 @@ runs:
   steps:
     - name: Build PR comment body
       shell: bash
+      env:
+        PROJECT: ${{ inputs.project }}
       run: bash .github/scripts/render-bench-phases-comment.sh ${{ inputs.platform }} ${{ inputs.os }}
     - name: Find Current PR
       id: findPr

--- a/.github/scripts/render-bench-phases-comment.mjs
+++ b/.github/scripts/render-bench-phases-comment.mjs
@@ -113,6 +113,7 @@ for (const { reg, dir } of resultDirs) {
         min: r.min,
         max: r.max,
         runs: r.times?.length ?? 0,
+        times: r.times ?? [],
       };
     }
   }
@@ -129,21 +130,41 @@ const fmtB = (b) =>
         : Math.round(b) + "B";
 const fmtPct = (d) => (d > 0 ? "+" : "") + (d * 100).toFixed(1) + "%";
 
-// Welch-style 2-sigma gate on the difference of means; with 3-7 runs this is
-// a coarse filter, which is exactly the point — only flag what the sample
-// can actually support.
+// Preferred gate: PAIRED per-round deltas. The interleaved bench runs each
+// PM once per round, so times[i] across PMs share the same weather window —
+// the median paired delta cancels drift that a means comparison can't. A
+// null test (identical binaries) under the old per-PM-block shape read
+// "p3 -27.9%" off one weather spike; pairing is what makes verdicts mean
+// something. Flag only when the median is past the threshold AND ≥80% of
+// rounds agree on the sign.
+//
+// Fallback (legacy non-interleaved data): Welch-style 2-sigma gate on the
+// difference of means.
 function compare(utoo, next) {
   if (!utoo?.timing || !next?.timing) return null;
   const a = utoo.timing;
   const b = next.timing;
   if (!b.mean) return null;
+
+  if (a.times.length >= 3 && a.times.length === b.times.length) {
+    const deltas = a.times.map((t, i) => (t - b.times[i]) / b.times[i]);
+    const sorted = [...deltas].sort((x, y) => x - y);
+    const mid = sorted.length >> 1;
+    const median = sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    const agreeing = deltas.filter((d) => Math.sign(d) === Math.sign(median)).length;
+    const significant =
+      Math.abs(median) > FLAG_THRESHOLD && agreeing >= Math.ceil(deltas.length * 0.8);
+    const verdict = !significant ? "✅" : median < 0 ? "🚀" : "⚠️";
+    return { delta: median, significant, verdict, paired: true };
+  }
+
   const delta = (a.mean - b.mean) / b.mean;
   const se = Math.sqrt(
     (a.stddev * a.stddev) / Math.max(a.runs, 1) + (b.stddev * b.stddev) / Math.max(b.runs, 1),
   );
   const significant = Math.abs(delta) > FLAG_THRESHOLD && Math.abs(a.mean - b.mean) > 2 * se;
   const verdict = !significant ? "✅" : delta < 0 ? "🚀" : "⚠️";
-  return { delta, significant, verdict };
+  return { delta, significant, verdict, paired: false };
 }
 
 const sha = (process.env.GITHUB_SHA || "").slice(0, 7);
@@ -175,7 +196,7 @@ if (!resultDirs.length) {
       lines.push(`**utoo (PR) vs utoo-next (baseline):** ${verdicts.join(" · ")}`);
       lines.push("");
       lines.push(
-        "_✅ within noise · 🚀 faster · ⚠️ slower (|Δ| > 5% and beyond 2σ of the run spread)_",
+        "_✅ within noise · 🚀 faster · ⚠️ slower — Δ is the median of per-round paired deltas (interleaved rounds share weather windows); flagged when |Δ| > 5% and ≥80% of rounds agree on sign_",
       );
       lines.push("");
     }

--- a/.github/scripts/render-bench-phases-comment.mjs
+++ b/.github/scripts/render-bench-phases-comment.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// Render the pm-bench-phases sticky PR comment from the raw per-cell JSON
+// exported by bench/pm-bench-phases.sh (BENCH_OUT_DIR/results-<registry>/),
+// instead of awk-scraping fixed-width log tables.
+//
+// The headline is the verdict: utoo (PR build) vs utoo-next (baseline) per
+// phase, with a significance gate so registry weather doesn't read as a
+// regression. Raw numbers stay available below; resources fold into
+// <details>.
+//
+// Usage: render-bench-phases-comment.mjs <platform> <os>
+// Env:   PROJECT (default ant-design), OUT_DIR (default /tmp/pm-bench-output),
+//        GITHUB_SHA / GITHUB_REPOSITORY / GITHUB_SERVER_URL / GITHUB_RUN_ID,
+//        GITHUB_STEP_SUMMARY (appended when set).
+
+import fs from "node:fs";
+import path from "node:path";
+
+const [platform = "linux", os = "ubuntu-latest"] = process.argv.slice(2);
+const PROJECT = process.env.PROJECT || "ant-design";
+const OUT_DIR = process.env.OUT_DIR || "/tmp/pm-bench-output";
+
+const PHASES = [
+  ["p0_full_cold", "p0 · full cold install"],
+  ["p1_resolve", "p1 · resolve"],
+  ["p3_cold_install", "p3 · cold install"],
+  ["p4_warm_link", "p4 · warm link"],
+];
+const PM_ORDER = ["utoo", "utoo-alt", "utoo-next", "utoo-npm", "bun"];
+const PM_LABEL = {
+  utoo: "utoo (PR)",
+  "utoo-alt": "utoo-alt (PR + alt env)",
+  "utoo-next": "utoo-next (baseline)",
+  "utoo-npm": "utoo-npm (published)",
+  bun: "bun",
+};
+
+// Relative delta below this is never flagged, whatever the sigmas say.
+const FLAG_THRESHOLD = 0.05;
+
+const parseKey = (file, suffix) => {
+  const base = file.slice(0, -suffix.length);
+  for (const [phase] of PHASES) {
+    const idx = base.indexOf(`_${phase}_`);
+    if (idx === -1) continue;
+    return { phase, pm: base.slice(idx + phase.length + 2) };
+  }
+  return null;
+};
+
+const readJson = (p) => {
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+};
+
+// registry label -> phase -> pm -> cell
+const registries = new Map();
+const cell = (reg, phase, pm) => {
+  if (!registries.has(reg)) registries.set(reg, {});
+  const phases = registries.get(reg);
+  return ((phases[phase] ??= {})[pm] ??= {});
+};
+
+const resultDirs = fs.existsSync(OUT_DIR)
+  ? fs
+      .readdirSync(OUT_DIR)
+      .filter((d) => d.startsWith("results-"))
+      .map((d) => ({ reg: d.slice("results-".length), dir: path.join(OUT_DIR, d) }))
+  : [];
+
+for (const { reg, dir } of resultDirs) {
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.startsWith(`${PROJECT}_`)) continue;
+    const full = path.join(dir, f);
+    if (f.endsWith("_failed.json")) {
+      const key = parseKey(f, "_failed.json");
+      if (key) cell(reg, key.phase, key.pm).failed = readJson(full)?.failed || "failed";
+    } else if (f.endsWith("_metrics.jsonl")) {
+      const key = parseKey(f, "_metrics.jsonl");
+      if (!key) continue;
+      const rows = fs
+        .readFileSync(full, "utf8")
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => {
+          try {
+            return JSON.parse(l);
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean);
+      if (!rows.length) continue;
+      const avg = {};
+      for (const k of Object.keys(rows[0])) {
+        avg[k] = rows.reduce((s, r) => s + Number(r[k] || 0), 0) / rows.length;
+      }
+      cell(reg, key.phase, key.pm).metrics = avg;
+    } else if (f.endsWith("_footprint.json")) {
+      const key = parseKey(f, "_footprint.json");
+      if (key) cell(reg, key.phase, key.pm).footprint = readJson(full);
+    } else if (f.endsWith(".json")) {
+      const key = parseKey(f, ".json");
+      if (!key) continue;
+      const r = readJson(full)?.results?.[0];
+      if (!r) continue;
+      cell(reg, key.phase, key.pm).timing = {
+        mean: r.mean,
+        stddev: r.stddev ?? 0,
+        min: r.min,
+        max: r.max,
+        runs: r.times?.length ?? 0,
+      };
+    }
+  }
+}
+
+const fmtS = (s) => (s >= 10 ? s.toFixed(1) : s.toFixed(2)) + "s";
+const fmtB = (b) =>
+  b >= 1 << 30
+    ? (b / (1 << 30)).toFixed(2) + "G"
+    : b >= 1 << 20
+      ? (b / (1 << 20)).toFixed(0) + "M"
+      : b >= 1 << 10
+        ? (b / (1 << 10)).toFixed(0) + "K"
+        : Math.round(b) + "B";
+const fmtPct = (d) => (d > 0 ? "+" : "") + (d * 100).toFixed(1) + "%";
+
+// Welch-style 2-sigma gate on the difference of means; with 3-7 runs this is
+// a coarse filter, which is exactly the point — only flag what the sample
+// can actually support.
+function compare(utoo, next) {
+  if (!utoo?.timing || !next?.timing) return null;
+  const a = utoo.timing;
+  const b = next.timing;
+  if (!b.mean) return null;
+  const delta = (a.mean - b.mean) / b.mean;
+  const se = Math.sqrt(
+    (a.stddev * a.stddev) / Math.max(a.runs, 1) + (b.stddev * b.stddev) / Math.max(b.runs, 1),
+  );
+  const significant = Math.abs(delta) > FLAG_THRESHOLD && Math.abs(a.mean - b.mean) > 2 * se;
+  const verdict = !significant ? "✅" : delta < 0 ? "🚀" : "⚠️";
+  return { delta, significant, verdict };
+}
+
+const sha = (process.env.GITHUB_SHA || "").slice(0, 7);
+const runUrl = `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${process.env.GITHUB_REPOSITORY || ""}/actions/runs/${process.env.GITHUB_RUN_ID || ""}`;
+
+const lines = [];
+lines.push(`## 📊 pm-bench-phases · \`${sha}\` · ${platform} (\`${os}\`)`);
+lines.push("");
+lines.push(`[Workflow run](${runUrl}) — ${PROJECT}`);
+lines.push("");
+
+if (!resultDirs.length) {
+  lines.push("_No bench results captured (bench aborted before export?). See the workflow log._");
+} else {
+  for (const { reg } of resultDirs) {
+    const phases = registries.get(reg) || {};
+
+    // Headline: utoo vs utoo-next per phase.
+    const verdicts = [];
+    for (const [phase, label] of PHASES) {
+      const pms = phases[phase];
+      if (!pms) continue;
+      const cmp = compare(pms["utoo"], pms["utoo-next"]);
+      if (cmp) verdicts.push(`${cmp.verdict} ${label.split(" · ")[0]} ${fmtPct(cmp.delta)}`);
+    }
+    lines.push(`### ${reg}`);
+    lines.push("");
+    if (verdicts.length) {
+      lines.push(`**utoo (PR) vs utoo-next (baseline):** ${verdicts.join(" · ")}`);
+      lines.push("");
+      lines.push(
+        "_✅ within noise · 🚀 faster · ⚠️ slower (|Δ| > 5% and beyond 2σ of the run spread)_",
+      );
+      lines.push("");
+    }
+
+    for (const [phase, label] of PHASES) {
+      const pms = phases[phase];
+      if (!pms) continue;
+      const present = PM_ORDER.filter((pm) => pms[pm]);
+      if (!present.length) continue;
+
+      lines.push(`#### ${label}`);
+      lines.push("");
+      lines.push("| PM | wall (mean ± σ) | min | user | sys | RSS | Δ vs baseline |");
+      lines.push("|---|---|---|---|---|---|---|");
+      for (const pm of present) {
+        const c = pms[pm];
+        if (c.failed) {
+          lines.push(`| ${PM_LABEL[pm] ?? pm} | — ${c.failed} failed | | | | | |`);
+          continue;
+        }
+        const t = c.timing;
+        const m = c.metrics || {};
+        const cmp = pm === "utoo-next" ? null : compare(c, pms["utoo-next"]);
+        lines.push(
+          `| ${PM_LABEL[pm] ?? pm} | ${t ? `${fmtS(t.mean)} ± ${fmtS(t.stddev)}` : "—"} | ${t ? fmtS(t.min) : "—"} | ${m.user_s != null ? fmtS(m.user_s) : "—"} | ${m.sys_s != null ? fmtS(m.sys_s) : "—"} | ${m.rss ? fmtB(m.rss) : "—"} | ${cmp ? `${fmtPct(cmp.delta)} ${cmp.verdict}` : "—"} |`,
+        );
+      }
+      lines.push("");
+    }
+
+    // Resources fold.
+    lines.push("<details><summary>Resources & footprint</summary>");
+    lines.push("");
+    for (const [phase, label] of PHASES) {
+      const pms = phases[phase];
+      if (!pms) continue;
+      const present = PM_ORDER.filter((pm) => pms[pm] && !pms[pm].failed);
+      if (!present.length) continue;
+      lines.push(`**${label}**`);
+      lines.push("");
+      lines.push("| PM | vCtx | iCtx | netRX | netTX | cache | node_modules | lock |");
+      lines.push("|---|---|---|---|---|---|---|---|");
+      for (const pm of present) {
+        const m = pms[pm].metrics || {};
+        const fp = pms[pm].footprint || {};
+        lines.push(
+          `| ${pm} | ${Math.round(m.vol_ctx || 0)} | ${Math.round(m.invol_ctx || 0)} | ${fmtB(m.net_rx || 0)} | ${fmtB(m.net_tx || 0)} | ${fmtB(fp.cache || 0)} | ${fmtB(fp.node_modules || 0)} | ${fmtB(fp.lockfile || 0)} |`,
+        );
+      }
+      lines.push("");
+    }
+    lines.push("</details>");
+    lines.push("");
+  }
+}
+
+const body = lines.join("\n");
+fs.mkdirSync(OUT_DIR, { recursive: true });
+fs.writeFileSync(path.join(OUT_DIR, "pr_comment.md"), body);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, body + "\n");
+}
+console.log(body);

--- a/.github/scripts/render-bench-phases-comment.mjs
+++ b/.github/scripts/render-bench-phases-comment.mjs
@@ -36,7 +36,12 @@ const PM_LABEL = {
 };
 
 // Relative delta below this is never flagged, whatever the sigmas say.
+// p4 carries a ~5% cache-identity systematic even between identical
+// binaries (each utoo variant hardlinks from its own cache dir, whose
+// physical layout differs — measured by the #3147 null test at -4..-12%
+// per round, median -5.4%), so its bar sits at 2x the measured bias.
 const FLAG_THRESHOLD = 0.05;
+const PHASE_FLAG_THRESHOLD = { p4_warm_link: 0.1 };
 
 const parseKey = (file, suffix) => {
   const base = file.slice(0, -suffix.length);
@@ -140,7 +145,8 @@ const fmtPct = (d) => (d > 0 ? "+" : "") + (d * 100).toFixed(1) + "%";
 //
 // Fallback (legacy non-interleaved data): Welch-style 2-sigma gate on the
 // difference of means.
-function compare(utoo, next) {
+function compare(utoo, next, phase) {
+  const threshold = PHASE_FLAG_THRESHOLD[phase] ?? FLAG_THRESHOLD;
   if (!utoo?.timing || !next?.timing) return null;
   const a = utoo.timing;
   const b = next.timing;
@@ -153,7 +159,7 @@ function compare(utoo, next) {
     const median = sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
     const agreeing = deltas.filter((d) => Math.sign(d) === Math.sign(median)).length;
     const significant =
-      Math.abs(median) > FLAG_THRESHOLD && agreeing >= Math.ceil(deltas.length * 0.8);
+      Math.abs(median) > threshold && agreeing >= Math.ceil(deltas.length * 0.8);
     const verdict = !significant ? "✅" : median < 0 ? "🚀" : "⚠️";
     return { delta: median, significant, verdict, paired: true };
   }
@@ -162,7 +168,7 @@ function compare(utoo, next) {
   const se = Math.sqrt(
     (a.stddev * a.stddev) / Math.max(a.runs, 1) + (b.stddev * b.stddev) / Math.max(b.runs, 1),
   );
-  const significant = Math.abs(delta) > FLAG_THRESHOLD && Math.abs(a.mean - b.mean) > 2 * se;
+  const significant = Math.abs(delta) > threshold && Math.abs(a.mean - b.mean) > 2 * se;
   const verdict = !significant ? "✅" : delta < 0 ? "🚀" : "⚠️";
   return { delta, significant, verdict, paired: false };
 }
@@ -187,7 +193,7 @@ if (!resultDirs.length) {
     for (const [phase, label] of PHASES) {
       const pms = phases[phase];
       if (!pms) continue;
-      const cmp = compare(pms["utoo"], pms["utoo-next"]);
+      const cmp = compare(pms["utoo"], pms["utoo-next"], phase);
       if (cmp) verdicts.push(`${cmp.verdict} ${label.split(" · ")[0]} ${fmtPct(cmp.delta)}`);
     }
     lines.push(`### ${reg}`);
@@ -219,7 +225,7 @@ if (!resultDirs.length) {
         }
         const t = c.timing;
         const m = c.metrics || {};
-        const cmp = pm === "utoo-next" ? null : compare(c, pms["utoo-next"]);
+        const cmp = pm === "utoo-next" ? null : compare(c, pms["utoo-next"], phase);
         lines.push(
           `| ${PM_LABEL[pm] ?? pm} | ${t ? `${fmtS(t.mean)} ± ${fmtS(t.stddev)}` : "—"} | ${t ? fmtS(t.min) : "—"} | ${m.user_s != null ? fmtS(m.user_s) : "—"} | ${m.sys_s != null ? fmtS(m.sys_s) : "—"} | ${m.rss ? fmtB(m.rss) : "—"} | ${cmp ? `${fmtPct(cmp.delta)} ${cmp.verdict}` : "—"} |`,
         );

--- a/.github/scripts/render-bench-phases-comment.sh
+++ b/.github/scripts/render-bench-phases-comment.sh
@@ -29,6 +29,14 @@ OUT=/tmp/pm-bench-output/pr_comment.md
 SHA="${GITHUB_SHA:0:7}"
 RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
+# Preferred path: the bench script exported raw per-cell JSON
+# (results-<registry>/ dirs). The node renderer computes Δ% vs utoo-next
+# with significance flags instead of scraping fixed-width log text. The awk
+# path below stays as a fallback for runs that died before the export step.
+if compgen -G "/tmp/pm-bench-output/results-*" > /dev/null; then
+  exec node "$(dirname "$0")/render-bench-phases-comment.mjs" "$PLATFORM" "$OS"
+fi
+
 mkdir -p /tmp/pm-bench-output
 {
   echo "## 📊 pm-bench-phases · \`$SHA\` · ${PLATFORM} (\`${OS}\`)"

--- a/.github/workflows/pm-e2e-bench.yml
+++ b/.github/workflows/pm-e2e-bench.yml
@@ -75,6 +75,27 @@ on:
         required: false
         default: '3'
         type: string
+      utoo_alt_env:
+        description: '[phases] Extra env for a second utoo variant (ablation A/B), e.g. "UTOO_TARBALL_HTTP=h2" or "UTOO_CLONE_CONCURRENCY=8"'
+        required: false
+        default: ''
+        type: string
+      phases:
+        description: '[phases] Comma-separated phase filter (p0,p1,p3,p4) - ablations can run just the relevant phases'
+        required: false
+        default: 'p0,p1,p3,p4'
+        type: string
+      phases_pm_list:
+        description: '[phases] PMs to bench - an utoo vs utoo-alt ablation only needs "utoo"'
+        required: false
+        default: 'utoo,utoo-next,utoo-npm,bun'
+        type: string
+      phases_registry:
+        description: '[phases] Registry leg(s) to run'
+        required: false
+        default: 'both'
+        type: choice
+        options: [both, npmjs, npmmirror]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -526,7 +547,11 @@ jobs:
       - uses: ./.github/actions/install-bench-tools
         with:
           platform: linux
-      - uses: ./.github/actions/install-utoo-npm-baseline
+      # utoo-npm (last published release) only changes on releases — bench it
+      # on manual dispatch only; label-triggered PR runs compare against
+      # utoo-next, which is the signal that can actually change per PR.
+      - if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/install-utoo-npm-baseline
       # The utoo-next binary is built upstream by build-linux's
       # "Build next branch utoo (bench baseline)" step. Just download.
       - name: Download utoo-next binary
@@ -544,7 +569,7 @@ jobs:
         run: |
           hyperfine --version
           utoo --version
-          "$UTOO_NPM_BIN" --version
+          if [ -n "${UTOO_NPM_BIN:-}" ]; then "$UTOO_NPM_BIN" --version; fi
           "$UTOO_NEXT_BIN" --version
           bun --version
       - name: Define cache wipe function
@@ -553,7 +578,7 @@ jobs:
           #!/usr/bin/env bash
           rm -rf /tmp/pm-bench /tmp/pm-bench-results /tmp/pm-bench-output \
                  /tmp/utoo-bench-cache /tmp/utoo-npm-bench-cache \
-                 /tmp/utoo-next-bench-cache /tmp/bun-bench-cache \
+                 /tmp/utoo-next-bench-cache /tmp/utoo-alt-bench-cache /tmp/bun-bench-cache \
                  ~/.bun/install/cache ~/.cache/nm 2>/dev/null || true
           mkdir -p /tmp/pm-bench-output
           WIPE
@@ -561,18 +586,25 @@ jobs:
       - name: Wipe bench state before npmjs
         run: bash /tmp/wipe-bench-state.sh
       - name: Run phase-isolated benchmark · npmjs
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.phases_registry != 'npmmirror'
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
-          PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
+          # p1/p4 cells finish in seconds — extra runs there sharpen the
+          # significance gate of the PR comment at negligible cost.
+          BENCH_RUNS_CHEAP: '5'
+          UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
+          PHASES: ${{ github.event.inputs.phases || 'p0,p1,p3,p4' }}
+          BENCH_OUT_DIR: '/tmp/pm-bench-output'
+          PM_LIST: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.phases_pm_list || 'utoo,utoo-next,utoo-npm,bun') || 'utoo,utoo-next,bun' }}
         run: |
           chmod +x bench/pm-bench-phases.sh
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmjs.log
       # npmmirror only runs on manual dispatch — label-triggered runs stick to
       # the npmjs leg to keep PR feedback loops short.
       - name: Stash npmjs logs and wipe state before npmmirror
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.phases_registry != 'npmjs'
         run: |
           mkdir -p /tmp/bench-logs-stash
           cp -r /tmp/pm-bench-output/. /tmp/bench-logs-stash/ 2>/dev/null || true
@@ -580,12 +612,16 @@ jobs:
           mkdir -p /tmp/pm-bench-output
           cp -r /tmp/bench-logs-stash/. /tmp/pm-bench-output/ 2>/dev/null || true
       - name: Run phase-isolated benchmark · npmmirror
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.phases_registry != 'npmjs'
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
-          PM_LIST: 'utoo,utoo-next,utoo-npm,bun'
+          BENCH_RUNS_CHEAP: '5'
+          UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
+          PHASES: ${{ github.event.inputs.phases || 'p0,p1,p3,p4' }}
+          BENCH_OUT_DIR: '/tmp/pm-bench-output'
+          PM_LIST: ${{ github.event.inputs.phases_pm_list || 'utoo,utoo-next,utoo-npm,bun' }}
         run: |
           mkdir -p /tmp/pm-bench-output
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmmirror.log
@@ -601,6 +637,7 @@ jobs:
         with:
           platform: linux
           os: ubuntu-latest
+          project: ${{ github.event.inputs.project || 'ant-design' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   bench-phases-mac:
@@ -642,7 +679,7 @@ jobs:
           cat > /tmp/wipe-bench-state.sh <<'WIPE'
           #!/usr/bin/env bash
           rm -rf /tmp/pm-bench /tmp/pm-bench-results /tmp/pm-bench-output \
-                 /tmp/utoo-bench-cache /tmp/utoo-npm-bench-cache /tmp/bun-bench-cache \
+                 /tmp/utoo-bench-cache /tmp/utoo-npm-bench-cache /tmp/utoo-alt-bench-cache /tmp/bun-bench-cache \
                  ~/.bun/install/cache ~/.cache/nm 2>/dev/null || true
           mkdir -p /tmp/pm-bench-output
           WIPE
@@ -650,15 +687,21 @@ jobs:
       - name: Wipe bench state before npmjs
         run: bash /tmp/wipe-bench-state.sh
       - name: Run phase-isolated benchmark · npmjs
+        if: github.event.inputs.phases_registry != 'npmmirror'
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmjs.org'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
-          PM_LIST: 'utoo,utoo-npm,bun'
+          BENCH_RUNS_CHEAP: '5'
+          UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
+          PHASES: ${{ github.event.inputs.phases || 'p0,p1,p3,p4' }}
+          BENCH_OUT_DIR: '/tmp/pm-bench-output'
+          PM_LIST: ${{ github.event.inputs.phases_pm_list || 'utoo,utoo-npm,bun' }}
         run: |
           chmod +x bench/pm-bench-phases.sh
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmjs.log
       - name: Stash npmjs logs and wipe state before npmmirror
+        if: github.event.inputs.phases_registry != 'npmjs'
         run: |
           mkdir -p /tmp/bench-logs-stash
           cp -r /tmp/pm-bench-output/. /tmp/bench-logs-stash/ 2>/dev/null || true
@@ -666,11 +709,16 @@ jobs:
           mkdir -p /tmp/pm-bench-output
           cp -r /tmp/bench-logs-stash/. /tmp/pm-bench-output/ 2>/dev/null || true
       - name: Run phase-isolated benchmark · npmmirror
+        if: github.event.inputs.phases_registry != 'npmjs'
         env:
           PROJECT: ${{ github.event.inputs.project || 'ant-design' }}
           REGISTRY: 'https://registry.npmmirror.com'
           BENCH_RUNS: ${{ github.event.inputs.bench_runs || '3' }}
-          PM_LIST: 'utoo,utoo-npm,bun'
+          BENCH_RUNS_CHEAP: '5'
+          UTOO_ALT_ENV: ${{ github.event.inputs.utoo_alt_env || '' }}
+          PHASES: ${{ github.event.inputs.phases || 'p0,p1,p3,p4' }}
+          BENCH_OUT_DIR: '/tmp/pm-bench-output'
+          PM_LIST: ${{ github.event.inputs.phases_pm_list || 'utoo,utoo-npm,bun' }}
         run: |
           mkdir -p /tmp/pm-bench-output
           bash bench/pm-bench-phases.sh 2>&1 | tee /tmp/pm-bench-output/bench-phases-npmmirror.log
@@ -686,6 +734,7 @@ jobs:
         with:
           platform: mac
           os: macos-latest
+          project: ${{ github.event.inputs.project || 'ant-design' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # ============================================================

--- a/bench/pm-bench-phases.sh
+++ b/bench/pm-bench-phases.sh
@@ -114,6 +114,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   INVOL_CTX=$(awk '/involuntary context switches/ {print $1}' "$TIME_TMP")
   USER_S=$(awk '/real/ && /user/ && /sys/ {print $3}' "$TIME_TMP")
   SYS_S=$(awk '/real/ && /user/ && /sys/ {print $5}' "$TIME_TMP")
+  WALL_S=$(awk '/real/ && /user/ && /sys/ {print $1}' "$TIME_TMP")
 else
   /usr/bin/time -v "$@" 2>"$TIME_TMP"
   EXIT_CODE=$?
@@ -125,6 +126,8 @@ else
   INVOL_CTX=$(awk '/Involuntary context switches/ {print $NF}' "$TIME_TMP")
   USER_S=$(awk -F': ' '/User time \(seconds\)/ {print $2}' "$TIME_TMP")
   SYS_S=$(awk -F': ' '/System time \(seconds\)/  {print $2}' "$TIME_TMP")
+  # "Elapsed (wall clock) time (h:mm:ss or m:ss): 0:05.83" → seconds
+  WALL_S=$(awk -F': ' '/Elapsed \(wall clock\)/ {n=split($NF,p,":"); s=0; for(i=1;i<=n;i++) s=s*60+p[i]; print s}' "$TIME_TMP")
 fi
 
 # --- snapshot network AFTER, compute delta ---
@@ -135,8 +138,8 @@ if [ -r /proc/net/dev ]; then
   net_tx=$(( cur_net_tx - snap_net_tx ))
 fi
 
-printf '{"rss":%d,"user_s":%s,"sys_s":%s,"page_major":%d,"page_minor":%d,"vol_ctx":%d,"invol_ctx":%d,"net_rx":%d,"net_tx":%d}\n' \
-  "${RSS:-0}" "${USER_S:-0}" "${SYS_S:-0}" "${PG_MAJOR:-0}" "${PG_MINOR:-0}" \
+printf '{"wall_s":%s,"rss":%d,"user_s":%s,"sys_s":%s,"page_major":%d,"page_minor":%d,"vol_ctx":%d,"invol_ctx":%d,"net_rx":%d,"net_tx":%d}\n' \
+  "${WALL_S:-0}" "${RSS:-0}" "${USER_S:-0}" "${SYS_S:-0}" "${PG_MAJOR:-0}" "${PG_MINOR:-0}" \
   "${VOL_CTX:-0}" "${INVOL_CTX:-0}" \
   "${net_rx:-0}" "${net_tx:-0}" >> "$METRICS_FILE"
 rm -f "$TIME_TMP"
@@ -232,35 +235,39 @@ echo "[prep] phase 1 $pm: cleaned lockfiles + caches + node_modules"
 EOF
       ;;
     p3_*)
-      # Phase 3: cold install — keep THIS pm's lockfile, wipe THIS pm's cache
-      # (the $cache resolved above). Delete the other pm's lockfile so bun
-      # doesn't try to migrate utoo's package-lock.json (and vice versa).
+      # Phase 3: cold install — restore THIS pm's seeded lockfile from the
+      # stash (interleaved rounds let other PMs' prepares delete it), wipe
+      # THIS pm's cache (the $cache resolved above).
       case "$pm" in
         bun) cat >> "$path" <<EOF
 rm -f package-lock.json yarn.lock pnpm-lock.yaml
+cp -f "$LOCK_STASH/bun.lock" bun.lock
 rm -rf "$BUN_CACHE"
-echo "[prep] phase 3 bun: kept bun.lock, wiped $BUN_CACHE"
+echo "[prep] phase 3 bun: restored bun.lock, wiped $BUN_CACHE"
 EOF
           ;;
         *) cat >> "$path" <<EOF
 rm -f bun.lock yarn.lock pnpm-lock.yaml
+cp -f "$LOCK_STASH/package-lock.json" package-lock.json
 rm -rf "$cache"
-echo "[prep] phase 3 $pm: kept package-lock.json, wiped $cache"
+echo "[prep] phase 3 $pm: restored package-lock.json, wiped $cache"
 EOF
           ;;
       esac
       ;;
     p4_*)
-      # Phase 4: warm link — keep lockfile AND cache, only drop node_modules.
+      # Phase 4: warm link — restore lockfile, keep cache, drop node_modules.
       case "$pm" in
         bun) cat >> "$path" <<EOF
 rm -f package-lock.json yarn.lock pnpm-lock.yaml
-echo "[prep] phase 4 bun: kept bun.lock + cache"
+cp -f "$LOCK_STASH/bun.lock" bun.lock
+echo "[prep] phase 4 bun: restored bun.lock, kept cache"
 EOF
           ;;
         *) cat >> "$path" <<EOF
 rm -f bun.lock yarn.lock pnpm-lock.yaml
-echo "[prep] phase 4 $pm: kept package-lock.json + cache"
+cp -f "$LOCK_STASH/package-lock.json" package-lock.json
+echo "[prep] phase 4 $pm: restored package-lock.json, kept cache"
 EOF
           ;;
       esac
@@ -293,23 +300,31 @@ seed_lockfile_cmd() {
   esac
 }
 
+# Interleaved rounds share the project dir across PMs whose lockfiles
+# conflict (bun deletes package-lock.json and vice versa), so seeded
+# lockfiles are stashed here and each cell's prepare restores its own.
+LOCK_STASH="$RESULTS_DIR/lock-stash"
+mkdir -p "$LOCK_STASH"
+
 seed_for_phase() {
   local phase=$1 pm=$2
   local seed_log="$RESULTS_DIR/seed_${phase}_${pm}.log"
   cd "$PROJECT_DIR"
   case "$phase:$pm" in
     p3_*:utoo|p4_*:utoo|p3_*:utoo-npm|p4_*:utoo-npm|p3_*:utoo-next|p4_*:utoo-next|p3_*:utoo-alt|p4_*:utoo-alt)
-      if [ ! -f package-lock.json ]; then
+      if [ ! -f package-lock.json ] && [ ! -f "$LOCK_STASH/package-lock.json" ]; then
         echo -e "  ${CYAN}seed: generating package-lock.json (baseline-pinned when available)${NC}"
         retry 3 bash -c "$(seed_lockfile_cmd "$pm") >> '$seed_log' 2>&1" || return 1
       fi
+      [ -f package-lock.json ] && cp -f package-lock.json "$LOCK_STASH/package-lock.json"
       ;;
     p3_*:bun|p4_*:bun)
-      if [ ! -f bun.lock ]; then
+      if [ ! -f bun.lock ] && [ ! -f "$LOCK_STASH/bun.lock" ]; then
         echo -e "  ${CYAN}seed: running \`bun install --lockfile-only\` to generate bun.lock${NC}"
         rm -f package-lock.json
         retry 3 bash -c "bun install --lockfile-only --registry='$REGISTRY' >> '$seed_log' 2>&1" || return 1
       fi
+      [ -f bun.lock ] && cp -f bun.lock "$LOCK_STASH/bun.lock"
       ;;
   esac
   # Phase 4 also needs a pre-warmed cache.
@@ -325,6 +340,15 @@ seed_for_phase() {
     if [ ! -d "$cache" ] || [ -z "$(ls -A "$cache" 2>/dev/null)" ]; then
       echo -e "  ${CYAN}seed: warming $pm cache via full install${NC}"
       rm -rf node_modules
+      # Restore this PM's lockfile from the stash — an earlier cell's prepare
+      # may have removed it (bun and the utoo variants delete each other's).
+      if [ "$pm" = bun ]; then
+        rm -f package-lock.json
+        [ -f "$LOCK_STASH/bun.lock" ] && cp -f "$LOCK_STASH/bun.lock" bun.lock
+      else
+        rm -f bun.lock
+        [ -f "$LOCK_STASH/package-lock.json" ] && cp -f "$LOCK_STASH/package-lock.json" package-lock.json
+      fi
       retry 3 bash -c "$(install_cmd "$pm") >> '$RESULTS_DIR/seed_warmup_${pm}.log' 2>&1" || return 1
       rm -rf node_modules
     fi
@@ -351,55 +375,111 @@ resolve_cmd() {
   esac
 }
 
-run_phase() {
-  local phase=$1 pm=$2 cmd=$3
-  local json="$RESULTS_DIR/${PROJECT}_${phase}_${pm}.json"
-  local metrics="$RESULTS_DIR/${PROJECT}_${phase}_${pm}_metrics.jsonl"
-  local prep_script="$RESULTS_DIR/prep_${phase}_${pm}.sh"
-  local cmd_script="$RESULTS_DIR/cmd_${phase}_${pm}.sh"
-
-  # Cheap phases get more runs (see RUNS_CHEAP).
+# Run one phase as INTERLEAVED rounds: every timed round executes each PM's
+# cell back-to-back (prepare → timed run), so registry/runner weather drift
+# hits all PMs of a round near-simultaneously and cancels in per-round paired
+# deltas. The previous shape (hyperfine: all runs of PM A, then all of PM B,
+# minutes apart) let weather spikes and a systematic cell-order bias
+# masquerade as PM deltas — a null test (identical binaries) read
+# "p3 -27.9% / p4 -6.3%" under it.
+#
+# Per-cell wall times come from the metrics wrapper (/usr/bin/time elapsed),
+# then get aggregated into hyperfine-shaped JSON so the summary and the CI
+# comment renderer consume the same files as before — with `times` now
+# index-aligned across PMs for paired analysis.
+run_phase_matrix() {
+  local phase=$1 cmd_fn=$2
   local runs=$RUNS
   case "$phase" in
     p1_* | p4_*) runs=$RUNS_CHEAP ;;
   esac
 
-  if ! seed_for_phase "$phase" "$pm"; then
-    echo -e "  ${RED}$pm $phase seed failed after retries — skipping this cell${NC}"
-    printf '{"failed":"seed"}\n' > "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_failed.json"
-    return 0
-  fi
-  write_prepare "$prep_script" "$phase" "$pm"
+  # Seed every PM's state up front; only cells that seeded OK join the rounds.
+  local -a live_pms=()
+  local pm
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    if seed_for_phase "$phase" "$pm"; then
+      live_pms+=("$pm")
+      write_prepare "$RESULTS_DIR/prep_${phase}_${pm}.sh" "$phase" "$pm"
+      printf 'set -eo pipefail\ncd %s\n%s\n' "$PROJECT_DIR" "$($cmd_fn "$pm")" \
+        > "$RESULTS_DIR/cmd_${phase}_${pm}.sh"
+      : > "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_metrics.jsonl"
+    else
+      echo -e "  ${RED}$pm $phase seed failed after retries — skipping this cell${NC}"
+      printf '{"failed":"seed"}\n' > "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_failed.json"
+    fi
+  done
+  [ ${#live_pms[@]} -eq 0 ] && return 0
 
-  # Reset metrics file; wrap the bench command so /usr/bin/time can measure it.
-  # The wrapper reads PROJECT_DIR / UTOO_CACHE / BUN_CACHE from env to scope du.
-  : > "$metrics"
-  printf 'set -eo pipefail\ncd %s\n%s\n' "$PROJECT_DIR" "$cmd" > "$cmd_script"
-
-  echo -e "  ${CYAN}$pm${NC} · $phase"
   export PROJECT_DIR UTOO_CACHE BUN_CACHE
-  # `--warmup 1`: untimed iteration before the timed runs so each PM enters
-  # its measurement window with DNS resolver cached, TLS session ticket
-  # primed, and the CDN edge POP populated. Without this, the first PM in
-  # the per-phase loop pays the cold-network tax (~+1s on p0) which the
-  # 3-run `--runs` mean cannot fully amortize, biasing the first PM
-  # systematically slow vs PMs that follow it. `--prepare` resets the
-  # filesystem state (lockfile / cache / node_modules) on every iteration
-  # — warmup included — so warmup leaves no on-disk artifact behind.
-  if ! hyperfine \
-    --runs "$RUNS" \
-    --warmup 1 \
-    --prepare "bash $prep_script" \
-    --export-json "$json" \
-    --show-output \
-    -n "${pm}-${phase}" \
-    "bash $METRICS_WRAPPER $metrics bash $cmd_script"; then
-    echo -e "  ${RED}$pm $phase failed${NC}"
-  fi
 
-  # After the timed runs: capture the state left on disk by the last run.
-  # Done outside hyperfine so du's traversal doesn't pollute wall-clock.
-  capture_footprint "$phase" "$pm" "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_footprint.json"
+  # Untimed warmup round: DNS resolver cached, TLS session ticket primed,
+  # CDN edge POP populated per PM before any timed window opens.
+  echo -e "  ${CYAN}warmup round${NC} (${live_pms[*]})"
+  for pm in "${live_pms[@]}"; do
+    bash "$RESULTS_DIR/prep_${phase}_${pm}.sh" > /dev/null 2>&1 || true
+    bash "$RESULTS_DIR/cmd_${phase}_${pm}.sh" \
+      > "$RESULTS_DIR/warmup_${phase}_${pm}.log" 2>&1 || true
+  done
+
+  local r
+  for ((r = 1; r <= runs; r++)); do
+    # Alternate cell order between rounds: a fixed within-round order would
+    # let a systematic position effect (page-cache warmth, CPU thermal)
+    # accumulate into the paired deltas; reversing on odd rounds averages
+    # it out while keeping times[i] round-aligned across PMs.
+    local -a round_order=("${live_pms[@]}")
+    if ((r % 2 == 0)); then
+      local -a reversed=()
+      local i
+      for ((i = ${#round_order[@]} - 1; i >= 0; i--)); do
+        reversed+=("${round_order[$i]}")
+      done
+      round_order=("${reversed[@]}")
+    fi
+    echo -e "  ${CYAN}round $r/$runs${NC} (${round_order[*]})"
+    for pm in "${round_order[@]}"; do
+      bash "$RESULTS_DIR/prep_${phase}_${pm}.sh" > /dev/null 2>&1 || true
+      if ! bash "$METRICS_WRAPPER" \
+        "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_metrics.jsonl" \
+        bash "$RESULTS_DIR/cmd_${phase}_${pm}.sh" \
+        > "$RESULTS_DIR/run_${phase}_${pm}_r${r}.log" 2>&1; then
+        echo -e "  ${RED}$pm $phase round $r failed${NC} (see run_${phase}_${pm}_r${r}.log)"
+      fi
+      # Capture the on-disk state right after this PM's final round — under
+      # interleaving node_modules belongs to whichever cell ran last, so the
+      # snapshot must happen inside the loop (du runs between cells; its
+      # traversal stays outside every timed window either way).
+      if [ "$r" -eq "$runs" ]; then
+        capture_footprint "$phase" "$pm" "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_footprint.json"
+      fi
+    done
+  done
+
+  # Aggregate per-cell wall times (metrics jsonl) into hyperfine-shaped JSON.
+  RESULTS_DIR="$RESULTS_DIR" PROJECT="$PROJECT" PHASE="$phase" \
+    PMS="$(IFS=,; echo "${live_pms[*]}")" node -e '
+    const fs = require("fs");
+    const { RESULTS_DIR: dir, PROJECT: proj, PHASE: phase, PMS } = process.env;
+    for (const pm of PMS.split(",")) {
+      const base = `${dir}/${proj}_${phase}_${pm}`;
+      let rows = [];
+      try {
+        rows = fs.readFileSync(`${base}_metrics.jsonl`, "utf8")
+          .trim().split("\n").filter(Boolean).map(JSON.parse);
+      } catch {}
+      const times = rows.map(r => Number(r.wall_s)).filter(t => t > 0);
+      if (!times.length) {
+        fs.writeFileSync(`${base}_failed.json`, JSON.stringify({ failed: "run" }));
+        continue;
+      }
+      const mean = times.reduce((a, b) => a + b, 0) / times.length;
+      const sd = Math.sqrt(times.reduce((s, t) => s + (t - mean) ** 2, 0) / Math.max(times.length - 1, 1));
+      fs.writeFileSync(`${base}.json`, JSON.stringify({
+        results: [{ command: `${pm}-${phase}`, mean, stddev: sd, min: Math.min(...times), max: Math.max(...times), times }],
+      }));
+    }
+  '
 }
 
 # Optional phase filter: PHASES="p3,p4" runs only those phases — ablation
@@ -413,33 +493,25 @@ phase_enabled() { [[ ",$PHASES," == *",$1,"* ]]; }
 # Directly comparable to `bun install` / `utoo install` on a freshly cloned repo.
 if phase_enabled p0; then
   banner "Phase 0 · full cold install (lockfile + cache + node_modules all wiped)"
-  for pm in "${PACKAGE_MANAGERS[@]}"; do
-    run_phase "p0_full_cold" "$pm" "$(install_cmd "$pm")"
-  done
+  run_phase_matrix "p0_full_cold" install_cmd
 fi
 
 # === PHASE 1: resolve only (clean slate) ===
 if phase_enabled p1; then
   banner "Phase 1 · resolve (lockfile only, cold cache)"
-  for pm in "${PACKAGE_MANAGERS[@]}"; do
-    run_phase "p1_resolve" "$pm" "$(resolve_cmd "$pm")"
-  done
+  run_phase_matrix "p1_resolve" resolve_cmd
 fi
 
 # === PHASE 3: cold install (lockfile exists, cache empty) ===
 if phase_enabled p3; then
   banner "Phase 3 · cold install (lockfile present, empty cache, empty node_modules)"
-  for pm in "${PACKAGE_MANAGERS[@]}"; do
-    run_phase "p3_cold_install" "$pm" "$(install_cmd "$pm")"
-  done
+  run_phase_matrix "p3_cold_install" install_cmd
 fi
 
 # === PHASE 4: warm link (cache populated, lockfile exists) ===
 if phase_enabled p4; then
   banner "Phase 4 · warm link (lockfile present, populated cache, empty node_modules)"
-  for pm in "${PACKAGE_MANAGERS[@]}"; do
-    run_phase "p4_warm_link" "$pm" "$(install_cmd "$pm")"
-  done
+  run_phase_matrix "p4_warm_link" install_cmd
 fi
 
 # === SUMMARY ===

--- a/bench/pm-bench-phases.sh
+++ b/bench/pm-bench-phases.sh
@@ -7,6 +7,18 @@ set -eo pipefail
 PROJECT=${PROJECT:-ant-design}
 REGISTRY=${REGISTRY:-https://registry.npmjs.org}
 RUNS=${BENCH_RUNS:-3}
+# Cheap phases (p1 resolve / p4 warm link) finish in seconds; more runs there
+# buys statistical power exactly where it's affordable.
+RUNS_CHEAP=${BENCH_RUNS_CHEAP:-$RUNS}
+# Ablation variant: `utoo-alt` runs the SAME utoo binary with the extra env
+# from UTOO_ALT_ENV (e.g. "UTOO_TARBALL_HTTP=h2" or
+# "UTOO_CLONE_CONCURRENCY=8") and its own cache dir. Benching utoo vs
+# utoo-alt on one runner isolates a single knob from network/runner weather
+# — the way to validate protocol/concurrency choices instead of trusting
+# cross-run deltas. Auto-appended to PM_LIST when UTOO_ALT_ENV is set.
+if [ -n "${UTOO_ALT_ENV:-}" ] && [[ ",${PM_LIST:-}," != *",utoo-alt,"* ]]; then
+  PM_LIST="${PM_LIST:+$PM_LIST,}utoo-alt"
+fi
 IFS=',' read -ra PACKAGE_MANAGERS <<< "${PM_LIST:-utoo,bun}"
 
 BENCH_DIR=${BENCH_DIR:-/tmp/pm-bench}
@@ -19,6 +31,7 @@ mkdir -p "$BENCH_DIR" "$RESULTS_DIR"
 UTOO_CACHE="${UTOO_CACHE:-/tmp/utoo-bench-cache}"
 UTOO_NPM_CACHE="${UTOO_NPM_CACHE:-/tmp/utoo-npm-bench-cache}"
 UTOO_NEXT_CACHE="${UTOO_NEXT_CACHE:-/tmp/utoo-next-bench-cache}"
+UTOO_ALT_CACHE="${UTOO_ALT_CACHE:-/tmp/utoo-alt-bench-cache}"
 BUN_CACHE="${BUN_CACHE:-/tmp/bun-bench-cache}"
 export BUN_INSTALL_CACHE_DIR="$BUN_CACHE"
 
@@ -41,6 +54,12 @@ for pm in "${PACKAGE_MANAGERS[@]}"; do
         continue
       fi
       ;;
+    utoo-alt)
+      if [ -z "${UTOO_ALT_ENV:-}" ]; then
+        echo "skip utoo-alt: UTOO_ALT_ENV not set" >&2
+        continue
+      fi
+      ;;
   esac
   FILTERED+=("$pm")
 done
@@ -53,6 +72,20 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 banner() { echo -e "${YELLOW}=== $* ===${NC}"; }
+
+# Retry a command a few times with a short pause — registry/network hiccups
+# during the (untimed) seed installs were the dominant CI flake mode, and a
+# single blip used to abort the whole bench via `set -e`.
+retry() {
+  local attempts=$1 i
+  shift
+  for ((i = 1; i <= attempts; i++)); do
+    "$@" && return 0
+    echo -e "  ${RED}attempt $i/$attempts failed:${NC} $*" >&2
+    [ "$i" -lt "$attempts" ] && sleep 5
+  done
+  return 1
+}
 
 # --- metrics wrapper ---
 # Keeps the hot path fast: only /usr/bin/time + counter snapshots inside the
@@ -135,6 +168,7 @@ capture_footprint() {
     utoo)      cache=$UTOO_CACHE ;;
     utoo-npm)  cache=$UTOO_NPM_CACHE ;;
     utoo-next) cache=$UTOO_NEXT_CACHE ;;
+    utoo-alt)  cache=$UTOO_ALT_CACHE ;;
     bun)       cache=$BUN_CACHE ;;
   esac
   printf '{"cache":%d,"node_modules":%d,"lockfile":%d}\n' \
@@ -148,7 +182,7 @@ capture_footprint() {
 banner "Preparing $PROJECT"
 cd "$BENCH_DIR"
 if [ ! -d "$PROJECT" ]; then
-  git clone --depth=1 "https://github.com/ant-design/${PROJECT}.git" "$PROJECT"
+  retry 3 git clone --depth=1 "https://github.com/ant-design/${PROJECT}.git" "$PROJECT"
 fi
 PROJECT_DIR="$BENCH_DIR/$PROJECT"
 
@@ -162,6 +196,7 @@ write_prepare() {
     utoo)      cache=$UTOO_CACHE ;;
     utoo-npm)  cache=$UTOO_NPM_CACHE ;;
     utoo-next) cache=$UTOO_NEXT_CACHE ;;
+    utoo-alt)  cache=$UTOO_ALT_CACHE ;;
     bun)       cache=$BUN_CACHE ;;
   esac
 
@@ -184,7 +219,7 @@ EOF
       # Phase 0: full cold install — nothing reused. Lockfile + all caches wiped.
       cat >> "$path" <<EOF
 rm -f package-lock.json bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_CACHE" "$UTOO_NPM_CACHE" "$UTOO_NEXT_CACHE" "$BUN_CACHE"
+rm -rf "$UTOO_CACHE" "$UTOO_NPM_CACHE" "$UTOO_NEXT_CACHE" "$UTOO_ALT_CACHE" "$BUN_CACHE"
 echo "[prep] phase 0 $pm: full cold (lockfile + caches + node_modules wiped)"
 EOF
       ;;
@@ -192,37 +227,25 @@ EOF
       # Phase 1: cold resolve — wipe lockfiles AND caches so nothing can be reused.
       cat >> "$path" <<EOF
 rm -f package-lock.json bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_CACHE" "$UTOO_NPM_CACHE" "$UTOO_NEXT_CACHE" "$BUN_CACHE"
+rm -rf "$UTOO_CACHE" "$UTOO_NPM_CACHE" "$UTOO_NEXT_CACHE" "$UTOO_ALT_CACHE" "$BUN_CACHE"
 echo "[prep] phase 1 $pm: cleaned lockfiles + caches + node_modules"
 EOF
       ;;
     p3_*)
-      # Phase 3: cold install — keep THIS pm's lockfile, wipe THIS pm's cache.
-      # Delete the other pm's lockfile so bun doesn't try to migrate utoo's
-      # package-lock.json (and vice versa).
+      # Phase 3: cold install — keep THIS pm's lockfile, wipe THIS pm's cache
+      # (the $cache resolved above). Delete the other pm's lockfile so bun
+      # doesn't try to migrate utoo's package-lock.json (and vice versa).
       case "$pm" in
-        utoo) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_CACHE"
-echo "[prep] phase 3 utoo: kept package-lock.json, wiped $UTOO_CACHE"
-EOF
-          ;;
-        utoo-npm) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_NPM_CACHE"
-echo "[prep] phase 3 utoo-npm: kept package-lock.json, wiped $UTOO_NPM_CACHE"
-EOF
-          ;;
-        utoo-next) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-rm -rf "$UTOO_NEXT_CACHE"
-echo "[prep] phase 3 utoo-next: kept package-lock.json, wiped $UTOO_NEXT_CACHE"
-EOF
-          ;;
         bun) cat >> "$path" <<EOF
 rm -f package-lock.json yarn.lock pnpm-lock.yaml
 rm -rf "$BUN_CACHE"
 echo "[prep] phase 3 bun: kept bun.lock, wiped $BUN_CACHE"
+EOF
+          ;;
+        *) cat >> "$path" <<EOF
+rm -f bun.lock yarn.lock pnpm-lock.yaml
+rm -rf "$cache"
+echo "[prep] phase 3 $pm: kept package-lock.json, wiped $cache"
 EOF
           ;;
       esac
@@ -230,24 +253,14 @@ EOF
     p4_*)
       # Phase 4: warm link — keep lockfile AND cache, only drop node_modules.
       case "$pm" in
-        utoo) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-echo "[prep] phase 4 utoo: kept package-lock.json + cache"
-EOF
-          ;;
-        utoo-npm) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-echo "[prep] phase 4 utoo-npm: kept package-lock.json + cache"
-EOF
-          ;;
-        utoo-next) cat >> "$path" <<EOF
-rm -f bun.lock yarn.lock pnpm-lock.yaml
-echo "[prep] phase 4 utoo-next: kept package-lock.json + cache"
-EOF
-          ;;
         bun) cat >> "$path" <<EOF
 rm -f package-lock.json yarn.lock pnpm-lock.yaml
 echo "[prep] phase 4 bun: kept bun.lock + cache"
+EOF
+          ;;
+        *) cat >> "$path" <<EOF
+rm -f bun.lock yarn.lock pnpm-lock.yaml
+echo "[prep] phase 4 $pm: kept package-lock.json + cache"
 EOF
           ;;
       esac
@@ -258,34 +271,44 @@ EOF
 }
 
 # Seed PM-specific state before a phase runs (lockfile + cache where needed).
-# This runs ONCE before hyperfine starts, not per-iteration.
+# This runs ONCE before hyperfine starts, not per-iteration. Returns non-zero
+# on terminal seed failure so run_phase can skip just that (phase, pm) cell
+# instead of aborting the whole bench.
+#
+# Lockfile provenance: all utoo variants install from one package-lock.json.
+# Generate it with the *baseline* binary (utoo-next) when wired up, so a PR
+# that changes resolution/lockfile shape can never perturb the input the
+# baseline is measured against — p3/p4 compare install speed on equal input.
+seed_lockfile_cmd() {
+  local pm=$1
+  if [ -n "${UTOO_NEXT_BIN:-}" ]; then
+    echo "$UTOO_NEXT_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE"
+    return
+  fi
+  case "$pm" in
+    utoo)      echo "utoo deps --registry=$REGISTRY --cache-dir=$UTOO_CACHE" ;;
+    utoo-npm)  echo "$UTOO_NPM_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NPM_CACHE" ;;
+    utoo-next) echo "$UTOO_NEXT_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE" ;;
+    utoo-alt)  echo "env $UTOO_ALT_ENV utoo deps --registry=$REGISTRY --cache-dir=$UTOO_ALT_CACHE" ;;
+  esac
+}
+
 seed_for_phase() {
   local phase=$1 pm=$2
+  local seed_log="$RESULTS_DIR/seed_${phase}_${pm}.log"
   cd "$PROJECT_DIR"
   case "$phase:$pm" in
-    p3_*:utoo|p4_*:utoo)
+    p3_*:utoo|p4_*:utoo|p3_*:utoo-npm|p4_*:utoo-npm|p3_*:utoo-next|p4_*:utoo-next|p3_*:utoo-alt|p4_*:utoo-alt)
       if [ ! -f package-lock.json ]; then
-        echo -e "  ${CYAN}seed: running \`utoo deps\` to generate package-lock.json${NC}"
-        utoo deps --registry="$REGISTRY" --cache-dir="$UTOO_CACHE" > "$RESULTS_DIR/seed_${phase}_${pm}.log" 2>&1
-      fi
-      ;;
-    p3_*:utoo-npm|p4_*:utoo-npm)
-      if [ ! -f package-lock.json ]; then
-        echo -e "  ${CYAN}seed: running \`utoo-npm deps\` to generate package-lock.json${NC}"
-        "$UTOO_NPM_BIN" deps --registry="$REGISTRY" --cache-dir="$UTOO_NPM_CACHE" > "$RESULTS_DIR/seed_${phase}_${pm}.log" 2>&1
-      fi
-      ;;
-    p3_*:utoo-next|p4_*:utoo-next)
-      if [ ! -f package-lock.json ]; then
-        echo -e "  ${CYAN}seed: running \`utoo-next deps\` to generate package-lock.json${NC}"
-        "$UTOO_NEXT_BIN" deps --registry="$REGISTRY" --cache-dir="$UTOO_NEXT_CACHE" > "$RESULTS_DIR/seed_${phase}_${pm}.log" 2>&1
+        echo -e "  ${CYAN}seed: generating package-lock.json (baseline-pinned when available)${NC}"
+        retry 3 bash -c "$(seed_lockfile_cmd "$pm") >> '$seed_log' 2>&1" || return 1
       fi
       ;;
     p3_*:bun|p4_*:bun)
       if [ ! -f bun.lock ]; then
         echo -e "  ${CYAN}seed: running \`bun install --lockfile-only\` to generate bun.lock${NC}"
         rm -f package-lock.json
-        bun install --lockfile-only --registry="$REGISTRY" > "$RESULTS_DIR/seed_${phase}_${pm}.log" 2>&1
+        retry 3 bash -c "bun install --lockfile-only --registry='$REGISTRY' >> '$seed_log' 2>&1" || return 1
       fi
       ;;
   esac
@@ -296,17 +319,13 @@ seed_for_phase() {
       utoo)      cache=$UTOO_CACHE ;;
       utoo-npm)  cache=$UTOO_NPM_CACHE ;;
       utoo-next) cache=$UTOO_NEXT_CACHE ;;
+      utoo-alt)  cache=$UTOO_ALT_CACHE ;;
       bun)       cache=$BUN_CACHE ;;
     esac
     if [ ! -d "$cache" ] || [ -z "$(ls -A "$cache" 2>/dev/null)" ]; then
       echo -e "  ${CYAN}seed: warming $pm cache via full install${NC}"
       rm -rf node_modules
-      case "$pm" in
-        utoo)      utoo install --ignore-scripts --registry="$REGISTRY" --cache-dir="$UTOO_CACHE" > "$RESULTS_DIR/seed_warmup_${pm}.log" 2>&1 ;;
-        utoo-npm)  "$UTOO_NPM_BIN" install --ignore-scripts --registry="$REGISTRY" --cache-dir="$UTOO_NPM_CACHE" > "$RESULTS_DIR/seed_warmup_${pm}.log" 2>&1 ;;
-        utoo-next) "$UTOO_NEXT_BIN" install --ignore-scripts --registry="$REGISTRY" --cache-dir="$UTOO_NEXT_CACHE" > "$RESULTS_DIR/seed_warmup_${pm}.log" 2>&1 ;;
-        bun)       bun  install --ignore-scripts --registry="$REGISTRY" > "$RESULTS_DIR/seed_warmup_${pm}.log" 2>&1 ;;
-      esac
+      retry 3 bash -c "$(install_cmd "$pm") >> '$RESULTS_DIR/seed_warmup_${pm}.log' 2>&1" || return 1
       rm -rf node_modules
     fi
   fi
@@ -317,6 +336,7 @@ install_cmd() {
     utoo)      echo "utoo install --ignore-scripts --registry=$REGISTRY --cache-dir=$UTOO_CACHE" ;;
     utoo-npm)  echo "$UTOO_NPM_BIN install --ignore-scripts --registry=$REGISTRY --cache-dir=$UTOO_NPM_CACHE" ;;
     utoo-next) echo "$UTOO_NEXT_BIN install --ignore-scripts --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE" ;;
+    utoo-alt)  echo "env $UTOO_ALT_ENV utoo install --ignore-scripts --registry=$REGISTRY --cache-dir=$UTOO_ALT_CACHE" ;;
     bun)       echo "bun install --ignore-scripts --registry=$REGISTRY" ;;
   esac
 }
@@ -326,6 +346,7 @@ resolve_cmd() {
     utoo)      echo "utoo deps --registry=$REGISTRY --cache-dir=$UTOO_CACHE" ;;
     utoo-npm)  echo "$UTOO_NPM_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NPM_CACHE" ;;
     utoo-next) echo "$UTOO_NEXT_BIN deps --registry=$REGISTRY --cache-dir=$UTOO_NEXT_CACHE" ;;
+    utoo-alt)  echo "env $UTOO_ALT_ENV utoo deps --registry=$REGISTRY --cache-dir=$UTOO_ALT_CACHE" ;;
     bun)       echo "bun install --lockfile-only --registry=$REGISTRY" ;;
   esac
 }
@@ -337,7 +358,17 @@ run_phase() {
   local prep_script="$RESULTS_DIR/prep_${phase}_${pm}.sh"
   local cmd_script="$RESULTS_DIR/cmd_${phase}_${pm}.sh"
 
-  seed_for_phase "$phase" "$pm"
+  # Cheap phases get more runs (see RUNS_CHEAP).
+  local runs=$RUNS
+  case "$phase" in
+    p1_* | p4_*) runs=$RUNS_CHEAP ;;
+  esac
+
+  if ! seed_for_phase "$phase" "$pm"; then
+    echo -e "  ${RED}$pm $phase seed failed after retries — skipping this cell${NC}"
+    printf '{"failed":"seed"}\n' > "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_failed.json"
+    return 0
+  fi
   write_prepare "$prep_script" "$phase" "$pm"
 
   # Reset metrics file; wrap the bench command so /usr/bin/time can measure it.
@@ -371,31 +402,45 @@ run_phase() {
   capture_footprint "$phase" "$pm" "$RESULTS_DIR/${PROJECT}_${phase}_${pm}_footprint.json"
 }
 
+# Optional phase filter: PHASES="p3,p4" runs only those phases — ablation
+# runs targeting one subsystem (e.g. clone concurrency) don't need the full
+# matrix. Default runs everything.
+PHASES=${PHASES:-p0,p1,p3,p4}
+phase_enabled() { [[ ",$PHASES," == *",$1,"* ]]; }
+
 # === PHASE 0: full cold install (clean slate + full install) ===
 # Matches the end-to-end user scenario: no lockfile, no cache, no node_modules.
 # Directly comparable to `bun install` / `utoo install` on a freshly cloned repo.
-banner "Phase 0 · full cold install (lockfile + cache + node_modules all wiped)"
-for pm in "${PACKAGE_MANAGERS[@]}"; do
-  run_phase "p0_full_cold" "$pm" "$(install_cmd "$pm")"
-done
+if phase_enabled p0; then
+  banner "Phase 0 · full cold install (lockfile + cache + node_modules all wiped)"
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    run_phase "p0_full_cold" "$pm" "$(install_cmd "$pm")"
+  done
+fi
 
 # === PHASE 1: resolve only (clean slate) ===
-banner "Phase 1 · resolve (lockfile only, cold cache)"
-for pm in "${PACKAGE_MANAGERS[@]}"; do
-  run_phase "p1_resolve" "$pm" "$(resolve_cmd "$pm")"
-done
+if phase_enabled p1; then
+  banner "Phase 1 · resolve (lockfile only, cold cache)"
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    run_phase "p1_resolve" "$pm" "$(resolve_cmd "$pm")"
+  done
+fi
 
 # === PHASE 3: cold install (lockfile exists, cache empty) ===
-banner "Phase 3 · cold install (lockfile present, empty cache, empty node_modules)"
-for pm in "${PACKAGE_MANAGERS[@]}"; do
-  run_phase "p3_cold_install" "$pm" "$(install_cmd "$pm")"
-done
+if phase_enabled p3; then
+  banner "Phase 3 · cold install (lockfile present, empty cache, empty node_modules)"
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    run_phase "p3_cold_install" "$pm" "$(install_cmd "$pm")"
+  done
+fi
 
 # === PHASE 4: warm link (cache populated, lockfile exists) ===
-banner "Phase 4 · warm link (lockfile present, populated cache, empty node_modules)"
-for pm in "${PACKAGE_MANAGERS[@]}"; do
-  run_phase "p4_warm_link" "$pm" "$(install_cmd "$pm")"
-done
+if phase_enabled p4; then
+  banner "Phase 4 · warm link (lockfile present, populated cache, empty node_modules)"
+  for pm in "${PACKAGE_MANAGERS[@]}"; do
+    run_phase "p4_warm_link" "$pm" "$(install_cmd "$pm")"
+  done
+fi
 
 # === SUMMARY ===
 banner "Summary"
@@ -498,5 +543,16 @@ RESULTS_DIR="$RESULTS_DIR" node -e "
     }
   }
 "
+
+# Export raw per-cell results (hyperfine JSON, metrics, footprint, failure
+# markers) for the CI comment renderer — keyed by registry host so multi-leg
+# runs (npmjs + npmmirror) don't clobber each other across state wipes.
+if [ -n "${BENCH_OUT_DIR:-}" ]; then
+  REG_LABEL=$(echo "$REGISTRY" | sed -E 's|^https?://||; s|/.*$||')
+  EXPORT_DIR="$BENCH_OUT_DIR/results-$REG_LABEL"
+  mkdir -p "$EXPORT_DIR"
+  cp "$RESULTS_DIR/$PROJECT"_* "$EXPORT_DIR/" 2>/dev/null || true
+  echo -e "${GREEN}Exported raw results to $EXPORT_DIR${NC}"
+fi
 
 echo -e "${GREEN}Done. Raw results in $RESULTS_DIR${NC}"


### PR DESCRIPTION
Split out of #3146 — bench/CI infra only, **no Rust changes**.

- PR comment rendered from raw hyperfine JSON: headline verdict **utoo (PR) vs utoo-next** per phase with significance gate (|Δ| > 5% and beyond 2σ → 🚀/⚠️, else ✅), resources folded into `<details>`, failed cells explicit, copy in step summary
- seed retries + per-cell failure isolation (registry blips no longer abort the whole bench)
- p3/p4 lockfile generated by the **baseline** binary (PR can't perturb baseline input)
- `utoo-alt` ablation variant: same binary + `UTOO_ALT_ENV` + own cache → same-runner single-knob A/B (already used to settle H1-vs-H2: h2 is +9.8% slower on p3 npmjs, +35% on npmmirror)
- dispatch filters `phases` / `phases_pm_list` / `phases_registry`: ablation runs drop from ~50 min to ~8 min
- label runs drop utoo-npm; p1/p4 at 5 iterations; hyperfine pinned from GitHub releases

Since this PR contains no Rust changes, its own benchmark label run doubles as a **null test**: utoo vs utoo-next compare identical code, so every phase should read ✅ ~0% — a live calibration of the noise floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)