### PR TITLE
perf(pm): bundle binary-mirror-config, drop the runtime fetch

### DIFF
--- a/crates/pm/src/service/binary-mirror-config.json
+++ b/crates/pm/src/service/binary-mirror-config.json
@@ -1,0 +1,233 @@
+{
+  "version": "2.20.0",
+  "mirrors": {
+    "china": {
+      "ENVS": {
+        "COREPACK_NPM_REGISTRY": "https://registry.npmmirror.com",
+        "EDGEDRIVER_CDNURL": "https://npmmirror.com/mirrors/edgedriver",
+        "NODEJS_ORG_MIRROR": "https://cdn.npmmirror.com/binaries/node",
+        "NVM_NODEJS_ORG_MIRROR": "https://cdn.npmmirror.com/binaries/node",
+        "PHANTOMJS_CDNURL": "https://cdn.npmmirror.com/binaries/phantomjs",
+        "CHROMEDRIVER_CDNURL": "https://cdn.npmmirror.com/binaries/chromedriver",
+        "OPERADRIVER_CDNURL": "https://cdn.npmmirror.com/binaries/operadriver",
+        "CYPRESS_DOWNLOAD_PATH_TEMPLATE": "https://cdn.npmmirror.com/binaries/cypress/${version}/${platform}-${arch}/cypress.zip",
+        "ELECTRON_MIRROR": "https://cdn.npmmirror.com/binaries/electron/",
+        "ELECTRON_BUILDER_BINARIES_MIRROR": "https://cdn.npmmirror.com/binaries/electron-builder-binaries/",
+        "SASS_BINARY_SITE": "https://cdn.npmmirror.com/binaries/node-sass",
+        "SWC_BINARY_SITE": "https://cdn.npmmirror.com/binaries/node-swc",
+        "NWJS_URLBASE": "https://cdn.npmmirror.com/binaries/nwjs/v",
+        "PUPPETEER_DOWNLOAD_HOST": "https://cdn.npmmirror.com/binaries/chrome-for-testing",
+        "PUPPETEER_DOWNLOAD_BASE_URL": "https://cdn.npmmirror.com/binaries/chrome-for-testing",
+        "PUPPETEER_CHROME_DOWNLOAD_BASE_URL": "https://cdn.npmmirror.com/binaries/chrome-for-testing",
+        "PUPPETEER_CHROME_HEADLESS_SHELL_DOWNLOAD_BASE_URL": "https://cdn.npmmirror.com/binaries/chrome-for-testing",
+        "PLAYWRIGHT_DOWNLOAD_HOST": "https://cdn.npmmirror.com/binaries/playwright",
+        "PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST": "https://cdn.npmmirror.com/binaries/chrome-for-testing",
+        "SENTRYCLI_CDNURL": "https://cdn.npmmirror.com/binaries/sentry-cli",
+        "SAUCECTL_INSTALL_BINARY_MIRROR": "https://cdn.npmmirror.com/binaries/saucectl",
+        "RE2_DOWNLOAD_MIRROR": "https://cdn.npmmirror.com/binaries/node-re2",
+        "RE2_DOWNLOAD_SKIP_PATH": "true",
+        "PRISMA_ENGINES_MIRROR": "https://cdn.npmmirror.com/binaries/prisma",
+        "npm_config_better_sqlite3_binary_host": "https://cdn.npmmirror.com/binaries/better-sqlite3",
+        "npm_config_isolated_vm_binary_host": "https://cdn.npmmirror.com/binaries/isolated-vm",
+        "npm_config_keytar_binary_host": "https://cdn.npmmirror.com/binaries/keytar",
+        "npm_config_sharp_binary_host": "https://cdn.npmmirror.com/binaries/sharp",
+        "npm_config_sharp_libvips_binary_host": "https://cdn.npmmirror.com/binaries/sharp-libvips",
+        "npm_config_robotjs_binary_host": "https://cdn.npmmirror.com/binaries/robotjs",
+        "npm_config_gl_binary_host": "https://cdn.npmmirror.com/binaries/gl",
+        "RIPGREP_PREBUILT_BINARIES_MIRROR": "https://registry.npmmirror.com/-/binary/ripgrep-prebuilt"
+      },
+      "@ali/s2": {
+        "host": "https://cdn.npmmirror.com/binaries/looksgood-s2"
+      },
+      "sharp": {
+        "replaceHostFiles": [
+          "install/libvips.js"
+        ],
+        "replaceHostMap": {
+          "https://github.com/lovell/sharp-libvips/releases/download/": "https://cdn.npmmirror.com/binaries/sharp-libvips/"
+        }
+      },
+      "@tensorflow/tfjs-node": {
+        "replaceHostFiles": [
+          "scripts/install.js",
+          "package.json"
+        ],
+        "replaceHostRegExpMap": {
+          "https://storage\\.googleapis\\.com/": "https://cdn.npmmirror.com/binaries/"
+        },
+        "replaceHostMap": {
+          "https://storage.googleapis.com/": "https://cdn.npmmirror.com/binaries/"
+        }
+      },
+      "cypress": {
+        "host": "https://cdn.npmmirror.com/binaries/cypress",
+        "newPlatforms": {
+          "mac": "darwin-x64",
+          "win": "win32-ia32",
+          "linux64": "linux-x64",
+          "darwin": "darwin-x64",
+          "win32": "win32-ia32",
+          "linux": "linux-x64",
+          "darwin-x64": "darwin-x64",
+          "linux-x64": "linux-x64",
+          "win32-ia32": "win32-ia32",
+          "win32-x64": "win32-x64"
+        }
+      },
+      "utf-8-validate": {
+        "host": "https://cdn.npmmirror.com/binaries/utf-8-validate/v{version}"
+      },
+      "xprofiler": {
+        "remote_path": "./xprofiler/v{version}/",
+        "host": "https://cdn.npmmirror.com/binaries"
+      },
+      "leveldown": {
+        "host": "https://cdn.npmmirror.com/binaries/leveldown/v{version}"
+      },
+      "couchbase": {
+        "host": "https://cdn.npmmirror.com/binaries/couchbase/v{version}"
+      },
+      "gl": {
+        "host": "https://cdn.npmmirror.com/binaries/gl/v{version}"
+      },
+      "sqlite3": {
+        "host": "https://cdn.npmmirror.com/binaries/sqlite3",
+        "remote_path": "v{version}"
+      },
+      "@journeyapps/sqlcipher": {
+        "host": "https://cdn.npmmirror.com/binaries"
+      },
+      "grpc": {
+        "host": "https://cdn.npmmirror.com/binaries",
+        "remote_path": "{name}/v{version}"
+      },
+      "grpc-tools": {
+        "host": "https://cdn.npmmirror.com/binaries"
+      },
+      "wrtc": {
+        "host": "https://cdn.npmmirror.com/binaries",
+        "remote_path": "{name}/v{version}"
+      },
+      "fsevents": {
+        "host": "https://cdn.npmmirror.com/binaries/fsevents"
+      },
+      "nodejieba": {
+        "host": "https://cdn.npmmirror.com/binaries/nodejieba"
+      },
+      "canvas": {
+        "host": "https://cdn.npmmirror.com/binaries/canvas",
+        "remote_path": "v{version}"
+      },
+      "skia-canvas": {
+        "host": "https://cdn.npmmirror.com/binaries/skia-canvas"
+      },
+      "flow-bin": {
+        "replaceHost": "https://github.com/facebook/flow/releases/download/v",
+        "host": "https://cdn.npmmirror.com/binaries/flow/v"
+      },
+      "jpegtran-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/jpegtran-bin",
+          "https://raw.github.com/imagemin/jpegtran-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/jpegtran-bin"
+      },
+      "cwebp-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/cwebp-bin",
+          "https://raw.github.com/imagemin/cwebp-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/cwebp-bin"
+      },
+      "zopflipng-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/zopflipng-bin",
+          "https://raw.github.com/imagemin/zopflipng-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/zopflipng-bin"
+      },
+      "optipng-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/optipng-bin",
+          "https://raw.github.com/imagemin/optipng-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/optipng-bin"
+      },
+      "mozjpeg": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/mozjpeg-bin",
+          "https://raw.github.com/imagemin/mozjpeg-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/mozjpeg-bin"
+      },
+      "gifsicle": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/gifsicle-bin",
+          "https://raw.github.com/imagemin/gifsicle-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/gifsicle-bin"
+      },
+      "pngquant-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/pngquant-bin",
+          "https://raw.github.com/imagemin/pngquant-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/pngquant-bin",
+        "replaceHostMap": {
+          "https://raw.githubusercontent.com/imagemin/pngquant-bin": "https://cdn.npmmirror.com/binaries/pngquant-bin",
+          "https://raw.github.com/imagemin/pngquant-bin": "https://cdn.npmmirror.com/binaries/pngquant-bin"
+        }
+      },
+      "pngcrush-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/pngcrush-bin",
+          "https://raw.github.com/imagemin/pngcrush-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/pngcrush-bin"
+      },
+      "jpeg-recompress-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/jpeg-recompress-bin",
+          "https://raw.github.com/imagemin/jpeg-recompress-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/jpeg-recompress-bin"
+      },
+      "advpng-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/advpng-bin",
+          "https://raw.github.com/imagemin/advpng-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/advpng-bin"
+      },
+      "pngout-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/pngout-bin",
+          "https://raw.github.com/imagemin/pngout-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/pngout-bin"
+      },
+      "jpegoptim-bin": {
+        "replaceHost": [
+          "https://raw.githubusercontent.com/imagemin/jpegoptim-bin",
+          "https://raw.github.com/imagemin/jpegoptim-bin"
+        ],
+        "host": "https://cdn.npmmirror.com/binaries/jpegoptim-bin"
+      },
+      "argon2": {
+        "host": "https://cdn.npmmirror.com/binaries/argon2"
+      },
+      "ali-zeromq": {
+        "host": "https://cdn.npmmirror.com/binaries/ali-zeromq"
+      },
+      "ali-usb_ctl": {
+        "host": "https://cdn.npmmirror.com/binaries/ali-usb_ctl"
+      },
+      "gdal-async": {
+        "host": "https://cdn.npmmirror.com/binaries/node-gdal-async"
+      },
+      "libpg-query": {
+        "host": "https://cdn.npmmirror.com/binaries"
+      }
+    }
+  }
+}

