### PR TITLE
fix(pm): accept string-form replaceHost in binary-mirror-config

### DIFF
--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -49,9 +49,15 @@ struct BinaryMirror {
     #[serde(skip_serializing_if = "Option::is_none")]
     host: Option<String>,
     /// Hosts to rewrite to `host` (used when `replaceHostMap` is absent).
+    /// cnpm ships this in both shapes — a single host string (e.g. `flow-bin`)
+    /// or an array — so accept either and normalize to a list. A strict
+    /// `Vec<String>` would reject the bare-string form and, because the whole
+    /// `mirrors.china` map deserializes as one unit, fail the entire config
+    /// parse — silently disabling mirroring for every package.
     #[serde(
         rename = "replaceHost",
         default,
+        deserialize_with = "deserialize_string_or_vec",
         skip_serializing_if = "Option::is_none"
     )]
     replace_host: Option<Vec<String>>,
@@ -90,6 +96,27 @@ struct BinaryMirror {
     extra: Map<String, Value>,
 }
 
+/// Accept npm's `replaceHost` in either shape — a single host string or an
+/// array of host strings — normalizing to `Vec<String>`. See the field doc on
+/// [`BinaryMirror::replace_host`] for why the bare-string form must not fail
+/// the parse.
+fn deserialize_string_or_vec<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        One(String),
+        Many(Vec<String>),
+    }
+    Ok(match Option::<StringOrVec>::deserialize(deserializer)? {
+        Some(StringOrVec::One(s)) => Some(vec![s]),
+        Some(StringOrVec::Many(v)) => Some(v),
+        None => None,
+    })
+}
+
 static CONFIG: OnceCell<BinaryMirrorConfig> = OnceCell::const_new();
 /// Cached result of whether we should skip binary mirror envs
 static SKIP_BINARY_MIRROR: OnceLock<bool> = OnceLock::new();
@@ -106,7 +133,16 @@ async fn load_config() -> Result<&'static BinaryMirrorConfig> {
                 .fetch_version_manifest_bytes("binary-mirror-config", "latest")
                 .await
                 .context("Failed to fetch binary mirror config")?;
-            serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")
+            let config: BinaryMirrorConfig =
+                serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")?;
+            // A successful parse is the only signal that the mirror layer is
+            // live; the failure path is a swallowed debug log, so without this
+            // the whole layer can silently go dark on upstream schema drift.
+            tracing::debug!(
+                "Binary mirror config loaded: {} china package entries",
+                config.mirrors.china.packages.len()
+            );
+            Ok(config)
         })
         .await
 }
