### PR TITLE
fix(pm): accept string-typed `private` in package.json; warn on member parse failure

### DIFF
--- a/crates/ruborist/src/model/package_json.rs
+++ b/crates/ruborist/src/model/package_json.rs
@@ -24,6 +24,29 @@ where
         .collect())
 }
 
+/// Deserialize an optional bool that also tolerates a string-typed value
+/// (`"private": "true"` / `"false"`). npm/pnpm/yarn coerce these, and real
+/// manifests ship them (e.g. `@mui/internal-waterfall`). Without this, a single
+/// string-typed `private` fails the *whole* manifest parse — and since workspace
+/// discovery silently skips members that fail to parse, the member vanishes and
+/// later surfaces as a misleading "workspace: dependency does not match any
+/// workspace member". Unrecognised values (including numeric `1`/`0`, which npm
+/// does not coerce either) read as `None` so one odd field never sinks the parse.
+fn deserialize_lenient_opt_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(match Option::<Value>::deserialize(deserializer)? {
+        Some(Value::Bool(b)) => Some(b),
+        Some(Value::String(s)) => match s.trim().to_ascii_lowercase().as_str() {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        },
+        _ => None,
+    })
+}
+
 /// Parsed package.json content.
 ///
 /// This is the primary type for representing package.json in ruborist.
@@ -119,8 +142,14 @@ pub struct PackageJson {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    /// Whether package is private
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Whether package is private. Accepts boolean or string `"true"`/`"false"`
+    /// (some real manifests ship the string form); see
+    /// [`deserialize_lenient_opt_bool`].
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_lenient_opt_bool"
+    )]
     pub private: Option<bool>,
 
     /// Files whitelist for publishing
@@ -652,6 +681,39 @@ mod tests {
         assert_eq!(rt["private"], true);
         assert_eq!(rt["main"], "./lib/index.js");
         assert_eq!(rt["publishConfig"]["tag"], "beta");
+    }
+
+    #[test]
+    fn test_private_accepts_string_typed_value() {
+        // Some real manifests (e.g. @mui/internal-waterfall) ship `"private"` as
+        // a string. It must not fail the whole parse — that would drop the
+        // package as a workspace member and break sibling `workspace:` deps.
+        assert_eq!(
+            PackageJson::from_value(&json!({ "name": "x", "private": "true" }))
+                .unwrap()
+                .private,
+            Some(true)
+        );
+        assert_eq!(
+            PackageJson::from_value(&json!({ "private": "false" }))
+                .unwrap()
+                .private,
+            Some(false)
+        );
+        // Boolean form still works.
+        assert_eq!(
+            PackageJson::from_value(&json!({ "private": true }))
+                .unwrap()
+                .private,
+            Some(true)
+        );
+        // Unrecognised value reads as None rather than failing the parse.
+        assert_eq!(
+            PackageJson::from_value(&json!({ "private": "yes" }))
+                .unwrap()
+                .private,
+            None
+        );
     }
 
     #[test]

--- a/crates/ruborist/src/resolver/workspace.rs
+++ b/crates/ruborist/src/resolver/workspace.rs
@@ -99,12 +99,20 @@ impl<G: Glob> WorkspaceDiscovery<G> {
                     None => continue,
                 };
 
-                // Read workspace package.json
+                // Read workspace package.json. A parse failure here drops the
+                // member from the graph entirely, which later surfaces as a
+                // confusing "workspace: dependency does not match any workspace
+                // member" on any sibling that depends on it — so warn loudly
+                // rather than swallowing it at debug level.
                 let mut workspace_pkg: PackageJson = match read_package_json(&workspace_path).await
                 {
                     Ok(pkg) => pkg,
                     Err(e) => {
-                        tracing::debug!("Failed to read workspace package.json: {}", e);
+                        tracing::warn!(
+                            "Skipping workspace member at {}: package.json failed to parse ({e:#}); \
+                             `workspace:` deps on it will not resolve",
+                            workspace_path.display()
+                        );
                         continue;
                     }
                 };


### PR DESCRIPTION
## Problem

`ut install --from pnpm` fails on **mui/material-ui**:

```
ERROR Dependency resolution failed: Unsupported dependency 'workspace:^':
  workspace: dependency does not match any workspace member of this project
required by: @mui/icons-material@9.1.1 └── @mui/internal-waterfall@workspace:^
```

The error blames `workspace:^`, but the protocol is fine. Root cause: `@mui/internal-waterfall` ships `"private": "true"` (a **string**, not a boolean). utoo typed `private` as `Option<bool>`, so serde **failed the whole manifest parse**. Workspace discovery then **silently skipped** the unparseable member (`workspace.rs` `continue` + debug-only log), so it was never registered — and a sibling's `workspace:^` edge couldn't match it. (`:^`/`:~` parse fine and the member matcher is name-only; the protocol is a red herring.)

Closes #3189.

## Fix

1. **`package_json.rs`** — `private` now deserializes with a lenient bool-or-string parser: `"true"`/`"false"` → `Some(bool)` (value preserved, matching npm/pnpm/yarn coercion); unrecognised values → `None` so one odd field never sinks the parse. npm doesn't coerce numeric `1`/`0`, so neither do we.
2. **`workspace.rs`** — a member whose `package.json` fails to parse now `warn!`s with the path + full cause (`{e:#}`) instead of a swallowed `debug!`, so a parse-tolerance gap can't masquerade as a confusing downstream "does not match any workspace member".

## Verification

- New unit test `test_private_accepts_string_typed_value` (`"true"`/`"false"`/bool/unknown).
- `cargo fmt` + `clippy -p utoo-ruborist -p utoo-pm -D warnings` clean; rust-code-guard reviewed → "ship it".
- **End-to-end**: a minimal fixture (root `pnpm-workspace.yaml` + a `packages/*` member depending on a `packages-internal/*` member via `workspace:^`) reproduces the failure with `"private":"true"` and resolves cleanly after the fix (`RUST_LOG=debug` shows `Added workspace: @mui/internal-waterfall`, exit 0). Surfaced by the new `pm-benchmark-set` utoo-vs-pnpm bench (PR #3184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)