### PR TITLE
perf(pm): skip cache-plan lookup for prefetched registry tarballs

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -411,6 +411,19 @@ impl SchedulerState {
             return;
         }
 
+        // Fast path: a registry-style tarball whose download stage already
+        // completed (on warm installs the prefetch pass proves the cache for
+        // every package) goes straight to the clone queue. This skips the
+        // seeded-slot lookup task in `resolve_cache_for_clone` — a tokio spawn
+        // + URL sha256 + a stat of an `_http_` slot that only ever exists for
+        // non-registry tarballs.
+        if is_registry_tarball(&spec.package.tarball_url)
+            && let Some(cache_path) = self.download_done.get(&spec.package.key()).cloned()
+        {
+            self.clone_queue.push_back(ReadyClone { spec, cache_path });
+            return;
+        }
+
         self.resolve_cache_for_clone(spec);
     }
 


### PR DESCRIPTION
Split out of #3146 and narrowed after rebase: this keeps only the small registry-tarball clone fast path.

When the prefetch/download stage has already proven a registry tarball is cached, `queue_clone` can push the clone directly instead of spawning `resolve_cache_for_clone` just to recompute a cache plan and stat non-registry seeded slots that cannot exist for registry tarballs.

Removed the earlier concurrency env override experiment after the rebased benchmark showed no significant win.

Verification:
- `cargo fmt --check`
- GitHub CI/clippy on the pushed branch