### PR TITLE
fix(pm): enable reqwest `stream` feature for download progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6140,6 +6140,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -10929,6 +10930,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/pm/Cargo.toml
+++ b/crates/pm/Cargo.toml
@@ -48,6 +48,7 @@ reqwest            = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls-native-roots",
   "socks",
+  "stream",
 ] }
 serde              = { workspace = true }
 serde_json         = { version = "1.0", features = ["preserve_order"] }


### PR DESCRIPTION
## Problem

`crates/pm/src/util/downloader.rs` calls `response.bytes_stream()` (added in #3142 / a9ee35bb for live install progress), which requires reqwest's `stream` feature. The feature was never enabled, so `utoo-pm` fails to compile:

```
error[E0599]: no method named `bytes_stream` found for struct `reqwest::Response` in the current scope
  --> crates/pm/src/util/downloader.rs:65:47
```

This turns CI red on `next` (e.g. the `clippy` / `cargo clippy --all-targets` and `utoopm-ci` jobs), blocking all branches.

## Fix

Add `"stream"` to the reqwest feature list in `crates/pm/Cargo.toml` (and the resulting `Cargo.lock` update).

## Verification

```
cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps   # passes
```