### PR TITLE
fix(pm): cache binary-mirror-config load and accept string replaceHost

### DIFF
--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -4,10 +4,11 @@ use crate::util::json::read_json_file;
 use crate::util::user_config::get_registry;
 use anyhow::{Context, Result};
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::result::Result as StdResult;
 use std::sync::OnceLock;
 use tokio::sync::OnceCell;
 use utoo_ruborist::registry::is_npm_registry;
@@ -43,6 +44,27 @@ struct ChinaMirror {
     packages: BTreeMap<String, BinaryMirror>,
 }
 
+/// npm's `binary-mirror-config` lets `replaceHost`/`replaceHostFiles` be either
+/// a single string or an array of strings (e.g. `flow-bin.replaceHost` is a
+/// bare string). Normalize both shapes to a `Vec<String>`; a strict
+/// `Option<Vec<String>>` would reject the string form and fail the whole parse.
+fn de_string_or_seq<'de, D>(deserializer: D) -> StdResult<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrSeq {
+        String(String),
+        Seq(Vec<String>),
+    }
+    Ok(match Option::<StringOrSeq>::deserialize(deserializer)? {
+        None => None,
+        Some(StringOrSeq::String(s)) => Some(vec![s]),
+        Some(StringOrSeq::Seq(v)) => Some(v),
+    })
+}
+
 /// Per-package binary mirror settings.
 #[derive(Debug, Default, Clone, Deserialize, serde::Serialize)]
 struct BinaryMirror {
@@ -52,6 +74,7 @@ struct BinaryMirror {
     #[serde(
         rename = "replaceHost",
         default,
+        deserialize_with = "de_string_or_seq",
         skip_serializing_if = "Option::is_none"
     )]
     replace_host: Option<Vec<String>>,
@@ -60,6 +83,7 @@ struct BinaryMirror {
     #[serde(
         rename = "replaceHostFiles",
         default,
+        deserialize_with = "de_string_or_seq",
         skip_serializing_if = "Option::is_none"
     )]
     replace_host_files: Option<Vec<String>>,
@@ -90,25 +114,36 @@ struct BinaryMirror {
     extra: Map<String, Value>,
 }
 
-static CONFIG: OnceCell<BinaryMirrorConfig> = OnceCell::const_new();
+/// Cached config-load outcome. Stores `Result` rather than the bare config so
+/// a fetch/parse *failure* is memoized too: `get_or_try_init` would discard an
+/// `Err` and re-run the closure on the next call, and `update_package_binary`
+/// is called once per package — a single bad config would otherwise trigger a
+/// `binary-mirror-config` network fetch for every package in the tree.
+static CONFIG: OnceCell<Result<BinaryMirrorConfig, String>> = OnceCell::const_new();
 /// Cached result of whether we should skip binary mirror envs
 static SKIP_BINARY_MIRROR: OnceLock<bool> = OnceLock::new();
 
 async fn load_config() -> Result<&'static BinaryMirrorConfig> {
     CONFIG