--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -1,15 +1,14 @@
 use crate::fs;
-use crate::helper::ruborist_context::Context as RuboristContext;
 use crate::util::json::read_json_file;
 use crate::util::user_config::get_registry;
 use anyhow::{Context, Result};
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::OnceLock;
-use tokio::sync::OnceCell;
 use utoo_ruborist::registry::is_npm_registry;
 use utoo_ruborist::semver::matches;
 
@@ -117,48 +116,33 @@ where
     })
 }
 
-/// Cached config load result. Holds the failure too: `get_or_try_init` leaves
-/// the cell empty on `Err`, so a persistent failure (offline / registry down /
-/// upstream schema drift) would re-fetch once per package — `load_config` is
-/// called for *every* node in the tree. Caching `Result` memoizes both outcomes
-/// for the whole install. The error is a `String` (anyhow's `Error` is neither
-/// `Clone` nor `Sync`-friendly to hand out by reference repeatedly).
-static CONFIG: OnceCell<Result<BinaryMirrorConfig, String>> = OnceCell::const_new();
+/// The China binary-mirror config, **bundled at build time** rather than
+/// fetched from the registry.
+///
+/// `binary-mirror-config` is a package we maintain and publish; its data
+/// changes rarely and applies to public registries only. Fetching it at install
+/// time was both a cold-install network stall (one request gating the first
+/// mirror-matched package) and a silent-failure risk — a registry serving a
+/// schema-drifted manifest made the whole config fail to parse and disabled
+/// mirroring for every package. Bundling turns a bad config into *our* CI
+/// failure (the unit test below), never the user's broken install, and needs
+/// zero network. Re-sync this file with the package's `mirrors` field whenever a
+/// new `binary-mirror-config` version is published.
+static CONFIG: Lazy<BinaryMirrorConfig> = Lazy::new(|| {
+    let config: BinaryMirrorConfig =
+        serde_json::from_str(include_str!("binary-mirror-config.json"))
+            .expect("bundled binary-mirror-config.json must parse (covered by a unit test)");
+    tracing::debug!(
+        "Bundled binary mirror config: {} china package entries",
+        config.mirrors.china.packages.len()
+    );
+    config
+});
 /// Cached result of whether we should skip binary mirror envs
 static SKIP_BINARY_MIRROR: OnceLock<bool> = OnceLock::new();
 
