### PR TITLE
feat(pack): support rust react compiler

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -27,7 +27,9 @@ use turbopack_core::{
     resolve::options::{ImportMap, ImportMapping},
 };
 use turbopack_css::chunk::CssChunkType;
-use turbopack_ecmascript::{TypeofWindow, chunk::EcmascriptChunkType};
+use turbopack_ecmascript::{
+    TypeofWindow, chunk::EcmascriptChunkType, transform::ReactCompilerTarget,
+};
 use turbopack_node::{
     execution_context::ExecutionContext,
     transforms::postcss::{PostCssConfigLocation, PostCssTransform, PostCssTransformOptions},
@@ -369,6 +371,9 @@ pub async fn get_client_module_options_context(
         .css_modules
         .as_ref()
         .and_then(|css_modules| css_modules.local_ident_pattern());
+    let enable_rust_react_compiler = *config.rust_react_compiler().await?;
+    let rust_react_compiler_target: ReactCompilerTarget =
+        *config.rust_react_compiler_target().await?;
 
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
@@ -431,6 +436,8 @@ pub async fn get_client_module_options_context(
             enable_jsx: Some(jsx_transform_options),
             enable_typescript_transform: Some(tsconfig),
             enable_decorators: Some(decorators_options.to_resolved().await?),
+            enable_rust_react_compiler,
+            rust_react_compiler_target,
             ..module_options_context.ecmascript.clone()
         },
         enable_webpack_loaders,

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -24,7 +24,12 @@ use turbopack_core::{
     issue::{Issue, IssueExt, IssueStage, StyledString},
     resolve::ResolveAliasMap,
 };
-use turbopack_ecmascript::{OptionTreeShaking, TreeShakingMode};
+use turbopack_ecmascript::{
+    OptionTreeShaking, TreeShakingMode,
+    transform::{
+        OptionReactCompilerCompilationMode, ReactCompilerCompilationMode, ReactCompilerTarget,
+    },
+};
 use turbopack_ecmascript_plugins::transform::{
     emotion::EmotionTransformConfig, styled_components::StyledComponentsTransformConfig,
 };
@@ -177,6 +182,10 @@ pub struct Config {
     react: Option<ReactConfig>,
     optimization: Option<OptimizationConfig>,
     stats: Option<bool>,
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    react_compiler: Option<ReactCompilerOptionsOrBoolean>,
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    experimental: Option<ExperimentalConfig>,
     #[bincode(with = "turbo_bincode::serde_self_describing")]
     swc_plugins: Option<Vec<(RcStr, serde_json::Value)>>,
     #[cfg(any(feature = "process_pool", feature = "worker_pool"))]
@@ -806,6 +815,16 @@ pub enum ReactCompilerMode {
     All,
 }
 
+impl From<ReactCompilerMode> for ReactCompilerCompilationMode {
+    fn from(value: ReactCompilerMode) -> Self {
+        match value {
+            ReactCompilerMode::Infer => ReactCompilerCompilationMode::Infer,
+            ReactCompilerMode::Annotation => ReactCompilerCompilationMode::Annotation,
+            ReactCompilerMode::All => ReactCompilerCompilationMode::All,
+        }
+    }
+}
+
 /// Subset of react compiler options
 #[turbo_tasks::value(shared, operation)]
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -814,11 +833,12 @@ pub struct ReactCompilerOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compilation_mode: Option<ReactCompilerMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub panic_threshold: Option<RcStr>,
+    pub target: Option<ReactCompilerTarget>,
 }
 
-#[turbo_tasks::value]
-#[derive(Clone, Debug, Deserialize, OperationValue)]
+#[derive(
+    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+)]
 #[serde(untagged)]
 pub enum ReactCompilerOptionsOrBoolean {
     Boolean(bool),
@@ -827,6 +847,32 @@ pub enum ReactCompilerOptionsOrBoolean {
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionalReactCompilerOptions(Option<ResolvedVc<ReactCompilerOptions>>);
+
+#[turbo_tasks::value(transparent)]
+pub struct ReactCompilerTargetConfig(ReactCompilerTarget);
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ExperimentalConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    pub react_compiler: Option<ReactCompilerOptionsOrBoolean>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    pub swc_plugins: Option<Vec<(RcStr, serde_json::Value)>>,
+}
 
 #[turbo_tasks::value]
 #[derive(Clone, Debug, Deserialize, OperationValue)]
@@ -1154,6 +1200,45 @@ impl Config {
     #[turbo_tasks::function]
     pub fn react(&self) -> Vc<ReactConfig> {
         self.react.clone().unwrap_or_default().cell()
+    }
+
+    #[turbo_tasks::function]
+    pub fn rust_react_compiler(&self) -> Vc<OptionReactCompilerCompilationMode> {
+        let options = self.react_compiler.as_ref().or_else(|| {
+            self.experimental
+                .as_ref()
+                .and_then(|experimental| experimental.react_compiler.as_ref())
+        });
+
+        let mode = match options {
+            Some(ReactCompilerOptionsOrBoolean::Boolean(true)) => {
+                Some(ReactCompilerCompilationMode::Infer)
+            }
+            Some(ReactCompilerOptionsOrBoolean::Option(options)) => {
+                Some(options.compilation_mode.clone().unwrap_or_default().into())
+            }
+            _ => None,
+        };
+
+        Vc::cell(mode)
+    }
+
+    #[turbo_tasks::function]
+    pub fn rust_react_compiler_target(&self) -> Vc<ReactCompilerTargetConfig> {
+        let options = self.react_compiler.as_ref().or_else(|| {
+            self.experimental
+                .as_ref()
+                .and_then(|experimental| experimental.react_compiler.as_ref())
+        });
+
+        let target = match options {
+            Some(ReactCompilerOptionsOrBoolean::Option(options)) => {
+                options.target.unwrap_or_default()
+            }
+            _ => ReactCompilerTarget::default(),
+        };
+
+        Vc::cell(target)
     }
 
     #[turbo_tasks::function]
@@ -1490,7 +1575,14 @@ impl Config {
 
     #[turbo_tasks::function]
     pub fn swc_plugins(&self) -> Vc<SwcPlugins> {
-        Vc::cell(self.swc_plugins.clone().unwrap_or_default())
+        let mut swc_plugins = self.swc_plugins.clone().unwrap_or_default();
+        if let Some(experimental) = &self.experimental
+            && let Some(experimental_swc_plugins) = &experimental.swc_plugins
+        {
+            swc_plugins.extend(experimental_swc_plugins.clone());
+        }
+
+        Vc::cell(swc_plugins)
     }
 
     #[turbo_tasks::function]

--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
     module_graph::binding_usage_info::OptionBindingUsageInfo,
 };
 use turbopack_css::chunk::CssChunkType;
-use turbopack_ecmascript::chunk::EcmascriptChunkType;
+use turbopack_ecmascript::{chunk::EcmascriptChunkType, transform::ReactCompilerTarget};
 use turbopack_node::{
     execution_context::ExecutionContext,
     transforms::postcss::{PostCssConfigLocation, PostCssTransformOptions},
@@ -236,6 +236,9 @@ pub async fn get_server_module_options_context(
         .css_modules
         .as_ref()
         .and_then(|css_modules| css_modules.local_ident_pattern());
+    let enable_rust_react_compiler = *config.rust_react_compiler().await?;
+    let rust_react_compiler_target: ReactCompilerTarget =
+        *config.rust_react_compiler_target().await?;
 
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
@@ -297,6 +300,8 @@ pub async fn get_server_module_options_context(
             enable_jsx: Some(jsx_transform_options),
             enable_typescript_transform: Some(tsconfig),
             enable_decorators: Some(decorators_options.to_resolved().await?),
+            enable_rust_react_compiler,
+            rust_react_compiler_target,
             ..module_options_context.ecmascript.clone()
         },
         enable_webpack_loaders,

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -88,6 +88,11 @@ pub struct CompleteConfig {
     #[schemars(description = "Enable build statistics")]
     pub stats: Option<bool>,
 
+    /// Enable the Rust React Compiler transform
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "React compiler")]
+    pub react_compiler: Option<SchemaReactCompilerConfig>,
+
     /// Enable persistent caching
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Enable persistent caching")]
@@ -1118,7 +1123,39 @@ pub struct SchemaExperimentalConfig {
     /// React compiler
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "React compiler")]
-    pub react_compiler: Option<serde_json::Value>,
+    pub react_compiler: Option<SchemaReactCompilerConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SchemaReactCompilerConfig {
+    Boolean(bool),
+    Options(SchemaReactCompilerOptions),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaReactCompilerOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compilation_mode: Option<SchemaReactCompilerCompilationMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<SchemaReactCompilerTarget>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum SchemaReactCompilerCompilationMode {
+    Infer,
+    Annotation,
+    All,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub enum SchemaReactCompilerTarget {
+    #[serde(rename = "18")]
+    React18,
+    #[serde(rename = "19")]
+    React19,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler/config.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.jsx",
+        "name": "main"
+      }
+    ],
+    "output": {
+      "path": "output"
+    },
+    "mode": "production",
+    "reactCompiler": true,
+    "optimization": {
+      "minify": false,
+      "moduleIds": "named"
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler/input/index.jsx
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler/input/index.jsx
@@ -1,0 +1,16 @@
+import { useState } from "react";
+
+export function Counter({ initialCount }) {
+  const [count, setCount] = useState(initialCount);
+  const doubled = count * 2;
+
+  return (
+    <div>
+      <p>{count}</p>
+      <p>{doubled}</p>
+      <button onClick={() => setCount(count + 1)}>increment</button>
+    </div>
+  );
+}
+
+console.log(Counter);

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler/output/_project___1d570a0a.js
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler/output/_project___1d570a0a.js
@@ -1,0 +1,122 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/node_modules/react/jsx-runtime.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+function jsx() {
+    return 'purposefully empty stub for react/jsx-runtime.js';
+}
+function jsxs() {
+    return 'purposefully empty stub for react/jsx-runtime.js';
+}
+__turbopack_context__.s([
+    "jsx",
+    0,
+    jsx,
+    "jsxs",
+    0,
+    jsxs
+]);
+}),
+"[project]/node_modules/react/compiler-runtime.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+function c(size) {
+    return new Array(size);
+}
+__turbopack_context__.s([
+    "c",
+    0,
+    c
+]);
+}),
+"[project]/node_modules/react/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+function jsx() {
+    return 'purposefully empty stub for react/index.js';
+}
+function useState(initialState) {
+    return [
+        initialState,
+        ()=>{}
+    ];
+}
+__turbopack_context__.s([
+    "useState",
+    0,
+    useState
+]);
+}),
+"[project]/basic/react_compiler/input/index.jsx [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/node_modules/react/jsx-runtime.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$compiler$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/node_modules/react/compiler-runtime.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/node_modules/react/index.js [client] (ecmascript)");
+;
+;
+;
+function Counter(t0) {
+    const $ = (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$compiler$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["c"])(10);
+    const { initialCount } = t0;
+    const [count, setCount] = (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__["useState"])(initialCount);
+    const doubled = count * 2;
+    let t1;
+    if ($[0] !== count) {
+        t1 = /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["jsx"])("p", {
+            children: count
+        });
+        $[0] = count;
+        $[1] = t1;
+    } else {
+        t1 = $[1];
+    }
+    let t2;
+    if ($[2] !== doubled) {
+        t2 = /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["jsx"])("p", {
+            children: doubled
+        });
+        $[2] = doubled;
+        $[3] = t2;
+    } else {
+        t2 = $[3];
+    }
+    let t3;
+    if ($[4] !== count) {
+        t3 = /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["jsx"])("button", {
+            onClick: ()=>setCount(count + 1),
+            children: "increment"
+        });
+        $[4] = count;
+        $[5] = t3;
+    } else {
+        t3 = $[5];
+    }
+    let t4;
+    if ($[6] !== t1 || $[7] !== t2 || $[8] !== t3) {
+        t4 = /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["jsxs"])("div", {
+            children: [
+                t1,
+                t2,
+                t3
+            ]
+        });
+        $[6] = t1;
+        $[7] = t2;
+        $[8] = t3;
+        $[9] = t4;
+    } else {
+        t4 = $[9];
+    }
+    return t4;
+}
+console.log(Counter);
+__turbopack_context__.s([
+    "Counter",
+    0,
+    Counter
+]);
+}),
+]);
+
+//# sourceMappingURL=_project___1d570a0a.js.map

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler/output/_project___1d570a0a.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler/output/_project___1d570a0a.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/node_modules/react/jsx-runtime.js"],"sourcesContent":["export function jsx() {\n  return 'purposefully empty stub for react/jsx-runtime.js'\n}\nexport function jsxs() {\n  return 'purposefully empty stub for react/jsx-runtime.js'\n}\n"],"names":["jsx","jsxs"],"mappings":"AAAO,SAASA;IACd,OAAO;AACT;AACO,SAASC;IACd,OAAO;AACT","ignoreList":[0]}},
+    {"offset": {"line": 22, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/node_modules/react/compiler-runtime.js"],"sourcesContent":["export function c(size) {\n  return new Array(size);\n}\n"],"names":["c","size","Array"],"mappings":"AAAO,SAASA,EAAEC,IAAI;IACpB,OAAO,IAAIC,MAAMD;AACnB","ignoreList":[0]}},
+    {"offset": {"line": 34, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/node_modules/react/index.js"],"sourcesContent":["export function jsx() {\n  return 'purposefully empty stub for react/index.js'\n}\nexport function useState(initialState) {\n  return [initialState, () => {}]\n}\n"],"names":["jsx","useState","initialState"],"mappings":"AAAO,SAASA;IACd,OAAO;AACT;AACO,SAASC,SAASC,YAAY;IACnC,OAAO;QAACA;QAAc,KAAO;KAAE;AACjC","ignoreList":[0]}},
+    {"offset": {"line": 52, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/react_compiler/input/index.jsx"],"sourcesContent":["import { useState } from \"react\";\n\nexport function Counter({ initialCount }) {\n  const [count, setCount] = useState(initialCount);\n  const doubled = count * 2;\n\n  return (\n    <div>\n      <p>{count}</p>\n      <p>{doubled}</p>\n      <button onClick={() => setCount(count + 1)}>increment</button>\n    </div>\n  );\n}\n\nconsole.log(Counter);\n"],"names":["console","log","Counter"],"mappings":";;AAAA;;;;AAEO;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAaPA,QAAQC,GAAG,CAACC"}}]
+}

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler/output/main.js
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["_project___1d570a0a.js"],"runtimeModuleIds":["[project]/basic/react_compiler/input/index.jsx [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/node_modules/react/compiler-runtime.js
+++ b/crates/pack-tests/tests/snapshot/node_modules/react/compiler-runtime.js
@@ -1,0 +1,3 @@
+export function c(size) {
+  return new Array(size);
+}

--- a/crates/pack-tests/tests/snapshot/node_modules/react/index.js
+++ b/crates/pack-tests/tests/snapshot/node_modules/react/index.js
@@ -1,3 +1,6 @@
 export function jsx() {
   return 'purposefully empty stub for react/index.js'
 }
+export function useState(initialState) {
+  return [initialState, () => {}]
+}

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -36,6 +36,13 @@ export interface MdxTransformOptions {
 
 export type MdxOptions = boolean | MdxTransformOptions;
 
+export interface ReactCompilerOptions {
+  compilationMode?: "infer" | "annotation" | "all";
+  target?: "18" | "19";
+}
+
+export type ReactCompilerConfig = boolean | ReactCompilerOptions;
+
 // At the moment, Turbopack options must be JSON-serializable, so restrict values.
 export type TurbopackLoaderOptions = Record<string, JSONValue>;
 
@@ -310,6 +317,11 @@ export interface ConfigComplete {
     absoluteSourceFilename?: boolean;
   };
   stats?: boolean;
+  reactCompiler?: ReactCompilerConfig;
+  experimental?: {
+    reactCompiler?: ReactCompilerConfig;
+    swcPlugins?: [string, any][];
+  };
   swcPlugins?: [string, any][];
   pluginRuntimeStrategy?: "workerThreads" | "childProcesses";
   persistentCaching?: boolean;

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -158,6 +158,17 @@
         }
       ]
     },
