### PR TITLE
feat(pm): read registry configuration from .npmrc

### DIFF
--- a/crates/pm/src/service/auth.rs
+++ b/crates/pm/src/service/auth.rs
@@ -5,6 +5,7 @@ use tokio::sync::OnceCell;
 use crate::util::cli_enum::ConfigScope;
 use crate::util::config_file::Config;
 use crate::util::http::client;
+use crate::util::npmrc;
 
 fn registry_api(registry: &str, path: &str) -> String {
     format!("{}{}", registry.trim_end_matches('/'), path)
@@ -34,6 +35,10 @@ fn token_key(registry: &str) -> String {
 }
 
 /// Resolve auth token for a specific registry.
+///
+/// Priority: `NPM_TOKEN`/`NODE_AUTH_TOKEN` env > utoo config (`ut login`
+/// writes `auth-token:<host>` to the global config) > `.npmrc`
+/// `//host/:_authToken=` credentials (project file first, npm walk-up rules).
 pub async fn resolve_token(registry: &str) -> Option<String> {
     for var in ["NPM_TOKEN", "NODE_AUTH_TOKEN"] {
         if let Ok(token) = std::env::var(var)
@@ -43,9 +48,14 @@ pub async fn resolve_token(registry: &str) -> Option<String> {
         }
     }
 
-    let config = Config::load(ConfigScope::Global).await.ok()?;
-    let token = config.get(&token_key(registry)).ok().flatten()?;
-    if token.is_empty() { None } else { Some(token) }
+    if let Ok(config) = Config::load(ConfigScope::Global).await
+        && let Ok(Some(token)) = config.get(&token_key(registry))
+        && !token.is_empty()
+    {
+        return Some(token);
+    }
+
+    npmrc::load().await.auth_token_for(registry)
 }
 
 /// Token for the configured registry, resolved once and cached for the process.
@@ -75,14 +85,21 @@ pub(crate) fn parse_registry(registry: &str) -> Option<Url> {
     }
 }
 
-/// Whether `url` targets the same host as `registry`. The leak guard for
-/// attaching a token to a tarball download: credentials go to the registry
-/// host only, never to a third-party CDN a manifest's `dist.tarball` points at.
+/// Whether `url` targets the same host **and port** as `registry`. The leak
+/// guard for attaching a token to a tarball download: credentials go to the
+/// registry origin only, never to a third-party CDN a manifest's `dist.tarball`
+/// points at. Port is part of the identity (npm's nerf-dart keys include it),
+/// so a token for `http://localhost:4873` is not sent to `http://localhost:8080`.
 fn same_host(url: &str, registry: &str) -> bool {
-    fn host(s: &str) -> Option<String> {
-        parse_registry(s)?.host_str().map(str::to_ascii_lowercase)
+    fn origin(s: &str) -> Option<(String, Option<u16>)> {
+        let url = parse_registry(s)?;
+        let host = url.host_str()?.to_ascii_lowercase();
+        // `port()` is None for absent or scheme-default ports (the url crate
+        // strips `:443` from https, `:80` from http), so http and https on the
+        // same host still match, while an explicit `:4873` vs `:8080` does not.
+        Some((host, url.port()))
     }
-    matches!((host(url), host(registry)), (Some(a), Some(b)) if a == b)
+    matches!((origin(url), origin(registry)), (Some(a), Some(b)) if a == b)
 }
 
 /// The Bearer token to attach when fetching `url`, or `None` when there is no
@@ -287,9 +304,14 @@ mod tests {
             "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
             "registry.npmjs.org"
         ));
-        // Bare host with a port (e.g. a local Verdaccio) → matches by host.
+        // Bare host with a port (e.g. a local Verdaccio) → matches by host+port.
         assert!(same_host(
             "http://localhost:4873/pkg/-/pkg-1.0.0.tgz",
+            "localhost:4873"
+        ));
+        // Same host but a DIFFERENT explicit port → never leak the token.
+        assert!(!same_host(
+            "http://localhost:8080/pkg/-/pkg-1.0.0.tgz",
             "localhost:4873"
         ));
         // Host case is normalized.

--- a/crates/pm/src/util/config_file.rs
+++ b/crates/pm/src/util/config_file.rs
@@ -41,9 +41,24 @@ impl Config {
             return Ok(config.clone());
         }
 
-        let mut config = Self::load_from_path(&Self::global_config_path()?).await?;
+        Self::load_levels().await?;
+        Ok(MERGED_CONFIG
+            .get()
+            .expect("load_levels populates the merged cache")
+            .clone())
+    }
 