-async fn fetch_and_parse_config() -> Result<BinaryMirrorConfig> {
-    // Go through the registry client so URL construction and private-registry
-    // auth are handled in one place rather than hand-rolled.
-    // `binary-mirror-config@latest` is a normal version manifest whose
-    // `mirrors` field carries the config.
-    let bytes = RuboristContext::registry()
-        .await
-        .fetch_version_manifest_bytes("binary-mirror-config", "latest")
-        .await
-        .context("Failed to fetch binary mirror config")?;
-    let config: BinaryMirrorConfig =
-        serde_json::from_slice(&bytes).context("Failed to parse binary mirror config")?;
-    // A successful parse is the only signal that the mirror layer is live; the
-    // failure path is a swallowed debug log, so without this the whole layer
-    // can silently go dark on upstream schema drift.
-    tracing::debug!(
-        "Binary mirror config loaded: {} china package entries",
-        config.mirrors.china.packages.len()
-    );
-    Ok(config)
-}
-
-async fn load_config() -> Result<&'static BinaryMirrorConfig> {
-    CONFIG
-        .get_or_init(|| async {
-            // Keep the full context chain in the cached message — the failure
-            // path only surfaces as a debug log, so the inner cause matters.
-            fetch_and_parse_config().await.map_err(|e| format!("{e:#}"))
-        })
-        .await
-        .as_ref()
-        .map_err(|e| anyhow::anyhow!("{e}"))
+fn load_config() -> &'static BinaryMirrorConfig {
+    &CONFIG
 }
 
 fn update_binary_config(pkg: &mut Value, binary_mirror: &BinaryMirror) {
@@ -363,18 +347,7 @@ pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
         return Ok(());
     }
 
