### PR TITLE
fix(pm): normalize file: tarball cache slot so `..` paths resolve

### DIFF
--- a/crates/pm/src/util/package_cache.rs
+++ b/crates/pm/src/util/package_cache.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use utoo_ruborist::http::{file_cache_slot, http_cache_slot};
+use utoo_ruborist::cache_slot::{file_cache_slot, http_cache_slot};
 use utoo_ruborist::spec::Protocol;
 
 use super::cache::get_cache_dir;

--- a/crates/ruborist/src/lib.rs
+++ b/crates/ruborist/src/lib.rs
@@ -105,10 +105,12 @@ pub mod git {
     pub use crate::resolver::git::{GitCloneCache, ensure_repo_cached};
 }
 
-/// Non-registry tarball cache-slot helpers (http + local file).
-pub mod http {
+/// Non-registry tarball cache-slot helpers: http(s) tarballs keyed by URL,
+/// local `file:` tarballs keyed by absolute path. Implemented in
+/// `resolver::common` alongside the slot-commit protocol.
+pub mod cache_slot {
     #[cfg(feature = "http-tarball")]
-    pub use crate::resolver::http::{file_cache_slot, http_cache_slot};
+    pub use crate::resolver::common::{file_cache_slot, http_cache_slot};
 }
 
 /// Tar + gzip primitives and the atomic cache-slot commit protocol.

--- a/crates/ruborist/src/resolver/common.rs
+++ b/crates/ruborist/src/resolver/common.rs
@@ -23,6 +23,8 @@ use std::path::Path;
 #[cfg(any(feature = "native-git", feature = "http-tarball"))]
 use anyhow::Context;
 use anyhow::{Result, anyhow};
+#[cfg(feature = "http-tarball")]
+use sha2::{Digest, Sha256};
 
 use crate::model::manifest::{CoreVersionManifest, Dist};
 use crate::util::OnceMap;
@@ -180,9 +182,160 @@ where
         .await
 }
 
