### PR TITLE
fix(pack): checkout release tag for trusted publishing

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -181,6 +181,8 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - name: Setup node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- checkout the release tag in the `utoopack-release` publish job
- ensure npm trusted publishing provenance includes `SourceRepositoryRef` instead of an empty ref on release-triggered runs

## Root cause

The failed publish generated a Sigstore certificate with `repo:utooland/utoo:ref:` and npm rejected it with `Missing SourceRepositoryRef in signing certificate`. The release job was using the default detached checkout for the release event, so the provenance certificate did not include the tag ref.

## Validation

- `git diff --check -- .github/workflows/pack-release.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pack-release.yml"); puts "ok"'`