### PR TITLE
fix(pm): resolve override targets by protocol, not just registry

### DIFF
--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -496,6 +496,7 @@ pub async fn process_dependency<R: ManifestProvider>(
                 node_index,
                 edge_info,
                 &resolved.version,
+                config,
                 None,
             )
             .await?
@@ -532,6 +533,7 @@ pub(crate) async fn resolve_override<R: ManifestProvider>(
     parent: NodeIndex,
     edge: &DependencyEdgeInfo,
     resolved_version: &str,
+    config: &BuildDepsConfig,
     mut state: Option<&mut ManifestState>,
 ) -> Result<Option<Arc<CoreVersionManifest>>, ResolveError<R::Error>> {
     let Some(override_spec) = graph.check_override(parent, &edge.name, Some(resolved_version))
@@ -552,18 +554,191 @@ pub(crate) async fn resolve_override<R: ManifestProvider>(
         resolved_version,
         override_spec
     );
-    match resolve_registry_dep(registry, &edge.name, &override_spec, &edge.edge_type).await? {
-        Some(overridden) => {
+
+    match resolve_override_spec(
+        graph,
+        registry,
+        &edge.name,
+        &override_spec,
+        &edge.edge_type,
+        config,
+    )
+    .await?
+    {
+        Some(manifest) => {
             if let Some(state) = state {
-                state.cache_version(
-                    edge.name.clone(),
-                    override_spec,
-                    Arc::clone(&overridden.manifest),
-                );
+                state.cache_version(edge.name.clone(), override_spec, Arc::clone(&manifest));
             }
-            Ok(Some(overridden.manifest))
+            Ok(Some(manifest))
         }
         None => Ok(None),
+    }
+}
+
+/// Resolve an override *target* spec to a manifest, routing by protocol exactly
+/// like a normal dependency spec ([`process_dependency`]). An override value may
+/// be any spec npm accepts — a registry range, a `file:` tarball, an http(s)
+/// tarball, or a git URL — not just a registry version. The previous
+/// registry-only resolution turned `file:x.tgz` / URL overrides into bogus
+/// registry version lookups (→ 404), silently aborting the whole install.
+///
+/// Returns `Ok(None)` when an optional edge's override fails to resolve (npm
+/// falls back to the original resolution); `Err` for a load-bearing failure.
+/// All supported protocols yield a manifest that the caller places like any
+/// registry node — a `file:`/http tarball manifest carries a pinned
+/// `dist.tarball`, materialized into `node_modules` at install time.
+async fn resolve_override_spec<R: ManifestProvider>(
+    graph: &DependencyGraph,
+    registry: &R,
+    name: &str,
+    override_spec: &str,
+    edge_type: &EdgeType,
+    config: &BuildDepsConfig,
+) -> Result<Option<Arc<CoreVersionManifest>>, ResolveError<R::Error>> {
+    // Optional-edge failures fall back to the original resolution; load-bearing
+    // failures surface the wrapped cause.
+    fn optional_or_err<E>(
+        edge_type: &EdgeType,
+        name: &str,
+        spec: &str,
+        kind: &str,
+        wrap: impl FnOnce(anyhow::Error) -> ResolveError<E>,
+        err: anyhow::Error,
+    ) -> Result<Option<Arc<CoreVersionManifest>>, ResolveError<E>> {
+        if *edge_type == EdgeType::Optional {
+            tracing::debug!("Skipping optional {kind} override {name}@{spec}: {err}");
+            Ok(None)
+        } else {
+            Err(wrap(err))
+        }
+    }
+
+    let parsed = PackageSpec::from(override_spec);
+    match &parsed {
+        // `parsed` only selects the resolver; the registry path keeps receiving
+        // the raw `override_spec` so `npm:` alias / dist-tag / range handling is
+        // identical to the normal registry route.
+        PackageSpec::Registry { .. } => {
+            Ok(
+                resolve_registry_dep(registry, name, override_spec, edge_type)
+                    .await?
+                    .map(|r| r.manifest),
+            )
+        }
+        PackageSpec::Http { url } => match resolve_http_dep(url, &config.http_fetch_cache).await {
+            Ok(r) => Ok(Some(r.manifest)),
+            Err(e) => optional_or_err(
+                edge_type,
+                name,
+                override_spec,
+                "HTTP",
+                |source| ResolveError::Http {
+                    url: url.clone(),
+                    source,
+                },
+                e,
+            ),
+        },
+        PackageSpec::Git { .. } | PackageSpec::GitHub { .. } => {
+            match resolve_git_dep(
+                config.cache_dir.as_deref(),
+                &parsed,
+                name,
+                &config.git_clone_cache,
+            )
+            .await
+            {
+                Ok(r) => Ok(Some(r.manifest)),
+                Err(e) => optional_or_err(
+                    edge_type,
+                    name,
+                    override_spec,
+                    "git",
+                    |source| ResolveError::Git {
+                        url: override_spec.to_string(),
+                        source,
+                    },
+                    e,
+                ),
+            }
+        }
+        PackageSpec::Local {
+            protocol: Protocol::File,
+            path,
+        } => resolve_override_file_tarball(graph, edge_type, override_spec, path).await,
+        PackageSpec::Local { .. } => Err(ResolveError::Unsupported {
+            spec: override_spec.to_string(),
+            reason: "link:/portal:/workspace: overrides are not supported",
+        }),
+    }
+}
+
+/// Resolve a `file:` override target. Overrides are declared in the root
+/// package.json, so the path is resolved relative to the root project dir (not
+/// the overridden edge's parent). A tarball is parsed into a manifest with a
+/// pinned `file:<abs>` tarball; a directory would need a symlink (Link) node,
+/// which the override path can't place, so it is an explicit error rather than
+/// a misleading registry lookup.
+async fn resolve_override_file_tarball<E>(
+    graph: &DependencyGraph,
+    edge_type: &EdgeType,
+    override_spec: &str,
+    path: &str,
+) -> Result<Option<Arc<CoreVersionManifest>>, ResolveError<E>> {
+    #[cfg(not(feature = "http-tarball"))]
+    {
+        let _ = (graph, edge_type, path);
+        Err(ResolveError::Unsupported {
+            spec: override_spec.to_string(),
+            reason: "file: overrides require the 'http-tarball' feature",
+        })
+    }
+    #[cfg(feature = "http-tarball")]
+    {
+        let file_err = |source: anyhow::Error| ResolveError::File {
+            spec: override_spec.to_string(),
+            source,
+        };
+        let base = graph
+            .get_node(graph.root_index)
+            .map(|n| n.path.clone())
+            .ok_or_else(|| ResolveError::Unsupported {
+                spec: override_spec.to_string(),
+                reason: "root project directory unavailable for file: override",
+            })?;
+        let abs = base.join(path);
+
+        let meta = match std::fs::metadata(&abs) {
+            Ok(m) => m,
+            Err(_) if *edge_type == EdgeType::Optional => return Ok(None),
+            Err(e) => {
+                return Err(file_err(
+                    anyhow::Error::new(e)
+                        .context(format!("file: override target {}", abs.display())),
+                ));
+            }
+        };
+        if meta.is_dir() {
+            return Err(ResolveError::Unsupported {
+                spec: override_spec.to_string(),
+                reason: "file: directory overrides (symlink) are not supported — use a tarball (.tgz)",
+            });
+        }
+
+        let pinned = format!("file:{}", abs.display());
+        let manifest = match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let bytes = std::fs::read(&abs)
+                .map_err(|e| anyhow::anyhow!("failed to read tarball {}: {e}", abs.display()))?;
+            crate::resolver::tar::parse_tarball_manifest(&bytes, pinned)
+        })
+        .await
+        {
+            Ok(Ok(m)) => m,
+            Ok(Err(_)) | Err(_) if *edge_type == EdgeType::Optional => return Ok(None),
+            Ok(Err(source)) => return Err(file_err(source)),
+            Err(join) => return Err(file_err(join.into())),
+        };
+        Ok(Some(Arc::new(manifest)))
     }
 }
 

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -302,23 +302,25 @@ pub enum ProcessResult {
 /// Shared optional-edge policy for the non-registry resolvers (git/http): a
 /// failed optional edge logs and resolves to `Skipped`; a load-bearing one
 /// returns the spec-specific error built by `wrap`.
-/// Optional-edge resolution failures degrade to `Ok(None)` (the caller skips
-/// or falls back to its original resolution); load-bearing failures surface the
-/// wrapped cause. Shared by [`resolve_remote_spec`] across the normal and
-/// override paths.
-fn optional_or_err<E>(
+/// Collapse a non-registry resolver's result: success → `Some`; an *optional*
+/// edge's failure → `None` (caller skips / falls back); a load-bearing failure
+/// → the wrapped cause. Lets [`resolve_remote_spec`] keep each protocol arm to a
+/// single expression.
+fn resolve_or_skip<E>(
+    result: anyhow::Result<ResolvedPackage>,
     edge_type: &EdgeType,
     name: &str,
     spec: &str,
     kind: &str,
     wrap: impl FnOnce(anyhow::Error) -> ResolveError<E>,
-    err: anyhow::Error,
 ) -> Result<Option<ResolvedPackage>, ResolveError<E>> {
-    if *edge_type == EdgeType::Optional {
-        tracing::debug!("Skipping optional {kind} dependency {name}@{spec}: {err}");
-        Ok(None)
-    } else {
-        Err(wrap(err))
+    match result {
+        Ok(pkg) => Ok(Some(pkg)),
+        Err(e) if *edge_type == EdgeType::Optional => {
+            tracing::debug!("Skipping optional {kind} dependency {name}@{spec}: {e}");
+            Ok(None)
+        }
+        Err(e) => Err(wrap(e)),
     }
 }
 
@@ -514,43 +516,34 @@ async fn resolve_remote_spec<R: ManifestProvider>(
         PackageSpec::Registry { .. } => {
             resolve_registry_dep(registry, name, raw_spec, edge_type).await
         }
-        PackageSpec::Http { url } => match resolve_http_dep(url, &config.http_fetch_cache).await {
-            Ok(r) => Ok(Some(r)),
-            Err(e) => optional_or_err(
-                edge_type,
-                name,
-                raw_spec,
-                "HTTP",
-                |source| ResolveError::Http {
-                    url: url.clone(),
-                    source,
-                },
-                e,
-            ),
-        },
-        PackageSpec::Git { .. } | PackageSpec::GitHub { .. } => {
-            match resolve_git_dep(
+        PackageSpec::Http { url } => resolve_or_skip(
+            resolve_http_dep(url, &config.http_fetch_cache).await,
+            edge_type,
+            name,
+            raw_spec,
+            "HTTP",
+            |source| ResolveError::Http {
+                url: url.clone(),
+                source,
+            },
+        ),
+        PackageSpec::Git { .. } | PackageSpec::GitHub { .. } => resolve_or_skip(
+            resolve_git_dep(
                 config.cache_dir.as_deref(),
                 parsed,
                 name,
                 &config.git_clone_cache,
             )
-            .await
-            {
-                Ok(r) => Ok(Some(r)),
-                Err(e) => optional_or_err(
-                    edge_type,
-                    name,
-                    raw_spec,
-                    "git",
-                    |source| ResolveError::Git {
-                        url: raw_spec.to_string(),
-                        source,
-                    },
-                    e,
-                ),
-            }
-        }
+            .await,
+            edge_type,
+            name,
+            raw_spec,
+            "git",
+            |source| ResolveError::Git {
+                url: raw_spec.to_string(),
+                source,
+            },
+        ),
         // Callers route file:/link:/workspace:/catalog: elsewhere; reaching here
         // is an internal routing bug, not a user error.
         PackageSpec::Local { .. } => Err(ResolveError::Unsupported {
@@ -561,23 +554,16 @@ async fn resolve_remote_spec<R: ManifestProvider>(
 }
 
 /// Resolve a dependency override for `edge` against the already-resolved
-/// version, routing the override *target* by protocol just like a normal
-/// dependency spec. An override value may be any spec npm accepts — a registry
-/// range, a `file:` tarball, an http(s) tarball, or a git URL — not just a
-/// registry version (resolving everything as a registry version turned
-/// `file:x.tgz` overrides into bogus 404s). Shared by the demand driver and the
-/// sequential path in [`process_dependency`].
+/// version, routing the override *target* by protocol like a normal dependency
+/// spec (registry range / `file:` tarball / http(s) tarball / git — not just a
+/// registry version, which used to turn `file:x.tgz` overrides into bogus 404s).
+/// Shared by the demand driver and [`process_dependency`].
 ///
-/// Always yields a *manifest* (or `None` to fall back), so callers place the
-/// override result exactly like any registry node and stay agnostic of which
-/// protocol produced it — a `file:`/http tarball manifest just carries a pinned
-/// `dist.tarball`, materialized at install time. `file:` *directory* overrides
-/// (which would need a self-placed Link node) are an explicit error rather than
-/// leaking placement concerns into the resolver's callers.
-///
-/// With `state`, the per-run manifest cache is consulted and populated so
-/// sibling edges single-flight the override and the overridden manifest
-/// persists to the project cache.
+/// Always yields a *manifest* (or `None` to fall back to the original), so the
+/// callers place it like any registry node and stay agnostic of the protocol.
+/// `file:` *directory* overrides would need a self-placed Link node the manifest
+/// contract can't carry, so they are an explicit error. With `state`, the
+/// per-run manifest cache single-flights the override across sibling edges.
 pub(crate) async fn resolve_override<R: ManifestProvider>(
     graph: &DependencyGraph,
     registry: &R,
@@ -607,25 +593,16 @@ pub(crate) async fn resolve_override<R: ManifestProvider>(
     );
 
     let parsed = PackageSpec::from(override_spec.as_str());
-    let manifest = match &parsed {
+    let resolved = match &parsed {
         // `file:` overrides resolve relative to the ROOT project (overrides are
-        // root-declared, and a transitive parent is usually a registry node with
-        // no `file:` base). Optional file: override missing → fall back.
+        // root-declared; a transitive parent is usually a registry node with no
+        // `file:` base).
         PackageSpec::Local {
             protocol: Protocol::File,
             path,
         } => {
-            match resolve_override_file_tarball::<R::Error>(
-                graph,
-                &edge.edge_type,
-                &override_spec,
-                path,
-            )
-            .await?
-            {
-                Some(manifest) => manifest,
-                None => return Ok(None),
-            }
+            resolve_override_file_tarball::<R::Error>(graph, &edge.edge_type, &override_spec, path)
+                .await?
         }
         PackageSpec::Local { .. } => {
             return Err(ResolveError::Unsupported {
@@ -634,7 +611,7 @@ pub(crate) async fn resolve_override<R: ManifestProvider>(
             });
         }
         // registry / http / git share the normal-dependency resolver.
-        _ => match resolve_remote_spec(
+        _ => resolve_remote_spec(
             registry,
             &parsed,
             &override_spec,
@@ -643,26 +620,23 @@ pub(crate) async fn resolve_override<R: ManifestProvider>(
             config,
         )
         .await?
-        {
-            Some(pkg) => pkg.manifest,
-            None => return Ok(None),
-        },
+        .map(|pkg| pkg.manifest),
     };
 
+    // Optional edge whose override failed to resolve → fall back to the original.
+    let Some(manifest) = resolved else {
+        return Ok(None);
+    };
     if let Some(state) = state {
         state.cache_version(edge.name.clone(), override_spec, Arc::clone(&manifest));
     }
     Ok(Some(manifest))
 }
 
-/// Resolve a `file:` override target to a manifest. Overrides are declared in
-/// the root package.json, so the path is resolved relative to the root project
-/// dir (not the overridden edge's parent). A tarball is parsed into a manifest
-/// with a pinned `file:<abs>` tarball (materialized at install time); a
-/// directory would need a self-placed Link node, which the manifest-returning
-/// override contract can't express, so it is an explicit error rather than a
-/// misleading registry lookup. Read-only — no graph mutation — so the resolver
-/// stays decoupled from placement.
+/// Resolve a `file:` override target to a manifest, relative to the root project
+/// (overrides are root-declared). A tarball → manifest pinned to `file:<abs>`; a
+/// directory → error (it would need a Link node the manifest contract can't
+/// carry). Read-only, so the resolver stays decoupled from placement.
 async fn resolve_override_file_tarball<E>(
     graph: &DependencyGraph,
     edge_type: &EdgeType,

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -653,43 +653,33 @@ async fn resolve_override_file_tarball<E>(
     }
     #[cfg(feature = "http-tarball")]
     {
-        let file_err = |source: anyhow::Error| ResolveError::File {
+        let file_err = |source| ResolveError::File {
             spec: override_spec.to_string(),
             source,
         };
-        let base = graph
+        // The root node is a construction-time invariant; resolve the override's
+        // path against it (overrides are root-declared).
+        let abs = graph
             .get_node(graph.root_index)
-            .map(|n| n.path.clone())
-            .ok_or_else(|| ResolveError::Unsupported {
-                spec: override_spec.to_string(),
-                reason: "root project directory unavailable for file: override",
-            })?;
-        let abs = base.join(path);
-
-        let meta = match std::fs::metadata(&abs) {
-            Ok(m) => m,
-            Err(_) if *edge_type == EdgeType::Optional => return Ok(None),
-            Err(e) => {
-                return Err(file_err(
-                    anyhow::Error::new(e)
-                        .context(format!("file: override target {}", abs.display())),
-                ));
-            }
-        };
-        if meta.is_dir() {
-            return Err(ResolveError::Unsupported {
+            .expect("root node is always present")
+            .path
+            .join(path);
+        match std::fs::metadata(&abs) {
+            Ok(m) if m.is_dir() => Err(ResolveError::Unsupported {
                 spec: override_spec.to_string(),
                 reason: "file: directory overrides (symlink) are not supported — use a tarball (.tgz)",
-            });
+            }),
+            // Same local-tarball read+parse the normal file-dep resolver uses.
+            Ok(_) => match crate::resolver::tar::read_local_tarball_manifest(abs).await {
+                Ok(m) => Ok(Some(Arc::new(m))),
+                Err(_) if *edge_type == EdgeType::Optional => Ok(None),
+                Err(source) => Err(file_err(source)),
+            },
+            Err(_) if *edge_type == EdgeType::Optional => Ok(None),
+            Err(e) => Err(file_err(
+                anyhow::Error::new(e).context(format!("file: override target {}", abs.display())),
+            )),
         }
-
-        // Same local-tarball read+parse the normal file-dep resolver uses.
-        let manifest = match crate::resolver::tar::read_local_tarball_manifest(abs).await {
-            Ok(m) => m,
-            Err(_) if *edge_type == EdgeType::Optional => return Ok(None),
-            Err(source) => return Err(file_err(source)),
-        };
-        Ok(Some(Arc::new(manifest)))
     }
 }
 

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -709,18 +709,11 @@ async fn resolve_override_file_tarball<E>(
             });
         }
 
-        let pinned = format!("file:{}", abs.display());
-        let manifest = match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-            let bytes = std::fs::read(&abs)
-                .map_err(|e| anyhow::anyhow!("failed to read tarball {}: {e}", abs.display()))?;
-            crate::resolver::tar::parse_tarball_manifest(&bytes, pinned)
-        })
-        .await
-        {
-            Ok(Ok(m)) => m,
-            Ok(Err(_)) | Err(_) if *edge_type == EdgeType::Optional => return Ok(None),
-            Ok(Err(source)) => return Err(file_err(source)),
-            Err(join) => return Err(file_err(join.into())),
+        // Same local-tarball read+parse the normal file-dep resolver uses.
+        let manifest = match crate::resolver::tar::read_local_tarball_manifest(abs).await {
+            Ok(m) => m,
+            Err(_) if *edge_type == EdgeType::Optional => return Ok(None),
+            Err(source) => return Err(file_err(source)),
         };
         Ok(Some(Arc::new(manifest)))
     }

--- a/crates/ruborist/src/resolver/builder.rs
+++ b/crates/ruborist/src/resolver/builder.rs
@@ -302,19 +302,21 @@ pub enum ProcessResult {
 /// Shared optional-edge policy for the non-registry resolvers (git/http): a
 /// failed optional edge logs and resolves to `Skipped`; a load-bearing one
 /// returns the spec-specific error built by `wrap`.
-fn absorb_optional_failure<E>(
-    edge: &DependencyEdgeInfo,
+/// Optional-edge resolution failures degrade to `Ok(None)` (the caller skips
+/// or falls back to its original resolution); load-bearing failures surface the
+/// wrapped cause. Shared by [`resolve_remote_spec`] across the normal and
+/// override paths.
+fn optional_or_err<E>(
+    edge_type: &EdgeType,
+    name: &str,
+    spec: &str,
     kind: &str,
-    err: anyhow::Error,
     wrap: impl FnOnce(anyhow::Error) -> ResolveError<E>,
-) -> Result<ProcessResult, ResolveError<E>> {
-    if edge.edge_type == EdgeType::Optional {
-        tracing::debug!(
-            "Skipped optional {kind} dependency {}@{}",
-            edge.name,
-            edge.spec
-        );
-        Ok(ProcessResult::Skipped)
+    err: anyhow::Error,
+) -> Result<Option<ResolvedPackage>, ResolveError<E>> {
+    if *edge_type == EdgeType::Optional {
+        tracing::debug!("Skipping optional {kind} dependency {name}@{spec}: {err}");
+        Ok(None)
     } else {
         Err(wrap(err))
     }
@@ -363,31 +365,6 @@ pub async fn process_dependency<R: ManifestProvider>(
             // new PackageSpec variant — no silent fall-through to the wrong resolver.
             let parsed_spec = PackageSpec::from(edge_info.spec.as_str());
             let resolved: ResolvedPackage = match &parsed_spec {
-                PackageSpec::Git { .. } | PackageSpec::GitHub { .. } => {
-                    // TODO: add spec => version expiry check so stale git caches
-                    // are invalidated (e.g. branch refs that have moved forward).
-                    match resolve_git_dep(
-                        config.cache_dir.as_deref(),
-                        &parsed_spec,
-                        &edge_info.name,
-                        &config.git_clone_cache,
-                    )
-                    .await
-                    {
-                        Ok(r) => r,
-                        Err(e) => {
-                            return absorb_optional_failure(
-                                edge_info,
-                                "non-registry",
-                                e,
-                                |source| ResolveError::Git {
-                                    url: edge_info.spec.clone(),
-                                    source,
-                                },
-                            );
-                        }
-                    }
-                }
                 PackageSpec::Local {
                     protocol: Protocol::Workspace,
                     ..
@@ -453,25 +430,21 @@ pub async fn process_dependency<R: ManifestProvider>(
                         reason: "local (link:/portal:) dependencies are not yet supported",
                     });
                 }
-                PackageSpec::Http { url } => {
-                    match resolve_http_dep(url, &config.http_fetch_cache).await {
-                        Ok(r) => r,
-                        Err(e) => {
-                            return absorb_optional_failure(edge_info, "HTTP", e, |source| {
-                                ResolveError::Http {
-                                    url: url.clone(),
-                                    source,
-                                }
-                            });
-                        }
-                    }
-                }
-                PackageSpec::Registry { .. } => {
-                    match resolve_registry_dep(
+                // All remote protocols share one resolver — see
+                // [`resolve_remote_spec`]. The exhaustive listing (no `_`) keeps
+                // a new PackageSpec variant a compile error rather than silently
+                // routing it to the wrong resolver.
+                PackageSpec::Registry { .. }
+                | PackageSpec::Http { .. }
+                | PackageSpec::Git { .. }
+                | PackageSpec::GitHub { .. } => {
+                    match resolve_remote_spec(
                         registry,
-                        &edge_info.name,
+                        &parsed_spec,
                         &edge_info.spec,
+                        &edge_info.name,
                         &edge_info.edge_type,
+                        config,
                     )
                     .await?
                     {
@@ -488,7 +461,8 @@ pub async fn process_dependency<R: ManifestProvider>(
                 }
             };
 
-            // Check override using resolved version (not original spec).
+            // Apply any override against the resolved version (not the original
+            // spec). Non-registry override targets resolve here too.
             // No manifest cache on this path — non-registry specs are rare.
             let resolved = match resolve_override(
                 graph,
@@ -516,13 +490,90 @@ pub async fn process_dependency<R: ManifestProvider>(
     }
 }
 
-/// Resolve a dependency override for `edge` against the already-resolved
-/// version. Single implementation shared by the demand driver and the
-/// non-registry/sequential-fallback path in [`process_dependency`].
+/// Resolve a registry / git / http(s) spec to a package, mirroring the protocol
+/// dispatch in [`process_dependency`]. `None` means an *optional* edge's
+/// resolution failed and the caller should skip / fall back. Shared by the
+/// normal dependency path and override resolution so both treat these protocols
+/// identically.
 ///
-/// Returns `Some(manifest)` when an override rule matched and resolved, and
-/// `None` when no rule applies or the override failed to resolve — npm
-/// semantics fall back to the original resolution rather than erroring.
+/// `file:` is intentionally excluded: its base dir (the edge's parent for a
+/// normal dep, the root project for an override) and its dir→Link placement
+/// differ between the two callers, so each routes `file:` through
+/// [`process_file_dep`] with its own `node_index`.
+async fn resolve_remote_spec<R: ManifestProvider>(
+    registry: &R,
+    parsed: &PackageSpec,
+    raw_spec: &str,
+    name: &str,
+    edge_type: &EdgeType,
+    config: &BuildDepsConfig,
+) -> Result<Option<ResolvedPackage>, ResolveError<R::Error>> {
+    match parsed {
+        // The registry path keeps receiving the raw spec so `npm:` alias /
+        // dist-tag / range handling is identical regardless of caller.
+        PackageSpec::Registry { .. } => {
+            resolve_registry_dep(registry, name, raw_spec, edge_type).await
+        }
+        PackageSpec::Http { url } => match resolve_http_dep(url, &config.http_fetch_cache).await {
+            Ok(r) => Ok(Some(r)),
+            Err(e) => optional_or_err(
+                edge_type,
+                name,
+                raw_spec,
+                "HTTP",
+                |source| ResolveError::Http {
+                    url: url.clone(),
+                    source,
+                },
+                e,
+            ),
+        },
+        PackageSpec::Git { .. } | PackageSpec::GitHub { .. } => {
+            match resolve_git_dep(
+                config.cache_dir.as_deref(),
+                parsed,
+                name,
+                &config.git_clone_cache,
+            )
+            .await
+            {
+                Ok(r) => Ok(Some(r)),
+                Err(e) => optional_or_err(
+                    edge_type,
+                    name,
+                    raw_spec,
+                    "git",
+                    |source| ResolveError::Git {
+                        url: raw_spec.to_string(),
+                        source,
+                    },
+                    e,
+                ),
+            }
+        }
+        // Callers route file:/link:/workspace:/catalog: elsewhere; reaching here
+        // is an internal routing bug, not a user error.
+        PackageSpec::Local { .. } => Err(ResolveError::Unsupported {
+            spec: raw_spec.to_string(),
+            reason: "internal: resolve_remote_spec received a non-remote spec",
+        }),
+    }
+}
+
+/// Resolve a dependency override for `edge` against the already-resolved
+/// version, routing the override *target* by protocol just like a normal
+/// dependency spec. An override value may be any spec npm accepts — a registry
+/// range, a `file:` tarball, an http(s) tarball, or a git URL — not just a
+/// registry version (resolving everything as a registry version turned
+/// `file:x.tgz` overrides into bogus 404s). Shared by the demand driver and the
+/// sequential path in [`process_dependency`].
+///
+/// Always yields a *manifest* (or `None` to fall back), so callers place the
+/// override result exactly like any registry node and stay agnostic of which
+/// protocol produced it — a `file:`/http tarball manifest just carries a pinned
+/// `dist.tarball`, materialized at install time. `file:` *directory* overrides
+/// (which would need a self-placed Link node) are an explicit error rather than
+/// leaking placement concerns into the resolver's callers.
 ///
 /// With `state`, the per-run manifest cache is consulted and populated so
 /// sibling edges single-flight the override and the overridden manifest
@@ -555,130 +606,63 @@ pub(crate) async fn resolve_override<R: ManifestProvider>(
         override_spec
     );
 
-    match resolve_override_spec(
-        graph,
-        registry,
-        &edge.name,
-        &override_spec,
-        &edge.edge_type,
-        config,
-    )
-    .await?
-    {
-        Some(manifest) => {
-            if let Some(state) = state {
-                state.cache_version(edge.name.clone(), override_spec, Arc::clone(&manifest));
-            }
-            Ok(Some(manifest))
-        }
-        None => Ok(None),
-    }
-}
-
-/// Resolve an override *target* spec to a manifest, routing by protocol exactly
-/// like a normal dependency spec ([`process_dependency`]). An override value may
-/// be any spec npm accepts — a registry range, a `file:` tarball, an http(s)
-/// tarball, or a git URL — not just a registry version. The previous
-/// registry-only resolution turned `file:x.tgz` / URL overrides into bogus
-/// registry version lookups (→ 404), silently aborting the whole install.
-///
-/// Returns `Ok(None)` when an optional edge's override fails to resolve (npm
-/// falls back to the original resolution); `Err` for a load-bearing failure.
-/// All supported protocols yield a manifest that the caller places like any
-/// registry node — a `file:`/http tarball manifest carries a pinned
-/// `dist.tarball`, materialized into `node_modules` at install time.
-async fn resolve_override_spec<R: ManifestProvider>(
-    graph: &DependencyGraph,
-    registry: &R,
-    name: &str,
-    override_spec: &str,
-    edge_type: &EdgeType,
-    config: &BuildDepsConfig,
-) -> Result<Option<Arc<CoreVersionManifest>>, ResolveError<R::Error>> {
-    // Optional-edge failures fall back to the original resolution; load-bearing
-    // failures surface the wrapped cause.
-    fn optional_or_err<E>(
-        edge_type: &EdgeType,
-        name: &str,
-        spec: &str,
-        kind: &str,
-        wrap: impl FnOnce(anyhow::Error) -> ResolveError<E>,
-        err: anyhow::Error,
-    ) -> Result<Option<Arc<CoreVersionManifest>>, ResolveError<E>> {
-        if *edge_type == EdgeType::Optional {
-            tracing::debug!("Skipping optional {kind} override {name}@{spec}: {err}");
-            Ok(None)
-        } else {
-            Err(wrap(err))
-        }
-    }
-
-    let parsed = PackageSpec::from(override_spec);
-    match &parsed {
-        // `parsed` only selects the resolver; the registry path keeps receiving
-        // the raw `override_spec` so `npm:` alias / dist-tag / range handling is
-        // identical to the normal registry route.
-        PackageSpec::Registry { .. } => {
-            Ok(
-                resolve_registry_dep(registry, name, override_spec, edge_type)
-                    .await?
-                    .map(|r| r.manifest),
-            )
-        }
-        PackageSpec::Http { url } => match resolve_http_dep(url, &config.http_fetch_cache).await {
-            Ok(r) => Ok(Some(r.manifest)),
-            Err(e) => optional_or_err(
-                edge_type,
-                name,
-                override_spec,
-                "HTTP",
-                |source| ResolveError::Http {
-                    url: url.clone(),
-                    source,
-                },
-                e,
-            ),
-        },
-        PackageSpec::Git { .. } | PackageSpec::GitHub { .. } => {
-            match resolve_git_dep(
-                config.cache_dir.as_deref(),
-                &parsed,
-                name,
-                &config.git_clone_cache,
-            )
-            .await
-            {
-                Ok(r) => Ok(Some(r.manifest)),
-                Err(e) => optional_or_err(
-                    edge_type,
-                    name,
-                    override_spec,
-                    "git",
-                    |source| ResolveError::Git {
-                        url: override_spec.to_string(),
-                        source,
-                    },
-                    e,
-                ),
-            }
-        }
+    let parsed = PackageSpec::from(override_spec.as_str());
+    let manifest = match &parsed {
+        // `file:` overrides resolve relative to the ROOT project (overrides are
+        // root-declared, and a transitive parent is usually a registry node with
+        // no `file:` base). Optional file: override missing → fall back.
         PackageSpec::Local {
             protocol: Protocol::File,
             path,
-        } => resolve_override_file_tarball(graph, edge_type, override_spec, path).await,
-        PackageSpec::Local { .. } => Err(ResolveError::Unsupported {
-            spec: override_spec.to_string(),
-            reason: "link:/portal:/workspace: overrides are not supported",
-        }),
+        } => {
+            match resolve_override_file_tarball::<R::Error>(
+                graph,
+                &edge.edge_type,
+                &override_spec,
+                path,
+            )
+            .await?
+            {
+                Some(manifest) => manifest,
+                None => return Ok(None),
+            }
+        }
+        PackageSpec::Local { .. } => {
+            return Err(ResolveError::Unsupported {
+                spec: override_spec,
+                reason: "link:/portal:/workspace: overrides are not supported",
+            });
+        }
+        // registry / http / git share the normal-dependency resolver.
+        _ => match resolve_remote_spec(
+            registry,
+            &parsed,
+            &override_spec,
+            &edge.name,
+            &edge.edge_type,
+            config,
+        )
+        .await?
+        {
+            Some(pkg) => pkg.manifest,
+            None => return Ok(None),
+        },
+    };
+
+    if let Some(state) = state {
+        state.cache_version(edge.name.clone(), override_spec, Arc::clone(&manifest));
     }
+    Ok(Some(manifest))
 }
 
-/// Resolve a `file:` override target. Overrides are declared in the root
-/// package.json, so the path is resolved relative to the root project dir (not
-/// the overridden edge's parent). A tarball is parsed into a manifest with a
-/// pinned `file:<abs>` tarball; a directory would need a symlink (Link) node,
-/// which the override path can't place, so it is an explicit error rather than
-/// a misleading registry lookup.
+/// Resolve a `file:` override target to a manifest. Overrides are declared in
+/// the root package.json, so the path is resolved relative to the root project
+/// dir (not the overridden edge's parent). A tarball is parsed into a manifest
+/// with a pinned `file:<abs>` tarball (materialized at install time); a
+/// directory would need a self-placed Link node, which the manifest-returning
+/// override contract can't express, so it is an explicit error rather than a
+/// misleading registry lookup. Read-only — no graph mutation — so the resolver
+/// stays decoupled from placement.
 async fn resolve_override_file_tarball<E>(
     graph: &DependencyGraph,
     edge_type: &EdgeType,

--- a/crates/ruborist/src/resolver/demand/driver.rs
+++ b/crates/ruborist/src/resolver/demand/driver.rs
@@ -245,6 +245,7 @@ where
             parent,
             edge,
             &manifest.version,
+            self.config,
             Some(state),
         )
         .await

--- a/crates/ruborist/src/resolver/file.rs
+++ b/crates/ruborist/src/resolver/file.rs
@@ -9,12 +9,11 @@ use std::ops::ControlFlow;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::Context as _;
 use petgraph::graph::NodeIndex;
 
 use super::builder::ProcessResult;
 use super::edges::DependencyEdgeInfo;
-use super::tar::parse_tarball_manifest;
+use super::tar::read_local_tarball_manifest;
 use crate::model::graph::{DependencyGraph, PackageNode};
 use crate::model::manifest::NodeManifest;
 use crate::model::node::EdgeType;
@@ -23,7 +22,7 @@ use crate::traits::registry::ResolvedPackage;
 
 /// Handle a `file:` dep: dir → Link node inline (returns
 /// `ControlFlow::Break`); tarball → read the local bytes, parse the manifest
-/// via [`parse_tarball_manifest`] (no global cache), and hand the
+/// via [`read_local_tarball_manifest`] (no global cache), and hand the
 /// `ResolvedPackage` back to the normal BFS flow via `ControlFlow::Continue`.
 /// The tarball content is materialized into `node_modules` at install time.
 #[cfg(feature = "http-tarball")]
@@ -84,20 +83,12 @@ pub(crate) async fn process_file_dep<E>(
         return Ok(ControlFlow::Break(ProcessResult::Created(idx)));
     }
 
-    let pinned = format!("file:{}", abs.display());
-    let manifest = match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-        let bytes = std::fs::read(&abs)
-            .with_context(|| format!("failed to read tarball {}", abs.display()))?;
-        parse_tarball_manifest(&bytes, pinned)
-    })
-    .await
-    {
-        Ok(Ok(m)) => m,
-        Ok(Err(_)) | Err(_) if edge.edge_type == EdgeType::Optional => {
+    let manifest = match read_local_tarball_manifest(abs).await {
+        Ok(m) => m,
+        Err(_) if edge.edge_type == EdgeType::Optional => {
             return Ok(ControlFlow::Break(ProcessResult::Skipped));
         }
-        Ok(Err(source)) => return Err(file_err(source)),
-        Err(join) => return Err(file_err(join.into())),
+        Err(source) => return Err(file_err(source)),
     };
     Ok(ControlFlow::Continue(ResolvedPackage::from_manifest(
         manifest.name.clone(),

--- a/crates/ruborist/src/resolver/tar.rs
+++ b/crates/ruborist/src/resolver/tar.rs
@@ -202,6 +202,22 @@ pub(crate) fn parse_tarball_manifest(
     Ok(manifest)
 }
 
+/// Read a local `.tgz` from `abs` and parse its manifest, pinned to
+/// `file:<abs>` (the marker install uses to materialize it). The blocking
+/// read + inflate runs on the blocking pool. Shared by the normal file-dep
+/// resolver ([`super::file::process_file_dep`]) and override file-tarball
+/// resolution so both read local tarballs the same way.
+pub(crate) async fn read_local_tarball_manifest(abs: PathBuf) -> Result<CoreVersionManifest> {
+    let pinned = format!("file:{}", abs.display());
+    tokio::task::spawn_blocking(move || -> Result<CoreVersionManifest> {
+        let bytes = std::fs::read(&abs)
+            .with_context(|| format!("failed to read tarball {}", abs.display()))?;
+        parse_tarball_manifest(&bytes, pinned)
+    })
+    .await
+    .map_err(|e| anyhow!("tarball read task failed: {e}"))?
+}
+
 /// Extract a non-registry tarball's contents directly into `dest` (a
 /// `node_modules/<pkg>` directory), stripping the leading npm wrapper component
 /// (typically `package/`). Writes no `_resolved` marker and does not touch the

--- a/e2e/utoo-pm.ps1
+++ b/e2e/utoo-pm.ps1
@@ -718,17 +718,20 @@ try {
             overrides    = @{ "is-number" = "file:./local-is-number" }
         } | ConvertTo-Json -Depth 5 | Set-Content "package.json"
 
-        $ovdOut = utoo install --registry=https://registry.npmjs.org --ignore-scripts 2>&1
+        # Join to a single string: `2>&1` yields an array of lines, and
+        # `-match`/`-notmatch` over an array filter elements (truthy) rather
+        # than test a boolean.
+        $ovdOut = (utoo install --registry=https://registry.npmjs.org --ignore-scripts 2>&1 | Out-String)
         if ($LASTEXITCODE -eq 0) {
-            $ovdOut | Out-Host
+            Write-Host $ovdOut
             throw "file: directory override should not install successfully"
         }
         if ($ovdOut -notmatch "directory overrides") {
-            $ovdOut | Out-Host
+            Write-Host $ovdOut
             throw "file: directory override gave the wrong error (want 'directory overrides … use a tarball')"
         }
         if ($ovdOut -match "No matching version") {
-            $ovdOut | Out-Host
+            Write-Host $ovdOut
             throw "file: directory override regressed into a registry version lookup (404)"
         }
         Write-Green "PASS: overrides -> file: directory errors clearly"

--- a/e2e/utoo-pm.ps1
+++ b/e2e/utoo-pm.ps1
@@ -694,4 +694,49 @@ finally {
     Remove-Item -Recurse -Force $ovDir -ErrorAction SilentlyContinue
 }
 
+# ═══════════════════════════════════════════════════════════════
+# Case: overrides → file: DIRECTORY must fail with a clear error
+# ═══════════════════════════════════════════════════════════════
+# A `file:` directory dep installs as a symlink (Link node, no manifest), which
+# the manifest-returning override path can't express. It must fail with an
+# actionable "use a tarball" message rather than silently resolving it as a
+# registry version (→ 404). Guards the boundary against a regression.
+Write-Yellow "Case: overrides -> file: directory errors clearly"
+$ovdDir = Join-Path $env:TEMP "utoo-e2e-override-dir-$(Get-Random)"
+try {
+    New-Item -ItemType Directory -Path "$ovdDir\local-is-number" -Force | Out-Null
+    @{ name = "is-number"; version = "9.9.9"; main = "index.js" } |
+        ConvertTo-Json | Set-Content "$ovdDir\local-is-number\package.json"
+    Set-Content "$ovdDir\local-is-number\index.js" "module.exports = () => 'DIR';"
+
+    Push-Location $ovdDir
+    try {
+        @{
+            name         = "ov-file-dir-test"
+            version      = "1.0.0"
+            dependencies = @{ "is-odd" = "3.0.1" }
+            overrides    = @{ "is-number" = "file:./local-is-number" }
+        } | ConvertTo-Json -Depth 5 | Set-Content "package.json"
+
+        $ovdOut = utoo install --registry=https://registry.npmjs.org --ignore-scripts 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $ovdOut | Out-Host
+            throw "file: directory override should not install successfully"
+        }
+        if ($ovdOut -notmatch "directory overrides") {
+            $ovdOut | Out-Host
+            throw "file: directory override gave the wrong error (want 'directory overrides … use a tarball')"
+        }
+        if ($ovdOut -match "No matching version") {
+            $ovdOut | Out-Host
+            throw "file: directory override regressed into a registry version lookup (404)"
+        }
+        Write-Green "PASS: overrides -> file: directory errors clearly"
+    }
+    finally { Pop-Location }
+}
+finally {
+    Remove-Item -Recurse -Force $ovdDir -ErrorAction SilentlyContinue
+}
+
 Write-Green "All e2e tests passed successfully!"

--- a/e2e/utoo-pm.ps1
+++ b/e2e/utoo-pm.ps1
@@ -628,4 +628,70 @@ finally {
     Remove-Item -Recurse -Force $extDir -ErrorAction SilentlyContinue
 }
 
+# ═══════════════════════════════════════════════════════════════
+# Case: overrides target a local file: tarball (nested + direct)
+# ═══════════════════════════════════════════════════════════════
+# An override value may be any spec npm accepts — including a local `file:`
+# tarball — not just a registry version. Override resolution used to send the
+# target straight to the registry as a version, so `file:x.tgz` became a bogus
+# version lookup → 404 and the whole install aborted. Here a transitive dep
+# (is-number, pulled in by is-odd) is overridden to a locally packed tarball,
+# both via a nested rule (is-odd > is-number) and a direct rule.
+Write-Yellow "Case: overrides -> local file: tarball (nested + direct)"
+$ovDir = Join-Path $env:TEMP "utoo-e2e-override-tgz-$(Get-Random)"
+try {
+    New-Item -ItemType Directory -Path "$ovDir\src\is-number" -Force | Out-Null
+    @{ name = "is-number"; version = "9.9.9"; main = "index.js" } |
+        ConvertTo-Json | Set-Content "$ovDir\src\is-number\package.json"
+    Set-Content "$ovDir\src\is-number\index.js" "module.exports = () => 'OVERRIDE-LOCAL-TGZ';"
+
+    Push-Location "$ovDir\src\is-number"
+    try {
+        npm pack 2>&1 | Out-Null
+        $tgz = Get-ChildItem "is-number-*.tgz" | Select-Object -First 1
+        Move-Item $tgz.FullName "$ovDir\is-number.tgz"
+    }
+    finally { Pop-Location }
+
+    Push-Location $ovDir
+    try {
+        # Nested rule: is-odd > is-number -> file: tarball.
+        @{
+            name         = "ov-file-tarball-test"
+            version      = "1.0.0"
+            dependencies = @{ "is-odd" = "3.0.1" }
+            overrides    = @{ "is-odd" = @{ "is-number" = "file:./is-number.tgz" } }
+        } | ConvertTo-Json -Depth 5 | Set-Content "package.json"
+
+        utoo install --registry=https://registry.npmjs.org --ignore-scripts
+        if ($LASTEXITCODE -ne 0) { throw "install failed for nested file: tarball override" }
+        $ver = (node -p "require('./node_modules/is-number/package.json').version").Trim()
+        if ($ver -ne "9.9.9") { throw "nested override did not resolve to local tarball (is-number=$ver, want 9.9.9)" }
+        $out = (node -p "require('./node_modules/is-number')()").Trim()
+        if ($out -ne "OVERRIDE-LOCAL-TGZ") { throw "overridden is-number content wrong (got '$out')" }
+        node -e "const l=require('./package-lock.json');const r=(l.packages['node_modules/is-number']||{}).resolved||'';if(!r.startsWith('file:')){console.error('is-number not pinned to file: tarball, got',r);process.exit(1);}"
+        if ($LASTEXITCODE -ne 0) { throw "lockfile did not pin overridden is-number to file: tarball" }
+
+        # Direct (non-nested) rule must work too.
+        @{
+            name         = "ov-file-tarball-test"
+            version      = "1.0.0"
+            dependencies = @{ "is-odd" = "3.0.1" }
+            overrides    = @{ "is-number" = "file:./is-number.tgz" }
+        } | ConvertTo-Json -Depth 5 | Set-Content "package.json"
+        Remove-Item -Recurse -Force node_modules, package-lock.json -ErrorAction SilentlyContinue
+
+        utoo install --registry=https://registry.npmjs.org --ignore-scripts
+        if ($LASTEXITCODE -ne 0) { throw "install failed for direct file: tarball override" }
+        $ver2 = (node -p "require('./node_modules/is-number/package.json').version").Trim()
+        if ($ver2 -ne "9.9.9") { throw "direct override did not resolve to local tarball (is-number=$ver2, want 9.9.9)" }
+
+        Write-Green "PASS: overrides -> local file: tarball (nested + direct)"
+    }
+    finally { Pop-Location }
+}
+finally {
+    Remove-Item -Recurse -Force $ovDir -ErrorAction SilentlyContinue
+}
+
 Write-Green "All e2e tests passed successfully!"

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -1505,4 +1505,77 @@ if (pTimeout.dev === true) {
 echo -e "${GREEN}PASS: prod-reachable devDependency correctly not marked dev${NC}"
 cd ../../../
 
+# ═══════════════════════════════════════════════════════════════
+# Case: overrides target a local file: tarball (nested + direct)
+# ═══════════════════════════════════════════════════════════════
+# An override value may be any spec npm accepts — including a local `file:`
+# tarball — not just a registry version. Override resolution used to send the
+# target straight to the registry as a version, so `file:x.tgz` became a bogus
+# version lookup → 404 and the whole install aborted. Here a transitive dep
+# (is-number, pulled in by is-odd) is overridden to a locally packed tarball,
+# both via a nested rule (is-odd > is-number) and a direct rule; the local
+# build (version 9.9.9, sentinel export) must land in node_modules.
+echo -e "${YELLOW}Case: overrides → local file: tarball${NC}"
+OV_DIR=$(mktemp -d)
+trap 'rm -rf "$OV_DIR"' EXIT
+mkdir -p "$OV_DIR/src/is-number"
+cat > "$OV_DIR/src/is-number/package.json" << 'EOF'
+{ "name": "is-number", "version": "9.9.9", "main": "index.js" }
+EOF
+echo "module.exports = () => 'OVERRIDE-LOCAL-TGZ';" > "$OV_DIR/src/is-number/index.js"
+( cd "$OV_DIR/src/is-number" && npm pack --silent >/dev/null 2>&1 \
+  && mv is-number-9.9.9.tgz "$OV_DIR/is-number.tgz" ) \
+  || { echo -e "${RED}FAIL: could not pack is-number tarball${NC}"; exit 1; }
+
+cat > "$OV_DIR/package.json" << 'EOF'
+{
+  "name": "ov-file-tarball-test",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" },
+  "overrides": { "is-odd": { "is-number": "file:./is-number.tgz" } }
+}
+EOF
+pushd "$OV_DIR"
+utoo install --registry=https://registry.npmjs.org --ignore-scripts \
+  || { echo -e "${RED}FAIL: utoo install failed for nested file: tarball override${NC}"; exit 1; }
+OV_VER=$(node -p "require('./node_modules/is-number/package.json').version" 2>/dev/null)
+if [ "$OV_VER" != "9.9.9" ]; then
+    echo -e "${RED}FAIL: nested override did not resolve to local tarball (is-number=$OV_VER, want 9.9.9)${NC}"
+    exit 1
+fi
+OV_OUT=$(node -p "require('./node_modules/is-number')()" 2>/dev/null)
+if [ "$OV_OUT" != "OVERRIDE-LOCAL-TGZ" ]; then
+    echo -e "${RED}FAIL: overridden is-number content wrong (got '$OV_OUT')${NC}"
+    exit 1
+fi
+# Lockfile must pin the tarball as file:, not a registry version.
+node -e '
+const lock = require("./package-lock.json");
+const e = lock.packages["node_modules/is-number"] || {};
+const r = e.resolved || "";
+if (!r.startsWith("file:")) { console.error("is-number not pinned to file: tarball, got", r); process.exit(1); }
+' || { echo -e "${RED}FAIL: lockfile did not pin overridden is-number to file: tarball${NC}"; exit 1; }
+
+# Direct (non-nested) override form must work too.
+cat > package.json << 'EOF'
+{
+  "name": "ov-file-tarball-test",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" },
+  "overrides": { "is-number": "file:./is-number.tgz" }
+}
+EOF
+rm -rf node_modules package-lock.json
+utoo install --registry=https://registry.npmjs.org --ignore-scripts \
+  || { echo -e "${RED}FAIL: utoo install failed for direct file: tarball override${NC}"; exit 1; }
+OV_VER2=$(node -p "require('./node_modules/is-number/package.json').version" 2>/dev/null)
+if [ "$OV_VER2" != "9.9.9" ]; then
+    echo -e "${RED}FAIL: direct override did not resolve to local tarball (is-number=$OV_VER2, want 9.9.9)${NC}"
+    exit 1
+fi
+popd
+rm -rf "$OV_DIR"
+trap - EXIT
+echo -e "${GREEN}PASS: overrides → local file: tarball (nested + direct)${NC}"
+
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -1578,4 +1578,51 @@ rm -rf "$OV_DIR"
 trap - EXIT
 echo -e "${GREEN}PASS: overrides → local file: tarball (nested + direct)${NC}"
 
+# ═══════════════════════════════════════════════════════════════
+# Case: overrides → file: DIRECTORY must fail with a clear error
+# ═══════════════════════════════════════════════════════════════
+# A `file:` directory dep installs as a symlink (Link node, no manifest), which
+# the manifest-returning override path can't express. Rather than silently
+# resolving it as a registry version (→ 404) or leaking placement into the
+# resolver, it must fail with an actionable "use a tarball" message. Guards the
+# boundary so a future change can't regress it into a confusing 404.
+echo -e "${YELLOW}Case: overrides → file: directory errors clearly${NC}"
+OVD_DIR=$(mktemp -d)
+trap 'rm -rf "$OVD_DIR"' EXIT
+mkdir -p "$OVD_DIR/local-is-number"
+cat > "$OVD_DIR/local-is-number/package.json" << 'EOF'
+{ "name": "is-number", "version": "9.9.9", "main": "index.js" }
+EOF
+echo "module.exports = () => 'DIR';" > "$OVD_DIR/local-is-number/index.js"
+cat > "$OVD_DIR/package.json" << 'EOF'
+{
+  "name": "ov-file-dir-test",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" },
+  "overrides": { "is-number": "file:./local-is-number" }
+}
+EOF
+pushd "$OVD_DIR"
+if utoo install --registry=https://registry.npmjs.org --ignore-scripts > ovd.out 2>&1; then
+    echo -e "${RED}FAIL: file: directory override should not install successfully${NC}"
+    cat ovd.out
+    exit 1
+fi
+# Must be the clear directory-override error, not a registry 404 / version miss.
+if ! grep -qi "directory overrides" ovd.out; then
+    echo -e "${RED}FAIL: file: directory override gave the wrong error (want 'directory overrides … use a tarball')${NC}"
+    cat ovd.out
+    exit 1
+fi
+if grep -qi "No matching version" ovd.out; then
+    echo -e "${RED}FAIL: file: directory override regressed into a registry version lookup (404)${NC}"
+    cat ovd.out
+    exit 1
+fi
+rm -f ovd.out
+popd
+rm -rf "$OVD_DIR"
+trap - EXIT
+echo -e "${GREEN}PASS: overrides → file: directory errors clearly${NC}"
+
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"


### PR DESCRIPTION
## Problem

`overrides` (and yarn `resolutions`) **target** specs were always resolved as a registry version. Override resolution called `resolve_registry_dep(name, override_spec, …)` directly, bypassing the protocol-aware dispatch that normal dependency specs go through. So any non-registry override target failed:

```jsonc
// overrides: { "is-odd": { "is-number": "file:./is-number.tgz" } }
ERROR Dependency resolution failed: Version resolution failed:
  is-number@file:./is-number.tgz: No matching version found for spec
  'file:./is-number.tgz' from 15 available versions
```

`file:` tarball, http(s) tarball, and git override targets all became bogus registry version lookups → 404 → the whole install aborted with an empty `node_modules`. Only registry ranges / `npm:` aliases / dist-tags worked. This blocked the common local-debugging workflow of `npm pack`-ing a package and pinning it via a (often nested) override.

## Fix

`resolve_override` now parses the override target into a `PackageSpec` and dispatches by protocol, exactly like `process_dependency`:

| target | resolver |
|---|---|
| registry range / `npm:` / dist-tag | registry resolver (**unchanged**) |
| `https://…tgz` | http tarball resolver |
| `git+…` / `github:…` | git resolver |
| `file:…tgz` | parsed into a manifest with a pinned `file:<abs>` tarball, resolved **relative to the root project** (overrides are root-declared), materialized into `node_modules` at install time |
| `file:` **directory** | clear `Unsupported` error (would need a symlink/Link node the override path can't place) — better than the old misleading 404 |

`PackageSpec` only **selects** the resolver; the registry path still receives the raw `override_spec`, so `npm:`/range/dist-tag override behavior is byte-for-byte unchanged. All supported protocols yield a manifest the caller already knows how to place — a tarball manifest just carries a pinned `dist.tarball`, the same shape a normal `file:`/http tarball dep produces.

Optional-edge override failures fall back to the original resolution (npm semantics); load-bearing failures surface the wrapped cause.

## Tests

- Verified locally: nested + direct `file:` tarball overrides land the local build; `file:` dir override gives the clear error; registry override is unregressed.
- 186 ruborist unit tests + 10 doctests pass; clippy clean with **and** without `http-tarball`/`native-git` (wasm gating).
- e2e (bash + pwsh): nested and direct `file:` tarball overrides, asserting the locally-packed version lands and the lockfile pins `file:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)