### PR TITLE
feat(pack): expose client paths in dev ready hook

### DIFF
--- a/packages/pack/src/__test__/serveClientPaths.test.ts
+++ b/packages/pack/src/__test__/serveClientPaths.test.ts
@@ -12,8 +12,10 @@ const viteNode = path.join(repoRoot, "node_modules/vite-node/vite-node.mjs");
 
 function runServeClientPathsFixture() {
   return new Promise<unknown>((resolve, reject) => {
+    const targetDir = path.join(repoRoot, "target");
+    fs.mkdirSync(targetDir, { recursive: true });
     const projectPath = fs.mkdtempSync(
-      path.join(repoRoot, "target/serve-client-paths-"),
+      path.join(targetDir, "serve-client-paths-"),
     );
     const port = 44_200 + Math.floor(Math.random() * 1000);
     const child = spawn(
@@ -44,30 +46,37 @@ function runServeClientPathsFixture() {
     child.stderr.on("data", (chunk) => {
       stderr += chunk;
     });
-    child.on("error", reject);
+    const cleanup = () => {
+      fs.rmSync(projectPath, { recursive: true, force: true });
+    };
+
+    child.on("error", (error) => {
+      cleanup();
+      reject(error);
+    });
     child.on("exit", (code, signal) => {
-      if (code !== 0) {
-        reject(
-          new Error(
+      try {
+        if (code !== 0) {
+          throw new Error(
             `serve client paths fixture failed with code ${code}, signal ${signal}\n${stderr}\n${stdout}`,
-          ),
-        );
-        return;
-      }
+          );
+        }
 
-      const line = stdout
-        .split(/\r?\n/)
-        .find((item) => item.startsWith("__CLIENT_PATHS_SNAPSHOT__"));
-      if (!line) {
-        reject(
-          new Error(
+        const line = stdout
+          .split(/\r?\n/)
+          .find((item) => item.startsWith("__CLIENT_PATHS_SNAPSHOT__"));
+        if (!line) {
+          throw new Error(
             `serve client paths fixture did not print client paths\n${stderr}\n${stdout}`,
-          ),
-        );
-        return;
-      }
+          );
+        }
 
-      resolve(JSON.parse(line.slice("__CLIENT_PATHS_SNAPSHOT__".length)));
+        resolve(JSON.parse(line.slice("__CLIENT_PATHS_SNAPSHOT__".length)));
+      } catch (error) {
+        reject(error);
+      } finally {
+        cleanup();
+      }
     });
   });
 }

--- a/packages/pack/src/__test__/serveClientPaths.test.ts
+++ b/packages/pack/src/__test__/serveClientPaths.test.ts
@@ -1,0 +1,87 @@
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(testDir, "../..");
+const repoRoot = path.resolve(packageRoot, "../..");
+const childScript = path.join(testDir, "serveClientPathsChild.ts");
+const viteNode = path.join(repoRoot, "node_modules/vite-node/vite-node.mjs");
+
+function runServeClientPathsFixture() {
+  return new Promise<unknown>((resolve, reject) => {
+    const projectPath = fs.mkdtempSync(
+      path.join(repoRoot, "target/serve-client-paths-"),
+    );
+    const port = 44_200 + Math.floor(Math.random() * 1000);
+    const child = spawn(
+      process.execPath,
+      [viteNode, childScript, projectPath, `${port}`],
+      {
+        cwd: packageRoot,
+        env: {
+          ...process.env,
+          NODE_PATH: [
+            path.join(packageRoot, "node_modules"),
+            path.join(repoRoot, "node_modules"),
+            process.env.NODE_PATH,
+          ]
+            .filter(Boolean)
+            .join(path.delimiter),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `serve client paths fixture failed with code ${code}, signal ${signal}\n${stderr}\n${stdout}`,
+          ),
+        );
+        return;
+      }
+
+      const line = stdout
+        .split(/\r?\n/)
+        .find((item) => item.startsWith("__CLIENT_PATHS_SNAPSHOT__"));
+      if (!line) {
+        reject(
+          new Error(
+            `serve client paths fixture did not print client paths\n${stderr}\n${stdout}`,
+          ),
+        );
+        return;
+      }
+
+      resolve(JSON.parse(line.slice("__CLIENT_PATHS_SNAPSHOT__".length)));
+    });
+  });
+}
+
+describe("serve client paths", () => {
+  it("exposes initial client paths without webpack stats", async () => {
+    await expect(runServeClientPathsFixture()).resolves.toMatchInlineSnapshot(`
+      {
+        "clientPaths": [
+          "main.js",
+          "src_index_<hash>.js",
+        ],
+        "statsGenerated": false,
+      }
+    `);
+  }, 30_000);
+});

