### PR TITLE
perf(pm): drop redundant lockfile and package.json parsing on install

### DIFF
--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -16,7 +16,7 @@ use super::workspace::find_workspace_path;
 use crate::fs;
 use crate::util::cli_enum::{PackageAction, SaveType};
 use crate::util::git_resolver::{resolve_git_spec, resolve_github_spec};
-use crate::util::json::{load_package_lock_json_from_path, read_json_file};
+use crate::util::json::read_json_file;
 use crate::util::user_config::{
     get_catalogs, get_or_load_package_json, get_peer_deps, set_package_json,
 };
@@ -59,33 +59,35 @@ pub async fn ensure_package_lock(root_path: &Path) -> Result<PackageLock> {
         return Err(anyhow!("package.json not found"));
     }
 
-    // Check if we need to regenerate package-lock.json
-    let needs_regenerate = fs::metadata(root_path.join("package-lock.json"))
+    // Reuse the lockfile when it exists and is up to date; the freshness
+    // check already parsed it, so a fresh result is the loaded lock itself.
+    let fresh_lock = if fs::metadata(root_path.join("package-lock.json"))
         .await
-        .is_err()
-        || is_pkg_lock_outdated(root_path).await?;
+        .is_ok()
+    {
+        load_package_lock_if_fresh(root_path).await?
+    } else {
+        None
+    };
 
-    if needs_regenerate {
-        tracing::debug!("Resolving dependencies");
-        let output = Context::build_deps(root_path.to_path_buf()).await?;
-
-        // Write to disk asynchronously in background
-        let path = root_path.to_path_buf();
-        let lock_clone = output.lock.clone();
-        tokio::spawn(async move {
-            if let Err(e) = save_package_lock(&path, &lock_clone).await {
-                tracing::warn!("Failed to save package-lock.json: {e}");
-            }
-        });
-
-        return Ok(output.lock);
+    if let Some(package_lock) = fresh_lock {
+        tracing::debug!("Loading package-lock.json from current project");
+        return Ok(package_lock);
     }
 
-    // Load existing package-lock.json only when it's valid and up-to-date
-    tracing::debug!("Loading package-lock.json from current project");
-    let package_lock: PackageLock = load_package_lock_json_from_path(root_path).await?;
+    tracing::debug!("Resolving dependencies");
+    let output = Context::build_deps(root_path.to_path_buf()).await?;
 
-    Ok(package_lock)
+    // Write to disk asynchronously in background
+    let path = root_path.to_path_buf();
+    let lock_clone = output.lock.clone();
+    tokio::spawn(async move {
+        if let Err(e) = save_package_lock(&path, &lock_clone).await {
+            tracing::warn!("Failed to save package-lock.json: {e}");
+        }
+    });
+
+    Ok(output.lock)
 }
 
 /// Batch update package.json for multiple package specifications to reduce file I/O operations
@@ -260,7 +262,11 @@ fn root_optional_with_runtime(path: &str, pkg: &PackageJson) -> Option<HashMap<S
     Some(merged)
 }
 
-pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
+/// Freshness-check package-lock.json and return the parsed [`PackageLock`]
+/// when it is up to date — `Ok(None)` means outdated. Multi-MB lockfiles cost
+/// a full serde parse, so callers that go on to install from a fresh lock
+/// should consume this instead of re-reading the file after a boolean check.
+pub async fn load_package_lock_if_fresh(root_path: &Path) -> Result<Option<PackageLock>> {
     // Root package.json is served from the in-process cache. The cache
     // stays consistent with disk across the full `ut install` lifetime
     // because `update_package_json` calls `set_package_json` write-through
@@ -311,7 +317,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
             None => {
                 let name = if path.is_empty() { "root" } else { path };
                 tracing::warn!("package-lock.json is outdated, new workspace {name} not found");
-                return Ok(true);
+                return Ok(None);
             }
         };
 
@@ -319,7 +325,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
 
         if !deps_match(pkg.dependencies.as_ref(), lock.dependencies.as_ref()) {
             tracing::warn!("package-lock.json is outdated, {name} dependencies changed");
-            return Ok(true);
+            return Ok(None);
         }
 
         // `Context::build_deps` folds synthetic `node-bin-*` runtime deps into
@@ -332,7 +338,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
 
         if !deps_match(expected_optional, lock.optional_dependencies.as_ref()) {
             tracing::warn!("package-lock.json is outdated, {name} optionalDependencies changed");
-            return Ok(true);
+            return Ok(None);
         }
 
         if !deps_match(
@@ -340,7 +346,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
             lock.dev_dependencies.as_ref(),
         ) {
             tracing::warn!("package-lock.json is outdated, {name} devDependencies changed");
-            return Ok(true);
+            return Ok(None);
         }
 
         if peer_deps == PeerDeps::Include
@@ -350,7 +356,7 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
             )
         {
             tracing::warn!("package-lock.json is outdated, {name} peerDependencies changed");
-            return Ok(true);
+            return Ok(None);
         }
     }
 
