### PR TITLE
feat(pm): keep non-registry tarballs out of the global cache

### DIFF
--- a/crates/pm/src/service/install_scheduler.rs
+++ b/crates/pm/src/service/install_scheduler.rs
@@ -9,11 +9,12 @@ use utoo_ruborist::progress::{BuildEvent, EventReceiver, PackageTarballInfo};
 
 use crate::service::auth;
 use crate::util::cloner::{PackageClone, clone_package_sync};
-use crate::util::downloader::{download_bytes, is_registry_tarball_url};
+use crate::util::downloader::download_bytes;
 use crate::util::package_cache::{
-    ExtractOutcome, extract_to_cache, registry_cache_lookup, resolve_seeded_cache_path,
+    CachePlan, ExtractOutcome, extract_non_registry_to_target, extract_to_cache,
+    registry_cache_lookup, resolve_cache_plan,
 };
-use crate::util::user_config::get_manifests_concurrency_limit_sync;
+use crate::util::user_config::{get_manifests_concurrency_limit_sync, is_registry_tarball};
 
 /// Build event receiver that forwards download prefetch work to the scheduler.
 pub(crate) struct InstallEventReceiver<R: EventReceiver> {
@@ -89,7 +90,7 @@ enum Command {
 enum StageReport {
     CacheResolved {
         spec: CloneSpec,
-        result: Result<Option<PathBuf>, String>,
+        result: Result<CachePlan, String>,
     },
     Download {
         package: PackageRef,
@@ -98,6 +99,13 @@ enum StageReport {
     Extract {
         key: String,
         result: Result<ExtractOutcome, String>,
+    },
+    /// A non-registry tarball was fetched/read and extracted directly into its
+    /// `node_modules` target (no global cache). The target is fully materialized,
+    /// so this completes the clone for that target outright.
+    DirectExtract {
+        target: PathBuf,
+        result: Result<(), String>,
     },
     Clone {
         target: PathBuf,
@@ -159,7 +167,11 @@ impl InstallSchedulerHandle {
 
 impl InstallScheduler {
     pub(crate) fn prefetch_download(&self, name: String, version: String, tarball_url: String) {
-        if !is_registry_tarball_url(&tarball_url) {
+        // Only registry-host tarballs use the global download cache; git and
+        // non-registry (file:/untrusted-https) tarballs are not prefetched here
+        // (git is cloned in BFS; non-registry tarballs are materialized straight
+        // into node_modules at clone time).
+        if !is_registry_tarball(&tarball_url) {
             return;
         }
         let _ = self.tx.send(Command::PrefetchDownload(PackageRef {
@@ -259,6 +271,9 @@ struct SchedulerState {
     download_queue: VecDeque<PackageRef>,
     extract_active: HashSet<String>,
     extract_queue: VecDeque<DownloadedPackage>,
+    direct_extract_limit: usize,
+    direct_extract_active: HashSet<PathBuf>,
+    direct_extract_queue: VecDeque<CloneSpec>,
     clone_done: HashSet<PathBuf>,
     clone_active: HashSet<PathBuf>,
     clone_waiters: HashMap<PathBuf, Vec<CloneResponder>>,
@@ -285,6 +300,9 @@ impl SchedulerState {
             download_queue: VecDeque::new(),
             extract_active: HashSet::new(),
             extract_queue: VecDeque::new(),
+            direct_extract_limit: extract_concurrency_limit(),
+            direct_extract_active: HashSet::new(),
+            direct_extract_queue: VecDeque::new(),
             clone_done: HashSet::new(),
             clone_active: HashSet::new(),
             clone_waiters: HashMap::new(),
@@ -301,6 +319,7 @@ impl SchedulerState {
         loop {
             self.pump_downloads();
             self.pump_extracts();
+            self.pump_direct_extracts();
             self.pump_clones();
 
             if self.shutdown && self.is_idle() {
@@ -353,9 +372,11 @@ impl SchedulerState {
     fn is_idle(&self) -> bool {
         self.download_queue.is_empty()
             && self.extract_queue.is_empty()
+            && self.direct_extract_queue.is_empty()
             && self.clone_queue.is_empty()
             && self.download_active.is_empty()
             && self.extract_active.is_empty()
+            && self.direct_extract_active.is_empty()
             && self.clone_active.is_empty()
             && self.async_ops.is_empty()
     }
@@ -396,7 +417,7 @@ impl SchedulerState {
     fn resolve_cache_for_clone(&mut self, spec: CloneSpec) {
         let task_spec = spec.clone();
         self.async_ops.push(tokio::spawn(async move {
-            let result = resolve_seeded_cache_path(
+            let result = resolve_cache_plan(
                 &task_spec.package.name,
                 &task_spec.package.version,
                 &task_spec.package.tarball_url,
@@ -512,11 +533,40 @@ impl SchedulerState {
         }
     }
 
+    /// Materialize non-registry tarballs ([`CachePlan::DirectExtract`]) straight
+    /// into their `node_modules` target. Bounded the same way as registry
+    /// extraction; each completed target is reported via `DirectExtract` and
+    /// finalizes that clone outright (no global cache, no cloner step).
+    fn pump_direct_extracts(&mut self) {
+        let done = &self.clone_done;
+        let admitted = admit_stage(
+            &mut self.direct_extract_queue,
+            &mut self.direct_extract_active,
+            self.direct_extract_limit,
+            |spec| spec.target.clone(),
+            |key| done.contains(key),
+        );
+        for (spec, target) in admitted {
+            self.async_ops.push(tokio::spawn(async move {
+                let result =
+                    extract_non_registry_to_target(&spec.package.tarball_url, &spec.target)
+                        .await
+                        .map_err(|e| format!("{e:#}"));
+                StageReport::DirectExtract { target, result }
+            }));
+        }
+    }
+
     fn handle_report(&mut self, done: StageReport) {
         match done {
             StageReport::CacheResolved { spec, result } => match result {
-                Ok(Some(cache_path)) => self.clone_queue.push_back(ReadyClone { spec, cache_path }),
-                Ok(None) => self.ensure_download(spec.package.clone(), Some(spec)),
+                Ok(CachePlan::GitCache(cache_path)) => {
+                    self.clone_queue.push_back(ReadyClone { spec, cache_path })
+                }
+                Ok(CachePlan::RegistryDownload) => {
+                    self.ensure_download(spec.package.clone(), Some(spec))
+                }
+                Ok(CachePlan::DirectExtract) => self.direct_extract_queue.push_back(spec),
                 Err(error) => self.complete_clone(spec.target, Err(error)),
             },
             StageReport::Download { package, result } => {
@@ -550,6 +600,16 @@ impl SchedulerState {
                     Err(e) => Err(e),
                 };
                 self.complete_download(key, path_result);
+            }
+            StageReport::DirectExtract { target, result } => {
+                self.direct_extract_active.remove(&target);
+                // A direct extract writes the package straight into node_modules
+                // (no cloner step), so count it as a clone for the install summary
+                // and finalize the clone for this target.
+                let clone_result = result.inspect(|()| {
+                    self.counts.cloned += 1;
+                });
+                self.complete_clone(target, clone_result);
             }
             StageReport::Clone { target, result } => {
                 self.clone_active.remove(&target);

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -26,11 +26,6 @@ pub fn is_git_url(url: &str) -> bool {
     matches!(url.parse::<Protocol>(), Ok(Protocol::Git))
 }
 
-/// Check whether a tarball URL should be fetched by the registry downloader.
-pub fn is_registry_tarball_url(url: &str) -> bool {
-    matches!(url.parse::<Protocol>(), Ok(Protocol::Http))
-}
-
 /// Download tarball bytes with retries (network phase only).
 ///
 /// `auth_token` is attached as a Bearer header when present; callers are

--- a/crates/pm/src/util/package_cache.rs
+++ b/crates/pm/src/util/package_cache.rs
@@ -1,23 +1,27 @@
-//! Package cache layer: cache-path layout, seeded-slot lookups, and extracting
-//! downloaded tarball bytes into the cache. The network phase lives in
-//! [`super::downloader`]; the raw gzip/tar primitive lives in
-//! [`super::extractor`].
+//! Package cache layer: cache-path layout, install-time routing, and
+//! extracting tarball bytes. The network phase lives in [`super::downloader`];
+//! the raw gzip/tar primitive lives in [`super::extractor`].
 //!
-//! Lookups here key on the `_resolved` marker, whose contract is shared
-//! with ruborist's BFS-seeded slots (`resolver/common.rs`): every cache
-//! slot becomes visible only via atomic rename of a fully-written staging
-//! dir that already contains `_resolved`, so any slot with the marker is
-//! complete.
+//! Routing ([`resolve_cache_plan`]) classifies a lockfile entry by the host of
+//! its `resolved` URL: git deps and trusted-registry-host tarballs use the
+//! shared global `~/.cache/nm/` store, while non-registry tarballs (untrusted
+//! https + local `file:`) are materialized **directly** into `node_modules`
+//! ([`extract_non_registry_to_target`]) and never enter the cache.
+//!
+//! Cache lookups key on the `_resolved` marker, whose contract is shared with
+//! ruborist's BFS-seeded git slots (`resolver/common.rs`): every cache slot
+//! becomes visible only via atomic rename of a fully-written staging dir that
+//! already contains `_resolved`, so any slot with the marker is complete.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use utoo_ruborist::cache_slot::{file_cache_slot, http_cache_slot};
-use utoo_ruborist::spec::Protocol;
 
 use super::cache::get_cache_dir;
+use super::downloader::is_git_url;
 use super::extractor::extract_and_write;
+use super::user_config::is_registry_tarball;
 
 /// Outcome of materializing a registry tarball into the cache. Returned so the
 /// caller (the install scheduler) keeps its own download/reuse counts instead
@@ -55,57 +59,69 @@ pub async fn git_cache_lookup(name: &str, version: &str, tarball_url: &str) -> O
     None
 }
 
-/// Look up a ruborist-seeded cache slot at `<cache_dir>/<name>/<slot>/`.
+/// How the install phase should materialize a lockfile entry, decided purely
+/// by classifying its `resolved` URL by host/scheme (the lockfile stores no
+/// source tag — see [`is_registry_tarball`]).
+pub enum CachePlan {
+    /// A git dep, already cloned into the global cache during BFS at
+    /// `<cache>/<name>/<commit_sha>/`; clone from there.
+    GitCache(PathBuf),
+    /// A registry-host tarball: download into the global `<name>/<version>`
+    /// slot, then clone from there (the existing registry pipeline).
+    RegistryDownload,
+    /// A non-registry tarball (http(s) remote or local `file:`): fetch/read the
+    /// tarball and extract it **directly** into the package's `node_modules`
+    /// target. These never enter the global cache.
+    DirectExtract,
+}
+
+/// Classify a lockfile entry's `resolved` URL into a [`CachePlan`].
 ///
-/// Returns `Some(path)` only if the slot's `_resolved` marker exists —
-/// otherwise returns `None` so the caller can fall through to the next
-/// routing step (typically the registry download path).
-async fn slot_cache_lookup(name: &str, slot: String) -> Option<PathBuf> {
-    let cache_path = get_cache_dir().join(name).join(slot);
-    if crate::fs::try_exists(&cache_path.join("_resolved"))
-        .await
-        .unwrap_or(false)
-    {
-        Some(cache_path)
+/// Routing is by host/scheme only:
+/// - `git+…` / git URLs → [`CachePlan::GitCache`] (errors if the BFS-seeded
+///   git slot is missing, which would indicate a corrupt lockfile/cache).
+/// - a trusted registry-host tarball → [`CachePlan::RegistryDownload`].
+/// - anything else (untrusted https or `file:`) → [`CachePlan::DirectExtract`].
+pub async fn resolve_cache_plan(name: &str, version: &str, tarball_url: &str) -> Result<CachePlan> {
+    if is_git_url(tarball_url) {
+        return git_cache_lookup(name, version, tarball_url)
+            .await
+            .map(CachePlan::GitCache)
+            .ok_or_else(|| anyhow::anyhow!("git cache not found for {name}@{version}"));
+    }
+    if is_registry_tarball(tarball_url) {
+        return Ok(CachePlan::RegistryDownload);
+    }
+    Ok(CachePlan::DirectExtract)
+}
+
+/// Materialize a non-registry tarball ([`CachePlan::DirectExtract`]) straight
+/// into `target` (the package's `node_modules` directory), bypassing the global
+/// cache entirely.
+///
+/// `file:<abs>` tarballs are read from disk; everything else is fetched over
+/// http(s) (with a registry auth token only when the host warrants one). The
+/// tarball is then extracted via [`extract_tarball_to_dir`], which strips the
+/// npm `package/` wrapper and writes no `_resolved` marker.
+pub async fn extract_non_registry_to_target(tarball_url: &str, target: &Path) -> Result<()> {
+    let bytes: Bytes = if let Some(abs) = tarball_url.strip_prefix("file:") {
+        let abs = abs.to_string();
+        tokio::task::spawn_blocking(move || std::fs::read(&abs).map(Bytes::from))
+            .await
+            .context("file tarball read task failed")?
+            .with_context(|| format!("failed to read tarball {tarball_url}"))?
     } else {
-        None
-    }
-}
-
-/// Look up the cache path for a `file:<absolute_tarball>` dependency.
-///
-/// The URL must already be absolute; call sites that read relative URLs
-/// from the lockfile are responsible for re-absolutizing against the
-/// project root before reaching the cloner.
-pub async fn file_cache_lookup(name: &str, tarball_url: &str) -> Option<PathBuf> {
-    let abs_path = tarball_url.strip_prefix("file:")?;
-    slot_cache_lookup(name, file_cache_slot(std::path::Path::new(abs_path))).await
-}
-
-/// Look up the cache path for an HTTP(S) tarball dep.
-pub async fn http_tarball_cache_lookup(name: &str, tarball_url: &str) -> Option<PathBuf> {
-    slot_cache_lookup(name, http_cache_slot(tarball_url)).await
-}
-
-/// Resolve cache slots that may have been seeded during dependency resolution
-/// without falling through to registry download. `Ok(None)` means this is a
-/// registry-style HTTP tarball that should be downloaded into `<name>/<version>`.
-pub async fn resolve_seeded_cache_path(
-    name: &str,
-    version: &str,
-    tarball_url: &str,
-) -> Result<Option<PathBuf>> {
-    match tarball_url.parse::<Protocol>() {
-        Ok(Protocol::Git) => git_cache_lookup(name, version, tarball_url)
+        let token = crate::service::auth::token_for_url(tarball_url).await;
+        super::downloader::download_bytes(tarball_url, token.as_deref())
             .await
-            .map(Some)
-            .ok_or_else(|| anyhow::anyhow!("git cache not found for {name}@{version}")),
-        Ok(Protocol::File) => file_cache_lookup(name, tarball_url)
-            .await
-            .map(Some)
-            .ok_or_else(|| anyhow::anyhow!("file tarball cache not found for {name}@{version}")),
-        _ => Ok(http_tarball_cache_lookup(name, tarball_url).await),
-    }
+            .with_context(|| format!("failed to download tarball {tarball_url}"))?
+    };
+
+    let target = target.to_path_buf();
+    tokio::task::spawn_blocking(move || utoo_ruborist::tar::extract_tarball_to_dir(&bytes, &target))
+        .await
+        .context("direct-extract task failed")?
+        .with_context(|| format!("failed to extract tarball {tarball_url}"))
 }
 
 /// Return the registry cache path for a package version.

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -78,6 +78,44 @@ pub fn get_registry() -> String {
     REGISTRY.get_sync()
 }
 
+/// Scheme + host(+port) origin of an http(s) URL — e.g. `https://registry.npmjs.org`
+/// from `https://registry.npmjs.org/foo/-/foo-1.0.0.tgz`. `None` for non-http URLs.
+fn url_origin(url: &str) -> Option<&str> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let host_end = rest.find('/').unwrap_or(rest.len());
+    Some(&url[..url.len() - rest.len() + host_end])
+}
+
+/// Whether `resolved` is a tarball served by a trusted registry (the configured
+/// registry, or a well-known public one), so it is safe to materialize into the
+/// shared `<name>/<version>` global cache slot.
+///
+/// A registry download URL and a user-declared remote-tarball URL are
+/// indistinguishable in an npm `package-lock.json` (both are `https://….tgz`,
+/// the lockfile stores no source tag). We resolve that ambiguity by origin:
+/// only a tarball whose host is a trusted registry may enter the shared cache;
+/// any other https tarball is an untrusted remote tarball and is fetched +
+/// extracted directly into `node_modules`, never the global store — which also
+/// removes the cross-cache poisoning risk of an attacker URL self-declaring a
+/// `name@version` that collides with a real registry package.
+pub fn is_registry_tarball(resolved: &str) -> bool {
+    let Some(origin) = url_origin(resolved) else {
+        return false;
+    };
+    let configured = get_registry();
+    let trusted = [
+        url_origin(&configured),
+        url_origin(super::registry::REGISTRY_NPMMIRROR),
+        url_origin(super::registry::REGISTRY_NPMJS),
+    ];
+    trusted
+        .into_iter()
+        .flatten()
+        .any(|t| origin.eq_ignore_ascii_case(t))
+}
+
 static CATALOGS: tokio::sync::OnceCell<Catalogs> = tokio::sync::OnceCell::const_new();
 
 pub async fn get_catalogs() -> Catalogs {
@@ -461,6 +499,46 @@ mod tests {
     use super::*;
     use anyhow::Result;
     use tempfile::TempDir;
+
+    #[test]
+    fn url_origin_extracts_scheme_and_host() {
+        assert_eq!(
+            url_origin("https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz"),
+            Some("https://registry.npmjs.org")
+        );
+        assert_eq!(
+            url_origin("http://cdn.example.com:8080/x.tgz"),
+            Some("http://cdn.example.com:8080")
+        );
+        assert_eq!(
+            url_origin("https://registry.npmjs.org"),
+            Some("https://registry.npmjs.org")
+        );
+        assert_eq!(url_origin("file:/abs/x.tgz"), None);
+        assert_eq!(url_origin("git+https://github.com/u/r.git#abc"), None);
+    }
+
+    #[test]
+    fn is_registry_tarball_trusts_known_registries_only() {
+        // Well-known public registries → trusted (shared cache allowed).
+        assert!(is_registry_tarball(
+            "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz"
+        ));
+        assert!(is_registry_tarball(
+            "https://registry.npmmirror.com/abbrev/-/abbrev-2.0.0.tgz"
+        ));
+        // A remote tarball from an arbitrary host → NOT trusted (direct extract,
+        // never the shared `<name>/<version>` slot).
+        assert!(!is_registry_tarball(
+            "https://cdn.example.com/foo-1.0.0.tgz"
+        ));
+        // A registry-host *lookalike* path on an untrusted host stays untrusted.
+        assert!(!is_registry_tarball(
+            "https://evil.example.com/abbrev/-/abbrev-2.0.0.tgz"
+        ));
+        // Non-http resolveds are not registry tarballs.
+        assert!(!is_registry_tarball("file:../foo.tgz"));
+    }
 
     use super::super::config_file::ConfigValueParser;
 

--- a/crates/ruborist/src/lib.rs
+++ b/crates/ruborist/src/lib.rs
@@ -105,14 +105,6 @@ pub mod git {
     pub use crate::resolver::git::{GitCloneCache, ensure_repo_cached};
 }
 
-/// Non-registry tarball cache-slot helpers: http(s) tarballs keyed by URL,
-/// local `file:` tarballs keyed by absolute path. Implemented in
-/// `resolver::common` alongside the slot-commit protocol.
-pub mod cache_slot {
-    #[cfg(feature = "http-tarball")]
-    pub use crate::resolver::common::{file_cache_slot, http_cache_slot};
-}
-
 /// Tar + gzip primitives and the atomic cache-slot commit protocol.
 ///
 /// Shared with pm's install-phase extractor
@@ -127,7 +119,7 @@ pub mod tar {
     pub use crate::resolver::common::commit_cache_dir_atomic;
     #[cfg(feature = "http-tarball")]
     pub use crate::resolver::tar::{
-        MAX_UNCOMPRESSED_BYTES, estimate_uncompressed_size, gzip_decompress,
-        is_safe_tar_entry_path, normalize_entry_mode,
+        MAX_UNCOMPRESSED_BYTES, estimate_uncompressed_size, extract_tarball_to_dir,
+        gzip_decompress, is_safe_tar_entry_path, normalize_entry_mode,
     };
 }

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -54,20 +54,20 @@ async fn resolve_git_dep(
 /// Dispatch an HTTP(S) tarball spec to the real resolver when the
 /// `http-tarball` feature is enabled, otherwise error with a hint.
 ///
-/// BFS extracts to `<cache_dir>/<name>/_http_<url_hash>/` so install-phase
-/// skips re-download; see [`super::http`] module docs.
+/// BFS only reads the tarball's manifest; the content is materialized into
+/// `node_modules` at install time, never the global cache. See
+/// [`super::http`] module docs.
 async fn resolve_http_dep(
-    cache_dir: Option<&std::path::Path>,
     url: &str,
     fetch_cache: &HttpFetchCache,
 ) -> anyhow::Result<ResolvedPackage> {
     #[cfg(feature = "http-tarball")]
     {
-        crate::resolver::http::resolve_http_dep(cache_dir, url, fetch_cache).await
+        crate::resolver::http::resolve_http_dep(url, fetch_cache).await
     }
     #[cfg(not(feature = "http-tarball"))]
     {
-        let _ = (cache_dir, fetch_cache);
+        let _ = fetch_cache;
         anyhow::bail!(
             "HTTP tarball resolution not available for '{url}' (enable the 'http-tarball' feature)"
         )
@@ -431,15 +431,8 @@ pub async fn process_dependency<R: ManifestProvider>(
                 } => {
                     #[cfg(feature = "http-tarball")]
                     {
-                        match process_file_dep(
-                            graph,
-                            node_index,
-                            conflict_parent,
-                            edge_info,
-                            path,
-                            config.cache_dir.as_deref(),
-                        )
-                        .await?
+                        match process_file_dep(graph, node_index, conflict_parent, edge_info, path)
+                            .await?
                         {
                             std::ops::ControlFlow::Break(r) => return Ok(r),
                             std::ops::ControlFlow::Continue(pkg) => pkg,
@@ -461,13 +454,7 @@ pub async fn process_dependency<R: ManifestProvider>(
                     });
                 }
                 PackageSpec::Http { url } => {
-                    match resolve_http_dep(
-                        config.cache_dir.as_deref(),
-                        url,
-                        &config.http_fetch_cache,
-                    )
-                    .await
-                    {
+                    match resolve_http_dep(url, &config.http_fetch_cache).await {
                         Ok(r) => r,
                         Err(e) => {
                             return absorb_optional_failure(edge_info, "HTTP", e, |source| {

--- a/crates/ruborist/src/resolver/common.rs
+++ b/crates/ruborist/src/resolver/common.rs
@@ -1,4 +1,4 @@
-//! Shared helpers for native, non-registry resolvers (git, http tarball).
+//! Shared helpers for native, non-registry resolvers (git, http/file tarball).
 //!
 //! - [`DedupCache<T>`] — session-scoped single-flight cache (alias for
 //!   [`OnceMap`](crate::util::OnceMap)) so concurrent fetches of the same key
@@ -11,7 +11,9 @@
 //!
 //! Consumers:
 //!   `super::git`   — caches at `<cache>/<name>/<commit_sha>/`
-//!   `super::http`  — caches at `<cache>/<name>/_http_<url_hash>/`
+//!   `super::http`/`super::file` — read only the tarball manifest in BFS; the
+//!     tarball *content* is materialized directly into `node_modules` at
+//!     install time and never enters the global cache.
 
 use std::path::PathBuf;
 
@@ -23,8 +25,6 @@ use std::path::Path;
 #[cfg(any(feature = "native-git", feature = "http-tarball"))]
 use anyhow::Context;
 use anyhow::{Result, anyhow};
-#[cfg(feature = "http-tarball")]
-use sha2::{Digest, Sha256};
 
 use crate::model::manifest::{CoreVersionManifest, Dist};
 use crate::util::OnceMap;
@@ -182,160 +182,9 @@ where
         .await
 }
 
-// ---------------------------------------------------------------------------
-// Non-registry cache-slot addressing
-// ---------------------------------------------------------------------------
-//
-// The cache *key* for a non-registry tarball: an http(s) tarball is keyed by
-// its URL, a local `file:` tarball by its absolute path. Both share the
-// `cache_slot` sha256 primitive and live here — next to `commit_cache_dir_atomic`
-// (the slot *commit* protocol) — so all cache-slot concerns sit in one module
-// instead of the `file:` key living inside the http resolver. Consumed by
-// `super::http` and `super::file`, and re-exported to pm via the lib façade.
-
-/// `<prefix><16 hex>` from `sha256(bytes)`. Used by the two non-registry
-/// cache slots (`_http_<url>`, `_file_<path>`) to stay visually distinct
-/// from `<name>/<version>/` and 40-char git commit shas.
-#[cfg(feature = "http-tarball")]
-fn cache_slot(prefix: &str, bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-
-    let digest = Sha256::digest(bytes);
-    let mut out = String::with_capacity(prefix.len() + 16);
-    out.push_str(prefix);
-    for b in &digest[..8] {
-        let _ = write!(out, "{b:02x}");
-    }
-    out
-}
-
-/// Cache slot for an http(s) tarball, keyed on its URL.
-#[cfg(feature = "http-tarball")]
-pub fn http_cache_slot(url: &str) -> String {
-    cache_slot("_http_", url.as_bytes())
-}
-
-/// Cache slot for a local tarball keyed on its absolute path. The path is
-/// lexically normalized first so BFS and install hash to the same slot.
-///
-/// BFS resolves the tarball from a canonical absolute path
-/// (`base.join("/abs/foo.tgz")`), but install re-absolutizes a *root-relative*
-/// lockfile entry (`cwd.join("../../foo.tgz")`) whenever the tarball lives
-/// outside the project root. `Path::components()` collapses `.` and redundant
-/// separators but **keeps `..`**, so those two spellings of the same file would
-/// otherwise hash to different slots and the install-time lookup would miss.
-/// [`lexically_normalize`] collapses `..` so both spellings agree.
-#[cfg(feature = "http-tarball")]
-pub fn file_cache_slot(abs_path: &Path) -> String {
-    let normalized = lexically_normalize(abs_path);
-    cache_slot("_file_", normalized.as_os_str().as_encoded_bytes())
-}
-
-/// Collapse `.` and `..` purely lexically (no filesystem access, so it works
-/// for not-yet-existing paths and stays identical across BFS and install).
-///
-/// `..` pops the preceding normal component but never climbs past a root or
-/// prefix; a leading `..` in a relative path is preserved.
-///
-/// # Why lexical, not `fs::canonicalize`
-///
-/// This matches the semantics of Node's `path.resolve`/`path.normalize` — which
-/// is what npm uses to resolve `file:` specs — *not* `fs::realpath`. We only
-/// need BFS and install to agree on one canonical string for the cache key, and
-/// lexical collapsing achieves that without the costs of `fs::canonicalize`:
-/// the latter would require the tarball to already exist (breaking optional /
-/// not-yet-fetched deps), cost a syscall per package, and resolve symlinks —
-/// diverging from npm and changing the key based on FS state.
-///
-/// # Why hand-rolled
-///
-/// Rust std has no lexical `..`-collapse: `Path::components()` keeps `..` (the
-/// original bug), and `std::path::absolute` also deliberately keeps `..` on
-/// Unix. The `path-clean` crate exists in the tree but only as a transitive dep
-/// of the bundler half (swc/turbopack), not reachable from pm/ruborist, and it
-/// is not Windows-prefix aware. The `Component::Prefix` arm below handles
-/// Windows drive prefixes (e.g. `C:\`) so the win32 build stays correct even
-/// though no `file:`-tarball e2e currently exercises that target.
-#[cfg(feature = "http-tarball")]
-fn lexically_normalize(path: &Path) -> PathBuf {
-    use std::path::Component;
-
-    let mut stack: Vec<Component> = Vec::new();
-    for comp in path.components() {
-        match comp {
-            Component::CurDir => {}
-            Component::ParentDir => match stack.last() {
-                Some(Component::Normal(_)) => {
-                    stack.pop();
-                }
-                Some(Component::RootDir | Component::Prefix(_)) => {}
-                _ => stack.push(comp),
-            },
-            _ => stack.push(comp),
-        }
-    }
-    stack.iter().map(|c| c.as_os_str()).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[cfg(feature = "http-tarball")]
-    mod cache_slot {
-        use std::path::{Path, PathBuf};
-
-        use super::super::{file_cache_slot, http_cache_slot, lexically_normalize};
-
-        #[test]
-        fn http_slot_is_stable_and_url_specific() {
-            let a = http_cache_slot("https://example.com/foo.tgz");
-            let b = http_cache_slot("https://example.com/foo.tgz");
-            let c = http_cache_slot("https://example.com/foo.tgz?v=2");
-            assert_eq!(a, b);
-            assert_ne!(a, c);
-            assert!(a.starts_with("_http_"));
-            assert_eq!(a.len(), "_http_".len() + 16);
-        }
-
-        #[test]
-        fn file_slot_is_stable_across_dotdot_spellings() {
-            // BFS resolves from a canonical absolute path; install re-absolutizes
-            // a root-relative lockfile entry, which carries `..` when the tarball
-            // lives outside the project root. Both must hash to the same slot.
-            let canonical = Path::new("/tmp/pkgs/foo.tgz");
-            let via_dotdot = Path::new("/tmp/pkgs/app/../../pkgs/foo.tgz");
-            let via_curdir = Path::new("/tmp/pkgs/./foo.tgz");
-
-            assert_eq!(file_cache_slot(canonical), file_cache_slot(via_dotdot));
-            assert_eq!(file_cache_slot(canonical), file_cache_slot(via_curdir));
-            assert!(file_cache_slot(canonical).starts_with("_file_"));
-
-            // Distinct tarballs still get distinct slots.
-            assert_ne!(
-                file_cache_slot(canonical),
-                file_cache_slot(Path::new("/tmp/pkgs/bar.tgz"))
-            );
-        }
-
-        #[test]
-        fn lexically_normalize_collapses_dotdot_without_climbing_root() {
-            assert_eq!(
-                lexically_normalize(Path::new("/a/b/../c")),
-                PathBuf::from("/a/c")
-            );
-            // Excess `..` saturates at the root rather than escaping it.
-            assert_eq!(
-                lexically_normalize(Path::new("/a/../../../b")),
-                PathBuf::from("/b")
-            );
-            // Leading `..` in a relative path is preserved (nothing to pop).
-            assert_eq!(
-                lexically_normalize(Path::new("../a/b")),
-                PathBuf::from("../a/b")
-            );
-        }
-    }
 
     #[test]
     fn rejects_unsafe_package_names() {

--- a/crates/ruborist/src/resolver/file.rs
+++ b/crates/ruborist/src/resolver/file.rs
@@ -1,8 +1,9 @@
 //! `file:` dependency resolution — directory links and local tarballs.
 //!
 //! The non-registry sibling of [`super::git`] and [`super::http`]: a `file:`
-//! dir becomes a Link node inline; a `file:` tarball is committed into the
-//! shared cache-slot contract and rejoins the normal BFS placement flow.
+//! dir becomes a Link node inline; a `file:` tarball has its manifest parsed
+//! in BFS (no global cache) and rejoins the normal BFS placement flow. The
+//! tarball content is extracted directly into `node_modules` at install time.
 
 use std::ops::ControlFlow;
 use std::path::Path;
@@ -12,9 +13,8 @@ use anyhow::Context as _;
 use petgraph::graph::NodeIndex;
 
 use super::builder::ProcessResult;
-use super::common::file_cache_slot;
 use super::edges::DependencyEdgeInfo;
-use super::tar::commit_tarball_bytes;
+use super::tar::parse_tarball_manifest;
 use crate::model::graph::{DependencyGraph, PackageNode};
 use crate::model::manifest::NodeManifest;
 use crate::model::node::EdgeType;
@@ -22,9 +22,10 @@ use crate::resolver::registry::ResolveError;
 use crate::traits::registry::ResolvedPackage;
 
 /// Handle a `file:` dep: dir → Link node inline (returns
-/// `ControlFlow::Break`); tarball → stream bytes through the shared
-/// `commit_tarball_bytes` and hand the `ResolvedPackage` back to the
-/// normal BFS flow via `ControlFlow::Continue`.
+/// `ControlFlow::Break`); tarball → read the local bytes, parse the manifest
+/// via [`parse_tarball_manifest`] (no global cache), and hand the
+/// `ResolvedPackage` back to the normal BFS flow via `ControlFlow::Continue`.
+/// The tarball content is materialized into `node_modules` at install time.
 #[cfg(feature = "http-tarball")]
 pub(crate) async fn process_file_dep<E>(
     graph: &mut DependencyGraph,
@@ -32,7 +33,6 @@ pub(crate) async fn process_file_dep<E>(
     conflict_parent: NodeIndex,
     edge: &DependencyEdgeInfo,
     path_spec: &str,
-    cache_dir: Option<&Path>,
 ) -> Result<std::ops::ControlFlow<ProcessResult, ResolvedPackage>, ResolveError<E>> {
     let file_err = |source: anyhow::Error| ResolveError::File {
         spec: edge.spec.clone(),
@@ -84,15 +84,11 @@ pub(crate) async fn process_file_dep<E>(
         return Ok(ControlFlow::Break(ProcessResult::Created(idx)));
     }
 
-    let cache_dir = cache_dir
-        .ok_or_else(|| file_err(anyhow::anyhow!("cache_dir required for file: tarball")))?
-        .to_path_buf();
-    let slot = file_cache_slot(&abs);
     let pinned = format!("file:{}", abs.display());
     let manifest = match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
         let bytes = std::fs::read(&abs)
             .with_context(|| format!("failed to read tarball {}", abs.display()))?;
-        commit_tarball_bytes(&cache_dir, &bytes, pinned, &slot)
+        parse_tarball_manifest(&bytes, pinned)
     })
     .await
     {

--- a/crates/ruborist/src/resolver/http.rs
+++ b/crates/ruborist/src/resolver/http.rs
@@ -1,31 +1,24 @@
 //! HTTP(S) tarball resolver for `https://…/pkg.tgz` dependency specs.
 //!
-//! # Why BFS extracts up-front (like git) instead of deferring to install
+//! # Why BFS only reads the manifest (no global cache)
 //!
-//! A naive "just parse the manifest in BFS, let pm re-download at install
-//! time" design looks simpler but has two problems:
+//! A non-registry remote tarball is indistinguishable from a registry
+//! download URL in an npm `package-lock.json` — both are `https://….tgz`,
+//! and the lockfile stores no source tag. Routing such a tarball into the
+//! shared `<name>/<version>` global cache would let an attacker-controlled
+//! URL self-declare any `name@version` and poison the slot the registry
+//! uses for a real package (there is no `dist.integrity` to verify against
+//! on a cache hit).
 //!
-//! 1. **Cache-slot collision**. pm's `download_to_cache` keys on
-//!    `<name>/<version>/`. A URL-supplied tarball can self-declare any
-//!    `name@version`, so an attacker-controlled URL can poison the same
-//!    slot the npm registry uses for `lodash@4.17.21`. There is no
-//!    `dist.integrity` to verify against on cache hit.
-//!
-//! 2. **Double download**. BFS downloads the tarball to read its manifest,
-//!    then throws the bytes away; install downloads the same URL again to
-//!    extract it.
-//!
-//! We fix both by extracting in BFS to a **URL-hashed** cache slot —
-//! `<cache>/<name>/_http_<sha256(url)[:16]>/`. URL is the natural content
-//! address (there is no etag/integrity to rely on, but the URL is what the
-//! user committed to in package.json), so it plays the same role `<sha>`
-//! plays for git. Install's `resolve_cache_path` checks this slot *before*
-//! falling through to the registry cache path, so registry tarballs stay
-//! unchanged while HTTP tarballs never re-download.
-//!
-//! Same-URL content changes **are not detected** — npm-land convention is
-//! that tarball URLs are immutable. Users who break that rotate the URL or
-//! run `utoo clean`.
+//! So non-registry tarballs never enter the global cache. BFS downloads the
+//! tarball only to parse its manifest (name/version/deps + the pinned
+//! `dist.tarball`) so transitive resolution can continue; the bytes are
+//! dropped. At install time pm re-fetches the URL and extracts the contents
+//! **directly** into `node_modules/<pkg>` (see
+//! [`crate::tar::extract_tarball_to_dir`]). HTTP tarballs are therefore
+//! downloaded twice (manifest in BFS, content at install) — accepted, as
+//! remote tarballs are rare and this removes the cache-poisoning and
+//! path-hashed-slot-staleness problems entirely.
 //!
 //! # Flow
 //!
@@ -34,64 +27,40 @@
 //!                                    │
 //!  ┌── BFS resolution (this module) ──────────────────────────────────────────┐
 //!  │                                 ▼                                        │
-//!  │  resolve_http_dep(cache_dir, url, &fetch_cache)                          │
+//!  │  resolve_http_dep(url, &fetch_cache)                                     │
 //!  │       │                                                                  │
 //!  │       ▼                                                                  │
-//!  │  HttpFetchCache  ── dedup_init  ★                                        │
-//!  │       │           (one fetch per URL across BFS)                         │
+//!  │  HttpFetchCache  ── dedup_init  ★  (one fetch per URL across BFS)        │
+//!  │       │                                                                  │
 //!  │       ▼                                                                  │
 //!  │  download_tarball  ── FetchError + classify_*  ☆                         │
-//!  │       │                                                                  │
-//!  │       ▼  Bytes                                                           │
-//!  │  spawn_blocking → fetch_and_extract_blocking:                            │
-//!  │       gzip_decompress (libdeflater)                                      │
-//!  │       scan_tarball  (single pass; collects entries + finds pkg.json)     │
-//!  │       finalize_non_registry_manifest  ★                                  │
-//!  │       package_dir = <cache>/<name>/_http_<sha256(url)[:16]>/             │
-//!  │       commit_cache_dir_atomic  ★  (stage → rename → _resolved marker)   │
+//!  │       │  Bytes                                                           │
+//!  │       ▼                                                                  │
+//!  │  parse_tarball_manifest (no extraction; finalize_non_registry_manifest)  │
 //!  │       │                                                                  │
 //!  │       ▼                                                                  │
 //!  │  ResolvedPackage { dist.tarball = url, … }    ── bytes dropped here      │
 //!  └───────│──────────────────────────────────────────────────────────────────┘
 //!          ▼  (lockfile)
-//!  ┌── Install phase (pm/util/downloader.rs) ─────────────────────────────────┐
-//!  │  resolve_cache_path(name, version, url)                                  │
-//!  │       ├─ is_git_url?           → git_cache_lookup                        │
-//!  │       ├─ http_tarball_cache_lookup  → <name>/_http_<hash>/_resolved → ✓ │
-//!  │       └─ (fall through)        → download_to_cache  (registry path)     │
-//!  │                                                                          │
-//!  │  cloner:  clonefile (mac) / hardlink (linux)                             │
-//!  │       ~/.cache/nm/<name>/_http_<hash>/package/  →  node_modules/<name>/  │
+//!  ┌── Install phase (pm) ─────────────────────────────────────────────────────┐
+//!  │  non-registry tarball → re-download URL → extract_tarball_to_dir into     │
+//!  │  node_modules/<pkg> (no global cache slot)                                │
 //!  └──────────────────────────────────────────────────────────────────────────┘
-//!
-//!  Cache layout:
-//!
-//!    ~/.cache/nm/
-//!    └── foo/
-//!        ├── 1.2.3/                       registry tarball slot (untouched)
-//!        └── _http_<sha256(url)[:16]>/    HTTP tarball slot
-//!            ├── _resolved
-//!            └── package/
-//!                └── package.json
 //!
 //!  Legend:
 //!    ★ shared with the git resolver via `super::common`
 //!      (DedupCache, dedup_init, finalize_non_registry_manifest,
-//!       validate_package_name, commit_cache_dir_atomic)
+//!       validate_package_name)
 //!    ☆ shared with registry manifest fetching via `crate::service::fetch`
 //!      (FetchError, classify_reqwest_error, classify_status, retry_strategy)
 //! ```
-//!
-//! [`download_to_cache`]: https://github.com/utooland/utoo/blob/main/crates/pm/src/util/downloader.rs
-
-use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
 use tokio_retry::RetryIf;
 
-use super::common::{DedupCache, dedup_init, http_cache_slot};
-use super::tar::commit_tarball_bytes;
+use super::common::{DedupCache, dedup_init};
+use super::tar::parse_tarball_manifest;
 use crate::model::manifest::CoreVersionManifest;
 use crate::service::fetch::{
     FetchError, classify_reqwest_error, classify_status, is_retryable, retry_strategy,
@@ -101,19 +70,6 @@ use crate::traits::registry::ResolvedPackage;
 
 /// Session-scoped dedup cache: one fetch per URL even under concurrent BFS.
 pub(crate) type HttpFetchCache = DedupCache<CoreVersionManifest>;
-
-fn fetch_and_extract_blocking(
-    cache_dir: &Path,
-    url: &str,
-    tarball_bytes: Bytes,
-) -> Result<CoreVersionManifest> {
-    commit_tarball_bytes(
-        cache_dir,
-        tarball_bytes.as_ref(),
-        url.to_string(),
-        &http_cache_slot(url),
-    )
-}
 
 // ============================================================================
 // Async download + retry
@@ -153,27 +109,22 @@ async fn download_tarball(url: &str) -> Result<Bytes> {
 // High-level resolver — called by BFS `process_dependency`
 // ============================================================================
 
-/// Resolve an HTTP tarball spec to a [`ResolvedPackage`] and seed the cache.
+/// Resolve an HTTP tarball spec to a [`ResolvedPackage`].
 ///
-/// BFS extracts to `<cache_dir>/<name>/_http_<hash>/` so the install phase
-/// finds a cache hit and never re-downloads.
+/// Downloads the tarball only to parse its manifest; the bytes are not cached.
+/// The tarball content is materialized directly into `node_modules` at install
+/// time, so non-registry tarballs never enter the global cache.
 pub(crate) async fn resolve_http_dep(
-    cache_dir: Option<&Path>,
     url: &str,
     fetch_cache: &HttpFetchCache,
 ) -> Result<ResolvedPackage> {
-    let cache_dir =
-        cache_dir.ok_or_else(|| anyhow!("cache_dir required for http dependency resolution"))?;
-
     let url_owned = url.to_string();
-    let cache_dir_owned = cache_dir.to_path_buf();
     let manifest = dedup_init(fetch_cache, url_owned.clone(), move || async move {
         let bytes = download_tarball(&url_owned).await?;
-        tokio::task::spawn_blocking(move || {
-            fetch_and_extract_blocking(&cache_dir_owned, &url_owned, bytes)
-        })
-        .await
-        .context("http tarball extractor task failed")?
+        let url_for_blocking = url_owned.clone();
+        tokio::task::spawn_blocking(move || parse_tarball_manifest(&bytes, url_for_blocking))
+            .await
+            .context("http tarball manifest parse task failed")?
     })
     .await?;
 
@@ -211,74 +162,27 @@ mod tests {
     }
 
     #[test]
-    fn extracts_to_url_hashed_slot() {
-        let tmp = tempfile::tempdir().unwrap();
+    fn parses_manifest_with_pinned_url() {
         let pkg = br#"{"name":"demo","version":"1.2.3","scripts":{"install":"echo hi"}}"#;
         let bytes = make_targz(&[("package/package.json", pkg)]);
         let url = "https://example.com/demo.tgz";
 
-        let manifest = fetch_and_extract_blocking(tmp.path(), url, bytes).unwrap();
+        let manifest = parse_tarball_manifest(&bytes, url.to_string()).unwrap();
         assert_eq!(manifest.name, "demo");
         assert_eq!(manifest.version, "1.2.3");
         assert_eq!(manifest.has_install_script, Some(true));
         assert_eq!(manifest.dist.tarball.as_deref(), Some(url));
-
-        let expected_dir = tmp.path().join("demo").join(http_cache_slot(url));
-        assert!(expected_dir.join("_resolved").exists());
-        assert!(expected_dir.join("package").join("package.json").exists());
-    }
-
-    #[test]
-    fn different_urls_get_separate_slots_same_name() {
-        let tmp = tempfile::tempdir().unwrap();
-        let pkg = br#"{"name":"demo","version":"1.0.0"}"#;
-        let url_a = "https://a.example.com/demo.tgz";
-        let url_b = "https://b.example.com/demo.tgz";
-
-        fetch_and_extract_blocking(
-            tmp.path(),
-            url_a,
-            make_targz(&[("package/package.json", pkg)]),
-        )
-        .unwrap();
-        fetch_and_extract_blocking(
-            tmp.path(),
-            url_b,
-            make_targz(&[("package/package.json", pkg)]),
-        )
-        .unwrap();
-
-        let slot_a = tmp.path().join("demo").join(http_cache_slot(url_a));
-        let slot_b = tmp.path().join("demo").join(http_cache_slot(url_b));
-        assert_ne!(slot_a, slot_b);
-        assert!(slot_a.join("_resolved").exists());
-        assert!(slot_b.join("_resolved").exists());
-    }
-
-    #[test]
-    fn warm_cache_is_idempotent() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bytes = make_targz(&[(
-            "package/package.json",
-            br#"{"name":"demo","version":"0.0.1"}"#,
-        )]);
-        let url = "https://example.com/x.tgz";
-
-        fetch_and_extract_blocking(tmp.path(), url, bytes.clone()).unwrap();
-        fetch_and_extract_blocking(tmp.path(), url, bytes).unwrap();
     }
 
     #[test]
     fn rejects_tarball_without_package_json() {
-        let tmp = tempfile::tempdir().unwrap();
         let bytes = make_targz(&[("package/README.md", b"hi")]);
-        let err = fetch_and_extract_blocking(tmp.path(), "u", bytes).unwrap_err();
+        let err = parse_tarball_manifest(&bytes, "u".to_string()).unwrap_err();
         assert!(err.to_string().contains("package.json not found"));
     }
 
     #[test]
     fn shallowest_package_json_wins() {
-        let tmp = tempfile::tempdir().unwrap();
         let bytes = make_targz(&[
             (
                 "package/sub/package.json",
@@ -289,7 +193,7 @@ mod tests {
                 br#"{"name":"demo","version":"1.0.0"}"#,
             ),
         ]);
-        let manifest = fetch_and_extract_blocking(tmp.path(), "u", bytes).unwrap();
+        let manifest = parse_tarball_manifest(&bytes, "u".to_string()).unwrap();
         assert_eq!(manifest.name, "demo");
         assert_eq!(manifest.version, "1.0.0");
     }

--- a/crates/ruborist/src/resolver/tar.rs
+++ b/crates/ruborist/src/resolver/tar.rs
@@ -1,9 +1,10 @@
 //! Tar + gzip helpers shared by the HTTP and file tarball resolvers.
 //!
-//! Both resolvers need to parse an npm-style `package/`-prefixed tarball
-//! into in-memory [`TarEntry`]s (so the manifest can be inspected before
-//! deciding where to commit) and then emit those entries atomically into
-//! a cache slot.
+//! Both resolvers parse an npm-style `package/`-prefixed tarball into
+//! in-memory [`TarEntry`]s. Non-registry tarballs (http/file) never enter
+//! the global cache: BFS reads only their manifest via
+//! [`parse_tarball_manifest`], and install materializes their contents
+//! straight into `node_modules` via [`extract_tarball_to_dir`].
 //!
 //! The low-level primitives — [`estimate_uncompressed_size`],
 //! [`gzip_decompress`], [`is_safe_tar_entry_path`], and
@@ -19,7 +20,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 
-use super::common::{commit_cache_dir_atomic, finalize_non_registry_manifest};
+use super::common::finalize_non_registry_manifest;
 use crate::model::manifest::CoreVersionManifest;
 
 /// Decoded tar entry held in memory until the package name/version is known
@@ -180,37 +181,60 @@ pub fn estimate_uncompressed_size(gzip_bytes: &[u8]) -> usize {
     }
 }
 
-/// Shared tarball-commit pipeline used by the http and file tarball
-/// resolvers.
+/// Parse and finalize a non-registry tarball's manifest **without** extracting
+/// it anywhere.
 ///
-/// Decompresses `gzip_bytes`, parses the embedded `package.json`, stamps
-/// `pinned_url` onto `dist.tarball` via `finalize_non_registry_manifest`,
-/// and atomically commits the extracted tree to
-/// `<cache_dir>/<name>/<slot>/package/`.
-///
-/// Cache is idempotent: the `_resolved` marker short-circuits re-extraction
-/// on warm runs. Returns the finalized manifest so BFS can produce a
-/// [`crate::traits::registry::ResolvedPackage`].
-pub(crate) fn commit_tarball_bytes(
-    cache_dir: &Path,
+/// BFS only needs the manifest (name/version/deps + the pinned `dist.tarball`)
+/// to keep resolving; the tarball *content* for a non-registry dep is never
+/// cached in the global store — it is fetched and extracted directly into
+/// `node_modules` at install time. This keeps untrusted remote/local tarballs
+/// out of the shared `<name>/<version>` cache.
+pub(crate) fn parse_tarball_manifest(
     gzip_bytes: &[u8],
     pinned_url: String,
-    slot: &str,
 ) -> Result<CoreVersionManifest> {
     let decompressed = gzip_decompress(gzip_bytes)?;
-    let (entries, manifest_blob) = scan_tarball(&decompressed)?;
+    let (_entries, manifest_blob) = scan_tarball(&decompressed)?;
 
     let mut manifest: CoreVersionManifest = serde_json::from_slice(&manifest_blob)
         .context("failed to parse package.json from tarball")?;
     finalize_non_registry_manifest(&mut manifest, pinned_url)?;
-
-    let package_dir = cache_dir.join(&manifest.name).join(slot);
-    if package_dir.join("_resolved").exists() {
-        return Ok(manifest);
-    }
-    commit_cache_dir_atomic(&package_dir, |stage| write_entries(&entries, stage))?;
-
     Ok(manifest)
+}
+
+/// Extract a non-registry tarball's contents directly into `dest` (a
+/// `node_modules/<pkg>` directory), stripping the leading npm wrapper component
+/// (typically `package/`). Writes no `_resolved` marker and does not touch the
+/// global cache — it materializes the package straight into the tree at install
+/// time. This is the single materialization path for http(s) remote tarballs and
+/// local `file:` tarballs, which (unlike registry/git deps) never enter the
+/// shared `<name>/<version>` global cache store.
+pub fn extract_tarball_to_dir(gzip_bytes: &[u8], dest: &Path) -> Result<()> {
+    let decompressed = gzip_decompress(gzip_bytes)?;
+    let (entries, _manifest_blob) = scan_tarball(&decompressed)?;
+
+    // npm tarballs nest everything under a single top-level dir (`package/`);
+    // strip that first component so contents land at `dest` root.
+    let stripped: Vec<TarEntry> = entries
+        .into_iter()
+        .filter_map(|mut e| {
+            let mut comps = e.rel_path.components();
+            comps.next()?; // drop the wrapper dir
+            let rest: PathBuf = comps.collect();
+            if rest.as_os_str().is_empty() {
+                return None; // the wrapper dir entry itself
+            }
+            e.rel_path = rest;
+            Some(e)
+        })
+        .collect();
+
+    if dest.exists() {
+        let _ = std::fs::remove_dir_all(dest);
+    }
+    std::fs::create_dir_all(dest)
+        .with_context(|| format!("failed to create {}", dest.display()))?;
+    write_entries(&stripped, dest)
 }
 
 /// Decompress a gzip stream with libdeflate, sizing the output buffer from

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -195,13 +195,79 @@ for pkg in abbrev ini isexe; do
     fi
 done
 echo -e "${GREEN}PASS: HTTP tarball warm install successful${NC}"
+
 cd ../../..
 
+# Case 8.3b: a NON-registry HTTP(S) tarball (served from a host that is NOT a
+# trusted registry) must install directly into node_modules and must NOT create
+# ANY global cache entry. Classification is by host: the lockfile stores no
+# source tag, so a tarball whose origin is not the configured/well-known
+# registry is treated as a remote tarball and materialized straight into the
+# tree (single-path model), never the shared `<name>/<version>` cache.
+#
+# The other http fixture (Case 8.2/8.3) deliberately points at
+# registry.npmjs.org — a *trusted* registry host — so those URLs are classified
+# as registry downloads and DO use the cache; they exercise the URL-pinned
+# lockfile path, not the non-registry direct-extract path. We serve this case's
+# tarball from 127.0.0.1 (untrusted host) to exercise direct-extract + no-leak.
+echo -e "${YELLOW}Case 8.3b: non-registry HTTP tarball stays out of the global cache${NC}"
+HTTP_DIR=$(mktemp -d)
+HTTP_CACHE=$(mktemp -d)
+mkdir -p "$HTTP_DIR/pkg/remote-http-pkg"
+cat > "$HTTP_DIR/pkg/remote-http-pkg/package.json" <<'EOF'
+{ "name": "remote-http-pkg", "version": "4.5.6", "main": "index.js" }
+EOF
+echo "module.exports = 456;" > "$HTTP_DIR/pkg/remote-http-pkg/index.js"
+( cd "$HTTP_DIR/pkg/remote-http-pkg" && npm pack --silent >/dev/null 2>&1 \
+  && mv remote-http-pkg-*.tgz "$HTTP_DIR/remote-http-pkg.tgz" )
+# Serve the tarball dir on a random localhost port (untrusted, non-registry host).
+HTTP_PORT=$(node -e 'const s=require("net").createServer();s.listen(0,"127.0.0.1",()=>{console.log(s.address().port);s.close();})')
+node -e '
+const http=require("http"), fs=require("fs"), path=require("path");
+const dir=process.argv[1], port=Number(process.argv[2]);
+http.createServer((req,res)=>{
+  const f=path.join(dir, path.basename(req.url));
+  fs.readFile(f,(e,d)=>{ if(e){res.statusCode=404;res.end("nf");} else {res.end(d);} });
+}).listen(port,"127.0.0.1");
+' "$HTTP_DIR" "$HTTP_PORT" &
+HTTP_PID=$!
+# Give the server a moment to bind.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -fsS "http://127.0.0.1:$HTTP_PORT/remote-http-pkg.tgz" -o /dev/null 2>/dev/null; then break; fi
+  sleep 0.3
+done
+mkdir -p "$HTTP_DIR/app"
+cat > "$HTTP_DIR/app/package.json" <<EOF
+{ "name": "remote-http-app", "version": "1.0.0", "private": true,
+  "dependencies": { "remote-http-pkg": "http://127.0.0.1:$HTTP_PORT/remote-http-pkg.tgz" } }
+EOF
+http_cleanup() { kill "$HTTP_PID" 2>/dev/null; rm -rf "$HTTP_DIR" "$HTTP_CACHE"; }
+( cd "$HTTP_DIR/app" && UTOO_CACHE_DIR="$HTTP_CACHE" utoo install --ignore-scripts ) \
+  || { echo -e "${RED}FAIL: non-registry http tarball install failed${NC}"; http_cleanup; exit 1; }
+if [ ! -f "$HTTP_DIR/app/node_modules/remote-http-pkg/package.json" ]; then
+    echo -e "${RED}FAIL: remote-http-pkg not materialized into node_modules${NC}"; http_cleanup; exit 1
+fi
+ACTUAL=$(node -e "console.log(require('$HTTP_DIR/app/node_modules/remote-http-pkg/package.json').version)")
+if [ "$ACTUAL" != "4.5.6" ]; then
+    echo -e "${RED}FAIL: remote-http-pkg expected v4.5.6, got $ACTUAL${NC}"; http_cleanup; exit 1
+fi
+# No global cache entry for this package at all (no `<version>` slot, no `_http_`).
+if [ -d "$HTTP_CACHE/remote-http-pkg" ]; then
+    echo -e "${RED}FAIL: remote-http-pkg leaked into the global cache at $HTTP_CACHE/remote-http-pkg${NC}"
+    ls -la "$HTTP_CACHE/remote-http-pkg"; http_cleanup; exit 1
+fi
+http_cleanup
+echo -e "${GREEN}PASS: non-registry HTTP tarball stays out of the global cache${NC}"
+
 # Case 8.4: file: dependency install. Directory deps install as a SYMLINK
-# (npm-compatible); tarball deps extract + clone from the cache slot.
+# (npm-compatible); tarball deps are extracted directly into node_modules
+# (non-registry source — never the global cache).
 echo -e "${YELLOW}Case 8.4: file: dependency install${NC}"
 cd e2e/pm/file-deps
 rm -rf node_modules package-lock.json
+# Neither file: dep enters the global cache: the dir dep installs as a symlink
+# and the tarball dep is extracted directly into node_modules. Clean any slot a
+# prior pm build may have left so a stale entry can't mask a regression.
 rm -rf ~/.cache/nm/local-dir-pkg ~/.cache/nm/local-tarball-pkg
 utoo install --ignore-scripts || { echo -e "${RED}FAIL: utoo install failed for file-deps${NC}"; exit 1; }
 for pkg in local-dir-pkg local-tarball-pkg; do
@@ -220,9 +286,9 @@ if [ "$LINK_TARGET" != "../local-dir" ]; then
     echo -e "${RED}FAIL: local-dir-pkg symlink points to '$LINK_TARGET', expected '../local-dir'${NC}"
     exit 1
 fi
-# Tarball dep must be a real directory (clone from cache), not a symlink.
+# Tarball dep must be a real directory (direct-extract), not a symlink.
 if [ -L "node_modules/local-tarball-pkg" ]; then
-    echo -e "${RED}FAIL: local-tarball-pkg should be a real directory (clone), got a symlink${NC}"
+    echo -e "${RED}FAIL: local-tarball-pkg should be a real directory (direct-extract), got a symlink${NC}"
     exit 1
 fi
 ACTUAL=$(node -e "console.log(require('./node_modules/local-dir-pkg/package.json').version)")
@@ -260,12 +326,12 @@ echo -e "${GREEN}PASS: file: warm install successful${NC}"
 cd ../../..
 
 # Case 8.5b: file: tarball located OUTSIDE the project root.
-# Regression: such a tarball's root-relative lockfile entry carries `..`
-# (e.g. "file:../../pkgs/foo.tgz"). BFS hashes the cache slot from the
-# canonical absolute path, but install re-absolutizes the `..`-laden lockfile
-# path; if the slot key isn't normalized the two disagree and the clone fails
-# with "file tarball cache not found". The in-tree fixture above can't catch
-# this because its path has no `..`.
+# Such a tarball's root-relative lockfile entry carries `..`
+# (e.g. "file:../../pkgs/foo.tgz"); install re-absolutizes it against cwd and
+# extracts the tarball directly into node_modules. The in-tree fixture above
+# can't exercise the `..` re-absolutization because its path has none. Run under
+# an isolated cache so we can also assert the tarball never enters the global
+# cache (non-registry source — single-path direct extract).
 echo -e "${YELLOW}Case 8.5b: file: tarball outside project root${NC}"
 EXT_DIR=$(mktemp -d)
 mkdir -p "$EXT_DIR/src/ext-tarball-pkg"
@@ -284,15 +350,20 @@ cat > "$EXT_DIR/app/package.json" <<EOF
   "dependencies": { "ext-tarball-pkg": "file:$EXT_DIR/ext-tarball-pkg.tgz" }
 }
 EOF
-rm -rf ~/.cache/nm/ext-tarball-pkg
-( cd "$EXT_DIR/app" && utoo install --ignore-scripts ) \
-  || { echo -e "${RED}FAIL: install failed for tarball outside project root${NC}"; rm -rf "$EXT_DIR"; exit 1; }
+EXT_CACHE=$(mktemp -d)
+( cd "$EXT_DIR/app" && UTOO_CACHE_DIR="$EXT_CACHE" utoo install --ignore-scripts ) \
+  || { echo -e "${RED}FAIL: install failed for tarball outside project root${NC}"; rm -rf "$EXT_DIR" "$EXT_CACHE"; exit 1; }
 if [ ! -f "$EXT_DIR/app/node_modules/ext-tarball-pkg/package.json" ]; then
-    echo -e "${RED}FAIL: ext-tarball-pkg not materialized into node_modules${NC}"; rm -rf "$EXT_DIR"; exit 1
+    echo -e "${RED}FAIL: ext-tarball-pkg not materialized into node_modules${NC}"; rm -rf "$EXT_DIR" "$EXT_CACHE"; exit 1
+fi
+# Non-registry tarball must NOT create any global cache entry.
+if [ -d "$EXT_CACHE/ext-tarball-pkg" ]; then
+    echo -e "${RED}FAIL: ext-tarball-pkg leaked into the global cache at $EXT_CACHE/ext-tarball-pkg${NC}"
+    ls -la "$EXT_CACHE/ext-tarball-pkg"; rm -rf "$EXT_DIR" "$EXT_CACHE"; exit 1
 fi
 ACTUAL=$(node -e "console.log(require('$EXT_DIR/app/node_modules/ext-tarball-pkg/package.json').version)")
 if [ "$ACTUAL" != "5.6.7" ]; then
-    echo -e "${RED}FAIL: ext-tarball-pkg expected v5.6.7, got $ACTUAL${NC}"; rm -rf "$EXT_DIR"; exit 1
+    echo -e "${RED}FAIL: ext-tarball-pkg expected v5.6.7, got $ACTUAL${NC}"; rm -rf "$EXT_DIR" "$EXT_CACHE"; exit 1
 fi
 # Lockfile must stay portable: a root-relative `file:` path with `..`.
 # Check the *form*, not a substring: when cwd and the tarball spec disagree on
@@ -311,8 +382,8 @@ const p = r.slice(5);
 if (p[0] === "/" || /^[A-Za-z]:/.test(p)) {
   console.error("ext-tarball-pkg resolved should be root-relative, not absolute:", tar.resolved); process.exit(1);
 }
-' || { echo -e "${RED}FAIL: lockfile entry wrong for outside-root tarball${NC}"; rm -rf "$EXT_DIR"; exit 1; }
-rm -rf "$EXT_DIR"
+' || { echo -e "${RED}FAIL: lockfile entry wrong for outside-root tarball${NC}"; rm -rf "$EXT_DIR" "$EXT_CACHE"; exit 1; }
+rm -rf "$EXT_DIR" "$EXT_CACHE"
 echo -e "${GREEN}PASS: file: tarball outside project root installs${NC}"
 
 # Case 8.6: stale lockfile is detected and regenerated on `ut install`


### PR DESCRIPTION
## Problem

An npm `package-lock.json` stores **no source type** — a registry download URL and a user-declared remote-tarball URL are both `https://….tgz`. So routing a lockfile entry by its `resolved` URL alone is genuinely ambiguous (this is why npm/bun consult the declared spec / store a typed resolution).

Letting non-registry tarballs into the shared `<name>/<version>` global cache has two real problems:
- **Cross-cache poisoning**: a remote tarball (even a deep transitive one) can self-declare any `name@version` in its `package.json`; written into the shared slot it overwrites a real registry package for **every** project on the machine.
- **Staleness**: a path/url-hashed slot serves stale content when a `file:` tarball is repacked at the same path (the common local-framework-dev workflow).

## Approach

Classify by **host**, and keep untrusted tarballs out of the shared store entirely:

| source | handling |
|---|---|
| trusted registry-host tarball (configured registry + npmjs/npmmirror) | global `<name>/<version>` cache — **unchanged** |
| git | global commit-sha slot — **unchanged** |
| untrusted https + local `file:` tarball | fetched/read and extracted **directly into `node_modules`**, never the global store |

BFS reads only the **manifest** of a non-registry tarball (so transitive deps still resolve) and caches nothing; the content is materialized at install time. This removes the `_http_`/`_file_` cache slots, the slot-key helpers, and the spec-scan/`TarballSource` classification machinery — **net −28 lines**.

Single-path model (deliberate tradeoff): non-registry tarballs are materialized directly to `node_modules` in both fresh-resolve and lockfile-install. In fresh-resolve an http tarball is downloaded twice (BFS manifest + install content); http tarballs are rare, so this is accepted. Cross-install dedup for remote tarballs is intentionally dropped (which also removes the staleness footgun).

## Changes

- **ruborist**: `parse_tarball_manifest` (manifest only, no extraction) + `extract_tarball_to_dir` (strips the npm `package/` wrapper, writes into `node_modules`, no `_resolved` marker). http/file resolvers no longer cache. Deleted the `_http_`/`_file_` slot helpers and the `cache_slot` façade.
- **pm**: `resolve_cache_plan` → `{ GitCache, RegistryDownload, DirectExtract }`; the install scheduler gains a bounded direct-extract stage that materializes the tarball into the target and finalizes the clone outright (parent-blocking preserved). Host predicate `is_registry_tarball` decides registry-vs-direct.
- **e2e**: Case 8.3b serves a tarball from an untrusted `127.0.0.1` host (the npmjs fixture is a *trusted* registry host and legitimately uses the cache) to exercise direct-extract + assert no global-cache leak; `file:` cases assert no cache entry.

## Verification

- `cargo fmt` / `clippy -D warnings` (ruborist + pm) / no-feature wasm build — clean.
- `cargo test`: ruborist **196** + pm **270** pass.
- End-to-end: a `file:` tarball **with a transitive registry dep** installs into `node_modules` (transitive dep resolved), leaves the global cache untouched, while the registry dep still populates the global cache; the lockfile keeps a portable root-relative `file:` path. A non-registry http tarball (localhost) installs directly with no cache leak.

Supersedes #3161 (which fixed the same class of bug by isolating remote tarballs in URL-keyed cache slots; this removes the global slot for them instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)