### PR TITLE
feat(pm): support --access and --no-git-checks on publish

### DIFF
--- a/crates/pm/src/cli.rs
+++ b/crates/pm/src/cli.rs
@@ -19,6 +19,7 @@ use crate::constants::cmd::{
     WHOAMI_ABOUT, WHOAMI_ALIAS, WHOAMI_NAME,
 };
 use crate::constants::{APP_ABOUT, APP_NAME, APP_VERSION};
+use crate::util::cli_enum::PublishAccess;
 
 pub fn detect_shell_from_env() -> Option<clap_complete::Shell> {
     // Most common on Unix-like systems.
@@ -229,6 +230,14 @@ pub enum Commands {
         /// One-time password for 2FA
         #[arg(long)]
         otp: Option<String>,
+        /// Registry visibility for the package: `public` or `restricted`
+        /// (default: publishConfig.access, else public). Mirrors `npm --access`.
+        #[arg(long, value_enum)]
+        access: Option<PublishAccess>,
+        /// Skip Git working-tree cleanliness checks. Accepted for pnpm
+        /// compatibility; utoo performs no Git checks, so this is a no-op.
+        #[arg(long)]
+        no_git_checks: bool,
     },
 
     #[command(name = PING_NAME, alias = PING_ALIAS, about = PING_ABOUT)]

--- a/crates/pm/src/cmd/publish.rs
+++ b/crates/pm/src/cmd/publish.rs
@@ -11,6 +11,7 @@ use crate::model::RunMode;
 use crate::model::package::{PackageInfo, PublishMeta};
 use crate::service::publish::{self as publish_service, PublishOptions};
 use crate::service::workspace::{ResolvedWorkspaces, WorkspaceFilter, WorkspaceService};
+use crate::util::cli_enum::PublishAccess;
 use crate::util::user_config::{get_or_load_package_json, get_registry};
 
 /// Publish one or more packages.
@@ -23,12 +24,13 @@ pub async fn publish(
     tag: Option<&str>,
     mode: RunMode,
     otp: Option<&str>,
+    access: Option<PublishAccess>,
     filter: WorkspaceFilter,
 ) -> Result<()> {
     let cwd = std::env::current_dir().context("Failed to get current directory")?;
     let roots = resolve_publish_roots(&cwd, filter).await?;
     for root in roots {
-        publish_one(&root, tag, mode, otp).await?;
+        publish_one(&root, tag, mode, otp, access).await?;
     }
     Ok(())
 }
@@ -67,6 +69,7 @@ async fn publish_one(
     tag: Option<&str>,
     mode: RunMode,
     otp: Option<&str>,
+    access: Option<PublishAccess>,
 ) -> Result<()> {
     // Run each publish from inside its own package directory, matching the
     // single-package flow (`update_cwd_to_project`). The filtered path anchors
@@ -81,6 +84,7 @@ async fn publish_one(
     meta.validate()?;
 
     let tag = meta.resolve_tag(tag)?;
+    let access = meta.resolve_access(access)?;
     let registry = meta
         .publish_config
         .registry
@@ -94,6 +98,7 @@ async fn publish_one(
         tag: &tag,
         mode,
         otp,
+        access,
     })
     .await?;
 

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -216,7 +216,15 @@ async fn async_main() -> Result<()> {
             cmd::pm_pack::pack(path, dry_run.into()).await?;
             log_time_end("Pack complete");
         }
-        Some(Commands::Publish { tag, dry_run, otp }) => {
+        Some(Commands::Publish {
+            tag,
+            dry_run,
+            otp,
+            access,
+            // utoo performs no Git cleanliness checks, so `--no-git-checks` is a
+            // documented no-op accepted for pnpm/npm compatibility.
+            no_git_checks: _,
+        }) => {
             // `--workspace`/`--filter` selects member(s); empty means the current
             // package. `--workspaces` is intentionally NOT honored here to avoid
             // an accidental publish of every member.
@@ -225,7 +233,14 @@ async fn async_main() -> Result<()> {
             } else {
                 WorkspaceFilter::Selected(cli.workspace)
             };
-            cmd::publish::publish(tag.as_deref(), dry_run.into(), otp.as_deref(), filter).await?;
+            cmd::publish::publish(
+                tag.as_deref(),
+                dry_run.into(),
+                otp.as_deref(),
+                access,
+                filter,
+            )
+            .await?;
         }
         Some(Commands::Ping { registry }) => {
             cmd::ping::ping(registry.as_deref()).await?;

--- a/crates/pm/src/model/package.rs
+++ b/crates/pm/src/model/package.rs
@@ -109,7 +109,9 @@ impl PublishMeta {
             return Ok(access);
         }
         match self.publish_config.access.as_deref() {
-            Some(value) => PublishAccess::from_config_str(value).ok_or_else(|| {
+            // Parse via strum's derived `FromStr`; the accepted spellings live
+            // solely on the enum (mirrors `LifecycleHook`).
+            Some(value) => value.parse::<PublishAccess>().map_err(|_| {
                 anyhow::anyhow!(
                     "invalid 'publishConfig.access' value \"{value}\": \
                      expected \"public\" or \"restricted\""

--- a/crates/pm/src/model/package.rs
+++ b/crates/pm/src/model/package.rs
@@ -5,6 +5,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 use utoo_ruborist::manifest::{PackageInstallView, PackageJson, PublishConfig};
 
+use crate::util::cli_enum::PublishAccess;
 use crate::util::json::load_package_json;
 use crate::util::platform_const::PATH_SEPARATOR;
 use crate::util::user_config::get_or_load_package_json;
@@ -95,18 +96,27 @@ impl PublishMeta {
         if self.version.is_empty() {
             bail!("Cannot publish: package.json requires a non-empty 'version' field");
         }
-        if self
-            .publish_config
-            .access
-            .as_deref()
-            .is_some_and(|a| a != "public")
-        {
-            bail!(
-                "utoo publish currently only supports public access.\n\
-                 Remove or change 'publishConfig.access' to \"public\" in package.json."
-            );
-        }
         Ok(())
+    }
+
+    /// Resolve the effective registry access level.
+    ///
+    /// Precedence: CLI `--access` > `publishConfig.access` > `public`.
+    /// An unknown `publishConfig.access` value is rejected rather than silently
+    /// downgraded.
+    pub fn resolve_access(&self, cli_access: Option<PublishAccess>) -> Result<PublishAccess> {
+        if let Some(access) = cli_access {
+            return Ok(access);
+        }
+        match self.publish_config.access.as_deref() {
+            Some(value) => PublishAccess::from_config_str(value).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "invalid 'publishConfig.access' value \"{value}\": \
+                     expected \"public\" or \"restricted\""
+                )
+            }),
+            None => Ok(PublishAccess::Public),
+        }
     }
 
     /// Resolve the publish tag: CLI flag > publishConfig.tag > "latest".
@@ -349,5 +359,35 @@ mod tests {
         // Test PackageInfo::from_path with invalid JSON
         let result = PackageInfo::from_path(&package_dir).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_access_precedence() {
+        let mut meta = PublishMeta {
+            name: "pkg".into(),
+            version: "1.0.0".into(),
+            ..Default::default()
+        };
+
+        // CLI flag wins over publishConfig.
+        meta.publish_config.access = Some("restricted".into());
+        assert_eq!(
+            meta.resolve_access(Some(PublishAccess::Public)).unwrap(),
+            PublishAccess::Public
+        );
+
+        // Falls back to publishConfig.access.
+        assert_eq!(
+            meta.resolve_access(None).unwrap(),
+            PublishAccess::Restricted
+        );
+
+        // Defaults to public when neither is set.
+        meta.publish_config.access = None;
+        assert_eq!(meta.resolve_access(None).unwrap(), PublishAccess::Public);
+
+        // An unknown publishConfig.access value is rejected.
+        meta.publish_config.access = Some("secret".into());
+        assert!(meta.resolve_access(None).is_err());
     }
 }

--- a/crates/pm/src/service/publish.rs
+++ b/crates/pm/src/service/publish.rs
@@ -99,7 +99,7 @@ pub async fn publish(opts: &PublishOptions<'_>) -> Result<PublishResult> {
         integrity: &pack_result.integrity,
         tarball_data,
         registry: opts.registry,
-        access: Some(opts.access.as_str()),
+        access: Some(opts.access.into()),
     });
 
     tracing::info!("Publishing to {} with tag {}", opts.registry, opts.tag);

--- a/crates/pm/src/service/publish.rs
+++ b/crates/pm/src/service/publish.rs
@@ -34,6 +34,7 @@ use crate::service::auth;
 use crate::service::oidc;
 use crate::service::pm_pack;
 use crate::service::script::{ScriptOutput, ScriptService};
+use crate::util::cli_enum::PublishAccess;
 use crate::util::format_print::print_pack_details;
 use crate::util::integrity::compute_shasum;
 
@@ -44,6 +45,8 @@ pub struct PublishOptions<'a> {
     pub tag: &'a str,
     pub mode: RunMode,
     pub otp: Option<&'a str>,
+    /// Registry visibility (`public`/`restricted`) for the published package.
+    pub access: PublishAccess,
 }
 
 /// Result returned to the cmd layer after a successful publish.
@@ -96,7 +99,7 @@ pub async fn publish(opts: &PublishOptions<'_>) -> Result<PublishResult> {
         integrity: &pack_result.integrity,
         tarball_data,
         registry: opts.registry,
-        access: Some("public"),
+        access: Some(opts.access.as_str()),
     });
 
     tracing::info!("Publishing to {} with tag {}", opts.registry, opts.tag);

--- a/crates/pm/src/util/cli_enum.rs
+++ b/crates/pm/src/util/cli_enum.rs
@@ -88,3 +88,35 @@ impl From<bool> for RunMode {
         if dry_run { Self::DryRun } else { Self::Live }
     }
 }
+
+/// Registry visibility for a published package (npm `--access`).
+///
+/// Mirrors `npm publish --access <public|restricted>`. utoo historically only
+/// supported `public`; `restricted` is accepted for scoped packages on
+/// registries that support private publishing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum PublishAccess {
+    Public,
+    Restricted,
+}
+
+impl PublishAccess {
+    /// The wire value sent to the registry in the publish payload.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Restricted => "restricted",
+        }
+    }
+
+    /// Parse an access value from `publishConfig.access` in package.json.
+    /// Returns `None` for unknown values so callers can report them.
+    pub fn from_config_str(s: &str) -> Option<Self> {
+        match s {
+            "public" => Some(Self::Public),
+            "restricted" => Some(Self::Restricted),
+            _ => None,
+        }
+    }
+}