+// ---------------------------------------------------------------------------
+// Non-registry cache-slot addressing
+// ---------------------------------------------------------------------------
+//
+// The cache *key* for a non-registry tarball: an http(s) tarball is keyed by
+// its URL, a local `file:` tarball by its absolute path. Both share the
+// `cache_slot` sha256 primitive and live here — next to `commit_cache_dir_atomic`
+// (the slot *commit* protocol) — so all cache-slot concerns sit in one module
+// instead of the `file:` key living inside the http resolver. Consumed by
+// `super::http` and `super::file`, and re-exported to pm via the lib façade.
+
+/// `<prefix><16 hex>` from `sha256(bytes)`. Used by the two non-registry
+/// cache slots (`_http_<url>`, `_file_<path>`) to stay visually distinct
+/// from `<name>/<version>/` and 40-char git commit shas.
+#[cfg(feature = "http-tarball")]
+fn cache_slot(prefix: &str, bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(prefix.len() + 16);
+    out.push_str(prefix);
+    for b in &digest[..8] {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// Cache slot for an http(s) tarball, keyed on its URL.
+#[cfg(feature = "http-tarball")]
+pub fn http_cache_slot(url: &str) -> String {
+    cache_slot("_http_", url.as_bytes())
+}
+
+/// Cache slot for a local tarball keyed on its absolute path. The path is
+/// lexically normalized first so BFS and install hash to the same slot.
+///
+/// BFS resolves the tarball from a canonical absolute path
+/// (`base.join("/abs/foo.tgz")`), but install re-absolutizes a *root-relative*
+/// lockfile entry (`cwd.join("../../foo.tgz")`) whenever the tarball lives
+/// outside the project root. `Path::components()` collapses `.` and redundant
+/// separators but **keeps `..`**, so those two spellings of the same file would
+/// otherwise hash to different slots and the install-time lookup would miss.
+/// [`lexically_normalize`] collapses `..` so both spellings agree.
+#[cfg(feature = "http-tarball")]
+pub fn file_cache_slot(abs_path: &Path) -> String {
+    let normalized = lexically_normalize(abs_path);
+    cache_slot("_file_", normalized.as_os_str().as_encoded_bytes())
+}
+
+/// Collapse `.` and `..` purely lexically (no filesystem access, so it works
+/// for not-yet-existing paths and stays identical across BFS and install).
+///
+/// `..` pops the preceding normal component but never climbs past a root or
+/// prefix; a leading `..` in a relative path is preserved.
+///
+/// # Why lexical, not `fs::canonicalize`
+///
+/// This matches the semantics of Node's `path.resolve`/`path.normalize` — which
+/// is what npm uses to resolve `file:` specs — *not* `fs::realpath`. We only
+/// need BFS and install to agree on one canonical string for the cache key, and
+/// lexical collapsing achieves that without the costs of `fs::canonicalize`:
+/// the latter would require the tarball to already exist (breaking optional /
+/// not-yet-fetched deps), cost a syscall per package, and resolve symlinks —
+/// diverging from npm and changing the key based on FS state.
+///
+/// # Why hand-rolled
+///
+/// Rust std has no lexical `..`-collapse: `Path::components()` keeps `..` (the
+/// original bug), and `std::path::absolute` also deliberately keeps `..` on
+/// Unix. The `path-clean` crate exists in the tree but only as a transitive dep
+/// of the bundler half (swc/turbopack), not reachable from pm/ruborist, and it
+/// is not Windows-prefix aware. The `Component::Prefix` arm below handles
+/// Windows drive prefixes (e.g. `C:\`) so the win32 build stays correct even
+/// though no `file:`-tarball e2e currently exercises that target.
+#[cfg(feature = "http-tarball")]
+fn lexically_normalize(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut stack: Vec<Component> = Vec::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => match stack.last() {
+                Some(Component::Normal(_)) => {
+                    stack.pop();
+                }
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => stack.push(comp),
+            },
+            _ => stack.push(comp),
+        }
+    }
+    stack.iter().map(|c| c.as_os_str()).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "http-tarball")]
+    mod cache_slot {
+        use std::path::{Path, PathBuf};
+
+        use super::super::{file_cache_slot, http_cache_slot, lexically_normalize};
+
+        #[test]
+        fn http_slot_is_stable_and_url_specific() {
+            let a = http_cache_slot("https://example.com/foo.tgz");
+            let b = http_cache_slot("https://example.com/foo.tgz");
+            let c = http_cache_slot("https://example.com/foo.tgz?v=2");
+            assert_eq!(a, b);
+            assert_ne!(a, c);
+            assert!(a.starts_with("_http_"));
+            assert_eq!(a.len(), "_http_".len() + 16);
+        }
+
+        #[test]
+        fn file_slot_is_stable_across_dotdot_spellings() {
+            // BFS resolves from a canonical absolute path; install re-absolutizes
+            // a root-relative lockfile entry, which carries `..` when the tarball
+            // lives outside the project root. Both must hash to the same slot.
+            let canonical = Path::new("/tmp/pkgs/foo.tgz");
+            let via_dotdot = Path::new("/tmp/pkgs/app/../../pkgs/foo.tgz");
+            let via_curdir = Path::new("/tmp/pkgs/./foo.tgz");
+
+            assert_eq!(file_cache_slot(canonical), file_cache_slot(via_dotdot));
+            assert_eq!(file_cache_slot(canonical), file_cache_slot(via_curdir));
+            assert!(file_cache_slot(canonical).starts_with("_file_"));
+
+            // Distinct tarballs still get distinct slots.
+            assert_ne!(
+                file_cache_slot(canonical),
+                file_cache_slot(Path::new("/tmp/pkgs/bar.tgz"))
+            );
+        }
+
+        #[test]
+        fn lexically_normalize_collapses_dotdot_without_climbing_root() {
+            assert_eq!(
+                lexically_normalize(Path::new("/a/b/../c")),
+                PathBuf::from("/a/c")
+            );
+            // Excess `..` saturates at the root rather than escaping it.
+            assert_eq!(
+                lexically_normalize(Path::new("/a/../../../b")),
+                PathBuf::from("/b")
+            );
+            // Leading `..` in a relative path is preserved (nothing to pop).
+            assert_eq!(
+                lexically_normalize(Path::new("../a/b")),
+                PathBuf::from("../a/b")
+            );
+        }
+    }
 
     #[test]
     fn rejects_unsafe_package_names() {

--- a/crates/ruborist/src/resolver/file.rs
+++ b/crates/ruborist/src/resolver/file.rs
@@ -12,8 +12,8 @@ use anyhow::Context as _;
 use petgraph::graph::NodeIndex;
 
 use super::builder::ProcessResult;
+use super::common::file_cache_slot;
 use super::edges::DependencyEdgeInfo;
-use super::http::file_cache_slot;
 use super::tar::commit_tarball_bytes;
 use crate::model::graph::{DependencyGraph, PackageNode};
 use crate::model::manifest::NodeManifest;

--- a/crates/ruborist/src/resolver/http.rs
+++ b/crates/ruborist/src/resolver/http.rs
@@ -121,13 +121,44 @@ pub fn http_cache_slot(url: &str) -> String {
     cache_slot("_http_", url.as_bytes())
 }
 
-/// Cache slot for a local tarball keyed on its absolute path. Path is
-/// normalized via `Path::components()` first so BFS (`base.join("./foo.tgz")`)
-/// and install (`cwd.join("foo.tgz")` from a root-relative lockfile entry)
-/// hash to the same slot.
+/// Cache slot for a local tarball keyed on its absolute path. The path is
+/// lexically normalized first so BFS and install hash to the same slot.
+///
+/// BFS resolves the tarball from a canonical absolute path
+/// (`base.join("/abs/foo.tgz")`), but install re-absolutizes a *root-relative*
+/// lockfile entry (`cwd.join("../../foo.tgz")`) whenever the tarball lives
+/// outside the project root. `Path::components()` collapses `.` and redundant
+/// separators but **keeps `..`**, so those two spellings of the same file would
+/// otherwise hash to different slots and the install-time lookup would miss.
+/// [`lexically_normalize`] collapses `..` so both spellings agree.
 pub fn file_cache_slot(abs_path: &Path) -> String {
-    let normalized: PathBuf = abs_path.components().collect();
+    let normalized = lexically_normalize(abs_path);
     cache_slot("_file_", normalized.as_os_str().as_encoded_bytes())
+}
+
+/// Collapse `.` and `..` purely lexically (no filesystem access, so it works
+/// for not-yet-existing paths and stays identical across BFS and install).
+///
+/// `..` pops the preceding normal component but never climbs past a root or
+/// prefix; a leading `..` in a relative path is preserved.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut stack: Vec<Component> = Vec::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => match stack.last() {
+                Some(Component::Normal(_)) => {
+                    stack.pop();
+                }
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => stack.push(comp),
+            },
+            _ => stack.push(comp),
+        }
+    }
+    stack.iter().map(|c| c.as_os_str()).collect()
 }
 
 fn fetch_and_extract_blocking(
@@ -313,6 +344,44 @@ mod tests {
         let bytes = make_targz(&[("package/README.md", b"hi")]);
         let err = fetch_and_extract_blocking(tmp.path(), "u", bytes).unwrap_err();
         assert!(err.to_string().contains("package.json not found"));
+    }
+
+    #[test]
+    fn file_slot_is_stable_across_dotdot_spellings() {
+        // BFS resolves from a canonical absolute path; install re-absolutizes a
+        // root-relative lockfile entry, which carries `..` when the tarball
+        // lives outside the project root. Both must hash to the same slot.
+        let canonical = Path::new("/tmp/pkgs/foo.tgz");
+        let via_dotdot = Path::new("/tmp/pkgs/app/../../pkgs/foo.tgz");
+        let via_curdir = Path::new("/tmp/pkgs/./foo.tgz");
+
+        assert_eq!(file_cache_slot(canonical), file_cache_slot(via_dotdot));
+        assert_eq!(file_cache_slot(canonical), file_cache_slot(via_curdir));
+        assert!(file_cache_slot(canonical).starts_with("_file_"));
+
+        // Distinct tarballs still get distinct slots.
+        assert_ne!(
+            file_cache_slot(canonical),
+            file_cache_slot(Path::new("/tmp/pkgs/bar.tgz"))
+        );
+    }
+
+    #[test]
+    fn lexically_normalize_collapses_dotdot_without_climbing_root() {
+        assert_eq!(
+            lexically_normalize(Path::new("/a/b/../c")),
+            PathBuf::from("/a/c")
+        );
+        // Excess `..` saturates at the root rather than escaping it.
+        assert_eq!(
+            lexically_normalize(Path::new("/a/../../../b")),
+            PathBuf::from("/b")
+        );
+        // Leading `..` in a relative path is preserved (nothing to pop).
+        assert_eq!(
+            lexically_normalize(Path::new("../a/b")),
+            PathBuf::from("../a/b")
+        );
     }
 
     #[test]

--- a/crates/ruborist/src/resolver/http.rs
+++ b/crates/ruborist/src/resolver/http.rs
@@ -84,15 +84,13 @@
 //!
 //! [`download_to_cache`]: https://github.com/utooland/utoo/blob/main/crates/pm/src/util/downloader.rs
 
-use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
-use sha2::{Digest, Sha256};
 use tokio_retry::RetryIf;
 
-use super::common::{DedupCache, dedup_init};
+use super::common::{DedupCache, dedup_init, http_cache_slot};
 use super::tar::commit_tarball_bytes;
 use crate::model::manifest::CoreVersionManifest;
 use crate::service::fetch::{
@@ -103,63 +101,6 @@ use crate::traits::registry::ResolvedPackage;
 
 /// Session-scoped dedup cache: one fetch per URL even under concurrent BFS.
 pub(crate) type HttpFetchCache = DedupCache<CoreVersionManifest>;
-
-/// `<prefix><16 hex>` from `sha256(bytes)`. Used by the two non-registry
-/// cache slots (`_http_<url>`, `_file_<path>`) to stay visually distinct
-/// from `<name>/<version>/` and 40-char git commit shas.
-fn cache_slot(prefix: &str, bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    let mut out = String::with_capacity(prefix.len() + 16);
-    out.push_str(prefix);
-    for b in &digest[..8] {
-        let _ = write!(out, "{b:02x}");
-    }
-    out
-}
-
-pub fn http_cache_slot(url: &str) -> String {
-    cache_slot("_http_", url.as_bytes())
-}
-
-/// Cache slot for a local tarball keyed on its absolute path. The path is
-/// lexically normalized first so BFS and install hash to the same slot.
-///
-/// BFS resolves the tarball from a canonical absolute path
-/// (`base.join("/abs/foo.tgz")`), but install re-absolutizes a *root-relative*
-/// lockfile entry (`cwd.join("../../foo.tgz")`) whenever the tarball lives
-/// outside the project root. `Path::components()` collapses `.` and redundant
-/// separators but **keeps `..`**, so those two spellings of the same file would
-/// otherwise hash to different slots and the install-time lookup would miss.
-/// [`lexically_normalize`] collapses `..` so both spellings agree.
-pub fn file_cache_slot(abs_path: &Path) -> String {
-    let normalized = lexically_normalize(abs_path);
-    cache_slot("_file_", normalized.as_os_str().as_encoded_bytes())
-}
-
-/// Collapse `.` and `..` purely lexically (no filesystem access, so it works
-/// for not-yet-existing paths and stays identical across BFS and install).
-///
-/// `..` pops the preceding normal component but never climbs past a root or
-/// prefix; a leading `..` in a relative path is preserved.
-fn lexically_normalize(path: &Path) -> PathBuf {
-    use std::path::Component;
-
-    let mut stack: Vec<Component> = Vec::new();
-    for comp in path.components() {
-        match comp {
-            Component::CurDir => {}
-            Component::ParentDir => match stack.last() {
-                Some(Component::Normal(_)) => {
-                    stack.pop();
-                }
-                Some(Component::RootDir | Component::Prefix(_)) => {}
-                _ => stack.push(comp),
-            },
-            _ => stack.push(comp),
-        }
-    }
-    stack.iter().map(|c| c.as_os_str()).collect()
-}
 
 fn fetch_and_extract_blocking(
     cache_dir: &Path,
@@ -270,17 +211,6 @@ mod tests {
     }
 
     #[test]
-    fn slot_name_is_stable_and_url_specific() {
-        let a = http_cache_slot("https://example.com/foo.tgz");
-        let b = http_cache_slot("https://example.com/foo.tgz");
-        let c = http_cache_slot("https://example.com/foo.tgz?v=2");
-        assert_eq!(a, b);
-        assert_ne!(a, c);
-        assert!(a.starts_with("_http_"));
-        assert_eq!(a.len(), "_http_".len() + 16);
-    }
-
-    #[test]
     fn extracts_to_url_hashed_slot() {
         let tmp = tempfile::tempdir().unwrap();
         let pkg = br#"{"name":"demo","version":"1.2.3","scripts":{"install":"echo hi"}}"#;
@@ -344,44 +274,6 @@ mod tests {
         let bytes = make_targz(&[("package/README.md", b"hi")]);
         let err = fetch_and_extract_blocking(tmp.path(), "u", bytes).unwrap_err();
         assert!(err.to_string().contains("package.json not found"));
-    }
-
-    #[test]
-    fn file_slot_is_stable_across_dotdot_spellings() {
-        // BFS resolves from a canonical absolute path; install re-absolutizes a
-        // root-relative lockfile entry, which carries `..` when the tarball
-        // lives outside the project root. Both must hash to the same slot.
-        let canonical = Path::new("/tmp/pkgs/foo.tgz");
-        let via_dotdot = Path::new("/tmp/pkgs/app/../../pkgs/foo.tgz");
-        let via_curdir = Path::new("/tmp/pkgs/./foo.tgz");
-
-        assert_eq!(file_cache_slot(canonical), file_cache_slot(via_dotdot));
-        assert_eq!(file_cache_slot(canonical), file_cache_slot(via_curdir));
-        assert!(file_cache_slot(canonical).starts_with("_file_"));
-
-        // Distinct tarballs still get distinct slots.
-        assert_ne!(
-            file_cache_slot(canonical),
-            file_cache_slot(Path::new("/tmp/pkgs/bar.tgz"))
-        );
-    }
-
-    #[test]
-    fn lexically_normalize_collapses_dotdot_without_climbing_root() {
-        assert_eq!(
-            lexically_normalize(Path::new("/a/b/../c")),
-            PathBuf::from("/a/c")
-        );
-        // Excess `..` saturates at the root rather than escaping it.
-        assert_eq!(
-            lexically_normalize(Path::new("/a/../../../b")),
-            PathBuf::from("/b")
-        );
-        // Leading `..` in a relative path is preserved (nothing to pop).
-        assert_eq!(
-            lexically_normalize(Path::new("../a/b")),
-            PathBuf::from("../a/b")
-        );
     }
 
     #[test]

--- a/e2e/utoo-pm.ps1
+++ b/e2e/utoo-pm.ps1
@@ -567,4 +567,65 @@ if (-not (Get-Command cowsay -ErrorAction SilentlyContinue)) {
 }
 Write-Green "  ✓ PASS: utoo add -g works"
 
+# ═══════════════════════════════════════════════════════════════
+# Case: file: tarball located OUTSIDE the project root (Windows)
+# ═══════════════════════════════════════════════════════════════
+# Windows mirror of the bash Case 8.5b. A tarball outside the project root
+# yields a root-relative lockfile entry carrying `..` (e.g. "file:../foo.tgz").
+# BFS hashes the cache slot from the canonical absolute path, while install
+# re-absolutizes the `..`-laden lockfile path; without lexical `..`-collapse
+# (which must also handle the Windows `C:` drive prefix) the two disagree and
+# the clone fails with "file tarball cache not found". No other e2e exercises
+# this on win32-msvc.
+Write-Yellow "Case: file: tarball outside project root (Windows)"
+$extDir = Join-Path $env:TEMP "utoo-e2e-exttgz-$(Get-Random)"
+try {
+    New-Item -ItemType Directory -Path "$extDir\src\ext-tarball-pkg" -Force | Out-Null
+    New-Item -ItemType Directory -Path "$extDir\app" -Force | Out-Null
+
+    @{ name = "ext-tarball-pkg"; version = "5.6.7"; main = "index.js" } |
+        ConvertTo-Json | Set-Content "$extDir\src\ext-tarball-pkg\package.json"
+    Set-Content "$extDir\src\ext-tarball-pkg\index.js" "module.exports = 567;"
+
+    # Pack the leaf package into a tarball that sits OUTSIDE the app dir, so the
+    # lockfile's root-relative `file:` path carries a `..`.
+    Push-Location "$extDir\src\ext-tarball-pkg"
+    try {
+        npm pack 2>&1 | Out-Null
+        $tgz = Get-ChildItem "ext-tarball-pkg-*.tgz" | Select-Object -First 1
+        Move-Item $tgz.FullName "$extDir\ext-tarball-pkg.tgz"
+    }
+    finally { Pop-Location }
+
+    $tgzSpec = "file:" + ((Join-Path $extDir "ext-tarball-pkg.tgz") -replace '\\', '/')
+    @{
+        name         = "ext-tarball-app"
+        version      = "1.0.0"
+        private      = $true
+        dependencies = @{ "ext-tarball-pkg" = $tgzSpec }
+    } | ConvertTo-Json | Set-Content "$extDir\app\package.json"
+
+    Push-Location "$extDir\app"
+    try {
+        utoo install --ignore-scripts
+        if ($LASTEXITCODE -ne 0) { throw "install failed for tarball outside project root" }
+
+        if (-not (Test-Path "node_modules\ext-tarball-pkg\package.json")) {
+            throw "ext-tarball-pkg not materialized into node_modules"
+        }
+        $ver = node -p "require('./node_modules/ext-tarball-pkg/package.json').version"
+        if ($ver.Trim() -ne "5.6.7") { throw "ext-tarball-pkg expected v5.6.7, got $ver" }
+
+        # Lockfile must stay portable: a root-relative `file:` path, not absolute.
+        node -e "const lock=require('./package-lock.json');const tar=lock.packages['node_modules/ext-tarball-pkg']||{};const r=tar.resolved||'';if(!r.startsWith('file:')){console.error('resolved not file:',r);process.exit(1);}const p=r.slice(5);if(/^[A-Za-z]:/.test(p)||p[0]==='/'){console.error('resolved should be root-relative, got absolute:',r);process.exit(1);}console.log('  lockfile resolved (portable):',r);"
+        if ($LASTEXITCODE -ne 0) { throw "lockfile entry wrong for outside-root tarball" }
+
+        Write-Green "PASS: file: tarball outside project root installs (Windows)"
+    }
+    finally { Pop-Location }
+}
+finally {
+    Remove-Item -Recurse -Force $extDir -ErrorAction SilentlyContinue
+}
+
 Write-Green "All e2e tests passed successfully!"

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -295,13 +295,20 @@ if [ "$ACTUAL" != "5.6.7" ]; then
     echo -e "${RED}FAIL: ext-tarball-pkg expected v5.6.7, got $ACTUAL${NC}"; rm -rf "$EXT_DIR"; exit 1
 fi
 # Lockfile must stay portable: a root-relative `file:` path with `..`.
+# Check the *form*, not a substring: when cwd and the tarball spec disagree on
+# a symlinked prefix (e.g. macOS /var vs /private/var) the relative path climbs
+# to the filesystem root and re-descends, so it legitimately *contains* the abs
+# dir as a substring while still being relative. Absolute = the part after
+# `file:` starts at a root (`/` on unix, `C:` on windows).
 node -e '
 const lock = require("'"$EXT_DIR"'/app/package-lock.json");
 const tar = lock.packages["node_modules/ext-tarball-pkg"] || {};
-if (typeof tar.resolved !== "string" || !tar.resolved.startsWith("file:")) {
+const r = tar.resolved || "";
+if (!r.startsWith("file:")) {
   console.error("ext-tarball-pkg resolved should be a file: path, got", tar.resolved); process.exit(1);
 }
-if (tar.resolved.includes("'"$EXT_DIR"'")) {
+const p = r.slice(5);
+if (p[0] === "/" || /^[A-Za-z]:/.test(p)) {
   console.error("ext-tarball-pkg resolved should be root-relative, not absolute:", tar.resolved); process.exit(1);
 }
 ' || { echo -e "${RED}FAIL: lockfile entry wrong for outside-root tarball${NC}"; rm -rf "$EXT_DIR"; exit 1; }

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -259,6 +259,55 @@ utoo install --ignore-scripts || { echo -e "${RED}FAIL: utoo warm install failed
 echo -e "${GREEN}PASS: file: warm install successful${NC}"
 cd ../../..
 
+# Case 8.5b: file: tarball located OUTSIDE the project root.
+# Regression: such a tarball's root-relative lockfile entry carries `..`
+# (e.g. "file:../../pkgs/foo.tgz"). BFS hashes the cache slot from the
+# canonical absolute path, but install re-absolutizes the `..`-laden lockfile
+# path; if the slot key isn't normalized the two disagree and the clone fails
+# with "file tarball cache not found". The in-tree fixture above can't catch
+# this because its path has no `..`.
+echo -e "${YELLOW}Case 8.5b: file: tarball outside project root${NC}"
+EXT_DIR=$(mktemp -d)
+mkdir -p "$EXT_DIR/src/ext-tarball-pkg"
+cat > "$EXT_DIR/src/ext-tarball-pkg/package.json" <<'EOF'
+{ "name": "ext-tarball-pkg", "version": "5.6.7", "main": "index.js" }
+EOF
+echo "module.exports = 567;" > "$EXT_DIR/src/ext-tarball-pkg/index.js"
+( cd "$EXT_DIR/src/ext-tarball-pkg" && npm pack --silent >/dev/null 2>&1 \
+  && mv ext-tarball-pkg-*.tgz "$EXT_DIR/ext-tarball-pkg.tgz" )
+mkdir -p "$EXT_DIR/app"
+cat > "$EXT_DIR/app/package.json" <<EOF
+{
+  "name": "ext-tarball-app",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": { "ext-tarball-pkg": "file:$EXT_DIR/ext-tarball-pkg.tgz" }
+}
+EOF
+rm -rf ~/.cache/nm/ext-tarball-pkg
+( cd "$EXT_DIR/app" && utoo install --ignore-scripts ) \
+  || { echo -e "${RED}FAIL: install failed for tarball outside project root${NC}"; rm -rf "$EXT_DIR"; exit 1; }
+if [ ! -f "$EXT_DIR/app/node_modules/ext-tarball-pkg/package.json" ]; then
+    echo -e "${RED}FAIL: ext-tarball-pkg not materialized into node_modules${NC}"; rm -rf "$EXT_DIR"; exit 1
+fi
+ACTUAL=$(node -e "console.log(require('$EXT_DIR/app/node_modules/ext-tarball-pkg/package.json').version)")
+if [ "$ACTUAL" != "5.6.7" ]; then
+    echo -e "${RED}FAIL: ext-tarball-pkg expected v5.6.7, got $ACTUAL${NC}"; rm -rf "$EXT_DIR"; exit 1
+fi
+# Lockfile must stay portable: a root-relative `file:` path with `..`.
+node -e '
+const lock = require("'"$EXT_DIR"'/app/package-lock.json");
+const tar = lock.packages["node_modules/ext-tarball-pkg"] || {};
+if (typeof tar.resolved !== "string" || !tar.resolved.startsWith("file:")) {
+  console.error("ext-tarball-pkg resolved should be a file: path, got", tar.resolved); process.exit(1);
+}
+if (tar.resolved.includes("'"$EXT_DIR"'")) {
+  console.error("ext-tarball-pkg resolved should be root-relative, not absolute:", tar.resolved); process.exit(1);
+}
+' || { echo -e "${RED}FAIL: lockfile entry wrong for outside-root tarball${NC}"; rm -rf "$EXT_DIR"; exit 1; }
+rm -rf "$EXT_DIR"
+echo -e "${GREEN}PASS: file: tarball outside project root installs${NC}"
+
 # Case 8.6: stale lockfile is detected and regenerated on `ut install`
 #
 # package.json declares two deps; we seed an empty lockfile. A correct


### PR DESCRIPTION
## Problem

Installing a `file:` tarball dependency whose `.tgz` lives **outside** the project root fails:

```
ERROR Failed to install packages: file tarball cache not found for <pkg>@<version>
```

and the failure cascades into clone failures for everything that depends on it. A `file:` **directory** dep works (it installs as a symlink), and the same `.tgz` installs fine with npm — the problem is specific to the local `file:` **tarball** extract → cache-slot → clone path.

## Root cause

The cache slot for a local tarball is keyed on the tarball's absolute path:

- **BFS** (resolution) resolves the tarball from a canonical absolute path and seeds `<cache>/<name>/_file_<hash>/`.
- **Install** re-absolutizes the *root-relative* `file:` entry stored in the lockfile. When the tarball sits outside the project root, that path carries `..` segments (e.g. `cwd.join("../../foo.tgz")`).

`file_cache_slot` normalized the path with `Path::components()`, which collapses `.` and redundant separators but **keeps `..`**. So the canonical path and the `..`-laden path hash to **different slots**, and the install-time lookup misses the slot BFS already populated.

The existing in-tree e2e fixture didn't catch this because its tarball sits in the same directory (`file:local-tarball.tgz`), so the root-relative path has no `..` and the slots happen to match.

## Fix

Lexically normalize the path (collapse `..` without touching the filesystem, never climbing past a root/prefix) before hashing, so BFS and install agree regardless of how the path is spelled.

This is intentionally **lexical**, matching the semantics of Node's `path.resolve`/`path.normalize` (what npm uses for `file:` specs) — not `fs::canonicalize`/realpath, which would require the file to already exist (breaking optional/not-yet-fetched deps), cost a syscall per package, and resolve symlinks (diverging from npm). Hand-rolled because Rust std has no lexical `..`-collapse (`Path::components()` keeps `..`; `std::path::absolute` also keeps it on Unix), and it explicitly handles the Windows `C:` drive prefix.

## Placement / refactor

`file_cache_slot` + `lexically_normalize` (local-tarball path keying) previously lived in `resolver::http` purely because they shared the `cache_slot` sha256 primitive with `http_cache_slot`, which left `resolver::file` reaching into `resolver::http` for file logic. Moved all four slot helpers (`cache_slot`, `http_cache_slot`, `file_cache_slot`, `lexically_normalize`) and their tests into `resolver::common` — next to `commit_cache_dir_atomic` (the slot-*commit* protocol) — so all cache-slot concerns live in one shared module. The lib façade `http` is renamed to `cache_slot` (sole consumer is pm) so the public surface is honest. All helpers stay gated behind `http-tarball`; the wasm (no-feature) build is unaffected. Pure relocation, no behavior change.

## Tests

- **Unit** (`resolver::common::tests::cache_slot`): the slot invariant (`..` / `.` spellings hash to the same slot; distinct tarballs stay distinct) and the normalizer (`..` collapse, root saturation, leading-`..` preserved).
- **e2e (Unix, `utoo-pm.sh` Case 8.5b)**: a tarball located **outside** the project root installs successfully and records a portable root-relative `file:` lockfile entry.
- **e2e (Windows, `utoo-pm.ps1`)**: a mirror of the above on the only suite that runs on `windows-latest`, so the lexical `..`-collapse for the Windows `C:` drive prefix is exercised end-to-end (no other e2e covered win32-msvc here).

## Verification

Reproduced the failure on a minimal generic project (a packed leaf package referenced via an absolute `file:` path from a sibling app dir); confirmed the fix makes cold + warm installs succeed and the dependency resolves correctly. `cargo fmt`, `clippy -D warnings` (ruborist + pm), the full `utoo-ruborist` unit suite, and the no-feature (wasm-path) build all pass. The Windows e2e case was parse-checked and its logic executed under real `pwsh` against the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)