--- a/packages/pack/src/__test__/serveClientPathsChild.ts
+++ b/packages/pack/src/__test__/serveClientPathsChild.ts
@@ -1,0 +1,65 @@
+import fs from "fs";
+import path from "path";
+import { type DevServerReadyContext, serve } from "../index";
+
+const [, , projectPath, portArg] = process.argv;
+
+if (!projectPath || !portArg) {
+  throw new Error("Usage: serveClientPathsChild <projectPath> <port>");
+}
+
+const port = Number(portArg);
+const srcDir = path.join(projectPath, "src");
+const statsPath = path.join(projectPath, "dist", "stats.json");
+
+function normalizeFileName(name: string): string {
+  return name.replace(/_[0-9a-f]{8}(?=\.)/g, "_<hash>");
+}
+
+async function main() {
+  fs.rmSync(projectPath, { recursive: true, force: true });
+  fs.mkdirSync(srcDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(srcDir, "index.js"),
+    'console.log("serve client paths snapshot");\n',
+  );
+
+  let readyContext: DevServerReadyContext | undefined;
+
+  await serve(
+    {
+      config: {
+        entry: [{ import: "./src/index.js", name: "main" }],
+        output: { path: "./dist", clean: true },
+        stats: false,
+      },
+    },
+    projectPath,
+    projectPath,
+    {
+      hostname: "127.0.0.1",
+      logServerInfo: false,
+      port,
+      onReady(context) {
+        readyContext = context;
+      },
+    },
+  );
+
+  if (!readyContext) {
+    throw new Error("serve onReady callback was not called");
+  }
+
+  console.log(
+    `__CLIENT_PATHS_SNAPSHOT__${JSON.stringify({
+      clientPaths: readyContext.clientPaths.map(normalizeFileName).sort(),
+      statsGenerated: fs.existsSync(statsPath),
+    })}`,
+  );
+  process.kill(process.pid, "SIGTERM");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/pack/src/commands/dev.ts
+++ b/packages/pack/src/commands/dev.ts
@@ -99,6 +99,13 @@ export interface SelfSignedCertificate {
   rootCA?: string;
 }
 
+export interface DevServerReadyContext {
+  port: number;
+  hostname: string;
+  /** Initial client asset paths written for all configured endpoints. */
+  clientPaths: string[];
+}
+
 export interface StartServerOptions {
   port: number;
   https?: boolean;
@@ -110,10 +117,7 @@ export interface StartServerOptions {
    * listening. Integrations can await this instead of polling the internal
    * server port.
    */
-  onReady?: (context: {
-    port: number;
-    hostname: string;
-  }) => void | Promise<void>;
+  onReady?: (context: DevServerReadyContext) => void | Promise<void>;
 }
 
 /** Options for honoServe excluding fetch; we only use HTTP or HTTPS (no HTTP/2). */
@@ -338,6 +342,7 @@ async function runDev(
   await serverOptions?.onReady?.({
     port: serveOptsBase.port,
     hostname: serveOptsBase.hostname,
+    clientPaths: hotReloader.getClientPaths(),
   });
 
   if (serverOptions?.logServerInfo !== false) {

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -65,6 +65,7 @@ export interface WSLike {
 export interface HotReloaderInterface {
   turbopackProject?: Project;
   serverStats: WebpackStats | null;
+  getClientPaths(): string[];
   setHmrServerError(error: Error | null): void;
   clearHmrServerError(): void;
   start(): Promise<void>;
@@ -564,6 +565,16 @@ export async function createHotReloader(
   const hotReloader: HotReloaderInterface = {
     turbopackProject: project,
     serverStats: null,
+
+    getClientPaths() {
+      return [
+        ...new Set(
+          [...writtenEndpointPaths.values()].flatMap(
+            (endpoint) => endpoint.clientPaths,
+          ),
+        ),
+      ];
+    },
 
     onHMR(req, socket: Socket, head, onUpgrade) {
       wsServer.handleUpgrade(req, socket, head, (client) => {

--- a/packages/pack/src/index.ts
+++ b/packages/pack/src/index.ts
@@ -4,6 +4,10 @@ import * as webpackCompat from "./config/webpackCompat";
 
 export { build };
 export { serve };
+export type {
+  DevServerReadyContext,
+  StartServerOptions,
+} from "./commands/dev";
 export { defineConfig } from "./defineConfig";
 
 const utoopack = { build, serve };


### PR DESCRIPTION
## Summary

- expose the initial, deduplicated `clientPaths` through the dev server `onReady` callback
- export `DevServerReadyContext` and `StartServerOptions` from `@utoo/pack`
- add an integration test proving client paths are available with `stats: false`

## Why

`endpoint.writeToDisk()` already returns `WrittenEndpoint.clientPaths`, and the dev runtime keeps those paths internally for HTML generation. The public `serve()` integration boundary only exposed the server host and port, so framework adapters had to generate and parse full webpack stats to discover their initial client assets.

This change exposes the existing endpoint data without adding another graph traversal. It enables a follow-up Umi change to avoid full webpack stats during normal CSR development while retaining stats for analyze, SSR, and explicit stats use cases.

## Impact

`onReady` now receives `{ port, hostname, clientPaths }`. Existing consumers remain compatible, and builds that do not use `onReady` are unchanged.

## Verification

- `npm test --workspace @utoo/pack` (23 tests)
- `npm run build:js --workspace @utoo/pack`
- `npx biome ci` on the changed TypeScript files
- repository pre-push checks