+    "reactCompiler": {
+      "description": "React compiler",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaReactCompilerConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "resolve": {
       "description": "Resolve configuration",
       "anyOf": [
@@ -665,7 +676,15 @@
       "type": "object",
       "properties": {
         "reactCompiler": {
-          "description": "React compiler"
+          "description": "React compiler",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaReactCompilerConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "swcPlugins": {
           "description": "SWC plugins as [path, options] tuples",
@@ -1403,6 +1422,56 @@
             "type": "string"
           }
         }
+      ]
+    },
+    "SchemaReactCompilerCompilationMode": {
+      "type": "string",
+      "enum": [
+        "infer",
+        "annotation",
+        "all"
+      ]
+    },
+    "SchemaReactCompilerConfig": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/SchemaReactCompilerOptions"
+        }
+      ]
+    },
+    "SchemaReactCompilerOptions": {
+      "type": "object",
+      "properties": {
+        "compilationMode": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaReactCompilerCompilationMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "target": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaReactCompilerTarget"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "SchemaReactCompilerTarget": {
+      "type": "string",
+      "enum": [
+        "18",
+        "19"
       ]
     },
     "SchemaReactConfig": {


### PR DESCRIPTION
## Summary

Support Rust React Compiler in `@utoo/pack` by wiring the config into Turbopack's `EcmascriptOptionsContext` for user code on both client and server module contexts.

## Usage

Enable it with the top-level `reactCompiler` option:

```js
export default {
  reactCompiler: true,
}
```

Or pass the supported Rust React Compiler options:

```js
export default {
  reactCompiler: {
    compilationMode: "infer", // "infer" | "annotation" | "all"
    target: "19", // "18" | "19"
  },
}
```

`experimental.reactCompiler` is also accepted for the same Rust compiler path:

```js
export default {
  experimental: {
    reactCompiler: true,
  },
}
```

Notes:

- This PR only wires the Rust React Compiler path (`swc_ecma_react_compiler`), not the Babel plugin path.
- `panicThreshold` is intentionally not exposed here because the current upstream Turbopack Rust path does not provide a context option for it.
- If users want the Babel version, they can configure `babel-loader` themselves through existing `module.rules`.

## Test Plan

- `cargo run -p pack-schema`
- `cargo fmt`
- `npx biome check packages/pack-shared/src/config.ts`
- `node -e "JSON.parse(require('fs').readFileSync('packages/pack/config_schema.json','utf8'))"`
- `cargo test -p pack-tests --test snapshot react_compiler`
- `cargo clippy --all-targets -- -D warnings --no-deps`