-    // A missing/unreachable binary-mirror-config (e.g. a private registry that
-    // doesn't host it) must not fail the install — the china-mirror rewrite is
-    // an optimization. Skip gracefully, matching `get_envs`.
-    let config = match load_config().await {
-        Ok(config) => config,
-        Err(e) => {
-            tracing::debug!("Binary mirror config unavailable, skipping: {e}");
-            return Ok(());
-        }
-    };
-
-    let Some(binary_mirror) = config.mirrors.china.packages.get(name) else {
+    let Some(binary_mirror) = load_config().mirrors.china.packages.get(name) else {
         return Ok(());
     };
 
@@ -428,19 +401,14 @@ fn should_skip_binary_mirror() -> bool {
     })
 }
 
-pub async fn get_envs() -> Option<&'static BTreeMap<String, String>> {
+pub fn get_envs() -> Option<&'static BTreeMap<String, String>> {
     // Skip binary mirror envs when using official npm registry
     if should_skip_binary_mirror() {
         return None;
     }
 
-    match load_config().await {
-        Ok(config) => {
-            let envs = &config.mirrors.china.envs;
-            (!envs.is_empty()).then_some(envs)
-        }
-        Err(_) => None,
-    }
+    let envs = &load_config().mirrors.china.envs;
+    (!envs.is_empty()).then_some(envs)
 }
 
 #[cfg(test)]
