### PR TITLE
feat(pack): enable turbopack memory eviction

### DIFF
--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -191,6 +191,8 @@ pub struct Config {
     #[cfg(any(feature = "process_pool", feature = "worker_pool"))]
     plugin_runtime_strategy: Option<PluginRuntimeStrategy>,
     persistent_caching: Option<bool>,
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    turbopack_memory_eviction: Option<serde_json::Value>,
     node_polyfill: Option<bool>,
     mdx: Option<MdxOptions>,
     dev_server: Option<DevServer>,

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -171,6 +171,8 @@ pub struct NapiTurboEngineOptions {
     pub is_short_session: Option<bool>,
     /// Turbopack memory eviction mode for the persistent cache.
     pub turbopack_memory_eviction: Option<MemoryEvictionMode>,
+    /// Avoid large backend preallocations to reduce startup memory.
+    pub small_preallocation: Option<bool>,
 }
 
 /// Turbopack's memory eviction strategy for the persistent cache.
@@ -401,6 +403,7 @@ pub fn project_new(
             let turbopack_memory_eviction = turbo_engine_options
                 .turbopack_memory_eviction
                 .unwrap_or_else(MemoryEvictionMode::from_env_or_default);
+            let small_preallocation = turbo_engine_options.small_preallocation.unwrap_or(false);
             let turbo_tasks = create_turbo_tasks(
                 PathBuf::from(&options.project_path),
                 persistent_caching,
@@ -408,6 +411,7 @@ pub fn project_new(
                 dependency_tracking,
                 is_short_session,
                 turbopack_memory_eviction.evicts_after_snapshot(),
+                small_preallocation,
             )?;
             let turbopack_ctx = TurbopackContext::new(turbo_tasks.clone(), napi_callbacks);
 

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -169,6 +169,32 @@ pub struct NapiTurboEngineOptions {
     pub dependency_tracking: Option<bool>,
     /// Hint that this turbo-tasks instance is for a short-lived one-shot session.
     pub is_short_session: Option<bool>,
+    /// Turbopack memory eviction mode for the persistent cache.
+    pub turbopack_memory_eviction: Option<MemoryEvictionMode>,
+}
+
+/// Turbopack's memory eviction strategy for the persistent cache.
+#[napi(string_enum = "lowercase")]
+#[derive(Debug, PartialEq, Eq)]
+pub enum MemoryEvictionMode {
+    /// Never evict.
+    Off,
+    /// After every snapshot, evict all evictable tasks from memory, reloading
+    /// them from disk on demand.
+    Full,
+}
+
+impl MemoryEvictionMode {
+    fn from_env_or_default() -> Self {
+        match std::env::var("TURBO_ENGINE_EVICT_AFTER_SNAPSHOT") {
+            Ok(value) if value != "1" && value != "true" => Self::Off,
+            _ => Self::Full,
+        }
+    }
+
+    pub(crate) fn evicts_after_snapshot(self) -> bool {
+        matches!(self, Self::Full)
+    }
 }
 
 impl From<NapiWatchOptions> for WatchOptions {
@@ -372,12 +398,16 @@ pub fn project_new(
             let persistent_caching = turbo_engine_options.persistent_caching.unwrap_or_default();
             let dependency_tracking = turbo_engine_options.dependency_tracking.unwrap_or(true);
             let is_short_session = turbo_engine_options.is_short_session.unwrap_or(false);
+            let turbopack_memory_eviction = turbo_engine_options
+                .turbopack_memory_eviction
+                .unwrap_or_else(MemoryEvictionMode::from_env_or_default);
             let turbo_tasks = create_turbo_tasks(
                 PathBuf::from(&options.project_path),
                 persistent_caching,
                 memory_limit,
                 dependency_tracking,
                 is_short_session,
+                turbopack_memory_eviction.evicts_after_snapshot(),
             )?;
             let turbopack_ctx = TurbopackContext::new(turbo_tasks.clone(), napi_callbacks);
 

--- a/crates/pack-napi/src/pack_api/utils.rs
+++ b/crates/pack-napi/src/pack_api/utils.rs
@@ -31,6 +31,7 @@ pub fn create_turbo_tasks(
     dependency_tracking: bool,
     is_short_session: bool,
     evict_after_snapshot: bool,
+    small_preallocation: bool,
 ) -> Result<UtooTurboTasks> {
     Ok(if persistent_caching {
         let version_info = GitVersionInfo {
@@ -60,6 +61,7 @@ pub fn create_turbo_tasks(
                 dependency_tracking,
                 num_workers: Some(tokio::runtime::Handle::current().metrics().num_workers()),
                 evict_after_snapshot,
+                small_preallocation,
                 ..Default::default()
             },
             backing_storage,

--- a/crates/pack-napi/src/pack_api/utils.rs
+++ b/crates/pack-napi/src/pack_api/utils.rs
@@ -30,6 +30,7 @@ pub fn create_turbo_tasks(
     _memory_limit: usize,
     dependency_tracking: bool,
     is_short_session: bool,
+    evict_after_snapshot: bool,
 ) -> Result<UtooTurboTasks> {
     Ok(if persistent_caching {
         let version_info = GitVersionInfo {
@@ -58,6 +59,7 @@ pub fn create_turbo_tasks(
                 }),
                 dependency_tracking,
                 num_workers: Some(tokio::runtime::Handle::current().metrics().num_workers()),
+                evict_after_snapshot,
                 ..Default::default()
             },
             backing_storage,

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -98,6 +98,11 @@ pub struct CompleteConfig {
     #[schemars(description = "Enable persistent caching")]
     pub persistent_caching: Option<bool>,
 
+    /// Turbopack memory eviction mode for the persistent cache
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Turbopack memory eviction mode for the persistent cache")]
+    pub turbopack_memory_eviction: Option<SchemaTurbopackMemoryEviction>,
+
     /// Cache handler configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Cache handler configuration")]
@@ -166,6 +171,20 @@ pub enum SchemaMdxConfigOrBoolean {
     Boolean(bool),
     /// Advanced MDX transform options
     Options(SchemaMdxConfig),
+}
+
+/// Turbopack memory eviction mode.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SchemaTurbopackMemoryEviction {
+    Boolean(bool),
+    Mode(SchemaTurbopackMemoryEvictionMode),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SchemaTurbopackMemoryEvictionMode {
+    Full,
 }
 
 /// Rust MDX transform options

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -325,6 +325,7 @@ export interface ConfigComplete {
   swcPlugins?: [string, any][];
   pluginRuntimeStrategy?: "workerThreads" | "childProcesses";
   persistentCaching?: boolean;
+  turbopackMemoryEviction?: false | "full";
   nodePolyfill?: boolean;
   mdx?: MdxOptions;
   devServer?: DevServerConfig;

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -325,7 +325,7 @@ export interface ConfigComplete {
   swcPlugins?: [string, any][];
   pluginRuntimeStrategy?: "workerThreads" | "childProcesses";
   persistentCaching?: boolean;
-  turbopackMemoryEviction?: false | "full";
+  turbopackMemoryEviction?: boolean | "full";
   nodePolyfill?: boolean;
   mdx?: MdxOptions;
   devServer?: DevServerConfig;

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -222,6 +222,17 @@
         "string",
         "null"
       ]
+    },
+    "turbopackMemoryEviction": {
+      "description": "Turbopack memory eviction mode for the persistent cache",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaTurbopackMemoryEviction"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
@@ -1749,6 +1760,23 @@
             "minItems": 2
           }
         }
+      ]
+    },
+    "SchemaTurbopackMemoryEviction": {
+      "description": "Turbopack memory eviction mode.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/SchemaTurbopackMemoryEvictionMode"
+        }
+      ]
+    },
+    "SchemaTurbopackMemoryEvictionMode": {
+      "type": "string",
+      "enum": [
+        "full"
       ]
     },
     "SchemaTurbopackModuleType": {

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -125,6 +125,18 @@ export interface NapiTurboEngineOptions {
   dependencyTracking?: boolean
   /** Hint that this turbo-tasks instance is for a short-lived one-shot session. */
   isShortSession?: boolean
+  /** Turbopack memory eviction mode for the persistent cache. */
+  turbopackMemoryEviction?: MemoryEvictionMode
+}
+/** Turbopack's memory eviction strategy for the persistent cache. */
+export const enum MemoryEvictionMode {
+  /** Never evict. */
+  Off = "off",
+  /**
+   * After every snapshot, evict all evictable tasks from memory, reloading
+   * them from disk on demand.
+   */
+  Full = "full"
 }
 export declare function projectNew(options: NapiProjectOptions, turboEngineOptions: NapiTurboEngineOptions, napiCallbacks: NapiTurbopackCallbacksJsObject): Promise<{ __napiType: "Project" }>
 export declare function projectUpdate(project: { __napiType: "Project" }, options: NapiPartialProjectOptions): Promise<void>

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -127,6 +127,8 @@ export interface NapiTurboEngineOptions {
   isShortSession?: boolean
   /** Turbopack memory eviction mode for the persistent cache. */
   turbopackMemoryEviction?: MemoryEvictionMode
+  /** Avoid large backend preallocations to reduce startup memory. */
+  smallPreallocation?: boolean
 }
 /** Turbopack's memory eviction strategy for the persistent cache. */
 export const enum MemoryEvictionMode {

--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -9,6 +9,7 @@ import { projectFactory } from "../core/project";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
 import { blockStdout, getPackPath } from "../utils/common";
+import { isTruthyEnv } from "../utils/env";
 import { findRootDir } from "../utils/findRoot";
 import { getInitialAssetsFromEndpointPaths } from "../utils/getInitialAssets";
 import { processHtmlEntry } from "../utils/htmlEntry";
@@ -51,6 +52,9 @@ async function buildInternal(
   const turbopackMemoryEviction = (
     bundleOptions.config.turbopackMemoryEviction === false ? "off" : "full"
   ) as MemoryEvictionMode;
+  const smallPreallocation = isTruthyEnv(
+    process.env.UTOO_TURBOPACK_SMALL_PREALLOCATION,
+  );
   const shouldCreateWebpackStats =
     Boolean(process.env.ANALYZE) || Boolean(bundleOptions.config.stats);
   processHtmlEntry(bundleOptions.config, resolvedProjectPath);
@@ -91,6 +95,7 @@ async function buildInternal(
       {
         persistentCaching,
         turbopackMemoryEviction,
+        smallPreallocation,
         // Build mode is a short-lived, one-shot compilation, so avoid paying
         // dependency graph bookkeeping cost unless the persistent cache needs it.
         dependencyTracking: persistentCaching,

--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -9,7 +9,7 @@ import { projectFactory } from "../core/project";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
 import { blockStdout, getPackPath } from "../utils/common";
-import { isTruthyEnv } from "../utils/env";
+import { isTruthyEnv, normalizeTurbopackMemoryEviction } from "../utils/env";
 import { findRootDir } from "../utils/findRoot";
 import { getInitialAssetsFromEndpointPaths } from "../utils/getInitialAssets";
 import { processHtmlEntry } from "../utils/htmlEntry";
@@ -49,8 +49,8 @@ async function buildInternal(
   const resolvedProjectPath = projectPath || process.cwd();
   const resolvedRootPath = rootPath || projectPath || process.cwd();
   const persistentCaching = bundleOptions.config.persistentCaching ?? true;
-  const turbopackMemoryEviction = (
-    bundleOptions.config.turbopackMemoryEviction === false ? "off" : "full"
+  const turbopackMemoryEviction = normalizeTurbopackMemoryEviction(
+    bundleOptions.config.turbopackMemoryEviction,
   ) as MemoryEvictionMode;
   const smallPreallocation = isTruthyEnv(
     process.env.UTOO_TURBOPACK_SMALL_PREALLOCATION,

--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -18,6 +18,8 @@ import { useWorkerThreads } from "../utils/runtimePluginStratety";
 import { validateEntryPaths } from "../utils/validateEntry";
 import { xcodeProfilingReady } from "../utils/xcodeProfile";
 
+type MemoryEvictionMode = import("../binding").MemoryEvictionMode;
+
 export function build(
   options: BundleOptions | WebpackConfig,
   projectPath?: string,
@@ -46,6 +48,9 @@ async function buildInternal(
   const resolvedProjectPath = projectPath || process.cwd();
   const resolvedRootPath = rootPath || projectPath || process.cwd();
   const persistentCaching = bundleOptions.config.persistentCaching ?? true;
+  const turbopackMemoryEviction = (
+    bundleOptions.config.turbopackMemoryEviction === false ? "off" : "full"
+  ) as MemoryEvictionMode;
   const shouldCreateWebpackStats =
     Boolean(process.env.ANALYZE) || Boolean(bundleOptions.config.stats);
   processHtmlEntry(bundleOptions.config, resolvedProjectPath);
@@ -85,6 +90,7 @@ async function buildInternal(
       },
       {
         persistentCaching,
+        turbopackMemoryEviction,
         // Build mode is a short-lived, one-shot compilation, so avoid paying
         // dependency graph bookkeeping cost unless the persistent cache needs it.
         dependencyTracking: persistentCaching,

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -19,6 +19,7 @@ import { BundleOptions } from "../config/types";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
 import { debounce, getPackPath, processIssues } from "../utils/common";
+import { isTruthyEnv } from "../utils/env";
 import { getInitialAssetsFromEndpointPaths } from "../utils/getInitialAssets";
 import { processHtmlEntry } from "../utils/htmlEntry";
 import { acquirePersistentCacheLock } from "../utils/lockfile";
@@ -168,6 +169,9 @@ export async function createHotReloader(
   const turbopackMemoryEviction = (
     bundleOptions.config.turbopackMemoryEviction === false ? "off" : "full"
   ) as MemoryEvictionMode;
+  const smallPreallocation = isTruthyEnv(
+    process.env.UTOO_TURBOPACK_SMALL_PREALLOCATION,
+  );
   const persistentCacheLock = await acquirePersistentCacheLock(
     resolvedProjectPath,
     "utoo pack dev",
@@ -219,6 +223,7 @@ export async function createHotReloader(
       {
         persistentCaching,
         turbopackMemoryEviction,
+        smallPreallocation,
       },
     );
   } catch (error) {

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -14,7 +14,7 @@ import { nanoid } from "nanoid";
 import type { Socket } from "net";
 import { Duplex } from "stream";
 import { WebSocketServer } from "ws";
-import type { NapiWrittenEndpoint } from "../binding";
+import type { MemoryEvictionMode, NapiWrittenEndpoint } from "../binding";
 import { BundleOptions } from "../config/types";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
@@ -165,6 +165,9 @@ export async function createHotReloader(
 
   const createProject = projectFactory();
   const persistentCaching = bundleOptions.config.persistentCaching ?? true;
+  const turbopackMemoryEviction = (
+    bundleOptions.config.turbopackMemoryEviction === false ? "off" : "full"
+  ) as MemoryEvictionMode;
   const persistentCacheLock = await acquirePersistentCacheLock(
     resolvedProjectPath,
     "utoo pack dev",
@@ -215,6 +218,7 @@ export async function createHotReloader(
       },
       {
         persistentCaching,
+        turbopackMemoryEviction,
       },
     );
   } catch (error) {

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -19,7 +19,7 @@ import { BundleOptions } from "../config/types";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
 import { debounce, getPackPath, processIssues } from "../utils/common";
-import { isTruthyEnv } from "../utils/env";
+import { isTruthyEnv, normalizeTurbopackMemoryEviction } from "../utils/env";
 import { getInitialAssetsFromEndpointPaths } from "../utils/getInitialAssets";
 import { processHtmlEntry } from "../utils/htmlEntry";
 import { acquirePersistentCacheLock } from "../utils/lockfile";
@@ -166,8 +166,8 @@ export async function createHotReloader(
 
   const createProject = projectFactory();
   const persistentCaching = bundleOptions.config.persistentCaching ?? true;
-  const turbopackMemoryEviction = (
-    bundleOptions.config.turbopackMemoryEviction === false ? "off" : "full"
+  const turbopackMemoryEviction = normalizeTurbopackMemoryEviction(
+    bundleOptions.config.turbopackMemoryEviction,
   ) as MemoryEvictionMode;
   const smallPreallocation = isTruthyEnv(
     process.env.UTOO_TURBOPACK_SMALL_PREALLOCATION,

--- a/packages/pack/src/utils/env.ts
+++ b/packages/pack/src/utils/env.ts
@@ -1,3 +1,17 @@
 export function isTruthyEnv(value: string | undefined): boolean {
   return value === "1" || value === "true";
 }
+
+export function normalizeTurbopackMemoryEviction(
+  value: false | "full" | undefined,
+): "off" | "full" {
+  if (value === false) {
+    return "off";
+  }
+  if (value === "full") {
+    return "full";
+  }
+
+  const rawEnv = process.env.TURBO_ENGINE_EVICT_AFTER_SNAPSHOT;
+  return rawEnv == null || rawEnv === "1" || rawEnv === "true" ? "full" : "off";
+}

--- a/packages/pack/src/utils/env.ts
+++ b/packages/pack/src/utils/env.ts
@@ -1,0 +1,3 @@
+export function isTruthyEnv(value: string | undefined): boolean {
+  return value === "1" || value === "true";
+}

--- a/packages/pack/src/utils/env.ts
+++ b/packages/pack/src/utils/env.ts
@@ -3,12 +3,12 @@ export function isTruthyEnv(value: string | undefined): boolean {
 }
 
 export function normalizeTurbopackMemoryEviction(
-  value: false | "full" | undefined,
+  value: boolean | "full" | undefined,
 ): "off" | "full" {
   if (value === false) {
     return "off";
   }
-  if (value === "full") {
+  if (value === true || value === "full") {
     return "full";
   }
 


### PR DESCRIPTION
## Summary

- wire Utoo pack persistent-cache sessions into Turbopack memory eviction
- expose `turbopackMemoryEviction` in pack config and generated schema
- pass `off`/`full` through the NAPI TurboEngine options into `BackendOptions.evict_after_snapshot`

## Validation

- `cargo check -p pack-napi`
- `npx tsc -p packages/pack/tsconfig.json --noEmit`
- `npx tsc -p packages/pack-shared/tsconfig.json --noEmit`
- `cargo test -p pack-schema`
- pre-push Biome format check