### PR TITLE
fix(wasm): use thin lto for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,16 @@ virtue           = { git = "https://github.com/bgw/virtue.git", branch = "bgw/fi
 [profile.release]
 opt-level = "z"
 strip     = "symbols"
-lto       = "fat"
+# Keep release builds on thin LTO instead of fat LTO for wasm compatibility.
+# `utoo-wasm` uses link-section's wasm backend, which counts registration slots
+# with one-byte marker statics in `.data.link_section.*` custom sections and
+# sizes its runtime storage from that byte length during startup. Fat LTO can
+# merge or drop those identical marker statics while leaving the `.init_array.0`
+# registration constructors in place, so the runtime observes a section length
+# of 1 but still registers many items, then panics with:
+# "Link section already initialized". Thin LTO keeps release optimization while
+# preserving the counting metadata in the verified @utoo/web production build.
+lto       = "thin"
 
 # cargo build --profile instruments --bin pack-cli
 # xcrun xctrace record --template "Time Profiler" --launch -- ./target/instruments/pack-cli --mode build --project-path ./examples/with-antd --root-path .


### PR DESCRIPTION
## Summary
- Change the workspace release profile from fat LTO to thin LTO.
- This keeps release LTO enabled while avoiding the wasm link-section startup failure seen with fat LTO.

## Changes
- Update `Cargo.toml` `[profile.release]` from `lto = "fat"` to `lto = "thin"`.
- Restore the `@utoo/web` build script to its normal release build path; no package-level LTO override is needed.

## Validation
- User verified `lto = "thin"` works for the @utoo/web production wasm build.
- `tombi format --check Cargo.toml`
- `npx biome check packages/utoo-web/package.json`

## Risk / rollout
- This changes the workspace release profile, so it can affect release builds beyond @utoo/web.
- Thin LTO should preserve most cross-crate optimization benefits while avoiding the fat LTO behavior that collapses wasm link-section counting metadata.

## Reviewer notes
- Please focus on whether thin LTO is acceptable as the shared release profile setting for wasm and native release builds.