### PR TITLE
feat(pm): show proxy env hint during install

### DIFF
--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -24,6 +24,7 @@ use crate::util::linker::link;
 use crate::util::logger::{
     PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
 };
+use crate::util::proxy_env::print_proxy_env_hint_once;
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
 use utoo_ruborist::progress::PackageTarballInfo;
 
@@ -291,6 +292,7 @@ impl InstallService {
         root_path: &Path,
         omit: &HashSet<OmitType>,
     ) -> Result<()> {
+        print_proxy_env_hint_once();
         install_progress::start_install_run();
         let lock_path = root_path.join("package-lock.json");
         // Treat a failing freshness check as stale: regenerate rather than
@@ -393,6 +395,7 @@ impl InstallService {
     /// the global `node_modules` is the source of truth, reified **additively**
     /// so previously-installed globals survive.
     pub async fn install_global_package(npm_spec: &str, prefix: Option<&str>) -> Result<()> {
+        print_proxy_env_hint_once();
         install_progress::start_install_run();
         let (name, resolved_version, version_spec) = resolve_package_spec(npm_spec).await?;
         // Resolvable spec for the synthetic dependency: registry ranges pinned to

--- a/crates/pm/src/util/mod.rs
+++ b/crates/pm/src/util/mod.rs
@@ -34,6 +34,7 @@ pub mod manifest_store;
 pub mod npmrc;
 pub mod package_cache;
 pub mod platform_const;
+pub mod proxy_env;
 pub mod registry;
 pub mod retry;
 pub mod sysconf;

--- a/crates/pm/src/util/proxy_env.rs
+++ b/crates/pm/src/util/proxy_env.rs
@@ -1,0 +1,72 @@
+use colored::Colorize;
+use std::ffi::OsStr;
+use std::sync::Once;
+
+const PROXY_ENV_VARS: [&str; 6] = [
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+];
+
+static PRINT_PROXY_HINT_ONCE: Once = Once::new();
+
+fn collect_proxy_env_vars_from<I, V>(vars: I) -> Vec<&'static str>
+where
+    I: IntoIterator<Item = (&'static str, Option<V>)>,
+    V: AsRef<OsStr>,
+{
+    vars.into_iter()
+        .filter_map(|(key, value)| value.filter(|v| !v.as_ref().is_empty()).map(|_| key))
+        .collect()
+}
+
+pub fn print_proxy_env_hint_once() {
+    PRINT_PROXY_HINT_ONCE.call_once(|| {
+        let detected =
+            collect_proxy_env_vars_from(PROXY_ENV_VARS.map(|key| (key, std::env::var_os(key))));
+        if !detected.is_empty() {
+            eprintln!(
+                "{} {} {}",
+                "!".blue().bold(),
+                "proxy env:".blue().bold(),
+                detected.join(", ").cyan()
+            );
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_proxy_env_vars_ignores_unset_and_empty_values() {
+        let vars = [
+            ("http_proxy", Some("")),
+            ("https_proxy", None),
+            ("all_proxy", Some("socks5://127.0.0.1:7891")),
+        ];
+
+        assert_eq!(collect_proxy_env_vars_from(vars), vec!["all_proxy"]);
+    }
+
+    #[test]
+    fn collect_proxy_env_vars_reports_supported_proxy_keys_in_stable_order() {
+        let vars = [
+            ("http_proxy", Some("http://127.0.0.1:7890")),
+            ("https_proxy", None),
+            ("all_proxy", Some("socks5://127.0.0.1:7891")),
+            ("HTTP_PROXY", None),
+            ("HTTPS_PROXY", Some("http://127.0.0.1:7890")),
+            ("ALL_PROXY", None),
+        ];
+
+        assert_eq!(
+            collect_proxy_env_vars_from(vars),
+            vec!["http_proxy", "all_proxy", "HTTPS_PROXY"]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- show a one-time install hint when proxy environment variables are enabled
- include http_proxy, https_proxy, all_proxy and uppercase variants
- avoid printing proxy values and use var_os over a fixed allowlist

## Test plan
- cargo fmt
- cargo clippy --all-targets -- -D warnings --no-deps
- cargo test -p utoo-pm proxy_env