@@ -580,5 +616,82 @@ mod tests {
         // Should not change version
         assert_eq!(updated_pkg["name"], "fsevents");
         assert_eq!(updated_pkg["version"], "2.3.3");
+    }
+
+    #[test]
+    fn test_replace_host_accepts_string_and_array() {
+        // `flow-bin` ships the bare-string form; it must parse and normalize
+        // to a single-element list so the rewrite logic treats it like any
+        // other host list.
+        let single = serde_json::from_value::<BinaryMirror>(json!({
+            "replaceHost": "https://github.com/facebook/flow/releases/download/v",
+            "host": "https://cdn.npmmirror.com/binaries/flow/v"
+        }))
+        .unwrap();
+        assert_eq!(
+            single.replace_host.as_deref(),
+            Some(&["https://github.com/facebook/flow/releases/download/v".to_string()][..])
+        );
+
+        // The array form keeps every entry.
+        let many = serde_json::from_value::<BinaryMirror>(json!({
+            "replaceHost": ["a.com", "b.com"],
+            "host": "new.com"
+        }))
+        .unwrap();
+        assert_eq!(
+            many.replace_host.as_deref(),
+            Some(&["a.com".to_string(), "b.com".to_string()][..])
+        );
+
+        // Absent → None.
+        let none = serde_json::from_value::<BinaryMirror>(json!({ "host": "new.com" })).unwrap();
+        assert!(none.replace_host.is_none());
+    }
+
+    #[test]
+    fn test_china_config_with_string_replace_host_does_not_fail_parse() {
+        // A single string-form `replaceHost` entry (the real `flow-bin` shape)
+        // must not fail the whole `mirrors.china` parse — otherwise mirroring
+        // is silently disabled for every package, including the `ENVS` block.
+        let config = serde_json::from_value::<BinaryMirrorConfig>(json!({
+            "mirrors": {
+                "china": {
+                    "ENVS": { "SASS_BINARY_SITE": "https://cdn.npmmirror.com/binaries/node-sass" },
+                    "flow-bin": {
+                        "replaceHost": "https://github.com/facebook/flow/releases/download/v",
+                        "host": "https://cdn.npmmirror.com/binaries/flow/v"
+                    },
+                    "sharp": {
+                        "replaceHostFiles": ["install/libvips.js"],
+                        "replaceHostMap": {
+                            "https://github.com/lovell/sharp-libvips/releases/download/":
+                                "https://cdn.npmmirror.com/binaries/sharp-libvips/"
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("config with string-form replaceHost must parse");
+
+        assert_eq!(
+            config
+                .mirrors
+                .china
+                .envs
+                .get("SASS_BINARY_SITE")
+                .map(String::as_str),
+            Some("https://cdn.npmmirror.com/binaries/node-sass")
+        );
+        assert_eq!(
+            config
+                .mirrors
+                .china
+                .packages
+                .get("flow-bin")
+                .and_then(|m| m.replace_host.as_deref()),
+            Some(&["https://github.com/facebook/flow/releases/download/v".to_string()][..])
+        );
+        assert!(config.mirrors.china.packages.contains_key("sharp"));
     }
 }

--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -117,34 +117,48 @@ where
     })
 }
 
-static CONFIG: OnceCell<BinaryMirrorConfig> = OnceCell::const_new();
+/// Cached config load result. Holds the failure too: `get_or_try_init` leaves
+/// the cell empty on `Err`, so a persistent failure (offline / registry down /
+/// upstream schema drift) would re-fetch once per package — `load_config` is
+/// called for *every* node in the tree. Caching `Result` memoizes both outcomes
+/// for the whole install. The error is a `String` (anyhow's `Error` is neither
+/// `Clone` nor `Sync`-friendly to hand out by reference repeatedly).
+static CONFIG: OnceCell<Result<BinaryMirrorConfig, String>> = OnceCell::const_new();
 /// Cached result of whether we should skip binary mirror envs
 static SKIP_BINARY_MIRROR: OnceLock<bool> = OnceLock::new();
 
+async fn fetch_and_parse_config() -> Result<BinaryMirrorConfig> {
+    // Go through the registry client so URL construction and private-registry
+    // auth are handled in one place rather than hand-rolled.
+    // `binary-mirror-config@latest` is a normal version manifest whose
+    // `mirrors` field carries the config.
+    let bytes = RuboristContext::registry()
+        .await
+        .fetch_version_manifest_bytes("binary-mirror-config", "latest")
+        .await
+        .context("Failed to fetch binary mirror config")?;
+    let config: BinaryMirrorConfig =
+        serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")?;
+    // A successful parse is the only signal that the mirror layer is live; the
+    // failure path is a swallowed debug log, so without this the whole layer
+    // can silently go dark on upstream schema drift.
+    tracing::debug!(
+        "Binary mirror config loaded: {} china package entries",
+        config.mirrors.china.packages.len()
+    );
+    Ok(config)
+}
+
 async fn load_config() -> Result<&'static BinaryMirrorConfig> {
     CONFIG
-        .get_or_try_init(|| async {
-            // Go through the registry client so URL construction and private-
-            // registry auth are handled in one place rather than hand-rolled.
-            // `binary-mirror-config@latest` is a normal version manifest whose
-            // `mirrors` field carries the config.
-            let bytes = RuboristContext::registry()
-                .await
-                .fetch_version_manifest_bytes("binary-mirror-config", "latest")
-                .await
-                .context("Failed to fetch binary mirror config")?;
-            let config: BinaryMirrorConfig =
-                serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")?;
-            // A successful parse is the only signal that the mirror layer is
-            // live; the failure path is a swallowed debug log, so without this
-            // the whole layer can silently go dark on upstream schema drift.
-            tracing::debug!(
-                "Binary mirror config loaded: {} china package entries",
-                config.mirrors.china.packages.len()
-            );
-            Ok(config)
+        .get_or_init(|| async {
+            // Keep the full context chain in the cached message — the failure
+            // path only surfaces as a debug log, so the inner cause matters.
+            fetch_and_parse_config().await.map_err(|e| format!("{e:#}"))
         })
         .await
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 fn update_binary_config(pkg: &mut Value, binary_mirror: &BinaryMirror) {

--- a/e2e/utoo-pm.ps1
+++ b/e2e/utoo-pm.ps1
@@ -628,4 +628,51 @@ finally {
     Remove-Item -Recurse -Force $extDir -ErrorAction SilentlyContinue
 }
 
+# ═══════════════════════════════════════════════════════════════
+# Case: latest binary-mirror-config still parses under our schema
+# ═══════════════════════════════════════════════════════════════
+# `binary-mirror-config`'s `mirrors.china` map is parsed into a strongly-typed
+# schema (crates/pm/src/service/binary.rs). The whole map deserializes as one
+# unit, so a single drifted entry fails the parse and silently disables the
+# China mirror layer for every package — `get_envs()`/`update_package_binary()`
+# swallow the error as a debug log. (`flow-bin` ships `replaceHost` as a bare
+# string, not an array, which previously broke the parse.)
+#
+# Guard against upstream drift: install against a non-npm registry (npm.org has
+# no mirror layer and is skipped) with --verbose, then assert the config loaded
+# and did NOT fail to parse. flow-bin is the dep on purpose — it is the exact
+# entry that regressed.
+Write-Yellow "Case: latest binary-mirror-config parses under our schema"
+$bmcDir = Join-Path $env:TEMP "utoo-e2e-bmc-$(Get-Random)"
+try {
+    New-Item -ItemType Directory -Path $bmcDir -Force | Out-Null
+    @{
+        name         = "binary-mirror-config-parse-test"
+        version      = "1.0.0"
+        dependencies = @{ "flow-bin" = "0.180.0" }
+    } | ConvertTo-Json | Set-Content "$bmcDir\package.json"
+
+    Push-Location $bmcDir
+    try {
+        # --ignore-scripts keeps this fast (no native binary download); the
+        # mirror config is loaded on the clone path regardless of script exec.
+        $bmcOut = utoo install --registry=https://registry.npmmirror.com --ignore-scripts --verbose 2>&1
+        $bmcOut | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "utoo install failed for binary-mirror-config parse test" }
+
+        if ($bmcOut -match "Failed to parse binary mirror config") {
+            throw "latest binary-mirror-config no longer matches our schema (mirrors.china drift)"
+        }
+        if (-not ($bmcOut -match "Binary mirror config loaded:")) {
+            throw "binary-mirror-config was never parsed (registry unreachable or mirror layer skipped)"
+        }
+
+        Write-Green "PASS: latest binary-mirror-config parses cleanly"
+    }
+    finally { Pop-Location }
+}
+finally {
+    Remove-Item -Recurse -Force $bmcDir -ErrorAction SilentlyContinue
+}
+
 Write-Green "All e2e tests passed successfully!"

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -1521,6 +1521,8 @@ cd ../../../
 # entry that regressed.
 echo -e "${YELLOW}Case: latest binary-mirror-config parses under our schema${NC}"
 BMC_DIR=$(mktemp -d)
+# Remove the temp dir even if an assertion below exits the script mid-case.
+trap 'rm -rf "$BMC_DIR"' EXIT
 cat > "$BMC_DIR/package.json" << 'EOF'
 {
   "name": "binary-mirror-config-parse-test",
@@ -1549,6 +1551,7 @@ fi
 rm -f bmc.out
 popd
 rm -rf "$BMC_DIR"
+trap - EXIT
 echo -e "${GREEN}PASS: latest binary-mirror-config parses cleanly${NC}"
 
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -1505,4 +1505,50 @@ if (pTimeout.dev === true) {
 echo -e "${GREEN}PASS: prod-reachable devDependency correctly not marked dev${NC}"
 cd ../../../
 
+# ═══════════════════════════════════════════════════════════════
+# Case: latest binary-mirror-config still parses under our schema
+# ═══════════════════════════════════════════════════════════════
+# `binary-mirror-config`'s `mirrors.china` map is parsed into a strongly-typed
+# schema (crates/pm/src/service/binary.rs). The whole map deserializes as one
+# unit, so a single drifted entry fails the parse and silently disables the
+# China mirror layer for every package — `get_envs()`/`update_package_binary()`
+# swallow the error as a debug log. (`flow-bin` ships `replaceHost` as a bare
+# string, not an array, which previously broke the parse.)
+#
+# Guard against upstream drift: install against a non-npm registry (npm.org has
+# no mirror layer and is skipped) with --verbose, then assert the config loaded
+# and did NOT fail to parse. flow-bin is the dep on purpose — it is the exact
+# entry that regressed.
+echo -e "${YELLOW}Case: latest binary-mirror-config parses under our schema${NC}"
+BMC_DIR=$(mktemp -d)
+cat > "$BMC_DIR/package.json" << 'EOF'
+{
+  "name": "binary-mirror-config-parse-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "flow-bin": "0.180.0"
+  }
+}
+EOF
+pushd "$BMC_DIR"
+# --ignore-scripts keeps this fast (no native binary download); the mirror
+# config is loaded on the clone path regardless of script execution.
+utoo install --registry=https://registry.npmmirror.com --ignore-scripts --verbose 2>&1 \
+  | tee bmc.out \
+  || { echo -e "${RED}FAIL: utoo install failed for binary-mirror-config parse test${NC}"; cat bmc.out; exit 1; }
+if grep -q "Failed to parse binary mirror config" bmc.out; then
+    echo -e "${RED}FAIL: latest binary-mirror-config no longer matches our schema (mirrors.china drift)${NC}"
+    grep "binary mirror" bmc.out
+    exit 1
+fi
+if ! grep -q "Binary mirror config loaded:" bmc.out; then
+    echo -e "${RED}FAIL: binary-mirror-config was never parsed (registry unreachable or mirror layer skipped)${NC}"
+    cat bmc.out
+    exit 1
+fi
+rm -f bmc.out
+popd
+rm -rf "$BMC_DIR"
+echo -e "${GREEN}PASS: latest binary-mirror-config parses cleanly${NC}"
+
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"


### PR DESCRIPTION
## Problem

`binary-mirror-config`'s `mirrors.china` map is parsed as **one unit** into a strongly-typed schema (`crates/pm/src/service/binary.rs`). A single entry whose shape drifts from the schema fails the *whole* parse — and `get_envs()` / `update_package_binary()` swallow that failure as a debug log, **silently disabling the entire China mirror layer** (ENVS injection + per-package binary host rewrite) for every package.

The latest upstream config trips exactly this: `flow-bin` ships

```json
"flow-bin": { "replaceHost": "https://github.com/facebook/flow/releases/download/v", "host": "..." }
```

`replaceHost` is a **bare string**, but the field is typed `Option<Vec<String>>`, so deserialization rejects it. Consequence on any non-npm registry (npmmirror / antgroup …): mirror ENVS never get injected and native-binary packages (sharp, node-sass, node-pre-gyp/prebuild consumers) fall back to their original, often-blocked download hosts → install-script failures that surface as "依赖安装失败".

> npm's own registry path is unaffected — it's skipped via `should_skip_binary_mirror()`, which is why plain `binary-mirror-config` installs against npm.org looked fine.

## Fix

- Accept `replaceHost` in **either** shape (single string or array), normalizing to `Vec<String>` — matches cnpm semantics.
- Add a success debug log (`Binary mirror config loaded: N china package entries`) so the layer going dark is observable; previously only the swallowed failure path logged.

## Tests

- Unit: `replaceHost` string/array/absent normalization, plus a full `mirrors.china` parse with the real `flow-bin` string-form entry.
- e2e (bash + pwsh): install `flow-bin` against a non-npm registry with `--verbose`, assert the config loaded and did **not** fail to parse — guards against future upstream schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)