-        let local_config = {
+    /// Read the global (`~/.utoo/config.toml`) and local (`.utoo.toml`) config
+    /// files once each and return the per-level views (`local` is `None` when
+    /// no `.utoo.toml` exists), populating the merged cache as a side effect.
+    ///
+    /// For callers that interleave other sources between the two levels
+    /// (registry resolution slots `.npmrc` files in between); everything else
+    /// should use `load`, which returns the merged view.
+    pub(crate) async fn load_levels() -> ConfigResult<(Self, Option<Self>)> {
+        let global = Self::load_from_path(&Self::global_config_path()?).await?;
+
+        let local = {
             let local_path = Self::local_config_path()?;
             if crate::fs::try_exists(&local_path).await? {
                 Some(Self::load_from_path(&local_path).await?)
@@ -51,16 +66,18 @@ impl Config {
                 None
             }
         };
-        if let Some(local) = local_config {
-            config.values.extend(local.values);
-            config.arrays.extend(local.arrays);
-            // Catalogs are project-local only; take them from the local config
-            config.catalog = local.catalog;
-            config.catalogs = local.catalogs;
-        }
 
-        let _ = MERGED_CONFIG.set(config.clone());
-        Ok(config)
+        let mut merged = global.clone();
+        if let Some(local) = &local {
+            merged.values.extend(local.values.clone());
+            merged.arrays.extend(local.arrays.clone());
+            // Catalogs are project-local only; take them from the local config
+            merged.catalog = local.catalog.clone();
+            merged.catalogs = local.catalogs.clone();
+        }
+        let _ = MERGED_CONFIG.set(merged);
+
+        Ok((global, local))
     }
 
     pub fn set(&mut self, key: &str, value: String, scope: ConfigScope) -> ConfigResult<()> {

--- a/crates/pm/src/util/mod.rs
+++ b/crates/pm/src/util/mod.rs
@@ -31,6 +31,7 @@ pub mod json;
 pub mod linker;
 pub mod logger;
 pub mod manifest_store;
+pub mod npmrc;
 pub mod package_cache;
 pub mod platform_const;
 pub mod registry;

--- a/crates/pm/src/util/npmrc.rs
+++ b/crates/pm/src/util/npmrc.rs
@@ -1,0 +1,412 @@
+//! Minimal npm `.npmrc` reader (compat layer).
+//!
+//! utoo's native config lives in `.utoo.toml` / `~/.utoo/config.toml`, but the
+//! npm ecosystem configures clients through `.npmrc` files (registry bridges,
+//! private registries, corporate proxies all drop one). Reading them lets `ut`
+//! work in such projects without utoo-specific setup.
+//!
+//! Supported subset:
+//! - `registry=<url>`
+//! - `//host[/path]/:_authToken=<token>` credentials, matched with npm's
+//!   walk-up ("nerf dart") rules
+//! - `${VAR}` environment interpolation in values
+//!
+//! Not supported (yet): `@scope:registry=` routing (resolution currently uses
+//! a single registry per install), `_auth`/`username`/`_password` credentials,
+//! and npm's global/builtin config files. Where these interact with utoo's own
+//! config, `.npmrc` sits below the same-level `.utoo.toml` (see
+//! `user_config::init_registry`).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::service::auth::parse_registry;
+
+/// Parsed `.npmrc` values, kept per level so callers can interleave them with
+/// utoo's own project/user config in precedence order.
+#[derive(Debug, Default)]
+pub struct Npmrc {
+    /// `<cwd>/.npmrc` (project level).
+    project: HashMap<String, String>,
+    /// `~/.npmrc` (user level).
+    user: HashMap<String, String>,
+}
+
+static NPMRC: tokio::sync::OnceCell<Npmrc> = tokio::sync::OnceCell::const_new();
+
+/// The process-wide `.npmrc` view (project + user), loaded once. Missing or
+/// unreadable files simply contribute no values.
+pub async fn load() -> &'static Npmrc {
+    NPMRC
+        .get_or_init(|| async { Npmrc::from_disk().await })
+        .await
+}
+
+impl Npmrc {
+    async fn from_disk() -> Self {
+        let project = async {
+            match std::env::current_dir() {
+                Ok(dir) => read_values(&dir.join(".npmrc")).await,
+                Err(_) => HashMap::new(),
+            }
+        };
+        let user = async {
+            match dirs::home_dir() {
+                Some(dir) => read_values(&dir.join(".npmrc")).await,
+                None => HashMap::new(),
+            }
+        };
+        let (project, user) = tokio::join!(project, user);
+        Self { project, user }
+    }
+
+    /// `registry=` from the project `.npmrc`, if any.
+    pub fn project_registry(&self) -> Option<String> {
+        registry_value(&self.project)
+    }
+
+    /// `registry=` from the user `~/.npmrc`, if any.
+    pub fn user_registry(&self) -> Option<String> {
+        registry_value(&self.user)
+    }
+
+    /// The `//host[/path]/:_authToken` credential for `registry`, matched with
+    /// npm's rules: config sources are merged (project overrides user for the
+    /// same key), then the most specific nerf-dart path wins. So a more
+    /// specific user-level token beats a less specific project-level one, while
+    /// project wins on an exact key tie.
+    pub fn auth_token_for(&self, registry: &str) -> Option<String> {
+        auth_token_from(&[&self.project, &self.user], registry).filter(|token| !token.is_empty())
+    }
+}
+
+fn registry_value(values: &HashMap<String, String>) -> Option<String> {
+    values.get("registry").filter(|v| !v.is_empty()).cloned()
+}
+
+async fn read_values(path: &Path) -> HashMap<String, String> {
+    match crate::fs::read_to_string(path).await {
+        Ok(content) => parse(&content),
+        // A missing file is the norm (not every project/home has an .npmrc). A
+        // present-but-unreadable one (permissions, etc.) is worth surfacing, but
+        // not fatal: `.npmrc` is an optional compat layer, so a bad file must
+        // not break commands that don't depend on it. Warn and contribute none.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+        Err(e) => {
+            tracing::warn!("ignoring unreadable npmrc at {}: {e}", path.display());
+            HashMap::new()
+        }
+    }
+}
+
+/// Parse ini-style `.npmrc` content into a key → value map.
+///
+/// Follows npm's config format: `#`/`;` comment lines, `key=value` pairs with
+/// surrounding whitespace trimmed, optional quotes around the value, and
+/// `${VAR}` environment interpolation. Bare keys (ini shorthand for `true`)
+/// carry nothing we consume and are skipped, as is any entry referencing an
+/// unset environment variable (npm errors there; we log and treat it as
+/// absent so an optional token line can't break unrelated commands).
+fn parse(content: &str) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+    for raw_line in content.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = strip_quotes(value.trim());
+        match interpolate(value, |var| std::env::var(var).ok()) {
+            Some(value) => {
+                values.insert(key.to_string(), value);
+            }
+            None => {
+                tracing::warn!("ignoring npmrc key {key:?}: value references an unset env var");
+            }
+        }
+    }
+    values
+}
+
+/// Strip one pair of matching surrounding quotes, npm-ini style.
+fn strip_quotes(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2
+        && (bytes[0] == b'"' || bytes[0] == b'\'')
+        && bytes[bytes.len() - 1] == bytes[0]
+    {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
+}
+
+/// Expand `${VAR}` references via `lookup`. Returns `None` when a referenced
+/// variable is unset (the caller drops the entry). An unterminated `${` is
+/// kept literally, matching npm's leniency for non-reference `$` uses.
+fn interpolate(value: &str, lookup: impl Fn(&str) -> Option<String>) -> Option<String> {
+    let mut out = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let Some(end) = after.find('}') else {
+            out.push_str(&rest[start..]);
+            return Some(out);
+        };
+        out.push_str(&lookup(&after[..end])?);
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    Some(out)
+}
+
+/// Look up `<nerf-dart>:_authToken` for a registry URL, walking the path up
+/// exactly like npm's `regKeyFromURI`: starting from `//host/path/`, strip one
+/// trailing slash or path segment per step until only `//host` remains, and
+/// return the first match. This makes `//npm.corp/api/:_authToken` cover a
+/// registry at `https://npm.corp/api/npm/repo`, while a more specific
+/// `//npm.corp/api/npm/repo/:_authToken` wins over it.
+///
+/// `maps` are consulted in precedence order (project before user) at each path
+/// level, so a longer path always wins over a shorter one regardless of source,
+/// and an exact-key tie goes to the earlier (higher-precedence) map — matching
+/// npm's merge-then-most-specific-path semantics without allocating a merged map.
+fn auth_token_from(maps: &[&HashMap<String, String>], registry: &str) -> Option<String> {
+    // parse_registry (not raw Url::parse) so scheme-less registry values like
+    // `localhost:4873` match, consistent with the rest of the auth stack.
+    let url = parse_registry(registry)?;
+    let host = url.host_str()?;
+    let mut reg_key = match url.port() {
+        Some(port) => format!("//{host}:{port}{}", url.path()),
+        None => format!("//{host}{}", url.path()),
+    };
+    if !reg_key.ends_with('/') {
+        reg_key.push('/');
+    }
+    while reg_key.len() > 2 {
+        let key = format!("{reg_key}:_authToken");
+        if let Some(token) = maps.iter().find_map(|values| values.get(&key)) {
+            return Some(token.clone());
+        }
+        if reg_key.ends_with('/') {
+            reg_key.pop();
+        } else {
+            let last_slash = reg_key.rfind('/').unwrap_or(1);
+            reg_key.truncate(last_slash + 1);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn npmrc(project: &str, user: &str) -> Npmrc {
+        Npmrc {
+            project: parse(project),
+            user: parse(user),
+        }
+    }
+
+    #[test]
+    fn parse_reads_key_values_and_skips_comments() {
+        let values = parse(
+            "# a comment\n\
+             ; another comment\n\
+             \n\
+             registry=https://registry.npmmirror.com\n\
+             legacy-peer-deps\n\
+             always-auth = true \n",
+        );
+        assert_eq!(
+            values.get("registry").map(String::as_str),
+            Some("https://registry.npmmirror.com")
+        );
+        // Bare key (ini `true` shorthand) is skipped, not misparsed.
+        assert!(!values.contains_key("legacy-peer-deps"));
+        assert_eq!(values.get("always-auth").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn parse_strips_quotes() {
+        let values = parse("registry=\"https://npm.corp/repo\"\ntoken='abc'\n");
+        assert_eq!(
+            values.get("registry").map(String::as_str),
+            Some("https://npm.corp/repo")
+        );
+        assert_eq!(values.get("token").map(String::as_str), Some("abc"));
+    }
+
+    #[test]
+    fn interpolate_expands_env_references() {
+        let lookup = |var: &str| match var {
+            "TOKEN" => Some("secret".to_string()),
+            "HOST" => Some("npm.corp".to_string()),
+            _ => None,
+        };
+        assert_eq!(interpolate("${TOKEN}", lookup).as_deref(), Some("secret"));
+        assert_eq!(
+            interpolate("https://${HOST}/x-${TOKEN}", lookup).as_deref(),
+            Some("https://npm.corp/x-secret")
+        );
+        // Unset variable → entry dropped.
+        assert_eq!(interpolate("${MISSING}", lookup), None);
+        // Unterminated ${ is kept literally.
+        assert_eq!(interpolate("a${b", lookup).as_deref(), Some("a${b"));
+        // No references → unchanged.
+        assert_eq!(interpolate("plain", lookup).as_deref(), Some("plain"));
+    }
+
+    #[test]
+    fn registry_project_wins_over_user() {
+        let rc = npmrc(
+            "registry=https://project.example.com\n",
+            "registry=https://user.example.com\n",
+        );
+        assert_eq!(
+            rc.project_registry().as_deref(),
+            Some("https://project.example.com")
+        );
+        assert_eq!(
+            rc.user_registry().as_deref(),
+            Some("https://user.example.com")
+        );
+
+        let rc = npmrc("", "registry=https://user.example.com\n");
+        assert_eq!(rc.project_registry(), None);
+        assert_eq!(
+            rc.user_registry().as_deref(),
+            Some("https://user.example.com")
+        );
+    }
+
+    #[test]
+    fn empty_registry_value_is_ignored() {
+        let rc = npmrc("registry=\n", "");
+        assert_eq!(rc.project_registry(), None);
+    }
+
+    #[test]
+    fn auth_token_exact_host_match() {
+        let rc = npmrc("//registry.npmjs.org/:_authToken=npm-token\n", "");
+        assert_eq!(
+            rc.auth_token_for("https://registry.npmjs.org").as_deref(),
+            Some("npm-token")
+        );
+        // Different host → no token.
+        assert_eq!(rc.auth_token_for("https://registry.npmmirror.com"), None);
+    }
+
+    #[test]
+    fn auth_token_matches_host_with_port() {
+        let rc = npmrc("//127.0.0.1:8080/:_authToken=local-token\n", "");
+        assert_eq!(
+            rc.auth_token_for("http://127.0.0.1:8080").as_deref(),
+            Some("local-token")
+        );
+        assert_eq!(rc.auth_token_for("http://127.0.0.1:9090"), None);
+    }
+
+    #[test]
+    fn auth_token_matches_scheme_less_registry() {
+        // A registry configured without a scheme (e.g. `localhost:4873`) still
+        // resolves its credential, like the rest of the auth stack.
+        let rc = npmrc("//localhost:4873/:_authToken=bare-token\n", "");
+        assert_eq!(
+            rc.auth_token_for("localhost:4873").as_deref(),
+            Some("bare-token")
+        );
+    }
+
+    #[test]
+    fn auth_token_walks_up_sub_paths() {
+        // A host-level token covers a registry served under a sub-path…
+        let rc = npmrc("//npm.corp/:_authToken=host-token\n", "");
+        assert_eq!(
+            rc.auth_token_for("https://npm.corp/api/npm/repo")
+                .as_deref(),
+            Some("host-token")
+        );
+
+        // …and a more specific path-level token wins over the host-level one.
+        let rc = npmrc(
+            "//npm.corp/:_authToken=host-token\n\
+             //npm.corp/api/npm/repo/:_authToken=repo-token\n",
+            "",
+        );
+        assert_eq!(
+            rc.auth_token_for("https://npm.corp/api/npm/repo")
+                .as_deref(),
+            Some("repo-token")
+        );
+        // Key without the trailing slash matches too (npm checks both forms).
+        let rc = npmrc("//npm.corp/api/npm/repo:_authToken=noslash-token\n", "");
+        assert_eq!(
+            rc.auth_token_for("https://npm.corp/api/npm/repo")
+                .as_deref(),
+            Some("noslash-token")
+        );
+    }
+
+    #[test]
+    fn auth_token_project_wins_over_user() {
+        let rc = npmrc(
+            "//registry.npmjs.org/:_authToken=project-token\n",
+            "//registry.npmjs.org/:_authToken=user-token\n",
+        );
+        assert_eq!(
+            rc.auth_token_for("https://registry.npmjs.org").as_deref(),
+            Some("project-token")
+        );
+    }
+
+    #[test]
+    fn auth_token_more_specific_user_path_beats_project_host() {
+        // npm merges all config, then matches the most specific path: a
+        // user-level path-scoped token must win over a project-level host-scoped
+        // token, since path specificity outranks file precedence.
+        let rc = npmrc(
+            "//npm.corp/:_authToken=project-host-token\n",
+            "//npm.corp/api/npm/repo/:_authToken=user-repo-token\n",
+        );
+        assert_eq!(
+            rc.auth_token_for("https://npm.corp/api/npm/repo")
+                .as_deref(),
+            Some("user-repo-token")
+        );
+        // But at the same path level, project still wins the tie.
+        let rc = npmrc(
+            "//npm.corp/:_authToken=project-host-token\n",
+            "//npm.corp/:_authToken=user-host-token\n",
+        );
+        assert_eq!(
+            rc.auth_token_for("https://npm.corp/api").as_deref(),
+            Some("project-host-token")
+        );
+    }
+
+    #[test]
+    fn auth_token_ignores_empty_and_invalid() {
+        let rc = npmrc("//registry.npmjs.org/:_authToken=\n", "");
+        assert_eq!(rc.auth_token_for("https://registry.npmjs.org"), None);
+        // Non-URL registry input never panics.
+        assert_eq!(rc.auth_token_for("not a url"), None);
+    }
+
+    #[test]
+    fn auth_token_matches_registry_with_explicit_default_port() {
+        // The url crate strips scheme-default ports, so an explicit `:443` still
+        // resolves against a standard `//host/:_authToken` key (no port).
+        let rc = npmrc("//registry.npmjs.org/:_authToken=npm-token\n", "");
+        assert_eq!(
+            rc.auth_token_for("https://registry.npmjs.org:443")
+                .as_deref(),
+            Some("npm-token")
+        );
+    }
+}

--- a/crates/pm/src/util/user_config.rs
+++ b/crates/pm/src/util/user_config.rs
@@ -42,30 +42,70 @@ fn default_cache_dir() -> PathBuf {
         .join(".cache/nm")
 }
 
-pub async fn init_registry(registry: Option<String>) -> Result<()> {
-    // Priority: CLI argument > UTOO_REGISTRY env > config > auto-select
-    let (raw_registry, registry_source) = if let Some(reg) = registry {
-        tracing::debug!("Using registry from CLI: {}", reg);
-        (reg, "CLI")
-    } else if let Ok(env_reg) = std::env::var("UTOO_REGISTRY")
-        && !env_reg.is_empty()
-    {
-        tracing::debug!("Using registry from env: {}", env_reg);
-        (env_reg, "UTOO_REGISTRY")
-    } else {
-        let config_registry = Config::load(ConfigScope::Local)
-            .await
-            .ok()
-            .and_then(|c| c.get("registry").ok().flatten());
+/// Registry candidates from the config *profiles*, most specific first. These
+/// are consulted only when neither `--registry` nor `UTOO_REGISTRY` is set;
+/// both take precedence and short-circuit before any profile is read. `.npmrc`
+/// slots in per level: a project `.npmrc` beats the user-level utoo config (a
+/// project must be able to redirect any npm client, which is exactly what
+/// registry bridges and corporate proxies rely on), but never the same-level
+/// `.utoo.toml`, where utoo-native config stays authoritative.
+#[derive(Default)]
+struct ProfileRegistries {
+    project_config: Option<String>,
+    project_npmrc: Option<String>,
+    global_config: Option<String>,
+    user_npmrc: Option<String>,
+}
 
-        if let Some(ref reg) = config_registry {
-            tracing::debug!("Using registry from config: {}", reg);
-            (reg.clone(), "config")
-        } else {
-            // No config, auto-select fastest registry
-            (select_fastest_registry().await, "auto-select")
+fn pick_profile_registry(sources: ProfileRegistries) -> Option<(String, &'static str)> {
+    [
+        (sources.project_config, ".utoo.toml"),
+        (sources.project_npmrc, "project .npmrc"),
+        (sources.global_config, "global config"),
+        (sources.user_npmrc, "user .npmrc"),
+    ]
+    .into_iter()
+    .find_map(|(value, source)| value.filter(|v| !v.is_empty()).map(|v| (v, source)))
+}
+
+pub async fn init_registry(registry: Option<String>) -> Result<()> {
+    // init_registry is the process config chokepoint (see main.rs):
+    // `load_levels` seeds the merged-config cache that later ConfigValue reads
+    // rely on (from the invocation cwd, before any workspace chdir), and
+    // returns the per-level views used for registry resolution below. Fail loud
+    // on a malformed/unreadable utoo config rather than silently resolving
+    // against the wrong registry; the error carries the offending file + reason.
+    let (global_config, local_config) = Config::load_levels()
+        .await
+        .context("failed to load utoo config")?;
+
+    // An explicit `--registry` or `UTOO_REGISTRY` wins outright, so short-circuit
+    // before touching any profile: only when neither is set do we read the
+    // `.utoo.toml`/global `registry` keys and load `.npmrc` (see
+    // `ProfileRegistries` for the inter-profile precedence).
+    let (raw_registry, registry_source) = if let Some(reg) = registry.filter(|r| !r.is_empty()) {
+        (reg, "CLI")
+    } else if let Some(env) = std::env::var("UTOO_REGISTRY")
+        .ok()
+        .filter(|v| !v.is_empty())
+    {
+        (env, "UTOO_REGISTRY")
+    } else {
+        let npmrc = super::npmrc::load().await;
+        let registry_of = |c: &Config| c.get("registry").ok().flatten();
+        let sources = ProfileRegistries {
+            project_config: local_config.as_ref().and_then(registry_of),
+            project_npmrc: npmrc.project_registry(),
+            global_config: registry_of(&global_config),
+            user_npmrc: npmrc.user_registry(),
+        };
+        match pick_profile_registry(sources) {
+            Some(picked) => picked,
+            // Nothing configured anywhere, auto-select fastest registry
+            None => (select_fastest_registry().await, "auto-select"),
         }
     };
+    tracing::debug!("Using registry from {}: {}", registry_source, raw_registry);
 
     // Canonicalize at the single resolution chokepoint so every downstream
     // consumer sees a validated, slash-normalized URL. Explicit invalid values
@@ -586,6 +626,74 @@ mod tests {
         ));
         // Non-http resolveds are not registry tarballs.
         assert!(!is_registry_tarball("file:../foo.tgz"));
+    }
+
+    fn src(value: &str) -> Option<String> {
+        Some(value.to_string())
+    }
+
+    #[test]
+    fn pick_profile_registry_precedence_order() {
+        // `--registry` and `UTOO_REGISTRY` are handled ahead of these profiles
+        // (they short-circuit in init_registry), so this covers the inter-profile
+        // order only. Same-level utoo config beats the project .npmrc…
+        let picked = pick_profile_registry(ProfileRegistries {
+            project_config: src("https://project-toml.example.com"),
+            project_npmrc: src("https://project-npmrc.example.com"),
+            ..Default::default()
+        });
+        assert_eq!(
+            picked,
+            Some(("https://project-toml.example.com".to_string(), ".utoo.toml"))
+        );
+
+        // …but the project .npmrc beats the user-level global config: a
+        // project must be able to redirect any npm client (registry bridges,
+        // corporate proxies).
+        let picked = pick_profile_registry(ProfileRegistries {
+            project_npmrc: src("https://project-npmrc.example.com"),
+            global_config: src("https://global-toml.example.com"),
+            user_npmrc: src("https://user-npmrc.example.com"),
+            ..Default::default()
+        });
+        assert_eq!(
+            picked,
+            Some((
+                "https://project-npmrc.example.com".to_string(),
+                "project .npmrc"
+            ))
+        );
+
+        // User .npmrc is the last configured fallback before auto-select.
+        let picked = pick_profile_registry(ProfileRegistries {
+            user_npmrc: src("https://user-npmrc.example.com"),
+            ..Default::default()
+        });
+        assert_eq!(
+            picked,
+            Some(("https://user-npmrc.example.com".to_string(), "user .npmrc"))
+        );
+
+        // Nothing configured → None (caller auto-selects).
+        assert_eq!(pick_profile_registry(ProfileRegistries::default()), None);
+    }
+
+    #[test]
+    fn pick_profile_registry_skips_empty_values() {
+        // An empty config value is "unset", not a broken override, so a lower
+        // profile with a real value wins over a higher one left blank.
+        let picked = pick_profile_registry(ProfileRegistries {
+            project_config: Some(String::new()),
+            project_npmrc: src("https://project-npmrc.example.com"),
+            ..Default::default()
+        });
+        assert_eq!(
+            picked,
+            Some((
+                "https://project-npmrc.example.com".to_string(),
+                "project .npmrc"
+            ))
+        );
     }
 
     #[test]

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -2137,4 +2137,77 @@ rm -rf "$WSP_DIR"
 trap - EXIT
 echo -e "${GREEN}PASS: workspace --filter publish resolves protocols + topological order${NC}"
 
+# ---------------------------------------------------------------------------
+# Case: registry read from the project .npmrc (npm compat) + //host/:_authToken.
+# The stub registry REQUIRES `Authorization: Bearer <token>` on every request,
+# so a passing install proves three things at once:
+#   1. the project `.npmrc` `registry=` beats the global utoo config that this
+#      script sets at the top (project-level config must win, like npm);
+#   2. the `//host:port/:_authToken=` credential is matched (nerf-dart) and
+#      attached to both the manifest fetch and the tarball download;
+#   3. `${VAR}` env interpolation in .npmrc values works end-to-end.
+# ---------------------------------------------------------------------------
+echo -e "${YELLOW}Case: .npmrc registry= and //host/:_authToken${NC}"
+NPMRC_DIR=$(mktemp -d)
+NPMRC_CACHE=$(mktemp -d)
+mkdir -p "$NPMRC_DIR/pkg/npmrc-reg-pkg"
+cat > "$NPMRC_DIR/pkg/npmrc-reg-pkg/package.json" <<'EOF'
+{ "name": "npmrc-reg-pkg", "version": "1.0.0", "main": "index.js" }
+EOF
+echo "module.exports = 1;" > "$NPMRC_DIR/pkg/npmrc-reg-pkg/index.js"
+( cd "$NPMRC_DIR/pkg/npmrc-reg-pkg" && npm pack --silent >/dev/null 2>&1 \
+  && mv npmrc-reg-pkg-*.tgz "$NPMRC_DIR/npmrc-reg-pkg.tgz" )
+NPMRC_PORT=$(node -e 'const s=require("net").createServer();s.listen(0,"127.0.0.1",()=>{console.log(s.address().port);s.close();})')
+node -e '
+const http=require("http"), fs=require("fs"), crypto=require("crypto"), path=require("path");
+const dir=process.argv[1], port=Number(process.argv[2]);
+const tgz=fs.readFileSync(path.join(dir,"npmrc-reg-pkg.tgz"));
+const integrity="sha512-"+crypto.createHash("sha512").update(tgz).digest("base64");
+http.createServer((req,res)=>{
+  if(req.headers.authorization!=="Bearer e2e-npmrc-token"){res.statusCode=401;return res.end("unauthorized");}
+  if(req.url==="/npmrc-reg-pkg.tgz"){return res.end(tgz);}
+  if(req.url.split("?")[0].startsWith("/npmrc-reg-pkg")){
+    const manifest={name:"npmrc-reg-pkg","dist-tags":{latest:"1.0.0"},versions:{"1.0.0":{
+      name:"npmrc-reg-pkg",version:"1.0.0",
+      dist:{tarball:"http://127.0.0.1:"+port+"/npmrc-reg-pkg.tgz",integrity}}}};
+    res.setHeader("content-type","application/json");
+    return res.end(JSON.stringify(manifest));
+  }
+  res.statusCode=404;res.end("nf");
+}).listen(port,"127.0.0.1");
+' "$NPMRC_DIR" "$NPMRC_PORT" &
+NPMRC_PID=$!
+npmrc_cleanup() { kill "$NPMRC_PID" 2>/dev/null; rm -rf "$NPMRC_DIR" "$NPMRC_CACHE"; }
+# Wait for the server to accept authenticated requests.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -fsS -H "Authorization: Bearer e2e-npmrc-token" \
+    "http://127.0.0.1:$NPMRC_PORT/npmrc-reg-pkg.tgz" -o /dev/null 2>/dev/null; then break; fi
+  sleep 0.3
+done
+mkdir -p "$NPMRC_DIR/app"
+cat > "$NPMRC_DIR/app/package.json" <<'EOF'
+{ "name": "npmrc-app", "version": "1.0.0", "private": true,
+  "dependencies": { "npmrc-reg-pkg": "^1.0.0" } }
+EOF
+cat > "$NPMRC_DIR/app/.npmrc" <<EOF
+registry=http://127.0.0.1:$NPMRC_PORT
+//127.0.0.1:$NPMRC_PORT/:_authToken=\${E2E_NPMRC_TOKEN}
+EOF
+# NPM_TOKEN/NODE_AUTH_TOKEN/UTOO_REGISTRY are cleared so only the .npmrc path
+# can supply the registry and its credential.
+( cd "$NPMRC_DIR/app" && env -u NPM_TOKEN -u NODE_AUTH_TOKEN -u UTOO_REGISTRY \
+    E2E_NPMRC_TOKEN=e2e-npmrc-token UTOO_CACHE_DIR="$NPMRC_CACHE" utoo install --ignore-scripts ) \
+  || { echo -e "${RED}FAIL: install via .npmrc registry + _authToken failed${NC}"; npmrc_cleanup; exit 1; }
+if [ ! -f "$NPMRC_DIR/app/node_modules/npmrc-reg-pkg/package.json" ]; then
+    echo -e "${RED}FAIL: npmrc-reg-pkg not installed from the .npmrc registry${NC}"; npmrc_cleanup; exit 1
+fi
+# The tarball came from the configured (.npmrc) registry origin, so it is
+# trusted and must land in the shared cache (registry-tarball classification).
+if [ ! -d "$NPMRC_CACHE/npmrc-reg-pkg" ]; then
+    echo -e "${RED}FAIL: npmrc-reg-pkg missing from the global cache (registry origin not trusted?)${NC}"
+    npmrc_cleanup; exit 1
+fi
+npmrc_cleanup
+echo -e "${GREEN}PASS: .npmrc registry= and //host/:_authToken honored${NC}"
+
 echo -e "${GREEN}All e2e tests passed successfully!${NC}"


### PR DESCRIPTION
Closes #3212

utoo now reads npm's `.npmrc` files, so registry bridges, private registries, and corporate proxies work with `ut` without utoo-specific setup. Supported subset:

- `registry=` from the project (`<cwd>/.npmrc`) and user (`~/.npmrc`) files
- `//host[/path]/:_authToken=` credentials, matched with npm's nerf-dart walk-up rules (most specific path wins, scheme-less registry values supported)
- `${VAR}` environment interpolation in values (an unset var drops that entry with a warning)

Registry resolution precedence, interleaved by level so a project `.npmrc` can redirect any npm client while utoo-native config stays authoritative at the same level:

1. `--registry` CLI flag
2. `UTOO_REGISTRY` env
3. project `.utoo.toml`
4. project `.npmrc`
5. global `~/.utoo/config.toml`
6. user `~/.npmrc`
7. auto-select fastest registry

Auth tokens resolve `NPM_TOKEN`/`NODE_AUTH_TOKEN` > `ut login` config > `.npmrc`, and flow to both manifest fetches and tarball downloads through the existing plumbing.

Implementation notes: the parsing lives in a new pm-only `util/npmrc.rs` module (wasm build untouched), and `Config::load_levels()` now reads each utoo config file once, populating the merged cache and returning per-level views for the interleaving. `@scope:registry=` routing is deferred to a follow-up, since resolution currently uses a single registry per install (`UnifiedRegistry` holds one URL).

Tested with unit tests for parsing, token matching, and precedence, plus a new e2e case: a stub registry that rejects any request without `Authorization: Bearer <token>`, where the registry URL and token come only from the project `.npmrc` (token via `${E2E_NPMRC_TOKEN}`), proving the override, the auth flow, and env interpolation end-to-end. This fixes the vite-plus ecosystem-ci failure mode where a bridge `.npmrc` was silently ignored.
