### PR TITLE
perf(pm): drop reqwest `stream` feature, stream download via `Response::chunk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6140,7 +6140,6 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -10930,19 +10929,6 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/crates/pm/Cargo.toml
+++ b/crates/pm/Cargo.toml
@@ -48,7 +48,6 @@ reqwest            = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls-native-roots",
   "socks",
-  "stream",
 ] }
 serde              = { workspace = true }
 serde_json         = { version = "1.0", features = ["preserve_order"] }

--- a/crates/pm/src/util/downloader.rs
+++ b/crates/pm/src/util/downloader.rs
@@ -2,7 +2,6 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use anyhow::{Context, Result};
 use bytes::{Bytes, BytesMut};
-use futures::StreamExt;
 use once_cell::sync::Lazy;
 use reqwest::{Client, StatusCode};
 use tokio_retry::RetryIf;
@@ -45,27 +44,32 @@ pub async fn download_bytes(url: &str, auth_token: Option<&str>) -> Result<Bytes
             if let Some(token) = auth_token {
                 request = request.bearer_auth(token);
             }
-            let response = request
+            let mut response = request
                 .send()
                 .await
                 .map_err(|e| RetryableError::Temporary(format!("Network error: {e}")))?;
 
             match response.status() {
                 StatusCode::OK => {
-                    // Stream chunks instead of buffering the whole body in one
-                    // await: each chunk feeds the live byte counter the spinner
-                    // renders as `↓ 23.4 MB 8.2 MB/s`. The guard surfaces this
-                    // request in the `N downloading` concurrency count.
+                    // Read the body chunk-by-chunk via `Response::chunk` (which
+                    // needs no reqwest `stream` feature) instead of buffering it
+                    // in one await: each chunk feeds the live byte counter the
+                    // spinner renders as `↓ 23.4 MB 8.2 MB/s`. The body is still
+                    // fully buffered before return — the downstream extractor is
+                    // not streaming — so `chunk` only buys the progress signal,
+                    // not lower peak memory. The guard surfaces this request in
+                    // the `N downloading` concurrency count.
                     let _gauge = DownloadGuard::enter();
                     // Capacity hint only — capped so a bogus Content-Length
                     // can't force a huge allocation; BytesMut grows as needed.
                     const MAX_PREALLOC: u64 = 32 * 1024 * 1024;
                     let hint = response.content_length().unwrap_or(0).min(MAX_PREALLOC);
                     let mut buf = BytesMut::with_capacity(hint as usize);
-                    let mut stream = response.bytes_stream();
-                    while let Some(chunk) = stream.next().await {
-                        let chunk = chunk
-                            .map_err(|e| RetryableError::Temporary(format!("Stream error: {e}")))?;
+                    while let Some(chunk) = response
+                        .chunk()
+                        .await
+                        .map_err(|e| RetryableError::Temporary(format!("Stream error: {e}")))?
+                    {
                         DOWNLOADED_BYTES.fetch_add(chunk.len() as u64, Ordering::Relaxed);
                         buf.extend_from_slice(&chunk);
                     }


### PR DESCRIPTION
## Background

`crates/pm/src/util/downloader.rs` reported live install progress via `response.bytes_stream()` (added in #3142 / a9ee35bb), which requires reqwest's `stream` feature. #3183 (binary slimming) had removed `stream` on a base that predated that call site, so once both PRs landed on `next` the combination failed to compile:

```
error[E0599]: no method named `bytes_stream` found for struct `reqwest::Response`
```

#3187 unblocked `next` by **re-adding** the `stream` feature. This PR does it properly instead.

## Why progress never needed `stream`

`reqwest::Response::chunk()` reads the body frame-by-frame with **no feature gate** (only `bytes_stream()` is `#[cfg(feature = "stream")]`). It feeds the exact same per-chunk `DOWNLOADED_BYTES` counter the spinner renders as `↓ 23.4 MB 8.2 MB/s`.

The body is still **fully buffered** before return — the downstream extractor is not streaming (the decompression path isn't incremental) — so `chunk()` only buys the progress signal, not lower peak memory. Behavior is byte-for-byte identical: npm `.tgz` aren't transfer-`gzip`-encoded, so both paths count raw tarball bytes the same.

## Changes

- Revert #3187's `stream` feature (the `Cargo.lock` diff is the exact inverse of #3187 — only the wasm-only `wasm-streams` dep is dropped; native binary size is unaffected).
- Rewrite the download loop to use `Response::chunk()`.
- Drop the now-unused `futures::StreamExt` import.

## Verification

```
cargo check  -p utoo-pm                                   # ok
cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps   # ok
cargo fmt                                                 # no changes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)