@@ -369,10 +375,10 @@ pub async fn is_pkg_lock_outdated(root_path: &Path) -> Result<bool> {
 
     if !engines_match {
         tracing::warn!("package-lock.json is outdated, engines changed");
-        return Ok(true);
+        return Ok(None);
     }
 
-    Ok(false)
+    Ok(Some(lock_file))
 }
 
 /// Save PackageLock to disk synchronously
@@ -515,7 +521,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            is_pkg_lock_outdated(temp_path).await.unwrap(),
+            load_package_lock_if_fresh(temp_path)
+                .await
+                .unwrap()
+                .is_none(),
             expected,
             "package.json:\n{pkg_json}"
         );
@@ -615,7 +624,12 @@ mod tests {
         });
         fs::write(temp_path.join("package.json"), pkg_json.to_string()).unwrap();
         fs::write(temp_path.join("package-lock.json"), pkg_lock.to_string()).unwrap();
-        assert!(!is_pkg_lock_outdated(temp_path).await.unwrap());
+        assert!(
+            load_package_lock_if_fresh(temp_path)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -704,7 +718,12 @@ mod tests {
         fs::write(temp_path.join("package-lock.json"), pkg_lock.to_string()).unwrap();
 
         // Test that empty object and missing field are treated as equal
-        assert!(!is_pkg_lock_outdated(temp_path).await.unwrap());
+        assert!(
+            load_package_lock_if_fresh(temp_path)
+                .await
+                .unwrap()
+                .is_some()
+        );
 
         // Test reverse case: package.json has no dependencies field, package-lock.json has empty dependencies
         let pkg_json_no_deps = json!({
@@ -735,7 +754,12 @@ mod tests {
         .unwrap();
 
         // Test that missing field and empty object are treated as equal
-        assert!(!is_pkg_lock_outdated(temp_path).await.unwrap());
+        assert!(
+            load_package_lock_if_fresh(temp_path)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -10,7 +10,7 @@ use crate::fs;
 use crate::helper::global_bin::{get_global_bin_dir, get_global_package_dir};
 use crate::helper::lock::{
     Package, UpdatePackageJsonOptions, extract_package_name, format_save_spec, group_by_depth,
-    is_pkg_lock_outdated, resolve_package_spec, save_package_lock, update_package_json,
+    load_package_lock_if_fresh, resolve_package_spec, save_package_lock, update_package_json,
 };
 use crate::helper::ruborist_context::{Context, spawn_save_project_cache};
 use crate::helper::workspace::init_project_root;
@@ -18,7 +18,6 @@ use crate::model::package::PackageInfo;
 use crate::service::package::PackageService;
 use crate::service::rebuild::RebuildService;
 use crate::util::cli_enum::{OmitType, PackageAction, SaveType};
-use crate::util::json::load_package_lock_json_from_path;
 use crate::util::linker::link;
 use crate::util::logger::{
     PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
@@ -269,21 +268,19 @@ impl InstallService {
     ) -> Result<()> {
         let lock_path = root_path.join("package-lock.json");
         // Treat a failing freshness check as stale: regenerate rather than
-        // install from a lockfile we couldn't validate. `is_pkg_lock_outdated`
-        // itself emits a `tracing::warn` with the specific mismatch reason.
-        let use_fresh_lock = fs::try_exists(&lock_path).await.unwrap_or(false)
-            && !is_pkg_lock_outdated(root_path).await.unwrap_or(true);
+        // install from a lockfile we couldn't validate. The check parses the
+        // lockfile, so a fresh result is the loaded lock itself — no second
+        // multi-MB parse. `load_package_lock_if_fresh` emits a
+        // `tracing::warn` with the specific mismatch reason when outdated.
+        let fresh_lock = if fs::try_exists(&lock_path).await.unwrap_or(false) {
+            load_package_lock_if_fresh(root_path).await.unwrap_or(None)
+        } else {
+            None
+        };
         let scheduler_handle = super::install_scheduler::InstallSchedulerHandle::start();
         let scheduler = scheduler_handle.scheduler();
 
-        let (package_lock, events_prefetched) = if use_fresh_lock {
-            let lock = match load_package_lock_json_from_path(root_path).await {
-                Ok(lock) => lock,
-                Err(e) => {
-                    scheduler_handle.shutdown().await;
-                    return Err(e);
-                }
-            };
+        let (package_lock, events_prefetched) = if let Some(lock) = fresh_lock {
             (lock, false)
         } else {
             start_progress_bar();

--- a/crates/pm/src/service/package.rs
+++ b/crates/pm/src/service/package.rs
@@ -3,7 +3,7 @@ use crate::model::package::{LifecycleHook, LifecycleScripts, PackageInfo};
 use crate::util::cli_enum::ScriptPolicy;
 use crate::util::logger::{PROGRESS_BAR, finish_progress_bar, log_progress, start_progress_bar};
 use anyhow::{Context, Result};
-use futures;
+use futures::{self, StreamExt as _};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -151,6 +151,8 @@ impl PackageService {
             .collect();
 
         let mut packages = Vec::new();
+        // (index into `packages`, lock path, is_link) for deferred script reads.
+        let mut pending_script_reads: Vec<(usize, String, bool)> = Vec::new();
         for (path, lock_package) in &package_lock.packages {
             if path.is_empty() {
                 continue;
@@ -219,44 +221,69 @@ impl PackageService {
                 continue;
             }
 
-            // Read lifecycle scripts from package.json only if needed. A
-            // workspace link contributes bin linking only — leave its scripts
-            // empty so `create_execution_queues` never queues them (owned by
+            // Read lifecycle scripts from package.json only when they can end
+            // up in an execution queue: the queues only consume
+            // preinstall/install/postinstall under `ScriptPolicy::Run`, and the
+            // lock's `hasInstallScript` marker covers exactly those three hooks
+            // — the same marker the early filter above already trusts. So a
+            // bin-only package (no marker) and the whole `Ignore` policy skip
+            // the read; a link's scripts are decided from disk. A workspace
+            // link contributes bin linking only — its scripts stay empty so
+            // `create_execution_queues` never queues them (owned by
             // `process_workspace_install_hooks`).
-            let lifecycle_scripts =
-                if !is_workspace_link && (has_scripts || scripts == ScriptPolicy::Run) {
-                    match Self::read_lifecycle_scripts(&package_path).await {
-                        Ok(s) => s,
-                        // A `file:` link can resolve to a missing or degenerate
-                        // `package.json` (e.g. a conflict artifact keyed
-                        // `node_modules/` with an empty name). Treat that as "no
-                        // scripts" rather than failing the whole install; a real
-                        // dependency with an unreadable manifest still errors.
-                        Err(_) if is_link => LifecycleScripts::default(),
-                        Err(e) => {
-                            return Err(e).with_context(|| {
-                                format!("Failed to read scripts for package: {path}")
-                            });
-                        }
-                    }
-                } else {
-                    LifecycleScripts::default()
-                };
+            let needs_script_read =
+                scripts == ScriptPolicy::Run && !is_workspace_link && (has_scripts || is_link);
 
             // Check if this package is an optional dependency (based on edge type)
             let is_optional =
                 lock_package.optional == Some(true) || lock_package.dev_optional == Some(true);
 
+            if needs_script_read {
+                pending_script_reads.push((packages.len(), path.clone(), is_link));
+            }
+
             let package_info = PackageInfo {
                 path: package_path,
                 bin_files,
                 scripts: Default::default(),
-                lifecycle_scripts,
+                lifecycle_scripts: LifecycleScripts::default(),
                 name: package_name,
             };
 
             packages.push((package_info, is_optional));
         }
+
+        // The reads are independent point lookups; run them concurrently
+        // instead of one awaited syscall+parse at a time.
+        let read_results = futures::stream::iter(pending_script_reads.into_iter().map(
+            |(idx, path, is_link)| {
+                let package_path = packages[idx].0.path.clone();
+                async move {
+                    let result = Self::read_lifecycle_scripts(&package_path).await;
+                    (idx, path, is_link, result)
+                }
+            },
+        ))
+        .buffer_unordered(32)
+        .collect::<Vec<_>>()
+        .await;
+
+        for (idx, path, is_link, result) in read_results {
+            match result {
+                Ok(s) => packages[idx].0.lifecycle_scripts = s,
+                // A `file:` link can resolve to a missing or degenerate
+                // `package.json` (e.g. a conflict artifact keyed
+                // `node_modules/` with an empty name). Treat that as "no
+                // scripts" rather than failing the whole install; a real
+                // dependency with an unreadable manifest still errors.
+                Err(_) if is_link => {}
+                Err(e) => {
+                    return Err(e)
+                        .with_context(|| format!("Failed to read scripts for package: {path}"));
+                }
+            }
+        }
+
         Ok(packages)
     }
 

--- a/crates/pm/src/util/json.rs
+++ b/crates/pm/src/util/json.rs
@@ -79,12 +79,6 @@ pub async fn load_package_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
     }
 }
 
-pub async fn load_package_lock_json_from_path(
-    path: &Path,
-) -> Result<utoo_ruborist::lock::PackageLock> {
-    read_json_file(&path.join("package-lock.json")).await
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Split out of #3146 — single orthogonal change so the benchmark comment shows its isolated effect.

- **package-lock.json parsed once per install**: the freshness check now returns the parsed lock (`load_package_lock_if_fresh`), killing the second multi-MB serde parse in both `install()` and `ensure_package_lock()`.
- **Rebuild collect trusts the lock's `hasInstallScript` marker**: the execution queues only consume preinstall/install/postinstall — exactly what the marker covers, and the same signal the early filter already trusts. Bin-only packages and `--ignore-scripts` runs (what the bench measures) skip the per-package package.json read entirely; remaining reads run `buffer_unordered(32)` instead of one awaited syscall+parse at a time.

Expected bench signal: **p3/p4 improve modestly** (startup + post-link tail), p1 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)