### PR TITLE
perf(pm): cut resolver CPU on the driver hot path

### DIFF
--- a/crates/pm/src/helper/tree_builder.rs
+++ b/crates/pm/src/helper/tree_builder.rs
@@ -7,7 +7,9 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use serde_json::{Value, json};
-use utoo_ruborist::builder::{DevDeps, EdgeContext, add_edges_from, add_workspace_member};
+use utoo_ruborist::builder::{
+    DevDeps, EdgeContext, add_edges_from, add_workspace_member, resolve_workspace_member_edges,
+};
 use utoo_ruborist::graph::{DependencyGraph, EdgeType};
 use utoo_ruborist::resolver::runtime::install_runtime;
 
@@ -101,6 +103,9 @@ impl TreeBuilder {
                 &edge_ctx,
             );
         }
+        // Settle importer-declared workspace: edges so topology consumers see
+        // resolved member edges, matching the install graph's init shape.
+        resolve_workspace_member_edges(graph);
 
         Ok(())
     }

--- a/crates/pm/src/util/manifest_store.rs
+++ b/crates/pm/src/util/manifest_store.rs
@@ -205,6 +205,7 @@ mod tests {
                     },
                     etag: Some("etag".to_string()),
                     last_updated: 1,
+                    parsed_versions: Default::default(),
                 }),
             );
             store.store_version_manifest(

--- a/crates/ruborist/src/lib.rs
+++ b/crates/ruborist/src/lib.rs
@@ -69,7 +69,7 @@ pub mod semver {
 /// Dependency resolution builder.
 pub mod builder {
     pub use crate::model::node::{DevDeps, PeerDeps};
-    pub use crate::resolver::builder::add_workspace_member;
+    pub use crate::resolver::builder::{add_workspace_member, resolve_workspace_member_edges};
     pub use crate::resolver::edges::{DependencySource, EdgeContext, add_edges_from};
 }
 

--- a/crates/ruborist/src/model/graph.rs
+++ b/crates/ruborist/src/model/graph.rs
@@ -210,6 +210,12 @@ pub struct DependencyGraph {
     /// millions of comparisons on large trees, all inside the single-threaded
     /// resolver driver.
     child_index: HashMap<NodeIndex, HashMap<String, NodeIndex>>,
+    /// Workspace members by package name, registered in
+    /// [`add_node`](Self::add_node) — the single node-creation chokepoint —
+    /// so `workspace:` edge settlement never re-derives the member set from
+    /// physical children (which would also have to dodge the same-name link
+    /// node `add_workspace_member` attaches alongside each member).
+    workspace_members: HashMap<String, NodeIndex>,
 }
 
 impl DependencyGraph {
@@ -250,12 +256,27 @@ impl DependencyGraph {
             overrides,
             override_names,
             child_index: HashMap::new(),
+            workspace_members: HashMap::new(),
         }
     }
 
     /// Add a package node to the graph.
     pub fn add_node(&mut self, node: PackageNode) -> NodeIndex {
-        self.graph.add_node(node)
+        let is_workspace = node.is_workspace();
+        let name = is_workspace.then(|| node.name.clone());
+        let idx = self.graph.add_node(node);
+        // Register workspace members at the single node-creation chokepoint,
+        // so `workspace_members` is correct for every construction path
+        // (install graph init, lockfile load, tests) with no rebuild pass.
+        if let Some(name) = name {
+            self.workspace_members.insert(name, idx);
+        }
+        idx
+    }
+
+    /// Workspace members by package name, maintained by [`add_node`](Self::add_node).
+    pub fn workspace_members(&self) -> &HashMap<String, NodeIndex> {
+        &self.workspace_members
     }
 
     /// Add a physical parent-child edge.

--- a/crates/ruborist/src/model/graph.rs
+++ b/crates/ruborist/src/model/graph.rs
@@ -261,8 +261,12 @@ impl DependencyGraph {
     /// Add a physical parent-child edge.
     pub fn add_physical_edge(&mut self, parent: NodeIndex, child: NodeIndex) -> EdgeIndex {
         // `insert` (last wins) mirrors petgraph's reverse-insertion edge
-        // iteration the linear scan used to see first; duplicate names under
-        // one parent don't occur in a valid node_modules tree anyway.
+        // iteration the linear scan used to see first. Duplicate names under
+        // one parent DO occur: `add_workspace_member` attaches a workspace
+        // node and its link node under root with the same name — last-wins
+        // keeps the link node, exactly what the old scan found first.
+        // Workspace-member lookups therefore bypass this index (see
+        // `find_workspace_member`).
         let name = self.graph[child].name.clone();
         self.child_index
             .entry(parent)
@@ -279,9 +283,30 @@ impl DependencyGraph {
     /// Whether any workspace member is attached under root — `workspace:`
     /// specs are only meaningful between members of a workspace project.
     pub fn has_workspace_members(&self) -> bool {
-        self.child_index
-            .get(&self.root_index)
-            .is_some_and(|children| children.values().any(|&idx| self.graph[idx].is_workspace()))
+        self.find_workspace_member_by(|_| true).is_some()
+    }
+
+    /// Look up a workspace member by package name (root children only —
+    /// workspace nodes always attach directly under root).
+    ///
+    /// Walks the real physical edges rather than `child_index`:
+    /// `add_workspace_member` attaches TWO same-name children under root (the
+    /// workspace node and its link node), and the name index keeps only the
+    /// most recent of the pair. Cold path — only unresolved `workspace:`
+    /// edges ever get here.
+    pub fn find_workspace_member(&self, name: &str) -> Option<NodeIndex> {
+        self.find_workspace_member_by(|node| node.name == name)
+    }
+
+    fn find_workspace_member_by(&self, pred: impl Fn(&PackageNode) -> bool) -> Option<NodeIndex> {
+        self.graph
+            .edges_directed(self.root_index, Outgoing)
+            .filter(|edge| matches!(edge.weight(), GraphEdge::Physical))
+            .map(|edge| edge.target())
+            .find(|&idx| {
+                let node = &self.graph[idx];
+                node.is_workspace() && pred(node)
+            })
     }
 
     /// Add a dependency edge (self-loop for tracking).

--- a/crates/ruborist/src/model/graph.rs
+++ b/crates/ruborist/src/model/graph.rs
@@ -202,6 +202,14 @@ pub struct DependencyGraph {
     overrides: Option<Overrides>,
     /// Fast lookup set for override names
     override_names: HashSet<String>,
+    /// Per-parent `name → child` index over physical edges, maintained by
+    /// [`add_physical_edge`](Self::add_physical_edge) (the graph is
+    /// append-only — no edge ever gets removed). Hoisting parks most packages
+    /// directly under root, so the parent-chain search would otherwise scan
+    /// every root child (string compare each) for every edge — tens of
+    /// millions of comparisons on large trees, all inside the single-threaded
+    /// resolver driver.
+    child_index: HashMap<NodeIndex, HashMap<String, NodeIndex>>,
 }
 
 impl DependencyGraph {
@@ -241,6 +249,7 @@ impl DependencyGraph {
             root_index,
             overrides,
             override_names,
+            child_index: HashMap::new(),
         }
     }
 
@@ -251,7 +260,28 @@ impl DependencyGraph {
 
     /// Add a physical parent-child edge.
     pub fn add_physical_edge(&mut self, parent: NodeIndex, child: NodeIndex) -> EdgeIndex {
+        // `insert` (last wins) mirrors petgraph's reverse-insertion edge
+        // iteration the linear scan used to see first; duplicate names under
+        // one parent don't occur in a valid node_modules tree anyway.
+        let name = self.graph[child].name.clone();
+        self.child_index
+            .entry(parent)
+            .or_default()
+            .insert(name, child);
         self.graph.add_edge(parent, child, GraphEdge::Physical)
+    }
+
+    /// O(1) lookup of a physical child by name (see `child_index`).
+    fn find_physical_child(&self, parent: NodeIndex, name: &str) -> Option<NodeIndex> {
+        self.child_index.get(&parent)?.get(name).copied()
+    }
+
+    /// Whether any workspace member is attached under root — `workspace:`
+    /// specs are only meaningful between members of a workspace project.
+    pub fn has_workspace_members(&self) -> bool {
+        self.child_index
+            .get(&self.root_index)
+            .is_some_and(|children| children.values().any(|&idx| self.graph[idx].is_workspace()))
     }
 
     /// Add a dependency edge (self-loop for tracking).
@@ -454,23 +484,21 @@ impl DependencyGraph {
         spec: &str,
         requester: NodeIndex,
     ) -> FindResult {
-        // Check all physical children of current node
-        for child_idx in self.get_physical_children(current) {
+        // Probe the per-parent name index — O(depth) total instead of a
+        // linear scan over every physical child per ancestor level.
+        if let Some(child_idx) = self.find_physical_child(current, name) {
             let child = &self.graph[child_idx];
-            if child.name == name {
-                if matches(spec, &child.version) {
-                    return FindResult::Reuse(child_idx);
-                } else {
-                    tracing::debug!(
-                        "found conflict deps {}@{} got {}, conflict at {:?}",
-                        name,
-                        spec,
-                        child.version,
-                        child_idx
-                    );
-                    return FindResult::Conflict(requester);
-                }
+            if matches(spec, &child.version) {
+                return FindResult::Reuse(child_idx);
             }
+            tracing::debug!(
+                "found conflict deps {}@{} got {}, conflict at {:?}",
+                name,
+                spec,
+                child.version,
+                child_idx
+            );
+            return FindResult::Conflict(requester);
         }
 
         // Recurse to parent

--- a/crates/ruborist/src/model/graph.rs
+++ b/crates/ruborist/src/model/graph.rs
@@ -265,8 +265,6 @@ impl DependencyGraph {
         // one parent DO occur: `add_workspace_member` attaches a workspace
         // node and its link node under root with the same name — last-wins
         // keeps the link node, exactly what the old scan found first.
-        // Workspace-member lookups therefore bypass this index (see
-        // `find_workspace_member`).
         let name = self.graph[child].name.clone();
         self.child_index
             .entry(parent)
@@ -282,33 +280,6 @@ impl DependencyGraph {
 
     /// Whether any workspace member is attached under root — `workspace:`
     /// specs are only meaningful between members of a workspace project.
-    pub fn has_workspace_members(&self) -> bool {
-        self.find_workspace_member_by(|_| true).is_some()
-    }
-
-    /// Look up a workspace member by package name (root children only —
-    /// workspace nodes always attach directly under root).
-    ///
-    /// Walks the real physical edges rather than `child_index`:
-    /// `add_workspace_member` attaches TWO same-name children under root (the
-    /// workspace node and its link node), and the name index keeps only the
-    /// most recent of the pair. Cold path — only unresolved `workspace:`
-    /// edges ever get here.
-    pub fn find_workspace_member(&self, name: &str) -> Option<NodeIndex> {
-        self.find_workspace_member_by(|node| node.name == name)
-    }
-
-    fn find_workspace_member_by(&self, pred: impl Fn(&PackageNode) -> bool) -> Option<NodeIndex> {
-        self.graph
-            .edges_directed(self.root_index, Outgoing)
-            .filter(|edge| matches!(edge.weight(), GraphEdge::Physical))
-            .map(|edge| edge.target())
-            .find(|&idx| {
-                let node = &self.graph[idx];
-                node.is_workspace() && pred(node)
-            })
-    }
-
     /// Add a dependency edge (self-loop for tracking).
     pub fn add_dependency_edge(
         &mut self,

--- a/crates/ruborist/src/model/manifest.rs
+++ b/crates/ruborist/src/model/manifest.rs
@@ -95,6 +95,15 @@ pub struct FullManifest {
     #[serde(skip)]
     pub version_blobs: OnceLock<HashMap<String, Box<str>>>,
 
+    /// Parsed [`versions`](Self::versions), sorted descending, lazily built on
+    /// the first client-side semver match that the `latest` dist-tag doesn't
+    /// short-circuit. Every additional distinct spec for the package then walks
+    /// the sorted list top-down and early-exits, instead of re-parsing the full
+    /// version list per spec (react-scale packages: ~2k parses per spec, on the
+    /// single-threaded resolver driver).
+    #[serde(skip)]
+    pub parsed_versions: OnceLock<Vec<deno_semver::Version>>,
+
     pub time: HashMap<String, String>,
 
     #[serde(deserialize_with = "skip_on_error")]
@@ -171,20 +180,45 @@ impl FullManifest {
 
     /// One-shot extraction for the single speculative extract performed while a
     /// full manifest is first parsed. That call resolves exactly one version and
-    /// would never reuse the memoized split, so it parses the document directly
-    /// rather than paying to build (and retain) the per-version index.
+    /// would never reuse the memoized split, so it must not pay to build (and
+    /// retain) the per-version index — but it also must not pay a full-document
+    /// parse: a shallow borrowed `RawValue` pass brace-matches past every other
+    /// version without copying the body or materializing their objects (the
+    /// previous `simd_json::to_borrowed_value` route cloned the whole multi-MB
+    /// payload and parsed every version's subtree just to read one).
     pub fn get_core_version_oneshot(&self, version: &str) -> Option<CoreVersionManifest> {
-        use simd_json::prelude::ValueObjectAccess;
-        let mut buf = self.raw.to_vec();
-        let parsed = simd_json::to_borrowed_value(&mut buf).ok()?;
-        let version_obj = parsed.get("versions")?.get(version)?;
-        CoreVersionManifest::deserialize(version_obj).ok()
+        #[derive(Deserialize)]
+        struct VersionsOnly<'a> {
+            #[serde(borrow, default)]
+            versions: HashMap<&'a str, &'a serde_json::value::RawValue>,
+        }
+        let parsed: VersionsOnly = serde_json::from_slice(&self.raw).ok()?;
+        let blob = parsed.versions.get(version)?;
+        serde_json::from_str(blob.get()).ok()
     }
 
     /// Parse a single version on demand into full VersionManifest (cold path, e.g. `ut view`).
     pub fn get_full_version(&self, version: &str) -> Option<VersionManifest> {
         self.extract_version(version)
     }
+
+    /// Lazily parsed + descending-sorted version list (see
+    /// [`parsed_versions`](Self::parsed_versions)).
+    pub fn sorted_parsed_versions(&self) -> &[deno_semver::Version] {
+        self.parsed_versions
+            .get_or_init(|| sort_parsed_versions(&self.versions))
+    }
+}
+
+/// Parse a version-string list and sort descending — shared by the lazy
+/// per-package caches on [`FullManifest`] and `service::cache::VersionsInfo`.
+pub(crate) fn sort_parsed_versions(versions: &[String]) -> Vec<deno_semver::Version> {
+    let mut parsed: Vec<deno_semver::Version> = versions
+        .iter()
+        .filter_map(|v| deno_semver::Version::parse_from_npm(v).ok())
+        .collect();
+    parsed.sort_unstable_by(|a, b| b.cmp(a));
+    parsed
 }
 
 /// Extract a single version from `FullManifest` on rayon's CPU pool

--- a/crates/ruborist/src/model/package_lock.rs
+++ b/crates/ruborist/src/model/package_lock.rs
@@ -388,11 +388,20 @@ fn create_non_root_lock_package(
 }
 
 /// Populate dependency fields on LockPackage from graph edges.
-/// For root nodes, edges resolved to workspace nodes are excluded.
+///
+/// For root nodes, the SYNTHETIC workspace edge added by
+/// `add_workspace_member` (spec = the member's version) is excluded — a
+/// member only appears in root `dependencies` when the user declared it.
+/// A user-declared `workspace:` edge is kept even though it now also
+/// resolves to the workspace node (settled at graph init by
+/// `resolve_workspace_member_edges`).
 fn collect_edge_deps(graph: &DependencyGraph, node_index: NodeIndex, pkg: &mut LockPackage) {
     let is_root = graph.get_node(node_index).is_some_and(|n| n.is_root());
     for (_, dep_edge) in graph.get_dependency_edges(node_index) {
-        if is_root && graph.is_workspace_target(dep_edge) {
+        if is_root
+            && graph.is_workspace_target(dep_edge)
+            && !dep_edge.spec.starts_with("workspace:")
+        {
             continue;
         }
         let map = match dep_edge.edge_type {

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -561,14 +561,26 @@ pub async fn process_dependency<R: ManifestProvider>(
                     protocol: Protocol::Workspace,
                     ..
                 } => {
-                    // workspace: deps are resolved during graph initialisation.
-                    // If we reach here the workspace node wasn't found — skip
-                    // silently rather than aborting the whole resolution.
-                    tracing::debug!(
-                        "Skipping unresolved workspace dependency {}@{}",
-                        edge_info.name,
-                        edge_info.spec
-                    );
+                    // workspace: deps are resolved during graph initialisation
+                    // and are only meaningful between members of a workspace
+                    // project. Reaching here means the target member wasn't
+                    // found — for a project that declares no workspaces at
+                    // all that's almost certainly a misconfigured root, so
+                    // say it loudly; otherwise skip quietly (e.g. a stray
+                    // workspace: spec deep in a published manifest).
+                    if graph.has_workspace_members() {
+                        tracing::debug!(
+                            "Skipping unresolved workspace dependency {}@{}",
+                            edge_info.name,
+                            edge_info.spec
+                        );
+                    } else {
+                        tracing::warn!(
+                            "Ignoring workspace dependency {}@{} — this project declares no workspaces",
+                            edge_info.name,
+                            edge_info.spec
+                        );
+                    }
                     return Ok(ProcessResult::Skipped);
                 }
                 PackageSpec::Local {

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -247,14 +247,8 @@ pub fn add_workspace_member(
 /// by the optional-skip / prod-error policy in `process_dependency`.
 pub fn resolve_workspace_member_edges(graph: &mut DependencyGraph) {
     let root_index = graph.root_index;
-    let members: HashMap<String, NodeIndex> = graph
-        .get_physical_children(root_index)
-        .into_iter()
-        .filter_map(|idx| {
-            let node = graph.get_node(idx)?;
-            node.is_workspace().then(|| (node.name.clone(), idx))
-        })
-        .collect();
+    // Maintained by `DependencyGraph::add_node` — no member-set rebuild here.
+    let members = graph.workspace_members().clone();
     if members.is_empty() {
         return;
     }

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -12,7 +12,7 @@
 //! demand (no separate preload phase), overlapping network I/O with graph
 //! construction.
 
-use petgraph::graph::NodeIndex;
+use petgraph::graph::{EdgeIndex, NodeIndex};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -232,6 +232,52 @@ pub fn add_workspace_member(
     graph.mark_dependency_resolved(dep_edge_id, workspace_index);
 
     add_edges_from(graph, workspace_index, pkg, edge_ctx);
+}
+
+/// Resolve every importer-declared `workspace:` edge against the attached
+/// workspace members — to run AFTER all members are added (member→member
+/// edges can reference members attached later) and BEFORE the BFS.
+///
+/// `workspace:` specs only legally come from source-declared manifests (root
+/// and workspace members), and all of those edges exist by the end of graph
+/// initialisation — so they can be settled here in one pass and the resolver
+/// driver never sees a `workspace:` edge at all. Any `workspace:` spec that
+/// still reaches the BFS afterwards is a declaration anomaly (importer naming
+/// a missing member, or a spec leaked inside a published manifest), handled
+/// by the optional-skip / prod-error policy in `process_dependency`.
+pub fn resolve_workspace_member_edges(graph: &mut DependencyGraph) {
+    let root_index = graph.root_index;
+    let members: HashMap<String, NodeIndex> = graph
+        .get_physical_children(root_index)
+        .into_iter()
+        .filter_map(|idx| {
+            let node = graph.get_node(idx)?;
+            node.is_workspace().then(|| (node.name.clone(), idx))
+        })
+        .collect();
+    if members.is_empty() {
+        return;
+    }
+
+    let importers: Vec<NodeIndex> = std::iter::once(root_index)
+        .chain(members.values().copied())
+        .collect();
+    for importer in importers {
+        let pending: Vec<(EdgeIndex, String)> = graph
+            .get_dependency_edges(importer)
+            .into_iter()
+            .filter(|(_, dep)| !dep.valid && dep.spec.starts_with("workspace:"))
+            .map(|(edge_id, dep)| (edge_id, dep.name.clone()))
+            .collect();
+        for (edge_id, name) in pending {
+            if let Some(&target) = members.get(&name) {
+                graph.mark_dependency_resolved(edge_id, target);
+            }
+            // Missing member: leave the edge unresolved — the BFS terminal
+            // arm applies the optional-skip / prod-error policy with the
+            // dependency chain attached.
+        }
+    }
 }
 
 /// Update target node type based on source node and edge type.
@@ -561,24 +607,14 @@ pub async fn process_dependency<R: ManifestProvider>(
                     protocol: Protocol::Workspace,
                     ..
                 } => {
-                    // Workspace members are linked during graph initialisation
-                    // via a synthetic, pre-resolved edge — the importer's
-                    // original `workspace:` edge still flows through the BFS
-                    // and terminates here. When the member exists this edge is
-                    // already physically satisfied: nothing to do.
-                    if graph.find_workspace_member(&edge_info.name).is_some() {
-                        tracing::debug!(
-                            "workspace dependency {}@{} already linked at graph init",
-                            edge_info.name,
-                            edge_info.spec
-                        );
-                        return Ok(ProcessResult::Skipped);
-                    }
-                    // No such member: a misspelled name in an importer, or a
-                    // workspace: spec that leaked into a published manifest
-                    // (transitive deps must never declare it). Optional edges
-                    // skip with a warning; anything load-bearing fails with
-                    // the dependency chain attached (via `chain_err`) so the
+                    // Importer-declared workspace: edges are fully settled by
+                    // `resolve_workspace_member_edges` before the BFS starts,
+                    // so reaching this arm means a declaration anomaly: an
+                    // importer naming a missing member, or a workspace: spec
+                    // leaked inside a published manifest (transitive deps
+                    // must never declare it). Optional edges skip with a
+                    // warning; anything load-bearing fails with the
+                    // dependency chain attached (via `chain_err`) so the
                     // offending package is identifiable.
                     if edge_info.edge_type == EdgeType::Optional {
                         tracing::warn!(
@@ -590,11 +626,7 @@ pub async fn process_dependency<R: ManifestProvider>(
                     }
                     return Err(ResolveError::Unsupported {
                         spec: edge_info.spec.clone(),
-                        reason: if graph.has_workspace_members() {
-                            "workspace: dependency does not match any workspace member"
-                        } else {
-                            "workspace: dependency in a project that declares no workspaces"
-                        },
+                        reason: "workspace: dependency does not match any workspace member of this project",
                     });
                 }
                 PackageSpec::Local {
@@ -1072,6 +1104,73 @@ mod tests {
             version: version.to_string(),
             dependencies: Some(dependencies),
             ..Default::default()
+        }
+    }
+
+    /// Importer-declared workspace: edges (root → member and member → member)
+    /// are settled by `resolve_workspace_member_edges` before the BFS — the
+    /// build must succeed without the resolver ever seeing a workspace: spec.
+    #[tokio::test]
+    async fn test_workspace_member_edges_settled_before_bfs() {
+        let registry = MockRegistryClient::new();
+
+        let root_pkg = PackageJson {
+            dependencies: Some(HashMap::from([(
+                "lib-a".to_string(),
+                "workspace:*".to_string(),
+            )])),
+            workspaces: Some(crate::model::package_json::WorkspacesConfig::Array(vec![
+                "packages/*".to_string(),
+            ])),
+            ..PackageJson::new("ws-root", "1.0.0")
+        };
+        let mut graph = DependencyGraph::from_package_json(PathBuf::from("."), root_pkg.clone());
+        let root_index = graph.root_index;
+        let edge_ctx = EdgeContext::new(PeerDeps::Include, DevDeps::Include);
+        add_edges_from(&mut graph, root_index, &root_pkg, &edge_ctx);
+
+        // lib-b depends on lib-a via workspace:^1.0.0 — member→member edge.
+        let lib_a = PackageJson::new("lib-a", "1.0.0");
+        let lib_b = PackageJson {
+            dependencies: Some(HashMap::from([(
+                "lib-a".to_string(),
+                "workspace:^1.0.0".to_string(),
+            )])),
+            ..PackageJson::new("lib-b", "1.0.0")
+        };
+        add_workspace_member(
+            &mut graph,
+            root_index,
+            "lib-b",
+            PathBuf::from("packages/lib-b"),
+            &lib_b,
+            &edge_ctx,
+        );
+        add_workspace_member(
+            &mut graph,
+            root_index,
+            "lib-a",
+            PathBuf::from("packages/lib-a"),
+            &lib_a,
+            &edge_ctx,
+        );
+
+        resolve_workspace_member_edges(&mut graph);
+
+        build_deps(&mut graph, &registry, PeerDeps::Include)
+            .await
+            .expect("workspace edges must be settled before the BFS");
+
+        // Every workspace: edge is resolved — none left for the BFS.
+        for node in graph.graph.node_indices() {
+            for (_, dep) in graph.get_dependency_edges(node) {
+                assert!(
+                    !dep.spec.starts_with("workspace:") || dep.valid,
+                    "unresolved workspace edge survived: {}@{}",
+                    dep.name,
+                    dep.spec
+                );
+            }
         }
     }
 

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -561,27 +561,64 @@ pub async fn process_dependency<R: ManifestProvider>(
                     protocol: Protocol::Workspace,
                     ..
                 } => {
-                    // workspace: deps are resolved during graph initialisation
-                    // and are only meaningful between members of a workspace
-                    // project. Reaching here means the target member wasn't
-                    // found — for a project that declares no workspaces at
-                    // all that's almost certainly a misconfigured root, so
-                    // say it loudly; otherwise skip quietly (e.g. a stray
-                    // workspace: spec deep in a published manifest).
-                    if graph.has_workspace_members() {
+                    // Workspace members are linked during graph initialisation
+                    // via a synthetic, pre-resolved edge — the importer's
+                    // original `workspace:` edge still flows through the BFS
+                    // and terminates here. When the member exists this edge is
+                    // already physically satisfied: nothing to do.
+                    if graph.find_workspace_member(&edge_info.name).is_some() {
                         tracing::debug!(
-                            "Skipping unresolved workspace dependency {}@{}",
+                            "workspace dependency {}@{} already linked at graph init",
                             edge_info.name,
                             edge_info.spec
                         );
-                    } else {
-                        tracing::warn!(
-                            "Ignoring workspace dependency {}@{} — this project declares no workspaces",
-                            edge_info.name,
-                            edge_info.spec
-                        );
+                        return Ok(ProcessResult::Skipped);
                     }
-                    return Ok(ProcessResult::Skipped);
+                    // No such member: a misspelled name in an importer, or a
+                    // workspace: spec that leaked into a published manifest
+                    // (transitive deps must never declare it). Optional edges
+                    // skip with a warning; anything load-bearing fails with
+                    // the dependency chain attached (via `chain_err`) so the
+                    // offending package is identifiable.
+                    if edge_info.edge_type == EdgeType::Optional {
+                        tracing::warn!(
+                            "Skipping optional workspace dependency {}@{} — no matching workspace member",
+                            edge_info.name,
+                            edge_info.spec
+                        );
+                        return Ok(ProcessResult::Skipped);
+                    }
+                    return Err(ResolveError::Unsupported {
+                        spec: edge_info.spec.clone(),
+                        reason: if graph.has_workspace_members() {
+                            "workspace: dependency does not match any workspace member"
+                        } else {
+                            "workspace: dependency in a project that declares no workspaces"
+                        },
+                    });
+                }
+                PackageSpec::Local {
+                    protocol: Protocol::Catalog,
+                    ..
+                } => {
+                    // catalog: specs are resolved at edge-creation time for
+                    // importer (root/workspace) edges; reaching here means the
+                    // catalog entry was missing — or a catalog: spec shipped
+                    // inside a published manifest, which is a malformed
+                    // declaration. Same policy as workspace: above.
+                    if edge_info.edge_type == EdgeType::Optional {
+                        tracing::warn!(
+                            "Skipping optional catalog dependency {}@{} — unresolved catalog entry",
+                            edge_info.name,
+                            edge_info.spec
+                        );
+                        return Ok(ProcessResult::Skipped);
+                    }
+                    return Err(ResolveError::Unsupported {
+                        spec: edge_info.spec.clone(),
+                        reason: "catalog: spec was not resolved — published manifests must not \
+                                 carry catalog:, and importer catalogs must define the entry",
+                    });
                 }
                 PackageSpec::Local {
                     protocol: Protocol::File,
@@ -1036,6 +1073,110 @@ mod tests {
             dependencies: Some(dependencies),
             ..Default::default()
         }
+    }
+
+    /// A load-bearing `workspace:` spec that resolves to no workspace member
+    /// (here: a project with no workspaces at all) must fail resolution, not
+    /// silently vanish.
+    #[tokio::test]
+    async fn test_unresolved_workspace_prod_dep_errors() {
+        let registry = MockRegistryClient::new();
+        let root_pkg = PackageJson {
+            dependencies: Some(HashMap::from([(
+                "missing-member".to_string(),
+                "workspace:*".to_string(),
+            )])),
+            ..PackageJson::new("test-project", "1.0.0")
+        };
+
+        let mut graph = DependencyGraph::from_package_json(PathBuf::from("."), root_pkg.clone());
+        let root_index = graph.root_index;
+        add_edges_from(
+            &mut graph,
+            root_index,
+            &root_pkg,
+            &EdgeContext::new(PeerDeps::Include, DevDeps::Include),
+        );
+
+        let err = build_deps(&mut graph, &registry, PeerDeps::Include)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("workspace"),
+            "expected workspace error, got: {err}"
+        );
+    }
+
+    /// A `workspace:` spec inside a transitive (registry) manifest's
+    /// optionalDependencies is a malformed declaration — skip it with a
+    /// warning instead of failing the install.
+    #[tokio::test]
+    async fn test_transitive_optional_workspace_dep_skips() {
+        let mut registry = MockRegistryClient::new();
+        registry.add_package("dirty", "1.0.0", {
+            CoreVersionManifest {
+                optional_dependencies: Some(HashMap::from([(
+                    "ws-leak".to_string(),
+                    "workspace:*".to_string(),
+                )])),
+                ..create_version_manifest("dirty", "1.0.0")
+            }
+        });
+
+        let root_pkg = PackageJson {
+            dependencies: Some(HashMap::from([("dirty".to_string(), "^1.0.0".to_string())])),
+            ..PackageJson::new("test-project", "1.0.0")
+        };
+
+        let mut graph = DependencyGraph::from_package_json(PathBuf::from("."), root_pkg.clone());
+        let root_index = graph.root_index;
+        add_edges_from(
+            &mut graph,
+            root_index,
+            &root_pkg,
+            &EdgeContext::new(PeerDeps::Include, DevDeps::Include),
+        );
+
+        build_deps(&mut graph, &registry, PeerDeps::Include)
+            .await
+            .expect("optional workspace: leak must not fail the build");
+        // root + dirty; the leaked workspace dep is skipped, not materialized.
+        assert_eq!(graph.graph.node_count(), 2);
+    }
+
+    /// A `catalog:` spec inside a transitive (registry) manifest's regular
+    /// dependencies is a malformed declaration — fail with a message naming
+    /// catalog rather than the generic local-protocol error.
+    #[tokio::test]
+    async fn test_transitive_catalog_prod_dep_errors() {
+        let mut registry = MockRegistryClient::new();
+        registry.add_package(
+            "dirty",
+            "1.0.0",
+            create_version_manifest_with_deps("dirty", "1.0.0", vec![("react", "catalog:")]),
+        );
+
+        let root_pkg = PackageJson {
+            dependencies: Some(HashMap::from([("dirty".to_string(), "^1.0.0".to_string())])),
+            ..PackageJson::new("test-project", "1.0.0")
+        };
+
+        let mut graph = DependencyGraph::from_package_json(PathBuf::from("."), root_pkg.clone());
+        let root_index = graph.root_index;
+        add_edges_from(
+            &mut graph,
+            root_index,
+            &root_pkg,
+            &EdgeContext::new(PeerDeps::Include, DevDeps::Include),
+        );
+
+        let err = build_deps(&mut graph, &registry, PeerDeps::Include)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("catalog"),
+            "expected catalog error, got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/ruborist/src/resolver/demand/schedule.rs
+++ b/crates/ruborist/src/resolver/demand/schedule.rs
@@ -74,6 +74,7 @@ fn schedule_registry_fetch(
     priority: FetchPriority,
 ) {
     let (real_name, real_spec) = normalize_spec(&name, &spec);
+    let (real_name, real_spec) = (real_name.into_owned(), real_spec.into_owned());
     if matches!(supports_semver, ResolutionMode::Semver) {
         if state.is_version_settled(&real_name, &real_spec) {
             return;

--- a/crates/ruborist/src/resolver/demand/select.rs
+++ b/crates/ruborist/src/resolver/demand/select.rs
@@ -8,15 +8,15 @@ use crate::model::manifest::{CoreVersionManifest, FullManifest, VersionsRef};
 use crate::model::node::EdgeType;
 use crate::resolver::edges::DependencyEdgeInfo;
 use crate::resolver::registry::ResolveError;
-use crate::resolver::version::resolve_target_version_sorted;
+use crate::resolver::version::resolve_target_version_lazy;
 
 use super::state::{ManifestState, PackageVersions};
 
-fn resolve_version_from_versions<RE>(
+fn resolve_version_from_versions<'a, RE>(
     edge: &DependencyEdgeInfo,
     package_name: &str,
     versions: VersionsRef<'_>,
-    sorted: &[deno_semver::Version],
+    sorted: impl FnOnce() -> &'a [deno_semver::Version],
     real_spec: &str,
 ) -> Result<Option<String>, ResolveError<RE>> {
     if versions.versions.is_empty() {
@@ -26,7 +26,7 @@ fn resolve_version_from_versions<RE>(
         return Err(ResolveError::NoVersions(package_name.to_string()));
     }
 
-    let version = match resolve_target_version_sorted(versions, sorted, real_spec) {
+    let version = match resolve_target_version_lazy(versions, sorted, real_spec) {
         Ok(version) => version,
         Err(_) if edge.edge_type == EdgeType::Optional => return Ok(None),
         Err(e) => {
@@ -159,7 +159,7 @@ fn select_full_manifest<RE>(
                 edge,
                 name,
                 (&*full).into(),
-                full.sorted_parsed_versions(),
+                || full.sorted_parsed_versions(),
                 spec,
             )?
             else {
@@ -179,7 +179,7 @@ fn select_full_manifest<RE>(
                 edge,
                 name,
                 (&*list).into(),
-                list.sorted_parsed_versions(),
+                || list.sorted_parsed_versions(),
                 spec,
             )?
             else {

--- a/crates/ruborist/src/resolver/demand/select.rs
+++ b/crates/ruborist/src/resolver/demand/select.rs
@@ -8,7 +8,7 @@ use crate::model::manifest::{CoreVersionManifest, FullManifest, VersionsRef};
 use crate::model::node::EdgeType;
 use crate::resolver::edges::DependencyEdgeInfo;
 use crate::resolver::registry::ResolveError;
-use crate::resolver::version::resolve_target_version;
+use crate::resolver::version::resolve_target_version_sorted;
 
 use super::state::{ManifestState, PackageVersions};
 
@@ -16,6 +16,7 @@ fn resolve_version_from_versions<RE>(
     edge: &DependencyEdgeInfo,
     package_name: &str,
     versions: VersionsRef<'_>,
+    sorted: &[deno_semver::Version],
     real_spec: &str,
 ) -> Result<Option<String>, ResolveError<RE>> {
     if versions.versions.is_empty() {
@@ -25,7 +26,7 @@ fn resolve_version_from_versions<RE>(
         return Err(ResolveError::NoVersions(package_name.to_string()));
     }
 
-    let version = match resolve_target_version(versions, real_spec) {
+    let version = match resolve_target_version_sorted(versions, sorted, real_spec) {
         Ok(version) => version,
         Err(_) if edge.edge_type == EdgeType::Optional => return Ok(None),
         Err(e) => {
@@ -154,8 +155,13 @@ fn select_full_manifest<RE>(
         Some(PackageVersions::Failed(error)) => Ok(EdgeStep::Fail(format!("{name}: {error}"))),
         Some(PackageVersions::Full(full)) => {
             let full = Arc::clone(full);
-            let Some(version) =
-                resolve_version_from_versions::<RE>(edge, name, (&*full).into(), spec)?
+            let Some(version) = resolve_version_from_versions::<RE>(
+                edge,
+                name,
+                (&*full).into(),
+                full.sorted_parsed_versions(),
+                spec,
+            )?
             else {
                 return Ok(EdgeStep::Skip);
             };
@@ -169,8 +175,13 @@ fn select_full_manifest<RE>(
         }
         Some(PackageVersions::List(list)) => {
             let list = Arc::clone(list);
-            let Some(version) =
-                resolve_version_from_versions::<RE>(edge, name, (&*list).into(), spec)?
+            let Some(version) = resolve_version_from_versions::<RE>(
+                edge,
+                name,
+                (&*list).into(),
+                list.sorted_parsed_versions(),
+                spec,
+            )?
             else {
                 return Ok(EdgeStep::Skip);
             };

--- a/crates/ruborist/src/resolver/registry.rs
+++ b/crates/ruborist/src/resolver/registry.rs
@@ -134,8 +134,8 @@ pub async fn resolve_package<P: ManifestProvider>(
     // Non-semver: fetch the full manifest, resolve the version client-side.
     let done = provider
         .execute_manifest_job(ManifestJob::Full {
-            name: fetch_name.clone(),
-            spec: Some(fetch_spec.clone()),
+            name: fetch_name.clone().into_owned(),
+            spec: Some(fetch_spec.clone().into_owned()),
         })
         .await
         .map_err(ResolveError::Registry)?;
@@ -148,7 +148,7 @@ pub async fn resolve_package<P: ManifestProvider>(
             ManifestFullData::Full { manifest, .. } => {
                 let resolved = resolve_from_manifest::<P::Error>(&manifest, &fetch_spec)?;
                 Ok(ResolvedPackage {
-                    name: fetch_name,
+                    name: fetch_name.into_owned(),
                     ..resolved
                 })
             }

--- a/crates/ruborist/src/resolver/semver.rs
+++ b/crates/ruborist/src/resolver/semver.rs
@@ -1,5 +1,7 @@
 //! Semver matching utilities using deno_semver.
 
+use std::borrow::Cow;
+
 use deno_semver::{Version, VersionReq};
 
 /// Normalize spec for registry requests.
@@ -39,7 +41,7 @@ use deno_semver::{Version, VersionReq};
 /// assert_eq!(name, "lodash");
 /// assert_eq!(spec, "^4.0.0");
 /// ```
-pub fn normalize_spec(name: &str, spec: &str) -> (String, String) {
+pub fn normalize_spec<'a>(name: &'a str, spec: &'a str) -> (Cow<'a, str>, Cow<'a, str>) {
     // Handle npm: alias - fetch the aliased package instead
     if let Some(npm_spec) = spec.strip_prefix("npm:") {
         // Skip "npm:"
@@ -48,21 +50,22 @@ pub fn normalize_spec(name: &str, spec: &str) -> (String, String) {
             // Make sure we don't split on the @ of a scoped package
             if last_at_index > 0 {
                 let (pkg_name, version) = npm_spec.split_at(last_at_index);
-                return (pkg_name.to_string(), version[1..].to_string());
+                return (Cow::Borrowed(pkg_name), Cow::Borrowed(&version[1..]));
             }
         }
         // No version specified
-        return (npm_spec.to_string(), "*".to_string());
+        return (Cow::Borrowed(npm_spec), Cow::Borrowed("*"));
     }
 
     // Handle workspace: prefix - keep original name, extract version
     if let Some(workspace_spec) = spec.strip_prefix("workspace:") {
         // Skip "workspace:"
-        return (name.to_string(), workspace_spec.to_string());
+        return (Cow::Borrowed(name), Cow::Borrowed(workspace_spec));
     }
 
-    // No special prefix, return as-is
-    (name.to_string(), spec.to_string())
+    // No special prefix, return as-is — borrowed, so the per-edge common case
+    // (plain registry spec) allocates nothing.
+    (Cow::Borrowed(name), Cow::Borrowed(spec))
 }
 
 /// Check if a version matches a semver range.
@@ -223,48 +226,48 @@ mod tests {
         // npm alias
         assert_eq!(
             normalize_spec("string-width-cjs", "npm:string-width@^4.2.0"),
-            ("string-width".to_string(), "^4.2.0".to_string())
+            (Cow::Borrowed("string-width"), Cow::Borrowed("^4.2.0"))
         );
 
         // npm alias without version
         assert_eq!(
             normalize_spec("lodash-cjs", "npm:lodash"),
-            ("lodash".to_string(), "*".to_string())
+            (Cow::Borrowed("lodash"), Cow::Borrowed("*"))
         );
 
         // scoped npm alias
         assert_eq!(
             normalize_spec("my-pkg", "npm:@scope/pkg@^1.0.0"),
-            ("@scope/pkg".to_string(), "^1.0.0".to_string())
+            (Cow::Borrowed("@scope/pkg"), Cow::Borrowed("^1.0.0"))
         );
 
         // scoped npm alias without version
         assert_eq!(
             normalize_spec("my-pkg", "npm:@scope/pkg"),
-            ("@scope/pkg".to_string(), "*".to_string())
+            (Cow::Borrowed("@scope/pkg"), Cow::Borrowed("*"))
         );
 
         // workspace reference
         assert_eq!(
             normalize_spec("my-lib", "workspace:*"),
-            ("my-lib".to_string(), "*".to_string())
+            (Cow::Borrowed("my-lib"), Cow::Borrowed("*"))
         );
 
         assert_eq!(
             normalize_spec("my-lib", "workspace:^1.0.0"),
-            ("my-lib".to_string(), "^1.0.0".to_string())
+            (Cow::Borrowed("my-lib"), Cow::Borrowed("^1.0.0"))
         );
 
         // regular spec (unchanged)
         assert_eq!(
             normalize_spec("lodash", "^4.0.0"),
-            ("lodash".to_string(), "^4.0.0".to_string())
+            (Cow::Borrowed("lodash"), Cow::Borrowed("^4.0.0"))
         );
 
         // scoped package regular spec
         assert_eq!(
             normalize_spec("@types/node", "^18.0.0"),
-            ("@types/node".to_string(), "^18.0.0".to_string())
+            (Cow::Borrowed("@types/node"), Cow::Borrowed("^18.0.0"))
         );
     }
 }

--- a/crates/ruborist/src/resolver/semver.rs
+++ b/crates/ruborist/src/resolver/semver.rs
@@ -139,6 +139,18 @@ pub fn max_satisfying<'a>(versions: impl Iterator<Item = &'a str>, range: &str) 
     }
 }
 
+/// [`max_satisfying`] over a pre-parsed, descending-sorted list: the first
+/// match is the maximum, so this early-exits instead of parsing and scanning
+/// every version per spec. Pair with the per-package memoized sort
+/// (`FullManifest::sorted_parsed_versions`).
+pub fn max_satisfying_sorted_desc<'a>(sorted: &'a [Version], range: &str) -> Option<&'a Version> {
+    let req = VersionReq::parse_from_npm(range).ok()?;
+    if range == "*" {
+        return sorted.first();
+    }
+    sorted.iter().find(|v| req.matches(v))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ruborist/src/resolver/version.rs
+++ b/crates/ruborist/src/resolver/version.rs
@@ -63,6 +63,40 @@ pub fn resolve_target_version(view: VersionsRef<'_>, spec: &str) -> Result<Strin
     })
 }
 
+/// [`resolve_target_version`] over a per-package pre-parsed, descending-sorted
+/// version list (see `FullManifest::sorted_parsed_versions`): identical
+/// dist-tag / latest-preference policy, but the semver fallback early-exits on
+/// the first (= maximum) match instead of parsing every version per spec.
+pub fn resolve_target_version_sorted(
+    view: VersionsRef<'_>,
+    sorted: &[deno_semver::Version],
+    spec: &str,
+) -> Result<String, ResolveError> {
+    let VersionsRef {
+        versions,
+        dist_tags,
+    } = view;
+
+    if versions.is_empty() {
+        return Err(ResolveError::NoVersionsAvailable);
+    }
+
+    if let Some(version) = dist_tags.get(spec) {
+        return Ok(version.to_string());
+    }
+
+    let version = dist_tags
+        .get("latest")
+        .filter(|latest| matches(spec, latest))
+        .map(|latest| latest.to_string())
+        .or_else(|| super::semver::max_satisfying_sorted_desc(sorted, spec).map(|v| v.to_string()));
+
+    version.ok_or_else(|| ResolveError::NoMatchingVersion {
+        spec: spec.to_string(),
+        available_count: versions.len(),
+    })
+}
+
 /// Error type for version resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolveError {

--- a/crates/ruborist/src/resolver/version.rs
+++ b/crates/ruborist/src/resolver/version.rs
@@ -63,13 +63,20 @@ pub fn resolve_target_version(view: VersionsRef<'_>, spec: &str) -> Result<Strin
     })
 }
 
-/// [`resolve_target_version`] over a per-package pre-parsed, descending-sorted
-/// version list (see `FullManifest::sorted_parsed_versions`): identical
-/// dist-tag / latest-preference policy, but the semver fallback early-exits on
-/// the first (= maximum) match instead of parsing every version per spec.
-pub fn resolve_target_version_sorted(
+/// [`resolve_target_version`] backed by a per-package pre-parsed,
+/// descending-sorted version list (see `FullManifest::sorted_parsed_versions`):
+/// identical dist-tag / latest-preference policy, but the semver fallback
+/// early-exits on the first (= maximum) match instead of parsing every version
+/// per spec.
+///
+/// `sorted` is a closure on purpose: the sorted list is a lazily-built
+/// per-package cache whose first build parses the whole version list — an
+/// eager `&[Version]` argument would force that build even on the dist-tag /
+/// latest shortcuts that never look at it (and on the resolver driver thread,
+/// at that). The closure only runs when the fallback is actually reached.
+pub fn resolve_target_version_lazy<'a>(
     view: VersionsRef<'_>,
-    sorted: &[deno_semver::Version],
+    sorted: impl FnOnce() -> &'a [deno_semver::Version],
     spec: &str,
 ) -> Result<String, ResolveError> {
     let VersionsRef {
@@ -89,7 +96,9 @@ pub fn resolve_target_version_sorted(
         .get("latest")
         .filter(|latest| matches(spec, latest))
         .map(|latest| latest.to_string())
-        .or_else(|| super::semver::max_satisfying_sorted_desc(sorted, spec).map(|v| v.to_string()));
+        .or_else(|| {
+            super::semver::max_satisfying_sorted_desc(sorted(), spec).map(|v| v.to_string())
+        });
 
     version.ok_or_else(|| ResolveError::NoMatchingVersion {
         spec: spec.to_string(),
@@ -219,5 +228,64 @@ mod tests {
 
         let result = resolve_target_version(view(&versions, &dist_tags), "^1.0.0");
         assert_eq!(result, Err(ResolveError::NoVersionsAvailable));
+    }
+
+    /// The lazy variant must not build the sorted list when the dist-tag or
+    /// latest shortcut settles the spec — that build is the expensive
+    /// per-package parse+sort the shortcuts exist to avoid.
+    #[test]
+    fn test_lazy_skips_sorted_on_shortcut() {
+        use std::cell::Cell;
+
+        let mut dist_tags = HashMap::new();
+        dist_tags.insert("latest".to_string(), "1.5.0".to_string());
+        dist_tags.insert("beta".to_string(), "2.0.0-beta.1".to_string());
+        let versions = vec!["1.0.0".to_string(), "1.5.0".to_string()];
+
+        let called = Cell::new(false);
+        let sorted: Vec<deno_semver::Version> = vec![];
+
+        // dist-tag hit: closure untouched
+        let result = resolve_target_version_lazy(
+            view(&versions, &dist_tags),
+            || {
+                called.set(true);
+                &sorted
+            },
+            "beta",
+        );
+        assert_eq!(result, Ok("2.0.0-beta.1".to_string()));
+        assert!(
+            !called.get(),
+            "dist-tag shortcut must not build sorted list"
+        );
+
+        // latest satisfies: closure untouched
+        let result = resolve_target_version_lazy(
+            view(&versions, &dist_tags),
+            || {
+                called.set(true);
+                &sorted
+            },
+            "^1.0.0",
+        );
+        assert_eq!(result, Ok("1.5.0".to_string()));
+        assert!(!called.get(), "latest shortcut must not build sorted list");
+
+        // latest misses: closure runs, early-exit picks the max match
+        let parsed = crate::model::manifest::sort_parsed_versions(&[
+            "1.0.0".to_string(),
+            "0.9.0".to_string(),
+        ]);
+        let result = resolve_target_version_lazy(
+            view(&versions, &dist_tags),
+            || {
+                called.set(true);
+                &parsed
+            },
+            "^0.9.0",
+        );
+        assert_eq!(result, Ok("0.9.0".to_string()));
+        assert!(called.get(), "fallback must consult the sorted list");
     }
 }

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -32,7 +32,7 @@ use crate::model::package_json::PackageJson;
 use crate::model::package_lock::PackageLock;
 use crate::resolver::builder::{
     BuildDepsConfig, DevDeps, EdgeContext, PeerDeps, add_edges_from, add_workspace_member,
-    build_deps_with_config_output,
+    build_deps_with_config_output, resolve_workspace_member_edges,
 };
 use crate::resolver::runtime::install_runtime_from_map;
 use crate::resolver::workspace::WorkspaceDiscovery;
@@ -171,6 +171,9 @@ where
             &edge_ctx,
         );
     }
+    // Settle all importer-declared workspace: edges now that every member is
+    // attached — the BFS never sees a workspace: spec on the happy path.
+    resolve_workspace_member_edges(&mut graph);
 
     // 4. The host supplies the stateless registry client (URL, store, semver,
     //    auth) pre-built. The warm `project_cache` seeds the demand resolver's

--- a/crates/ruborist/src/service/cache.rs
+++ b/crates/ruborist/src/service/cache.rs
@@ -21,6 +21,20 @@ pub struct VersionsInfo {
     pub versions: Versions,
     pub etag: Option<String>,
     pub last_updated: u64,
+    /// Lazily parsed + descending-sorted `version_list` — same per-package
+    /// memoization as `FullManifest::parsed_versions`, for the versions-list
+    /// resolution path.
+    #[serde(skip)]
+    pub parsed_versions: std::sync::OnceLock<Vec<deno_semver::Version>>,
+}
+
+impl VersionsInfo {
+    /// Lazily parsed + descending-sorted version list.
+    pub fn sorted_parsed_versions(&self) -> &[deno_semver::Version] {
+        self.parsed_versions.get_or_init(|| {
+            crate::model::manifest::sort_parsed_versions(&self.versions.version_list)
+        })
+    }
 }
 
 impl<'a> From<&'a VersionsInfo> for VersionsRef<'a> {

--- a/crates/ruborist/src/service/manifest.rs
+++ b/crates/ruborist/src/service/manifest.rs
@@ -13,7 +13,7 @@ use super::fetch::{
 };
 use super::http::get_client;
 use crate::model::manifest::{CoreVersionManifest, FullManifest};
-use crate::resolver::version::resolve_target_version;
+use crate::resolver::version::resolve_target_version_lazy;
 
 /// Parse a JSON buffer on rayon's CPU thread pool (native) or inline
 /// (wasm32). The buffer is consumed because `simd_json` mutates it in-place.
@@ -68,8 +68,17 @@ fn parse_full_manifest_with_core_sync(
         .map_err(|e| anyhow!("JSON parse error: {e}"))?;
     manifest.raw = raw_bytes;
 
+    // Lazy + selective pre-warm: when the dist-tag / latest shortcuts settle
+    // the spec, no version is ever parsed; when they don't, the closure builds
+    // the package's sorted parsed-version cache HERE — on the rayon worker —
+    // so the resolver driver only ever sees a warm OnceLock for the packages
+    // that actually need full semver matching.
     let speculative = match spec {
-        Some(spec) => match resolve_target_version((&manifest).into(), &spec) {
+        Some(spec) => match resolve_target_version_lazy(
+            (&manifest).into(),
+            || manifest.sorted_parsed_versions(),
+            &spec,
+        ) {
             Ok(version) => match manifest.get_core_version_oneshot(&version) {
                 Some(core) => Some((spec, core)),
                 None => {

--- a/crates/ruborist/src/service/registry/provider.rs
+++ b/crates/ruborist/src/service/registry/provider.rs
@@ -109,6 +109,7 @@ impl ManifestProvider for UnifiedRegistry {
                             },
                             etag,
                             last_updated: super::current_timestamp_secs(),
+                            parsed_versions: Default::default(),
                         });
                         self.store.store_versions(&name, versions);
                         ManifestFullData::Full {

--- a/crates/ruborist/src/service/registry/provider.rs
+++ b/crates/ruborist/src/service/registry/provider.rs
@@ -21,6 +21,7 @@ use super::super::manifest_provider::{
 };
 use super::UnifiedRegistry;
 use crate::model::manifest::{CoreVersionManifest, extract_core_version_off_runtime};
+use crate::resolver::semver::matches as semver_matches;
 use crate::traits::registry::RegistryError;
 
 impl UnifiedRegistry {
@@ -118,6 +119,21 @@ impl ManifestProvider for UnifiedRegistry {
                         }
                     }
                     ProviderFullManifestBytes::NotModified { versions } => {
+                        // Selective pre-warm, mirroring the parse worker: when
+                        // the requesting spec won't settle via the dist-tag /
+                        // latest shortcuts, the driver is about to need the
+                        // full sorted version list — build it here, on this
+                        // spawned fetch task, not on the driver.
+                        if let Some(spec) = &spec {
+                            let dist_tags = &versions.versions.dist_tags;
+                            let shortcut_settles = dist_tags.contains_key(spec.as_str())
+                                || dist_tags
+                                    .get("latest")
+                                    .is_some_and(|latest| semver_matches(spec, latest));
+                            if !shortcut_settles {
+                                versions.sorted_parsed_versions();
+                            }
+                        }
                         ManifestFullData::Versions(versions)
                     }
                 };

--- a/crates/ruborist/src/spec/mod.rs
+++ b/crates/ruborist/src/spec/mod.rs
@@ -296,7 +296,28 @@ impl SpecStr for str {
     }
 
     fn is_registry_spec(&self) -> bool {
-        self.parse_spec().is_registry()
+        // Allocation-free mirror of `PackageSpec::from(..).is_registry()` —
+        // this runs once per dependency edge on the resolver driver, where the
+        // full parse built (and threw away) two `String`s per call. The
+        // `spec_str_registry_check_matches_full_parse` test pins equivalence.
+        match Protocol::strip_prefix(self) {
+            Some((Protocol::NpmAlias, _)) => true,
+            Some(_) => false,
+            None => {
+                // Bare GitHub shorthand (`user/repo`, optionally `#ref`) is the
+                // only prefix-less non-registry form.
+                if !self.is_scoped() {
+                    let (path, _) = split_fragment(self);
+                    if let Some((owner, repo)) = path.split_once('/')
+                        && !owner.is_empty()
+                        && !repo.is_empty()
+                    {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
     }
 }
 
@@ -378,6 +399,49 @@ mod tests {
 
     fn spec(s: &str) -> PackageSpec {
         s.parse_spec()
+    }
+
+    /// The allocation-free `is_registry_spec` must agree with the full parse
+    /// for every spec shape the resolver can see.
+    #[test]
+    fn spec_str_registry_check_matches_full_parse() {
+        let cases = [
+            "^1.0.0",
+            "~2.3.4",
+            "*",
+            "",
+            "latest",
+            "1.2.3-beta.1",
+            ">=1 <2",
+            "npm:lodash@^4.17.0",
+            "npm:@scope/pkg",
+            "@scope/pkg",
+            "@scope/pkg@^1.0.0",
+            "workspace:*",
+            "workspace:^1.0.0",
+            "catalog:",
+            "catalog:react",
+            "file:../local-pkg",
+            "link:../tool",
+            "portal:../portal",
+            "git+https://github.com/user/repo.git#main",
+            "git://github.com/user/repo.git",
+            "github:user/repo#v1",
+            "github:bare",
+            "user/repo",
+            "user/repo#branch",
+            "https://example.com/pkg.tgz",
+            "http://example.com/pkg.tgz",
+            "not-a-repo/",
+            "/leading-slash",
+        ];
+        for case in cases {
+            assert_eq!(
+                case.is_registry_spec(),
+                PackageSpec::from(case).is_registry(),
+                "is_registry_spec divergence for {case:?}"
+            );
+        }
     }
 
     // -- Protocol --


### PR DESCRIPTION
The p1 physics: metadata transfer is ~206MB on ant-design/npmjs (~1.4s at runner line rate); everything between that floor and utoo's ~2.2s is client CPU, most of it serialized on the single-threaded driver. Three structural costs removed:

1. **Speculative version extract no longer re-parses the packument.** The oneshot path cloned the multi-MB body and built a full `simd_json` borrowed tree to read one version object. Now: zero-copy shallow `RawValue` pass that brace-matches past every other version — still builds/retains no per-version index.
2. **O(1) physical-child lookup.** `find_in_parent_chain` scanned every root child (string compare each) per ancestor level, for every edge, twice (pre-fetch reuse probe + post-fetch placement — both still run; the graph changes between them). A per-parent `name → child` map maintained in `add_physical_edge` (graph is append-only) makes each probe a hash hit.
3. **Per-package memoized version selection.** When the `latest` dist-tag doesn't satisfy a spec (old-major pins like `^17.0.0`), `max_satisfying` parsed the entire version list per distinct spec — react-scale packages: ~2k parses each, on the driver. Version lists now parse + sort descending once per package (`OnceLock`); each spec walks top-down and early-exits on the first (= max) match. The latest-first shortcut is untouched.

Also per review: `workspace:` specs in a project that declares no workspaces now warn instead of vanishing into a debug-level skip; overrides already short-circuit on an empty name set.

Expected bench signal: **p1 (and p0's resolve half) improve**; p3/p4 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)