### PR TITLE
feat(pack): add css chunking configuration

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -665,6 +665,7 @@ pub async fn get_client_chunking_context(
             .dynamic_chunk_content_loading(true);
     } else {
         let split_chunks = &config.optimization().await?.split_chunks;
+        let style_groups_algorithm = config.css_chunking_algorithm().owned().await?;
 
         let (ecmascript_chunking_config, css_chunking_config) = (
             split_chunks.as_ref().and_then(|sc| sc.get("js")).map_or(
@@ -679,9 +680,14 @@ pub async fn get_client_chunking_context(
             split_chunks.as_ref().and_then(|sc| sc.get("css")).map_or(
                 ChunkingConfig {
                     max_merge_chunk_size: 100_000,
+                    style_groups_algorithm: style_groups_algorithm.clone(),
                     ..Default::default()
                 },
-                Into::into,
+                |config| {
+                    let mut config = ChunkingConfig::from(config);
+                    config.style_groups_algorithm = style_groups_algorithm.clone();
+                    config
+                },
             ),
         );
 

--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -677,18 +677,18 @@ pub async fn get_client_chunking_context(
                 },
                 Into::into,
             ),
-            split_chunks.as_ref().and_then(|sc| sc.get("css")).map_or(
-                ChunkingConfig {
+            match split_chunks.as_ref().and_then(|sc| sc.get("css")) {
+                None => ChunkingConfig {
                     max_merge_chunk_size: 100_000,
-                    style_groups_algorithm: style_groups_algorithm.clone(),
+                    style_groups_algorithm,
                     ..Default::default()
                 },
-                |config| {
+                Some(config) => {
                     let mut config = ChunkingConfig::from(config);
-                    config.style_groups_algorithm = style_groups_algorithm.clone();
+                    config.style_groups_algorithm = style_groups_algorithm;
                     config
-                },
-            ),
+                }
+            },
         );
 
         builder = builder

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -22,6 +22,7 @@ use turbopack_core::{
         CrossOrigin as RuntimeCrossOriginLoading,
     },
     issue::{Issue, IssueExt, IssueStage, StyledString},
+    module_graph::style_groups::StyleGroupsAlgorithm,
     resolve::ResolveAliasMap,
 };
 use turbopack_ecmascript::{
@@ -432,6 +433,7 @@ pub struct OptimizationConfig {
     pub remove_console: Option<RemoveConsoleConfig>,
     #[bincode(with = "turbo_bincode::serde_self_describing")]
     pub split_chunks: Option<FxIndexMap<RcStr, SplitChunkConfig>>,
+    pub css_chunking: Option<CssChunkingConfig>,
     /// Concatenate modules when possible to reduce the number of chunks.
     /// This can improve performance by reducing the number of requests and
     /// improving caching.
@@ -446,6 +448,110 @@ pub struct OptimizationConfig {
     /// When false, WASM files will be output as static assets.
     #[serde(default)]
     pub wasm_as_asset: Option<bool>,
+}
+
+const DEFAULT_CSS_CHUNKING_GRAPH_REQUEST_COST: f32 = 100_000.0;
+const DEFAULT_CSS_CHUNKING_GRAPH_WEIGHT_DISTRIBUTION: f32 = 0.1;
+
+#[derive(
+    Clone, Debug, PartialEq, Deserialize, TraceRawVcs, NonLocalValue, OperationValue, Encode, Decode,
+)]
+#[serde(untagged)]
+pub enum CssChunkingConfig {
+    Boolean(bool),
+    Mode(CssChunkingMode),
+    Object(CssChunkingObject),
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum CssChunkingMode {
+    Strict,
+    Loose,
+    Graph,
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Deserialize, TraceRawVcs, NonLocalValue, OperationValue, Encode, Decode,
+)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum CssChunkingObject {
+    Strict,
+    Loose,
+    Graph(CssChunkingGraphOptions),
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct CssChunkingGraphOptions {
+    pub request_cost: Option<f32>,
+    pub weight_distribution: Option<f32>,
+}
+
+impl OptimizationConfig {
+    pub fn css_chunking_algorithm(&self) -> Result<StyleGroupsAlgorithm> {
+        let Some(config) = &self.css_chunking else {
+            return Ok(StyleGroupsAlgorithm::Default);
+        };
+
+        match config {
+            CssChunkingConfig::Boolean(false)
+            | CssChunkingConfig::Mode(CssChunkingMode::Strict) => {
+                anyhow::bail!(
+                    "`optimization.cssChunking: false` and `\"strict\"` are not supported by \
+                     utoopack"
+                )
+            }
+            CssChunkingConfig::Object(CssChunkingObject::Strict) => {
+                anyhow::bail!(
+                    "`optimization.cssChunking: {{ type: \"strict\" }}` is not supported by \
+                     utoopack"
+                )
+            }
+            CssChunkingConfig::Boolean(true)
+            | CssChunkingConfig::Mode(CssChunkingMode::Loose)
+            | CssChunkingConfig::Object(CssChunkingObject::Loose) => {
+                Ok(StyleGroupsAlgorithm::Default)
+            }
+            CssChunkingConfig::Mode(CssChunkingMode::Graph) => Ok(StyleGroupsAlgorithm::graph(
+                DEFAULT_CSS_CHUNKING_GRAPH_REQUEST_COST,
+                DEFAULT_CSS_CHUNKING_GRAPH_WEIGHT_DISTRIBUTION,
+            )),
+            CssChunkingConfig::Object(CssChunkingObject::Graph(options)) => {
+                Ok(StyleGroupsAlgorithm::graph(
+                    options
+                        .request_cost
+                        .unwrap_or(DEFAULT_CSS_CHUNKING_GRAPH_REQUEST_COST),
+                    options
+                        .weight_distribution
+                        .unwrap_or(DEFAULT_CSS_CHUNKING_GRAPH_WEIGHT_DISTRIBUTION),
+                ))
+            }
+        }
+    }
 }
 
 #[turbo_tasks::value]
@@ -1179,6 +1285,17 @@ impl Config {
     #[turbo_tasks::function]
     pub fn optimization(&self) -> Vc<OptimizationConfig> {
         self.optimization.clone().unwrap_or_default().cell()
+    }
+
+    #[turbo_tasks::function]
+    pub async fn css_chunking_algorithm(&self) -> Result<Vc<StyleGroupsAlgorithm>> {
+        Ok(self
+            .optimization
+            .as_ref()
+            .map(OptimizationConfig::css_chunking_algorithm)
+            .transpose()?
+            .unwrap_or_default()
+            .cell())
     }
 
     #[turbo_tasks::function]

--- a/crates/pack-core/src/library/chunking_context.rs
+++ b/crates/pack-core/src/library/chunking_context.rs
@@ -30,6 +30,7 @@ use turbopack_core::{
         ModuleGraph,
         binding_usage_info::{BindingUsageInfo, ModuleExportUsage},
         chunk_group_info::ChunkGroup,
+        style_groups::StyleGroupsAlgorithm,
     },
     output::{OutputAsset, OutputAssets},
 };
@@ -148,6 +149,11 @@ impl LibraryChunkingContextBuilder {
         self
     }
 
+    pub fn style_groups_algorithm(mut self, style_groups_algorithm: StyleGroupsAlgorithm) -> Self {
+        self.chunking_context.style_groups_algorithm = style_groups_algorithm;
+        self
+    }
+
     pub fn debug_ids(mut self, debug_ids: bool) -> Self {
         self.chunking_context.debug_ids = debug_ids;
         self
@@ -213,6 +219,8 @@ pub struct LibraryChunkingContext {
     filename: Option<RcStr>,
     /// Initial css chunk filename template
     css_filename: Option<RcStr>,
+    /// CSS chunking algorithm.
+    style_groups_algorithm: StyleGroupsAlgorithm,
     /// Asset module filename template
     asset_module_filename: Option<RcStr>,
     /// Whether this library targets Node.js (affects runtime backend selection).
@@ -248,6 +256,7 @@ impl LibraryChunkingContext {
                 unused_references: None,
                 filename: Default::default(),
                 css_filename: Default::default(),
+                style_groups_algorithm: Default::default(),
                 asset_module_filename: Default::default(),
                 runtime_root,
                 runtime_export,
@@ -595,6 +604,7 @@ impl ChunkingContext for LibraryChunkingContext {
                 min_chunk_size: usize::MAX,
                 max_chunk_count_per_group: 1,
                 max_merge_chunk_size: usize::MAX,
+                style_groups_algorithm: self.style_groups_algorithm.clone(),
                 ..Default::default()
             },
         );

--- a/crates/pack-core/src/library/contexts.rs
+++ b/crates/pack-core/src/library/contexts.rs
@@ -148,6 +148,10 @@ pub async fn get_library_chunking_context(
         builder = builder.css_filename(css_filename.clone());
     }
 
+    if mode.is_production() {
+        builder = builder.style_groups_algorithm(config.css_chunking_algorithm().owned().await?);
+    }
+
     if let Some(asset_module_filename) = &output.asset_module_filename {
         builder = builder.asset_module_filename(asset_module_filename.clone());
     }

--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -486,6 +486,8 @@ pub async fn get_server_chunking_context(
     if mode.is_development() {
         builder = builder.source_map_source_type(SourceMapSourceType::AbsoluteFileUri);
     } else {
+        let style_groups_algorithm = config.css_chunking_algorithm().owned().await?;
+
         builder = builder
             .source_map_source_type(SourceMapSourceType::RelativeUri)
             .chunking_config(
@@ -501,6 +503,7 @@ pub async fn get_server_chunking_context(
                 Vc::<CssChunkType>::default().to_resolved().await?,
                 ChunkingConfig {
                     max_merge_chunk_size: 100_000,
+                    style_groups_algorithm,
                     ..Default::default()
                 },
             )

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -553,6 +553,11 @@ pub struct SchemaOptimizationConfig {
     #[schemars(description = "Split chunks configuration")]
     pub split_chunks: Option<HashMap<String, SchemaSplitChunkConfig>>,
 
+    /// CSS chunking algorithm
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "CSS chunking algorithm")]
+    pub css_chunking: Option<SchemaCssChunkingConfig>,
+
     /// Whether to concatenate modules when possible to reduce the number of chunks
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(
@@ -705,6 +710,48 @@ pub struct SchemaSplitChunkConfig {
     #[serde(default = "default_max_merge_chunk_size")]
     #[schemars(description = "Maximum merge chunk size")]
     pub max_merge_chunk_size: usize,
+}
+
+/// CSS chunking configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SchemaCssChunkingConfig {
+    Boolean(bool),
+    Mode(SchemaCssChunkingMode),
+    Object(SchemaCssChunkingObject),
+}
+
+/// CSS chunking mode
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SchemaCssChunkingMode {
+    Strict,
+    Loose,
+    Graph,
+}
+
+/// CSS chunking object configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum SchemaCssChunkingObject {
+    Strict,
+    Loose,
+    Graph(SchemaCssChunkingGraphOptions),
+}
+
+/// Graph CSS chunking options
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaCssChunkingGraphOptions {
+    /// Estimated cost of an additional request, in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Estimated cost of an additional request, in bytes")]
+    pub request_cost: Option<f32>,
+
+    /// Weight distribution used by the graph CSS chunking algorithm.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Weight distribution used by the graph CSS chunking algorithm")]
+    pub weight_distribution: Option<f32>,
 }
 
 // Import defaults from pack-core
@@ -1218,6 +1265,7 @@ mod tests {
         assert!(schema_str.contains("externals"));
         assert!(schema_str.contains("optimization"));
         assert!(schema_str.contains("concatenateModules"));
+        assert!(schema_str.contains("cssChunking"));
         assert!(schema_str.contains("html"));
         assert!(schema_str.contains("react"));
         assert!(schema_str.contains("provider"));

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -204,6 +204,20 @@ export interface DevServerConfig {
   proxy?: DevServerProxy;
 }
 
+export type CssChunkingConfig =
+  | boolean
+  | "strict"
+  | "loose"
+  | "graph"
+  | {
+      type: "strict" | "loose";
+    }
+  | {
+      type: "graph";
+      requestCost?: number;
+      weightDistribution?: number;
+    };
+
 export interface ConfigComplete {
   entry: EntryOptions[];
   mode?: "production" | "development";
@@ -257,6 +271,7 @@ export interface ConfigComplete {
         maxMergeChunkSize?: number;
       }
     >;
+    cssChunking?: CssChunkingConfig;
     modularizeImports?: Record<
       string,
       {

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -563,6 +563,93 @@
         "use-credentials"
       ]
     },
+    "SchemaCssChunkingConfig": {
+      "description": "CSS chunking configuration",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/SchemaCssChunkingMode"
+        },
+        {
+          "$ref": "#/definitions/SchemaCssChunkingObject"
+        }
+      ]
+    },
+    "SchemaCssChunkingMode": {
+      "description": "CSS chunking mode",
+      "type": "string",
+      "enum": [
+        "strict",
+        "loose",
+        "graph"
+      ]
+    },
+    "SchemaCssChunkingObject": {
+      "description": "CSS chunking object configuration",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "strict"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "loose"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Graph CSS chunking options",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "requestCost": {
+              "description": "Estimated cost of an additional request, in bytes",
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "float"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "graph"
+              ]
+            },
+            "weightDistribution": {
+              "description": "Weight distribution used by the graph CSS chunking algorithm",
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "float"
+            }
+          }
+        }
+      ]
+    },
     "SchemaCssModulesConfig": {
       "description": "CSS Modules configuration",
       "type": "object",
@@ -1188,6 +1275,17 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "cssChunking": {
+          "description": "CSS chunking algorithm",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaCssChunkingConfig"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "minify": {


### PR DESCRIPTION
## Summary

- add `optimization.cssChunking` to the public pack config type and generated schema
- map `true`/`loose` to the default CSS chunking algorithm and `graph` to Turbopack's graph style grouping algorithm
- thread the CSS chunking algorithm into client, server, and library production chunking contexts

## Verification

- cargo check -p pack-core --quiet
- cargo test -p pack-schema
- npx tsc -p packages/pack-shared/tsconfig.json --noEmit
- npx biome check packages/pack-shared/src/config.ts
- git diff --check