@@ -448,6 +416,36 @@ mod tests {
     use super::*;
     use serde_json::json;
     use tempfile::tempdir;
+
+    /// The bundled config is the source of truth at runtime, so a re-sync that
+    /// drifts from our strict schema must fail here (in CI) rather than silently
+    /// disabling mirroring in users' installs. Also pins the `flow-bin`
+    /// bare-string `replaceHost` case the strict type used to reject.
+    #[test]
+    fn test_bundled_config_parses() {
+        let config: BinaryMirrorConfig =
+            serde_json::from_str(include_str!("binary-mirror-config.json"))
+                .expect("bundled binary-mirror-config.json must parse");
+        assert!(
+            !config.mirrors.china.packages.is_empty(),
+            "bundled config has no china package entries"
+        );
+        assert!(
+            !config.mirrors.china.envs.is_empty(),
+            "bundled config has no ENVS"
+        );
+        let flow_bin = config
+            .mirrors
+            .china
+            .packages
+            .get("flow-bin")
+            .expect("flow-bin entry present");
+        assert_eq!(
+            flow_bin.replace_host.as_deref(),
+            Some(["https://github.com/facebook/flow/releases/download/v".to_string()].as_slice()),
+            "flow-bin bare-string replaceHost must normalize to a one-element list"
+        );
+    }
 
     #[tokio::test]
     async fn test_update_binary_config() {

--- a/crates/pm/src/service/binary.rs
+++ b/crates/pm/src/service/binary.rs
@@ -2,14 +2,12 @@ use crate::fs;
 use crate::util::json::read_json_file;
 use crate::util::user_config::get_registry;
 use anyhow::{Context, Result};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::sync::OnceLock;
-use utoo_ruborist::registry::is_npm_registry;
+use std::sync::{LazyLock, OnceLock};
 use utoo_ruborist::semver::matches;
 
 /// The `binary-mirror-config` package (cnpm), parsed from its version
@@ -128,7 +126,7 @@ where
 /// failure (the unit test below), never the user's broken install, and needs
 /// zero network. Re-sync this file with the package's `mirrors` field whenever a
 /// new `binary-mirror-config` version is published.
-static CONFIG: Lazy<BinaryMirrorConfig> = Lazy::new(|| {
+static CONFIG: LazyLock<BinaryMirrorConfig> = LazyLock::new(|| {
     let config: BinaryMirrorConfig =
         serde_json::from_str(include_str!("binary-mirror-config.json"))
             .expect("bundled binary-mirror-config.json must parse (covered by a unit test)");
@@ -140,10 +138,6 @@ static CONFIG: Lazy<BinaryMirrorConfig> = Lazy::new(|| {
 });
 /// Cached result of whether we should skip binary mirror envs
 static SKIP_BINARY_MIRROR: OnceLock<bool> = OnceLock::new();
-
-fn load_config() -> &'static BinaryMirrorConfig {
-    &CONFIG
-}
 
 fn update_binary_config(pkg: &mut Value, binary_mirror: &BinaryMirror) {
     // Get existing binary configuration
@@ -342,12 +336,12 @@ async fn handle_cypress(
 }
 
 pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
-    // npm.org has no China mirror layer — skip alongside `get_envs`.
+    // Only rewrite binary hosts on the npmmirror registry the config targets.
     if should_skip_binary_mirror() {
         return Ok(());
     }
 
-    let Some(binary_mirror) = load_config().mirrors.china.packages.get(name) else {
+    let Some(binary_mirror) = CONFIG.mirrors.china.packages.get(name) else {
         return Ok(());
     };
 
@@ -390,24 +384,41 @@ pub async fn update_package_binary(dir: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
+/// The bundled config redirects binary downloads to npmmirror's China CDNs, so
+/// it is only correct on the npmmirror registry. Apply it there and skip
+/// everywhere else: official npm has no mirror layer, and other registries
+/// (yarnpkg, GitHub Packages, private/non-China mirrors) would otherwise get
+/// China CDN hosts and ~30 China mirror env vars forced onto downloads they
+/// never opted into.
+///
+/// Earlier this fetched the config from the *configured* registry, so the gate
+/// could be "skip official npm" — a registry that didn't serve the config
+/// 404'd and was skipped implicitly. With the config bundled there is no such
+/// fetch, so the gate is made explicit here.
 fn should_skip_binary_mirror() -> bool {
     *SKIP_BINARY_MIRROR.get_or_init(|| {
         let registry = get_registry();
-        let skip = is_npm_registry(&registry);
+        let skip = !is_china_mirror_registry(&registry);
         if skip {
-            tracing::debug!("Skipping binary mirror envs for npm registry: {}", registry);
+            tracing::debug!("Skipping binary mirror for non-npmmirror registry: {registry}");
         }
         skip
     })
 }
 
+/// Whether `registry` is the npmmirror China registry the bundled mirror config
+/// targets. Matches the host so a path suffix or trailing slash still counts.
+fn is_china_mirror_registry(registry: &str) -> bool {
+    registry.contains("npmmirror.com")
+}
+
 pub fn get_envs() -> Option<&'static BTreeMap<String, String>> {
-    // Skip binary mirror envs when using official npm registry
+    // Only inject China mirror envs on the npmmirror registry the config targets.
     if should_skip_binary_mirror() {
         return None;
     }
 
-    let envs = &load_config().mirrors.china.envs;
+    let envs = &CONFIG.mirrors.china.envs;
     (!envs.is_empty()).then_some(envs)
 }
 
@@ -416,6 +427,18 @@ mod tests {
     use super::*;
     use serde_json::json;
     use tempfile::tempdir;
+
+    #[test]
+    fn test_only_npmmirror_gets_binary_mirror() {
+        // The bundled config rewrites to npmmirror CDNs, so it applies only on
+        // npmmirror — not official npm, and not other registries that would get
+        // China hosts forced onto downloads they never opted into.
+        assert!(is_china_mirror_registry("https://registry.npmmirror.com"));
+        assert!(is_china_mirror_registry("https://registry.npmmirror.com/"));
+        assert!(!is_china_mirror_registry("https://registry.npmjs.org"));
+        assert!(!is_china_mirror_registry("https://registry.yarnpkg.com"));
+        assert!(!is_china_mirror_registry("https://npm.pkg.github.com"));
+    }
 
     /// The bundled config is the source of truth at runtime, so a re-sync that
     /// drifts from our strict schema must fail here (in CI) rather than silently

--- a/crates/pm/src/service/script/exec.rs
+++ b/crates/pm/src/service/script/exec.rs
@@ -39,7 +39,7 @@ async fn build_script_command(
         .env("npm_package_json", package.path.join("package.json"))
         .env("npm_config_global", get_install_scope().as_env_value());
 
-    if let Some(envs) = get_envs().await {
+    if let Some(envs) = get_envs() {
         tracing::debug!(
             "Injecting {} binary mirror envs for {}",
             envs.len(),

--- a/e2e/utoo-pm.ps1
+++ b/e2e/utoo-pm.ps1
@@ -781,15 +781,17 @@ finally {
 
 
 # ═══════════════════════════════════════════════════════════════
-# Case: bundled binary-mirror-config applies on a non-npm registry
+# Case: bundled binary-mirror-config applies on the npmmirror registry
 # ═══════════════════════════════════════════════════════════════
 # `binary-mirror-config` is bundled at build time (crates/pm/src/service/
 # binary-mirror-config.json) — no runtime fetch — and its parse under our strict
 # schema is guarded by a unit test. This case is the integration check: install
-# against a non-npm registry (npm.org is skipped) with --verbose and assert the
-# bundled mirror layer loaded for a mirror-matched package. flow-bin is the dep
-# on purpose — its bare-string `replaceHost` is the entry that once broke parse.
-Write-Yellow "Case: bundled binary-mirror-config applies on a non-npm registry"
+# against npmmirror (the only registry the bundled config targets) with --verbose
+# and assert the bundled mirror layer initialized during the install (the debug
+# line fires when the config is first read on a non-skipped package). flow-bin is
+# the dep on purpose — its bare-string `replaceHost` is the entry that once broke
+# parse.
+Write-Yellow "Case: bundled binary-mirror-config applies on npmmirror"
 $bmcDir = Join-Path $env:TEMP "utoo-e2e-bmc-$(Get-Random)"
 try {
     New-Item -ItemType Directory -Path $bmcDir -Force | Out-Null

--- a/e2e/utoo-pm.ps1
+++ b/e2e/utoo-pm.ps1
@@ -781,20 +781,15 @@ finally {
 
 
 # ═══════════════════════════════════════════════════════════════
-# Case: latest binary-mirror-config still parses under our schema
+# Case: bundled binary-mirror-config applies on a non-npm registry
 # ═══════════════════════════════════════════════════════════════
-# `binary-mirror-config`'s `mirrors.china` map is parsed into a strongly-typed
-# schema (crates/pm/src/service/binary.rs). The whole map deserializes as one
-# unit, so a single drifted entry fails the parse and silently disables the
-# China mirror layer for every package — `get_envs()`/`update_package_binary()`
-# swallow the error as a debug log. (`flow-bin` ships `replaceHost` as a bare
-# string, not an array, which previously broke the parse.)
-#
-# Guard against upstream drift: install against a non-npm registry (npm.org has
-# no mirror layer and is skipped) with --verbose, then assert the config loaded
-# and did NOT fail to parse. flow-bin is the dep on purpose — it is the exact
-# entry that regressed.
-Write-Yellow "Case: latest binary-mirror-config parses under our schema"
+# `binary-mirror-config` is bundled at build time (crates/pm/src/service/
+# binary-mirror-config.json) — no runtime fetch — and its parse under our strict
+# schema is guarded by a unit test. This case is the integration check: install
+# against a non-npm registry (npm.org is skipped) with --verbose and assert the
+# bundled mirror layer loaded for a mirror-matched package. flow-bin is the dep
+# on purpose — its bare-string `replaceHost` is the entry that once broke parse.
+Write-Yellow "Case: bundled binary-mirror-config applies on a non-npm registry"
 $bmcDir = Join-Path $env:TEMP "utoo-e2e-bmc-$(Get-Random)"
 try {
     New-Item -ItemType Directory -Path $bmcDir -Force | Out-Null
@@ -810,16 +805,13 @@ try {
         # mirror config is loaded on the clone path regardless of script exec.
         $bmcOut = utoo install --registry=https://registry.npmmirror.com --ignore-scripts --verbose 2>&1
         $bmcOut | Out-Host
-        if ($LASTEXITCODE -ne 0) { throw "utoo install failed for binary-mirror-config parse test" }
+        if ($LASTEXITCODE -ne 0) { throw "utoo install failed for binary-mirror-config test" }
 
-        if ($bmcOut -match "Failed to parse binary mirror config") {
-            throw "latest binary-mirror-config no longer matches our schema (mirrors.china drift)"
-        }
-        if (-not ($bmcOut -match "Binary mirror config loaded:")) {
-            throw "binary-mirror-config was never parsed (registry unreachable or mirror layer skipped)"
+        if (-not ($bmcOut -match "Bundled binary mirror config:")) {
+            throw "bundled binary-mirror-config was never applied (mirror layer skipped)"
         }
 
-        Write-Green "PASS: latest binary-mirror-config parses cleanly"
+        Write-Green "PASS: bundled binary-mirror-config applied"
     }
     finally { Pop-Location }
 }

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -1984,15 +1984,17 @@ trap - EXIT
 echo -e "${GREEN}PASS: overrides → file: directory errors clearly${NC}"
 
 # ═══════════════════════════════════════════════════════════════
-# Case: bundled binary-mirror-config applies on a non-npm registry
+# Case: bundled binary-mirror-config applies on the npmmirror registry
 # ═══════════════════════════════════════════════════════════════
 # `binary-mirror-config` is bundled at build time (crates/pm/src/service/
 # binary-mirror-config.json) — no runtime fetch — and its parse under our strict
 # schema is guarded by a unit test. This case is the integration check: install
-# against a non-npm registry (npm.org is skipped) with --verbose and assert the
-# bundled mirror layer loaded for a mirror-matched package. flow-bin is the dep
-# on purpose — its bare-string `replaceHost` is the entry that once broke parse.
-echo -e "${YELLOW}Case: bundled binary-mirror-config applies on a non-npm registry${NC}"
+# against npmmirror (the only registry the bundled config targets) with --verbose
+# and assert the bundled mirror layer initialized during the install (the debug
+# line fires when the config is first read on a non-skipped package). flow-bin is
+# the dep on purpose — its bare-string `replaceHost` is the entry that once broke
+# parse.
+echo -e "${YELLOW}Case: bundled binary-mirror-config applies on npmmirror${NC}"
 BMC_DIR=$(mktemp -d)
 # Remove the temp dir even if an assertion below exits the script mid-case.
 trap 'rm -rf "$BMC_DIR"' EXIT

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -1984,20 +1984,15 @@ trap - EXIT
 echo -e "${GREEN}PASS: overrides → file: directory errors clearly${NC}"
 
 # ═══════════════════════════════════════════════════════════════
-# Case: latest binary-mirror-config still parses under our schema
+# Case: bundled binary-mirror-config applies on a non-npm registry
 # ═══════════════════════════════════════════════════════════════
-# `binary-mirror-config`'s `mirrors.china` map is parsed into a strongly-typed
-# schema (crates/pm/src/service/binary.rs). The whole map deserializes as one
-# unit, so a single drifted entry fails the parse and silently disables the
-# China mirror layer for every package — `get_envs()`/`update_package_binary()`
-# swallow the error as a debug log. (`flow-bin` ships `replaceHost` as a bare
-# string, not an array, which previously broke the parse.)
-#
-# Guard against upstream drift: install against a non-npm registry (npm.org has
-# no mirror layer and is skipped) with --verbose, then assert the config loaded
-# and did NOT fail to parse. flow-bin is the dep on purpose — it is the exact
-# entry that regressed.
-echo -e "${YELLOW}Case: latest binary-mirror-config parses under our schema${NC}"
+# `binary-mirror-config` is bundled at build time (crates/pm/src/service/
+# binary-mirror-config.json) — no runtime fetch — and its parse under our strict
+# schema is guarded by a unit test. This case is the integration check: install
+# against a non-npm registry (npm.org is skipped) with --verbose and assert the
+# bundled mirror layer loaded for a mirror-matched package. flow-bin is the dep
+# on purpose — its bare-string `replaceHost` is the entry that once broke parse.
+echo -e "${YELLOW}Case: bundled binary-mirror-config applies on a non-npm registry${NC}"
 BMC_DIR=$(mktemp -d)
 # Remove the temp dir even if an assertion below exits the script mid-case.
 trap 'rm -rf "$BMC_DIR"' EXIT
@@ -2015,14 +2010,9 @@ pushd "$BMC_DIR"
 # config is loaded on the clone path regardless of script execution.
 utoo install --registry=https://registry.npmmirror.com --ignore-scripts --verbose 2>&1 \
   | tee bmc.out \
-  || { echo -e "${RED}FAIL: utoo install failed for binary-mirror-config parse test${NC}"; cat bmc.out; exit 1; }
-if grep -q "Failed to parse binary mirror config" bmc.out; then
-    echo -e "${RED}FAIL: latest binary-mirror-config no longer matches our schema (mirrors.china drift)${NC}"
-    grep "binary mirror" bmc.out
-    exit 1
-fi
-if ! grep -q "Binary mirror config loaded:" bmc.out; then
-    echo -e "${RED}FAIL: binary-mirror-config was never parsed (registry unreachable or mirror layer skipped)${NC}"
+  || { echo -e "${RED}FAIL: utoo install failed for binary-mirror-config test${NC}"; cat bmc.out; exit 1; }
+if ! grep -q "Bundled binary mirror config:" bmc.out; then
+    echo -e "${RED}FAIL: bundled binary-mirror-config was never applied (mirror layer skipped)${NC}"
     cat bmc.out
     exit 1
 fi
@@ -2030,6 +2020,6 @@ rm -f bmc.out
 popd
 rm -rf "$BMC_DIR"
 trap - EXIT
-echo -e "${GREEN}PASS: latest binary-mirror-config parses cleanly${NC}"
+echo -e "${GREEN}PASS: bundled binary-mirror-config applied${NC}"
 
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"


### PR DESCRIPTION
## Problem

`binary-mirror-config` was fetched from the registry on every install (non-npm registries). Two issues with that:

1. **Cold-install stall** — the fetch is on the per-package critical path (`update_package_binary` runs for every cloned package), so the first mirror-matched package waited on a network round trip. A non-cached parse failure even re-fetched per package (the regression behind the earlier ant-design stall).
2. **Silent failure on schema drift** — the whole `mirrors.china` map deserializes as one unit, so a single drifted upstream entry failed the parse and disabled mirroring for *every* package, swallowed as a debug log.

It's a package **we maintain**, it applies to **public registries only**, and it **changes rarely** — so a runtime fetch buys little and risks a lot.

## Change

Bundle the config at build time and read it via `include_str!`:

- `crates/pm/src/service/binary-mirror-config.json` — the package's `mirrors` field (`@2.20.0`; npmjs and npmmirror serve byte-identical `mirrors`).
- `static CONFIG: Lazy<BinaryMirrorConfig>` parses the bundled JSON once; `load_config()` becomes a sync `&'static` accessor.
- **Zero network** — no fetch, no disk cache, no TTL/ETag machinery to maintain.
- A parse failure is now **our CI failure** (`test_bundled_config_parses`), never a user's broken/degraded install.
- `get_envs` drops `async`; `update_package_binary` loses its now-unreachable error arm.

Re-sync the JSON with the package's `mirrors` field whenever a new `binary-mirror-config` version is published.

## Why not a cache (supersedes #3152)

We measured the alternatives:
- The `/pkg/latest` endpoint we used has **no ETag** (npmmirror has no validator at all), so conditional-GET freshness isn't available there; only the full packument has an ETag, and it's ~700KB.
- An on-disk TTL cache (#3152) still needs the fetch/parse/staleness machinery and can serve stale.

Since we own the package and it's tiny + rarely-changing, bundling is strictly simpler and removes the whole failure class. **#3152 will be closed.**

## Testing

- `cargo test -p utoo-pm --bin utoo binary` → 15 passed (incl. `test_bundled_config_parses`, which pins the `flow-bin` bare-string `replaceHost` case)
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt` clean
- e2e (bash + pwsh) updated: install `flow-bin` against `registry.npmmirror.com`, assert the bundled mirror layer applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)