--- a/crates/pm/src/util/cli_enum.rs
+++ b/crates/pm/src/util/cli_enum.rs
@@ -94,29 +94,16 @@ impl From<bool> for RunMode {
 /// Mirrors `npm publish --access <public|restricted>`. utoo historically only
 /// supported `public`; `restricted` is accepted for scoped packages on
 /// registries that support private publishing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+///
+/// Single source of truth — strum derives the enum↔string conversions; the
+/// `public`/`restricted` spellings come from the variant names via
+/// `serialize_all` (and clap's `rename_all` for the `--access` flag).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, strum::EnumString, strum::IntoStaticStr,
+)]
 #[clap(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum PublishAccess {
     Public,
     Restricted,
-}
-
-impl PublishAccess {
-    /// The wire value sent to the registry in the publish payload.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Public => "public",
-            Self::Restricted => "restricted",
-        }
-    }
-
-    /// Parse an access value from `publishConfig.access` in package.json.
-    /// Returns `None` for unknown values so callers can report them.
-    pub fn from_config_str(s: &str) -> Option<Self> {
-        match s {
-            "public" => Some(Self::Public),
-            "restricted" => Some(Self::Restricted),
-            _ => None,
-        }
-    }
 }

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -2045,8 +2045,9 @@ echo -e "${GREEN}PASS: bundled binary-mirror-config applied${NC}"
 
 # ---------------------------------------------------------------------------
 # Case: `utoo --filter <pkg> publish` from a workspace root resolves the member