-        .get_or_try_init(|| async {
+        .get_or_init(|| async {
             // Go through the registry client so URL construction and private-
             // registry auth are handled in one place rather than hand-rolled.
             // `binary-mirror-config@latest` is a normal version manifest whose
             // `mirrors` field carries the config.
-            let bytes = RuboristContext::registry()
+            let bytes = match RuboristContext::registry()
                 .await
                 .fetch_version_manifest_bytes("binary-mirror-config", "latest")
                 .await
-                .context("Failed to fetch binary mirror config")?;
-            serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")
+            {
+                Ok(bytes) => bytes,
+                Err(e) => return Err(format!("Failed to fetch binary mirror config: {e:#}")),
+            };
+            serde_json::from_slice(&bytes)
+                .map_err(|e| format!("Failed to parse binary mirror config: {e}"))
         })
         .await
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 fn update_binary_config(pkg: &mut Value, binary_mirror: &BinaryMirror) {
@@ -474,6 +509,57 @@ mod tests {
             get_replace_host_files(&binary_mirror),
             vec!["lib/index.js", "lib/install.js"]
         );
+    }
+
+    #[test]
+    fn test_replace_host_accepts_string_or_array() {
+        // npm's config has `flow-bin.replaceHost` as a bare string; the strict
+        // `Vec<String>` form used to fail the whole config parse here.
+        let from_string = serde_json::from_value::<BinaryMirror>(json!({
+            "replaceHost": "https://github.com/facebook/flow/releases/download/v",
+            "replaceHostFiles": "lib/install.js"
+        }))
+        .unwrap();
+        assert_eq!(
+            from_string.replace_host.as_deref(),
+            Some(["https://github.com/facebook/flow/releases/download/v".to_string()].as_slice())
+        );
+        assert_eq!(
+            from_string.replace_host_files.as_deref(),
+            Some(["lib/install.js".to_string()].as_slice())
+        );
+
+        let from_array = serde_json::from_value::<BinaryMirror>(json!({
+            "replaceHost": ["a.com", "b.com"]
+        }))
+        .unwrap();
+        assert_eq!(
+            from_array.replace_host.as_deref(),
+            Some(["a.com".to_string(), "b.com".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn test_full_config_with_string_replace_host_parses() {
+        // A whole-config parse must not fail just because one entry uses the
+        // string form of `replaceHost` (regression: it disabled mirroring for
+        // every package and re-fetched the config per package).
+        let config: BinaryMirrorConfig = serde_json::from_value(json!({
+            "mirrors": {
+                "china": {
+                    "ENVS": { "SASS_BINARY_SITE": "https://npmmirror.com/mirrors/node-sass" },
+                    "flow-bin": {
+                        "replaceHost": "https://github.com/facebook/flow/releases/download/v",
+                        "host": "https://npmmirror.com/mirrors/flow"
+                    },
+                    "sharp": { "replaceHostFiles": ["lib/libvips.js"] }
+                }
+            }
+        }))
+        .unwrap();
+        assert!(config.mirrors.china.packages.contains_key("flow-bin"));
+        assert!(config.mirrors.china.packages.contains_key("sharp"));
+        assert!(config.mirrors.china.envs.contains_key("SASS_BINARY_SITE"));
     }
 
     #[tokio::test]

--- a/e2e/pm/binary-mirror/package.json
+++ b/e2e/pm/binary-mirror/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "e2e-binary-mirror",
+  "version": "1.0.0",
+  "private": true,
+  "description": "e2e: binary-mirror-config must parse against registry.npmmirror.com (regression for the strict-typed config that failed to parse and re-fetched per package)",
+  "dependencies": {
+    "utf-8-validate": "^6.0.3"
+  }
+}

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -1434,4 +1434,38 @@ if (pTimeout.dev === true) {
 echo -e "${GREEN}PASS: prod-reachable devDependency correctly not marked dev${NC}"
 cd ../../../
 
+# ═══════════════════════════════════════════════════════════════
+# Case: binary-mirror-config parses against registry.npmmirror.com
+# ═══════════════════════════════════════════════════════════════
+# npmmirror serves the canonical `binary-mirror-config`, whose
+# `flow-bin.replaceHost` is a bare string. Typing it strictly as `Vec<String>`
+# made the whole config fail to parse, and because the failure was not cached,
+# every cloned package re-fetched the config (hundreds of serialized network
+# round-trips → install crawled). Guard: against npmmirror the config must
+# parse, so the per-package "Binary mirror config unavailable" debug line must
+# never appear.
+echo -e "${YELLOW}Case: binary-mirror-config parses on registry.npmmirror.com${NC}"
+cd e2e/pm/binary-mirror
+rm -rf node_modules package-lock.json
+rm -rf ~/.cache/nm
+BMC_MARKER="$(mktemp)"
+utoo install --ignore-scripts --registry=https://registry.npmmirror.com \
+  || { echo -e "${RED}FAIL: utoo install failed for binary-mirror (npmmirror)${NC}"; exit 1; }
+[ -d node_modules/utf-8-validate ] \
+  || { echo -e "${RED}FAIL: utf-8-validate not installed via npmmirror${NC}"; exit 1; }
+# Scan this run's debug log(s) for the config-parse-failure spam. Each `utoo`
+# invocation writes one $TMPDIR/utoo-<ts>.log; pick those newer than the marker.
+BMC_FAILS=0
+for log in $(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'utoo-*.log' -newer "$BMC_MARKER" 2>/dev/null); do
+  n=$(grep -c "Binary mirror config unavailable" "$log" 2>/dev/null || true)
+  BMC_FAILS=$((BMC_FAILS + n))
+done
+rm -f "$BMC_MARKER"
+if [ "$BMC_FAILS" -ne 0 ]; then
+  echo -e "${RED}FAIL: binary-mirror-config failed to parse on npmmirror ($BMC_FAILS occurrences) — strict-type regression${NC}"
+  exit 1
+fi
+echo -e "${GREEN}PASS: binary-mirror-config parsed on npmmirror (no per-package re-fetch)${NC}"
+cd ../../../
+
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"


### PR DESCRIPTION
## Problem

On any **non-npmjs registry** (npmmirror / cnpm / aliyun mirrors — exactly where binary-mirror is meant to work), `utoo install`/`update` crawls and appears to hang. Surfaced while accepting #3142 on a large tree (ant-design): the spinner sat on the clone phase (`2720/5111 <pkg> resolved`) for ~92s. The debug log showed **838 repeated** `Binary mirror config unavailable` lines on the main thread, ~100ms apart.

Root cause is two compounding regressions from **#3157** (`service/binary.rs`):

1. **Uncached failure → per-package re-fetch (the stall).** `load_config` used `OnceCell::get_or_try_init`, which does **not** memoize an `Err`. Since `update_package_binary` runs once per cloned package, a parse failure re-ran the closure — a fresh network fetch of `binary-mirror-config@latest` — for *every* package, serialized on the main thread.
2. **Strict type rejects npm's polymorphic config (the parse failure).** `BinaryMirror.replace_host` was typed `Option<Vec<String>>`, but npm's `binary-mirror-config` has `flow-bin.replaceHost` as a **bare string** (`replaceHost` is string-or-array). The strict type failed the whole parse, silently disabling china-mirror rewrites.

Pre-#3157 the config was parsed as untyped `serde_json::Value`, which never failed — so this is a regression introduced by the strong-typing refactor.

## Fix

- Store `OnceCell<Result<BinaryMirrorConfig, String>>` and use `get_or_init`, so a fetch/parse failure is cached — **at most one attempt per process**.
- Add a `de_string_or_seq` deserializer so `replaceHost`/`replaceHostFiles` accept a string *or* an array, normalizing to `Vec<String>`.

## Tests

- Unit: `test_replace_host_accepts_string_or_array` (field-level) and `test_full_config_with_string_replace_host_parses` (whole-config regression).
- **e2e:** new `e2e/pm/binary-mirror` case installs `utf-8-validate` against `registry.npmmirror.com` and asserts the config parses — zero `Binary mirror config unavailable` lines in the run's debug log.

Verified locally against the real npmmirror config: **838 redundant fetches → 0**, install of the fixture in ~2s.

> Independent of #3142 (live install progress); that PR only *displayed* this stall faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)