### PR TITLE
feat(pack): support config cssModules like localIdentName

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -365,6 +365,11 @@ pub async fn get_client_module_options_context(
         .map(|postcss_transform_options| postcss_transform_options.resolved_cell());
     let enable_foreign_postcss_transform = postcss_foreign_transform_options
         .map(|postcss_foreign_transform_options| postcss_foreign_transform_options.resolved_cell());
+    let css_modules_pattern = styles
+        .css_modules
+        .as_ref()
+        .and_then(|css_modules| css_modules.local_ident_pattern());
+
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             enable_typeof_window_inlining: Some(TypeofWindow::Object),
@@ -379,6 +384,7 @@ pub async fn get_client_module_options_context(
         css: CssOptionsContext {
             source_maps,
             module_css_condition: Some(module_styles_rule_condition()),
+            css_modules_pattern,
             ..Default::default()
         },
         environment: Some(env),

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -331,6 +331,7 @@ pub struct StyleConfig {
     pub styled_components: Option<StyledComponentsTransformOptionsOrBoolean>,
     pub emotion: Option<EmotionTransformConfig>,
     pub auto_css_modules: Option<bool>,
+    pub css_modules: Option<CssModulesConfig>,
     #[bincode(with = "turbo_bincode::serde_self_describing")]
     pub postcss: Option<serde_json::Value>,
     #[bincode(with = "turbo_bincode::serde_self_describing")]
@@ -339,6 +340,42 @@ pub struct StyleConfig {
     less: Option<serde_json::Value>,
     #[bincode(with = "turbo_bincode::serde_self_describing")]
     inline_css: Option<serde_json::Value>,
+}
+
+#[turbo_tasks::value(eq = "manual")]
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, OperationValue)]
+#[serde(rename_all = "camelCase")]
+pub struct CssModulesConfig {
+    pub local_ident_name: Option<RcStr>,
+}
+
+impl CssModulesConfig {
+    pub fn local_ident_pattern(&self) -> Option<RcStr> {
+        self.local_ident_name
+            .as_ref()
+            .map(|pattern| normalize_css_modules_pattern(pattern).into())
+    }
+}
+
+fn normalize_css_modules_pattern(pattern: &str) -> String {
+    let mut normalized = String::with_capacity(pattern.len());
+    let mut rest = pattern;
+
+    while let Some(start) = rest.find("[hash:") {
+        normalized.push_str(&rest[..start]);
+
+        let placeholder = &rest[start..];
+        if let Some(end) = placeholder.find(']') {
+            normalized.push_str("[hash]");
+            rest = &placeholder[end + 1..];
+        } else {
+            normalized.push_str(placeholder);
+            return normalized;
+        }
+    }
+
+    normalized.push_str(rest);
+    normalized
 }
 
 #[turbo_tasks::value(eq = "manual")]

--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -232,6 +232,11 @@ pub async fn get_server_module_options_context(
     } else {
         SourceMapsType::None
     };
+    let css_modules_pattern = styles
+        .css_modules
+        .as_ref()
+        .and_then(|css_modules| css_modules.local_ident_pattern());
+
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             source_maps,
@@ -245,6 +250,7 @@ pub async fn get_server_module_options_context(
         css: CssOptionsContext {
             source_maps,
             module_css_condition: Some(module_styles_rule_condition()),
+            css_modules_pattern,
             ..Default::default()
         },
         environment: Some(env),

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -1027,6 +1027,11 @@ pub struct SchemaStyleConfig {
     #[schemars(description = "Enable automatic CSS Modules transform")]
     pub auto_css_modules: Option<bool>,
 
+    /// CSS Modules configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "CSS Modules configuration")]
+    pub css_modules: Option<SchemaCssModulesConfig>,
+
     /// Inline PostCSS configuration passed directly to the PostCSS transform
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Inline PostCSS configuration")]
@@ -1046,6 +1051,16 @@ pub struct SchemaStyleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Inline CSS configuration")]
     pub inline_css: Option<serde_json::Value>,
+}
+
+/// CSS Modules configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaCssModulesConfig {
+    /// CSS Modules local class name pattern
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "CSS Modules local class name pattern")]
+    pub local_ident_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/config.json
+++ b/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/config.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.ts",
+        "name": "main"
+      }
+    ],
+    "sourceMaps": false,
+    "styles": {
+      "cssModules": {
+        "localIdentName": "[local]__[hash:base64:6]"
+      }
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/input/index.ts
+++ b/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/input/index.ts
@@ -1,0 +1,3 @@
+import styles from "./style.less";
+
+console.log(styles.title, styles.primaryButton);

--- a/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/input/style.less
+++ b/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/input/style.less
@@ -1,0 +1,8 @@
+.title {
+  color: tomato;
+}
+
+.primaryButton {
+  background: black;
+  color: white;
+}

--- a/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/output/input_6ba844a1.js
+++ b/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/output/input_6ba844a1.js
@@ -1,0 +1,17 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/style/css_modules_local_ident/input/style.less?modules [client] (css module)", ((__turbopack_context__) => {
+
+__turbopack_context__.v({
+  "primaryButton": "primaryButton___cHsHq",
+  "title": "title___cHsHq",
+});
+}),
+"[project]/style/css_modules_local_ident/input/index.ts [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_modules_local_ident$2f$input$2f$style$2e$less$3f$modules__$5b$client$5d$__$28$css__module$29$__ = __turbopack_context__.i("[project]/style/css_modules_local_ident/input/style.less?modules [client] (css module)");
+;
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_modules_local_ident$2f$input$2f$style$2e$less$3f$modules__$5b$client$5d$__$28$css__module$29$__["default"].title, __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_modules_local_ident$2f$input$2f$style$2e$less$3f$modules__$5b$client$5d$__$28$css__module$29$__["default"].primaryButton);
+__turbopack_context__.s([]);
+}),
+]);

