### PR TITLE
chore(pack): not lock webpack version for @utoo/web

### DIFF
--- a/packages/utoo-web/cli/umd.js
+++ b/packages/utoo-web/cli/umd.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs/promises');
 const webpack = require('webpack');
 const yargs = require('yargs');
-const TerserPlugin = require('terser-webpack-plugin');
+const MinimizerPlugin = require('minimizer-webpack-plugin');
 const stdLibBrowser = require('node-stdlib-browser');
 const { NodeProtocolUrlPlugin } = require('node-stdlib-browser/helpers/webpack/plugin');
 
@@ -113,7 +113,7 @@ const config = {
     moduleIds: 'named',
     minimizer: [
       (compiler) => {
-        new TerserPlugin({
+        new MinimizerPlugin({
           terserOptions: {
             mangle: false,
             keep_fnames: true,

--- a/packages/utoo-web/package.json
+++ b/packages/utoo-web/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/systemjs": "^6.15.1",
     "binaryen": "^125.0.0",
+    "minimizer-webpack-plugin": "^5.6.1",
     "node-stdlib-browser": "^1.3.1",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",

--- a/packages/utoo-web/package.json
+++ b/packages/utoo-web/package.json
@@ -41,7 +41,7 @@
     "node-stdlib-browser": "^1.3.1",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
-    "webpack": "5.106.0",
+    "webpack": "^5.106.0",
     "webpack-merge": "^6.0.1",
     "yargs": "^18.0.0"
   },


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/utooland/utoo/blob/next/README.md
-->

## Summary

since https://github.com/webpack/webpack/pull/21041 has been released, so it's no need to lock aganin


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
