### PR TITLE
fix(pack): disable HMR socket retry

### DIFF
--- a/.github/workflows/utooweb-ci.yml
+++ b/.github/workflows/utooweb-ci.yml
@@ -37,6 +37,8 @@ jobs:
       #     shared-key: utooweb-ci
       - name: Setup Utoo
         uses: utooland/setup-utoo@v1
+        with:
+          utoo-version: 1.0.32
 
       - name: Install dependencies
         run: |

--- a/crates/pack-core/js/src/hmr/websocket.ts
+++ b/crates/pack-core/js/src/hmr/websocket.ts
@@ -67,7 +67,6 @@ export interface HMROptions {
   path: string;
 }
 
-let reconnections = 0;
 let reloading = false;
 let serverSessionId: number | null = null;
 
@@ -79,7 +78,6 @@ export function connectHMR(options: HMROptions) {
     console.log("[HMR] connecting...");
 
     function handleOnline() {
-      reconnections = 0;
       window.console.log("[HMR] connected");
 
       // Send the turbopack-connected message to trigger handleSocketConnected
@@ -148,27 +146,21 @@ export function connectHMR(options: HMROptions) {
       }
     }
 
-    let timer: ReturnType<typeof setTimeout>;
     function handleDisconnect() {
-      source.onerror = null;
-      source.onclose = null;
-      source.close();
-      reconnections++;
-      // After 25 reconnects we'll want to reload the page as it indicates the dev server is no longer running.
-      if (reconnections > 25) {
-        reloading = true;
-        window.location.reload();
-        return;
+      if (source) {
+        source.onerror = null;
+        source.onclose = null;
+        source.close();
+        source = null;
       }
 
-      clearTimeout(timer);
-      // Try again after 5 seconds
-      timer = setTimeout(init, reconnections > 5 ? 5000 : 1000);
+      window.console.warn("[HMR] disconnected");
     }
 
     source = new WebSocket(`${getSocketUrl()}${options.path}`);
     source.onopen = handleOnline;
     source.onerror = handleDisconnect;
+    source.onclose = handleDisconnect;
     source.onmessage = handleMessage;
   }
 

--- a/crates/pack-core/js/src/hmr/websocket.ts
+++ b/crates/pack-core/js/src/hmr/websocket.ts
@@ -146,7 +146,11 @@ export function connectHMR(options: HMROptions) {
       }
     }
 
-    function handleDisconnect() {
+    function handleDisconnect(event?: Event) {
+      if (event && event.target !== source) {
+        return;
+      }
+
       if (source) {
         source.onerror = null;
         source.onclose = null;


### PR DESCRIPTION
## Summary
- Stop the utoopack HMR WebSocket client from retrying after a connection failure or disconnect.
- Clean up the current socket and leave HMR disconnected instead of scheduling another connection attempt or forcing reload after repeated failures.

## Why
Some proxy tools are affected by the HMR client continuously reconnecting when the socket cannot be established. A single failed connection should not keep generating retry traffic.

## Validation
- npx biome check crates/pack-core/js/src/hmr/websocket.ts
- git diff --check -- crates/pack-core/js/src/hmr/websocket.ts
- push hook Biome check passed during git push