--- a/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/output/input_style_less_19769f23.css
+++ b/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/output/input_style_less_19769f23.css
@@ -1,0 +1,9 @@
+/* [project]/style/css_modules_local_ident/input/style.less.css?modules [client] (css) */
+.title___cHsHq {
+  color: tomato;
+}
+
+.primaryButton___cHsHq {
+  color: #fff;
+  background: #000;
+}

--- a/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/output/main.js
+++ b/crates/pack-tests/tests/snapshot/style/css_modules_local_ident/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_style_less_19769f23.css","input_6ba844a1.js"],"runtimeModuleIds":["[project]/style/css_modules_local_ident/input/index.ts [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -276,6 +276,9 @@ export interface ConfigComplete {
   };
   styles?: {
     autoCssModules?: boolean;
+    cssModules?: {
+      localIdentName?: string;
+    };
     emotion?: boolean | EmotionOptions;
     postcss?: JSONValue;
     less?: {

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -169,6 +169,17 @@
         }
       ]
     },
+    "server": {
+      "description": "Server-side configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaServerConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "sourceMaps": {
       "description": "Enable source maps",
       "type": [
@@ -529,6 +540,19 @@
         "anonymous",
         "use-credentials"
       ]
+    },
+    "SchemaCssModulesConfig": {
+      "description": "CSS Modules configuration",
+      "type": "object",
+      "properties": {
+        "localIdentName": {
+          "description": "CSS Modules local class name pattern",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     },
     "SchemaDevServer": {
       "description": "Development server configuration",
@@ -1392,13 +1416,6 @@
             "null"
           ]
         },
-        "absoluteSourceFilename": {
-          "description": "Keep React dev source filenames as absolute disk paths for editor integrations",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "runtime": {
           "description": "JSX runtime to use (automatic or classic)",
           "type": [
@@ -1478,9 +1495,6 @@
     "SchemaRuleConfigItem": {
       "description": "Full module rule configuration",
       "type": "object",
-      "required": [
-        "loaders"
-      ],
       "properties": {
         "condition": {
           "description": "Condition for applying the rule",
@@ -1522,6 +1536,49 @@
         }
       }
     },
+    "SchemaServerConfig": {
+      "description": "Server-side configuration",
+      "type": "object",
+      "properties": {
+        "entry": {
+          "description": "Entry point for the server runtime (e.g. \"src/server.ts\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "function": {
+          "description": "Configuration for Server Functions (RPC) boundaries",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaServerFunctionConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "SchemaServerFunctionConfig": {
+      "type": "object",
+      "properties": {
+        "clientProxy": {
+          "description": "Module that exports createServerReference(actionId, name) for client proxy",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "serverRegister": {
+          "description": "Module that exports registerServerReference(action, actionId, name) for the server bundle",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
     "SchemaSplitChunkConfig": {
       "description": "Split chunk configuration",
       "type": "object",
@@ -1558,6 +1615,17 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "cssModules": {
+          "description": "CSS Modules configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaCssModulesConfig"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "emotion": {


### PR DESCRIPTION

## Summary

Support config lightingcss css modules: https://lightningcss.dev/css-modules.html#custom-naming-patterns

```json
{
  "config": {
      "styles": {
         "cssModules": {
              "localIdentName": "[local]__[hash:base64:6]"
           }
       }
   }
}
```

## Test Plan

update snapshot test
