### PR TITLE
feat(pack): watch selected node_modules packages

### DIFF
--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -91,9 +91,14 @@ pub struct NapiWatchOptions {
     /// docker).
     pub poll_interval_ms: Option<f64>,
 
-    /// Paths to ignore when watching for file changes.
-    /// By default, ignores: node_modules
+    /// Paths to ignore when watching for file changes. `!node_modules/<regex>` exempts matching
+    /// dependency package names. By default, ignores: node_modules.
     pub ignored: Option<Vec<String>>,
+
+    /// Package name regular expressions for dependencies inside node_modules that should still be
+    /// watched when node_modules is ignored. Patterns are matched against package names such as
+    /// `rc-util` or `@rc-component/trigger`.
+    pub node_modules_regexes: Option<Vec<String>>,
 }
 
 #[napi(object)]
@@ -201,17 +206,54 @@ impl MemoryEvictionMode {
 
 impl From<NapiWatchOptions> for WatchOptions {
     fn from(val: NapiWatchOptions) -> Self {
+        let mut ignored = val
+            .ignored
+            .map(|v| v.into_iter().map(Into::into).collect())
+            .unwrap_or_else(pack_api::project::default_ignored_paths);
+        ignored.extend(
+            val.node_modules_regexes
+                .unwrap_or_default()
+                .into_iter()
+                .map(|pattern| format!("!node_modules/{pattern}").into()),
+        );
+
         WatchOptions {
             enable: val.enable,
             poll_interval: val
                 .poll_interval_ms
                 .filter(|interval| !interval.is_nan() && interval.is_finite() && *interval > 0.0)
                 .map(|interval| Duration::from_secs_f64(interval / 1000.0)),
-            ignored: val
-                .ignored
-                .map(|v| v.into_iter().map(|s| s.into()).collect())
-                .unwrap_or_else(pack_api::project::default_ignored_paths),
+            ignored,
         }
+    }
+}
+
+#[cfg(test)]
+mod watch_options_tests {
+    use super::{NapiWatchOptions, WatchOptions};
+
+    #[test]
+    fn converts_node_modules_regexes_and_keeps_default_ignored_paths() {
+        let options = WatchOptions::from(NapiWatchOptions {
+            enable: true,
+            poll_interval_ms: None,
+            ignored: None,
+            node_modules_regexes: Some(vec![
+                "rc-.*".into(),
+                ".*cssinjs.*".into(),
+                "@rc-component/.*".into(),
+            ]),
+        });
+
+        assert_eq!(
+            options.ignored,
+            vec![
+                "node_modules",
+                "!node_modules/rc-.*",
+                "!node_modules/.*cssinjs.*",
+                "!node_modules/@rc-component/.*",
+            ]
+        );
     }
 }
 

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -419,8 +419,22 @@ export interface BundleOptions {
    * Whether to watch the filesystem for file changes.
    */
   watch?: {
-    enable: boolean;
+    enable?: boolean;
     pollIntervalMs?: number;
+    /**
+     * Paths to ignore when watching. Defaults to `node_modules`.
+     * `!node_modules/<regex>` exempts matching dependency package names.
+     */
+    ignored?: string[];
+    /**
+     * Package name regular expressions for dependencies inside node_modules that should still be
+     * watched when node_modules is ignored. Patterns are matched against package names such as
+     * `rc-util` or `@rc-component/trigger`.
+     *
+     * @example
+     * `["rc-.*", ".*cssinjs.*", "@rc-component/.*"]`
+     */
+    nodeModulesRegexes?: string[];
   };
 
   /**

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -62,10 +62,16 @@ export interface NapiWatchOptions {
    */
   pollIntervalMs?: number
   /**
-   * Paths to ignore when watching for file changes.
-   * By default, ignores: node_modules
+   * Paths to ignore when watching for file changes. `!node_modules/<regex>` exempts matching
+   * dependency package names. By default, ignores: node_modules.
    */
   ignored?: Array<string>
+  /**
+   * Package name regular expressions for dependencies inside node_modules that should still be
+   * watched when node_modules is ignored. Patterns are matched against package names such as
+   * `rc-util` or `@rc-component/trigger`.
+   */
+  nodeModulesRegexes?: Array<string>
 }
 export interface NapiProjectOptions {
   /**

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -198,6 +198,7 @@ export async function createHotReloader(
       {
         processEnv: bundleOptions.processEnv ?? {},
         watch: {
+          ...bundleOptions.watch,
           enable: true,
         },
         dev: true,

--- a/packages/pack/src/core/project.ts
+++ b/packages/pack/src/core/project.ts
@@ -389,6 +389,10 @@ async function rustifyPartialProjectOptions(
     config:
       options.config && (await serializeConfig(options.config, !!options.dev)),
     processEnv: options.processEnv && rustifyEnv(options.processEnv),
+    watch: options.watch && {
+      ...options.watch,
+      enable: options.watch.enable ?? false,
+    },
   };
 }
 
@@ -411,6 +415,10 @@ async function rustifyProjectOptions(
     packPath: normalizePath(options.packPath),
     config: await serializeConfig(options.config, options.dev),
     processEnv: rustifyEnv(options.processEnv ?? {}),
+    watch: {
+      ...options.watch,
+      enable: options.watch.enable ?? false,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- expose `watch.nodeModulesRegexes` for selectively watching dependencies inside `node_modules`
- encode package regexes into the existing `ignored` watcher list as `!node_modules/<regex>` entries
- forward watch options through the dev/HMR project setup
- update the next.js submodule to include utooland/next.js#166

## Usage

```ts
watch: {
  nodeModulesRegexes: [
    "rc-.*",
    ".*cssinjs.*",
    "@rc-component/.*",
  ],
},
```

`node_modules` remains ignored by default. Only matching regular, scoped, nested, or pnpm dependency packages are opted back into watching.

## Validation

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- Biome check for changed TypeScript files
- `npm run build:js --workspace @utoo/pack`
