### PR TITLE
fix(pack): resolve CJS require() to main field on node target, not the ESM module field

### DIFF
--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -352,7 +352,13 @@ pub async fn get_server_resolve_options_context(
         custom_conditions,
         import_map: Some(server_import_map),
         fallback_import_map: Some(server_fallback_import_map),
-        module: true,
+        // Node honors neither the `module` main field nor the `module` exports condition; both are
+        // bundler-only conventions. Enabling them on a node target makes a `require()` (or `import`)
+        // of a package without an `exports` field resolve the ESM `module` build instead of the CJS
+        // `main` Node would load — yielding the ESM namespace (`{ default, __esModule }`) so named
+        // access becomes `undefined` (e.g. `require('json5').parse`). Keep it off to match Node.
+        // See https://github.com/utooland/utoo/issues/3185
+        module: false,
         before_resolve_plugins: vec![ResolvedVc::upcast(externals_plugin)],
         after_resolve_plugins: vec![ResolvedVc::upcast(externals_plugin)],
         ..Default::default()


### PR DESCRIPTION
## Problem

Fixes #3185.

When bundling for a **node** target, an authored-CJS module that does `require('pkg')` on a dependency whose only ESM export is `default` (and which has **no `exports` field**) received the ESM **namespace object** (`{ default, __esModule }`) instead of the CJS `main`'s value. Named access was therefore `undefined`.

Real-world crash: bundling [cnpmcore](https://github.com/cnpm/cnpmcore) → `tsconfig-paths` does `const JSON5 = require('json5'); JSON5.parse(...)`. `json5` ships `main: lib/index.js` (CJS), `module: dist/index.mjs` (ESM, only `export default`), and **no `exports`**. Pack resolved the `module` (ESM) field for the `require()`, so the caller got `{ default: { parse } }` and `JSON5.parse` was `undefined` → `JSON5.parse is not a function`.

## Root cause

`get_server_resolve_options_context` set `module: true`. In turbopack's resolver (`resolve.rs`), the `into_package` order is `exports` → `browser` → **`module`** → `main`, and `apply_cjs_specific_options` only flips the `import`/`require` conditions **inside the `exports`/`imports` condition maps** — it does **not** remove the `module` main-field entry for a `require()`. So for a package without `exports`, both `require()` and `import` resolved the ESM `module` field first.

**Node honors neither the `module` main field nor the `module` exports condition** — both are bundler-only conventions. Enabling them on a node target diverges from Node and produces this interop defect (it also breaks `import { parse } from 'json5'`, which would get `undefined` for the same reason).

## Fix

Disable the `module` field on the server (node) resolve context (`module: false`). Resolution now matches Node in both `require()` and `import` directions. Packages that ship an `exports` field are unaffected — `exports` takes priority over main fields.

## Verification

Self-contained repro from the issue (CJS `require()` of a json5-shaped dep, node-target standalone build, then run the output):

| Build | Result |
|---|---|
| Published `@utoo/pack@1.4.14` | ❌ `FAIL  named access is 'undefined'` |
| This branch (local build) | ✅ `PASS  named access works (value="cjs:ok")` |

`value="cjs:ok"` confirms the `require()` now resolves the CJS `main` (which prepends `cjs:`) rather than the ESM `module` build.

Also verified locally:
- `cargo fmt --check` — clean
- `cargo clippy -p pack-core --all-targets -- -D warnings --no-deps` — clean

## CI dependency

CI's `clippy` job is currently red on `next` due to a **pre-existing, unrelated** break (a9ee35bb added `bytes_stream()` without reqwest's `stream` feature). That is fixed separately in **#3187**. Once #3187 lands, this branch will be rebased onto `next` and CI will be fully green.