### PR TITLE
ci(pack): publish utoopack from tag push

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -10,8 +10,36 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  validate_release_ref:
+    name: Validate release ref
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.validate.outputs.publish }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate tag target
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" != "push" ]]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin next:refs/remotes/origin/next
+          if git merge-base --is-ancestor "$GITHUB_SHA" origin/next; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Ref ${GITHUB_REF_NAME} points to ${GITHUB_SHA}, which is not on origin/next."
+            exit 1
+          fi
+
   build:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'utoopack-v')
+    needs:
+      - validate_release_ref
+    if: github.event_name == 'workflow_dispatch' || needs.validate_release_ref.outputs.publish == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -171,7 +199,7 @@ jobs:
           path: ./packages/pack/src/pack.*.node
           if-no-files-found: error
   publish:
-    if: github.event_name == 'push' && startsWith(github.ref_name, 'utoopack-v')
+    if: needs.validate_release_ref.outputs.publish == 'true'
     name: Publish
     runs-on: ubuntu-latest
     permissions:
@@ -179,6 +207,7 @@ jobs:
       contents: read
       id-token: write
     needs:
+      - validate_release_ref
       - build
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -1,8 +1,9 @@
 name: utoopack-release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "utoopack-v*"
   workflow_dispatch:
 
 env:
@@ -10,7 +11,7 @@ env:
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'utoopack-v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'utoopack-v')
     strategy:
       fail-fast: true
       matrix:
@@ -170,7 +171,7 @@ jobs:
           path: ./packages/pack/src/pack.*.node
           if-no-files-found: error
   publish:
-    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'utoopack-v')
+    if: github.event_name == 'push' && startsWith(github.ref_name, 'utoopack-v')
     name: Publish
     runs-on: ubuntu-latest
     permissions:
@@ -182,7 +183,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.ref_name }}
       - name: Setup node
         uses: actions/setup-node@v6
         with:
@@ -208,11 +209,11 @@ jobs:
           npm run build --workspace=@utoo/pack-shared
           npm run build:js --workspace=@utoo/pack
           npm run build --workspace=@utoo/pack-cli
-      - name: Get version from release or use alpha version
+      - name: Get version from tag
         id: get_version
         shell: bash
         run: |
-          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_NAME="${{ github.ref_name }}"
           VERSION=${TAG_NAME#utoopack-v}
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: Update npm for trusted publishing

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -10,36 +10,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  validate_release_ref:
-    name: Validate release ref
-    runs-on: ubuntu-latest
-    outputs:
-      publish: ${{ steps.validate.outputs.publish }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Validate tag target
-        id: validate
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ "${GITHUB_EVENT_NAME}" != "push" ]]; then
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git fetch --no-tags --depth=1 origin next:refs/remotes/origin/next
-          if git merge-base --is-ancestor "$GITHUB_SHA" origin/next; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::Ref ${GITHUB_REF_NAME} points to ${GITHUB_SHA}, which is not on origin/next."
-            exit 1
-          fi
-
   build:
-    needs:
-      - validate_release_ref
-    if: github.event_name == 'workflow_dispatch' || needs.validate_release_ref.outputs.publish == 'true'
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'utoopack-v')
     strategy:
       fail-fast: true
       matrix:
@@ -199,7 +171,7 @@ jobs:
           path: ./packages/pack/src/pack.*.node
           if-no-files-found: error
   publish:
-    if: needs.validate_release_ref.outputs.publish == 'true'
+    if: github.event_name == 'push' && startsWith(github.ref_name, 'utoopack-v')
     name: Publish
     runs-on: ubuntu-latest
     permissions:
@@ -207,7 +179,6 @@ jobs:
       contents: read
       id-token: write
     needs:
-      - validate_release_ref
       - build
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- run `utoopack-release` on `push` events for `utoopack-v*` tags instead of GitHub Release publication
- keep `workflow_dispatch` for manual build runs, while npm publish only runs for tag pushes
- derive the publish version from `github.ref_name`

## Root cause

The release-triggered workflow still generated a GitHub OIDC token with an empty source repository ref, even after checking out the release tag. npm trusted publishing uses the OIDC token claims, not the checked-out git ref, so the Sigstore certificate continued to contain `repo:utooland/utoo:ref:` and npm rejected it with `Missing SourceRepositoryRef in signing certificate`.

A tag-push-triggered workflow should give the OIDC token a concrete `refs/tags/utoopack-v...` source ref, which is what npm expects for trusted publishing provenance verification.

## Validation

- `git diff --check HEAD~1..HEAD -- .github/workflows/pack-release.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pack-release.yml"); puts "ok"'`