-# and rewrites its `workspace:`/`catalog:` specifiers to concrete versions.
-# Also asserts that selecting multiple members publishes them in workspace
+# and rewrites its `workspace:`/`catalog:` specifiers to concrete versions, and
+# exercises `--no-git-checks` + `--access` over a dirty gitignored `dist`. Also
+# asserts that selecting multiple members publishes them in workspace
 # topological order (dependency before dependent). Runs fully in --dry-run.
 # ---------------------------------------------------------------------------
 echo -e "${YELLOW}Case: workspace --filter publish (dry-run resolves protocols)${NC}"
@@ -2071,7 +2072,11 @@ cat > "$WSP_DIR/packages/app/package.json" << 'EOF'
 }
 EOF
 pushd "$WSP_DIR"
-utoo --filter @wsp/app publish --tag beta --dry-run 2>&1 \
+# A gitignored build artifact makes the tree "dirty"; --no-git-checks must not
+# reject the publish (utoo performs no git checks).
+git init -q . && printf "dist/\n" > .gitignore && mkdir -p packages/app/dist \
+  && echo "x" > packages/app/dist/index.js
+utoo --filter @wsp/app publish --tag beta --dry-run --no-git-checks --access public 2>&1 \
   | tee wsp.out \
   || { echo -e "${RED}FAIL: filtered publish dry-run errored${NC}"; cat wsp.out; exit 1; }
 if ! grep -q '@wsp/lib: workspace:\^ -> \^1.2.3' wsp.out; then


