### PR TITLE
feat(pack): support custom less-loader in styles.less

### DIFF
--- a/crates/pack-core/src/shared/webpack_rules/less.rs
+++ b/crates/pack-core/src/shared/webpack_rules/less.rs
@@ -7,13 +7,22 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::LoaderRuleItem;
 use turbopack_node::transforms::webpack::WebpackLoaderItem;
 
+fn get_less_loader_name(less_options: &mut serde_json::Map<String, JsonValue>) -> Result<RcStr> {
+    match less_options.remove("loader") {
+        Some(JsonValue::String(loader)) if !loader.is_empty() => Ok(RcStr::from(loader)),
+        Some(_) => bail!("styles.less.loader must be a non-empty string"),
+        None => Ok(rcstr!("less-loader")),
+    }
+}
+
 pub async fn get_less_loader_rules(
     less_options: Vc<JsonValue>,
 ) -> Result<Vec<(RcStr, LoaderRuleItem)>> {
     let less_options = less_options.await?;
-    let Some(less_options) = less_options.as_object().cloned() else {
+    let Some(mut less_options) = less_options.as_object().cloned() else {
         bail!("less_options must be an object");
     };
+    let loader = get_less_loader_name(&mut less_options)?;
 
     // additionalData is a loader option but utoopack has it under `lessOptions` in
     // `project.json`
@@ -23,7 +32,7 @@ pub async fn get_less_loader_rules(
         .or(Some(&empty_additional_data)));
 
     let less_loader = WebpackLoaderItem {
-        loader: rcstr!("less-loader"),
+        loader,
         options: take(
             serde_json::json!({
                 "implementation": less_options.get("implementation"),
@@ -55,4 +64,57 @@ pub async fn get_less_loader_rules(
     }
 
     Ok(rules)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn defaults_to_less_loader_package_name() {
+        let mut less_options = serde_json::Map::new();
+
+        let loader = get_less_loader_name(&mut less_options).unwrap();
+
+        assert_eq!(loader.to_string(), "less-loader");
+    }
+
+    #[test]
+    fn uses_configured_less_loader_path_and_removes_it_from_options() {
+        let mut less_options = json!({
+            "loader": "/repo/node_modules/less-loader/dist/cjs.js",
+            "javascriptEnabled": true
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let loader = get_less_loader_name(&mut less_options).unwrap();
+
+        assert_eq!(
+            loader.to_string(),
+            "/repo/node_modules/less-loader/dist/cjs.js"
+        );
+        assert!(!less_options.contains_key("loader"));
+        assert_eq!(less_options.get("javascriptEnabled"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn rejects_invalid_less_loader_path() {
+        let mut less_options = json!({
+            "loader": false
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let err = get_less_loader_name(&mut less_options).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "styles.less.loader must be a non-empty string"
+        );
+    }
 }

--- a/crates/pack-core/src/shared/webpack_rules/less.rs
+++ b/crates/pack-core/src/shared/webpack_rules/less.rs
@@ -10,8 +10,8 @@ use turbopack_node::transforms::webpack::WebpackLoaderItem;
 fn get_less_loader_name(less_options: &mut serde_json::Map<String, JsonValue>) -> Result<RcStr> {
     match less_options.remove("loader") {
         Some(JsonValue::String(loader)) if !loader.is_empty() => Ok(RcStr::from(loader)),
+        Some(JsonValue::Null) | None => Ok(rcstr!("less-loader")),
         Some(_) => bail!("styles.less.loader must be a non-empty string"),
-        None => Ok(rcstr!("less-loader")),
     }
 }
 
@@ -75,6 +75,20 @@ mod tests {
     #[test]
     fn defaults_to_less_loader_package_name() {
         let mut less_options = serde_json::Map::new();
+
+        let loader = get_less_loader_name(&mut less_options).unwrap();
+
+        assert_eq!(loader.to_string(), "less-loader");
+    }
+
+    #[test]
+    fn treats_null_less_loader_as_default() {
+        let mut less_options = json!({
+            "loader": null
+        })
+        .as_object()
+        .unwrap()
+        .clone();
 
         let loader = get_less_loader_name(&mut less_options).unwrap();
 

--- a/crates/pack-tests/tests/snapshot/node_modules/less-loader-wrapper/index.js
+++ b/crates/pack-tests/tests/snapshot/node_modules/less-loader-wrapper/index.js
@@ -1,0 +1,3 @@
+module.exports = function lessLoaderWrapper() {
+  return ".less-loader-wrapper-marker { border-color: #13c2c2; }";
+};

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/config.json
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/config.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.ts",
+        "name": "index"
+      }
+    ],
+    "styles": {
+      "less": {
+        "loader": "less-loader-wrapper",
+        "implementation": "less",
+        "javascriptEnabled": true
+      }
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/input/index.ts
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/input/index.ts
@@ -1,0 +1,3 @@
+import "./style.less";
+
+export const value = "less-custom-loader";

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/input/style.less
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/input/style.less
@@ -1,0 +1,5 @@
+@color: #1677ff;
+
+.custom-loader-fixture {
+  color: @color;
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/index.js
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/index.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_style_less_e4614c70.css","input_index_ts_12aaf185.js"],"runtimeModuleIds":["[project]/webpack-loaders/less-custom-loader/input/index.ts [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/index.js.map
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/index.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/input_index_ts_12aaf185.js
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/input_index_ts_12aaf185.js
@@ -1,0 +1,15 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/webpack-loaders/less-custom-loader/input/index.ts [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+;
+const value = "less-custom-loader";
+__turbopack_context__.s([
+    "value",
+    0,
+    value
+]);
+}),
+]);
+
+//# sourceMappingURL=input_index_ts_12aaf185.js.map

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/input_index_ts_12aaf185.js.map
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/input_index_ts_12aaf185.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/webpack-loaders/less-custom-loader/input/index.ts"],"sourcesContent":["import \"./style.less\";\n\nexport const value = \"less-custom-loader\";\n"],"names":["value"],"mappings":";AAEO,MAAMA,QAAQ"}}]
+}

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/input_style_less_e4614c70.css
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/input_style_less_e4614c70.css
@@ -1,0 +1,6 @@
+/* [project]/webpack-loaders/less-custom-loader/input/style.less.css [client] (css) */
+.less-loader-wrapper-marker {
+  border-color: #13c2c2;
+}
+
+/*# sourceMappingURL=input_style_less_e4614c70.css.map*/

--- a/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/input_style_less_e4614c70.css.map
+++ b/crates/pack-tests/tests/snapshot/webpack-loaders/less-custom-loader/output/input_style_less_e4614c70.css.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/webpack-loaders/less-custom-loader/input/style.less.css"],"sourcesContent":[".less-loader-wrapper-marker { border-color: #13c2c2; }"],"names":[],"mappings":"AAAA"}}]
+}

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -304,6 +304,7 @@ export interface ConfigComplete {
     emotion?: boolean | EmotionOptions;
     postcss?: JSONValue;
     less?: {
+      loader?: string;
       implementation?: string;
       [key: string]: any;
     };


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/utooland/utoo/blob/next/README.md
-->

## Summary

support config `styles.less.loader` to help user to set less-loader to solve framework's problem which cause by tnpm hoist:

<img width="1658" height="676" alt="image" src="https://github.com/user-attachments/assets/db46ff04-8019-484a-81ee-54daa9e6eb74" />

The reason why i want to solve this because under [dumi utoopack](https://d.umijs.org/config#utoopack) it will hoist less and less-loader in high probability.


## Test Plan

I add snapshot test case.