### PR DESCRIPTION
## Summary

Stacked on [#3203](https://github.com/utooland/utoo/pull/3203) (the `--filter` PR) — both touch the `Publish` clap variant and `cmd/publish.rs`, so this branches off that PR rather than `next`.

Adds two pnpm/npm-compatible flags to `ut publish`:

- **`--access <public|restricted>`** — registry visibility for the package. Precedence: CLI `--access` > `publishConfig.access` > `public`, threaded into the publish payload (was hardcoded `"public"`). The old public-only validation is removed; an unknown `publishConfig.access` value is now rejected rather than silently downgraded.
- **`--no-git-checks`** — accepted for pnpm compatibility. utoo performs no Git cleanliness checks, so it is a **documented no-op** (destructured as `no_git_checks: _` in `main.rs`).

No `--provenance` in this PR — that is intentionally out of scope.

## Changes

- `util/cli_enum.rs`: add `PublishAccess` (clap `ValueEnum`: `public`/`restricted`) with `as_str()` + `from_config_str()`.
- `cli.rs`: add `--access <ACCESS>` and `--no-git-checks` to the `Publish` subcommand.
- `main.rs`: pass `access` to publish; destructure `no_git_checks: _` (no-op).
- `model/package.rs`: drop the public-only check from `PublishMeta::validate()`; add `resolve_access(cli)` (CLI > `publishConfig.access` > public; reject unknown).
- `service/publish.rs`: add `access: PublishAccess` to `PublishOptions`; send `opts.access.as_str()` in the payload.
- `cmd/publish.rs`: thread `access` through `publish` → `publish_one`.
- Unit test for `resolve_access` precedence; e2e case extended to publish over a dirty gitignored `dist` with `--no-git-checks --access public`.

## Verification

- `cargo build -p utoo-pm`, `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`, `cargo fmt --check` — all clean.
- `cargo test -p utoo-pm resolve_access_precedence` — passes.
- `ut publish --help` lists `--access` and `--no-git-checks` (no `--provenance`).
- Manual dry-run over a dirty/gitignored `dist` with `--no-git-checks --access public` / `--access restricted` exits 0 and resolves `workspace:`/`catalog:` specifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)