### PR TITLE
feat(pack): support inline type-only imports and exports

### DIFF
--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -59,6 +59,7 @@ use crate::{
             styled_components::get_styled_components_transform_rule,
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
+            type_only_import::get_type_only_import_rule,
             webpack_public_path::get_webpack_public_path_transform_rule,
         },
         webpack_rules::{WebpackLoaderBuiltinCondition, webpack_loader_options},
@@ -307,6 +308,9 @@ pub async fn get_client_module_options_context(
         get_client_transforms_rules(config, false, inline_postcss_transform).await?;
     let mut foreign_client_rules =
         get_client_transforms_rules(config, true, inline_foreign_postcss_transform).await?;
+
+    client_rules.push(get_type_only_import_rule(enable_mdx_rs.is_some()));
+    foreign_client_rules.push(get_type_only_import_rule(enable_mdx_rs.is_some()));
 
     // Ignore .d.ts files - they are TypeScript declaration files and should not be bundled
     let ignore_dts_rule = ModuleRule::new(

--- a/crates/pack-core/src/server/contexts.rs
+++ b/crates/pack-core/src/server/contexts.rs
@@ -45,6 +45,7 @@ use crate::{
             styled_components::get_styled_components_transform_rule,
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
+            type_only_import::get_type_only_import_rule,
         },
         webpack_rules::{WebpackLoaderBuiltinCondition, webpack_loader_options},
     },
@@ -159,6 +160,9 @@ pub async fn get_server_module_options_context(
 
     let mut server_rules = get_server_transforms_rules(config, false).await?;
     let mut foreign_server_rules = get_server_transforms_rules(config, true).await?;
+
+    server_rules.push(get_type_only_import_rule(enable_mdx_rs.is_some()));
+    foreign_server_rules.push(get_type_only_import_rule(enable_mdx_rs.is_some()));
 
     // Ignore .d.ts files - they are TypeScript declaration files and should not be bundled
     let ignore_dts_rule = ModuleRule::new(

--- a/crates/pack-core/src/shared/transforms/mod.rs
+++ b/crates/pack-core/src/shared/transforms/mod.rs
@@ -25,6 +25,7 @@ pub mod remove_console;
 pub mod styled_components;
 pub mod styled_jsx;
 pub mod swc_ecma_transform_plugins;
+pub mod type_only_import;
 pub mod wasm;
 pub mod webpack_public_path;
 

--- a/crates/pack-core/src/shared/transforms/type_only_import.rs
+++ b/crates/pack-core/src/shared/transforms/type_only_import.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use swc_core::ecma::ast::{ImportDecl, ImportSpecifier, ModuleDecl, ModuleItem, Program};
+use swc_core::ecma::ast::{
+    ExportSpecifier, ImportDecl, ImportSpecifier, ModuleDecl, ModuleItem, NamedExport, Program,
+};
 use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
@@ -14,12 +16,13 @@ pub fn get_type_only_import_rule(enable_mdx_rs: bool) -> ModuleRule {
     )
 }
 
-/// Normalizes `import { type Foo }` to the AST equivalent of `import type { Foo }`
-/// when every specifier is type-only.
+/// Normalizes inline type-only imports and exports to their declaration-level
+/// equivalents when every specifier is type-only.
 ///
 /// Utoopack enables SWC's `verbatimModuleSyntax` behavior by default so unused value
 /// imports survive classic JSX transforms. Without this normalization, SWC preserves
-/// an all-type named import as `import {}` and creates an unintended runtime dependency.
+/// all-type named imports and exports as `import {}` or `export {}` and creates
+/// unintended runtime dependencies.
 #[derive(Debug)]
 struct TypeOnlyImportTransformer;
 
@@ -36,12 +39,40 @@ impl CustomTransformer for TypeOnlyImportTransformer {
         };
 
         for item in &mut module.body {
-            if let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item {
-                normalize_type_only_import(import);
+            match item {
+                ModuleItem::ModuleDecl(ModuleDecl::Import(import)) => {
+                    normalize_type_only_import(import);
+                }
+                ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(export)) => {
+                    normalize_type_only_export(export);
+                }
+                _ => {}
             }
         }
 
         Ok(())
+    }
+}
+
+fn normalize_type_only_export(export: &mut NamedExport) {
+    if export.type_only || export.specifiers.is_empty() {
+        return;
+    }
+
+    let all_specifiers_are_type_only = export.specifiers.iter().all(|specifier| {
+        matches!(
+            specifier,
+            ExportSpecifier::Named(named) if named.is_type_only
+        )
+    });
+
+    if all_specifiers_are_type_only {
+        export.type_only = true;
+        for specifier in &mut export.specifiers {
+            if let ExportSpecifier::Named(named) = specifier {
+                named.is_type_only = false;
+            }
+        }
     }
 }
 

--- a/crates/pack-core/src/shared/transforms/type_only_import.rs
+++ b/crates/pack-core/src/shared/transforms/type_only_import.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use swc_core::ecma::ast::{ImportDecl, ImportSpecifier, ModuleDecl, ModuleItem, Program};
+use turbopack::module_options::ModuleRule;
+use turbopack_ecmascript::{CustomTransformer, TransformContext};
+
+use super::{EcmascriptTransformStage, get_ecma_transform_rule};
+
+pub fn get_type_only_import_rule(enable_mdx_rs: bool) -> ModuleRule {
+    get_ecma_transform_rule(
+        Box::new(TypeOnlyImportTransformer),
+        enable_mdx_rs,
+        EcmascriptTransformStage::Preprocess,
+    )
+}
+
+/// Normalizes `import { type Foo }` to the AST equivalent of `import type { Foo }`
+/// when every specifier is type-only.
+///
+/// Utoopack enables SWC's `verbatimModuleSyntax` behavior by default so unused value
+/// imports survive classic JSX transforms. Without this normalization, SWC preserves
+/// an all-type named import as `import {}` and creates an unintended runtime dependency.
+#[derive(Debug)]
+struct TypeOnlyImportTransformer;
+
+#[async_trait]
+impl CustomTransformer for TypeOnlyImportTransformer {
+    #[tracing::instrument(
+        level = tracing::Level::TRACE,
+        name = "type_only_import",
+        skip_all
+    )]
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
+        let Program::Module(module) = program else {
+            return Ok(());
+        };
+
+        for item in &mut module.body {
+            if let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item {
+                normalize_type_only_import(import);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn normalize_type_only_import(import: &mut ImportDecl) {
+    if import.type_only || import.specifiers.is_empty() {
+        return;
+    }
+
+    let all_specifiers_are_type_only = import.specifiers.iter().all(|specifier| {
+        matches!(
+            specifier,
+            ImportSpecifier::Named(named) if named.is_type_only
+        )
+    });
+
+    if all_specifiers_are_type_only {
+        import.type_only = true;
+        for specifier in &mut import.specifiers {
+            if let ImportSpecifier::Named(named) = specifier {
+                named.is_type_only = false;
+            }
+        }
+    }
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/config.json
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/config.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+        "entry": [
+            {
+                "import": "input/index.ts",
+                "name": "main"
+            }
+        ],
+        "optimization": {
+            "minify": false
+        }
+    }
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/input/index.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/input/index.ts
@@ -1,0 +1,2 @@
+export { type MyType, type TypeMetadata as Metadata } from './types';
+export { runtimeValue, type RuntimeType } from './runtime';

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/input/runtime.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/input/runtime.ts
@@ -1,0 +1,3 @@
+export type RuntimeType = string;
+
+export const runtimeValue = 'mixed value and type export';

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/input/types.d.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/input/types.d.ts
@@ -1,0 +1,5 @@
+export type MyType = string;
+
+export interface TypeMetadata {
+    source: string;
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/output/input_c211d37c.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/output/input_c211d37c.js
@@ -1,0 +1,31 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+90, ((__turbopack_context__) => {
+"use strict";
+
+const runtimeValue = 'mixed value and type export';
+__turbopack_context__.s([
+    "runtimeValue",
+    0,
+    runtimeValue
+]);
+}),
+96, ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__90__ = __turbopack_context__.i(90);
+;
+__turbopack_context__.s([]);
+}),
+38, ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__96__ = __turbopack_context__.i(96);
+var __TURBOPACK__imported__module__90__ = __turbopack_context__.i(90);
+__turbopack_context__.s([
+    "runtimeValue",
+    ()=>__TURBOPACK__imported__module__90__["runtimeValue"]
+]);
+}),
+]);
+
+//# sourceMappingURL=input_c211d37c.js.map

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/output/input_c211d37c.js.map
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/output/input_c211d37c.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/typescript/dts_inline_type_export/input/runtime.ts"],"sourcesContent":["export type RuntimeType = string;\n\nexport const runtimeValue = 'mixed value and type export';\n"],"names":["runtimeValue"],"mappings":"AAEO,MAAMA,eAAe"}},
+    {"offset": {"line": 14, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/typescript/dts_inline_type_export/input/index.ts"],"sourcesContent":["export { type MyType, type TypeMetadata as Metadata } from './types';\nexport { runtimeValue, type RuntimeType } from './runtime';\n"],"names":[],"mappings":"AACA"}}]
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/output/main.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_c211d37c.js"],"runtimeModuleIds":[38]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_export/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/config.json
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/config.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+        "entry": [
+            {
+                "import": "input/index.ts",
+                "name": "main"
+            }
+        ],
+        "optimization": {
+            "minify": false
+        }
+    }
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/input/index.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/input/index.ts
@@ -1,0 +1,8 @@
+import { type MyType, type TypeMetadata as Metadata } from './types';
+import { runtimeValue, type RuntimeType } from './runtime';
+
+const value: MyType = 'inline type import';
+const metadata: Metadata = { source: '.d.ts' };
+const runtime: RuntimeType = runtimeValue;
+
+console.log(value, metadata.source, runtime);

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/input/runtime.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/input/runtime.ts
@@ -1,0 +1,3 @@
+export type RuntimeType = string;
+
+export const runtimeValue = 'mixed value and type import';

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/input/types.d.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/input/types.d.ts
@@ -1,0 +1,5 @@
+export type MyType = string;
+
+export interface TypeMetadata {
+    source: string;
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/output/input_15d51ba4.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/output/input_15d51ba4.js
@@ -1,0 +1,27 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+46, ((__turbopack_context__) => {
+"use strict";
+
+const runtimeValue = 'mixed value and type import';
+__turbopack_context__.s([
+    "runtimeValue",
+    0,
+    runtimeValue
+]);
+}),
+75, ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__46__ = __turbopack_context__.i(46);
+;
+const value = 'inline type import';
+const metadata = {
+    source: '.d.ts'
+};
+const runtime = __TURBOPACK__imported__module__46__["runtimeValue"];
+console.log(value, metadata.source, runtime);
+__turbopack_context__.s([]);
+}),
+]);
+
+//# sourceMappingURL=input_15d51ba4.js.map

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/output/input_15d51ba4.js.map
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/output/input_15d51ba4.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/typescript/dts_inline_type_import/input/runtime.ts"],"sourcesContent":["export type RuntimeType = string;\n\nexport const runtimeValue = 'mixed value and type import';\n"],"names":["runtimeValue"],"mappings":"AAEO,MAAMA,eAAe"}},
+    {"offset": {"line": 14, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/typescript/dts_inline_type_import/input/index.ts"],"sourcesContent":["import { type MyType, type TypeMetadata as Metadata } from './types';\nimport { runtimeValue, type RuntimeType } from './runtime';\n\nconst value: MyType = 'inline type import';\nconst metadata: Metadata = { source: '.d.ts' };\nconst runtime: RuntimeType = runtimeValue;\n\nconsole.log(value, metadata.source, runtime);\n"],"names":["value","metadata","source","runtime","console","log"],"mappings":"AACA;;AAEA,MAAMA,QAAgB;AACtB,MAAMC,WAAqB;IAAEC,QAAQ;AAAQ;AAC7C,MAAMC,UAAuB,mDAAY;AAEzCC,QAAQC,GAAG,CAACL,OAAOC,SAASC,MAAM,EAAEC"}}]
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/output/main.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_15d51ba4.js"],"runtimeModuleIds":[75]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/config.json
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/config.json
@@ -1,0 +1,16 @@
+{
+    "config": {
+        "entry": [
+            {
+                "import": "input/index.tsx",
+                "name": "main"
+            }
+        ],
+        "optimization": {
+            "minify": false
+        },
+        "react": {
+            "runtime": "classic"
+        }
+    }
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/input/index.tsx
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/input/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { type Heading } from './types';
+
+const heading: Heading = 'Inline type import';
+
+export default function App() {
+    return <h1>{heading}</h1>;
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/input/types.d.ts
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/input/types.d.ts
@@ -1,0 +1,1 @@
+export type Heading = string;

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/node_modules/react/index.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/node_modules/react/index.js
@@ -1,0 +1,10 @@
+const React = {
+    createElement: function createElement() {},
+    Fragment: 'Fragment',
+    Component: function Component() {},
+};
+
+export default React;
+export const createElement = React.createElement;
+export const Fragment = React.Fragment;
+export const Component = React.Component;

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/output/_project__typescript_dts_inline_type_import_classic_jsx_5d71cf9b.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/output/_project__typescript_dts_inline_type_import_classic_jsx_5d71cf9b.js
@@ -1,0 +1,37 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+21, ((__turbopack_context__) => {
+"use strict";
+
+const React = {
+    createElement: function createElement() {},
+    Fragment: 'Fragment',
+    Component: function Component() {}
+};
+var __TURBOPACK__default__export__ = React;
+const createElement = React.createElement;
+const Fragment = React.Fragment;
+const Component = React.Component;
+__turbopack_context__.s([
+    "default",
+    0,
+    __TURBOPACK__default__export__
+]);
+}),
+56, ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__21__ = __turbopack_context__.i(21);
+;
+const heading = 'Inline type import';
+function App() {
+    return /*#__PURE__*/ __TURBOPACK__imported__module__21__["default"].createElement("h1", null, heading);
+}
+__turbopack_context__.s([
+    "default",
+    0,
+    App
+]);
+}),
+]);
+
+//# sourceMappingURL=_project__typescript_dts_inline_type_import_classic_jsx_5d71cf9b.js.map

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/output/_project__typescript_dts_inline_type_import_classic_jsx_5d71cf9b.js.map
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/output/_project__typescript_dts_inline_type_import_classic_jsx_5d71cf9b.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/typescript/dts_inline_type_import_classic_jsx/node_modules/react/index.js"],"sourcesContent":["const React = {\n    createElement: function createElement() {},\n    Fragment: 'Fragment',\n    Component: function Component() {},\n};\n\nexport default React;\nexport const createElement = React.createElement;\nexport const Fragment = React.Fragment;\nexport const Component = React.Component;\n"],"names":["React","createElement","Fragment","Component"],"mappings":"AAAA,MAAMA,QAAQ;IACVC,eAAe,SAASA,iBAAiB;IACzCC,UAAU;IACVC,WAAW,SAASA,aAAa;AACrC;qCAEeH;AACR,MAAMC,gBAAgBD,MAAMC,aAAa;AACzC,MAAMC,WAAWF,MAAME,QAAQ;AAC/B,MAAMC,YAAYH,MAAMG,SAAS","ignoreList":[0]}},
+    {"offset": {"line": 22, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/typescript/dts_inline_type_import_classic_jsx/input/index.tsx"],"sourcesContent":["import React from 'react';\nimport { type Heading } from './types';\n\nconst heading: Heading = 'Inline type import';\n\nexport default function App() {\n    return <h1>{heading}</h1>;\n}\n"],"names":["heading","App"],"mappings":"AAAA;;AAGA,MAAMA,UAAmB;AAEV,SAASC;IACpB,qBAAO,6DAAC,YAAID;AAChB"}}]
+}

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/output/main.js
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["_project__typescript_dts_inline_type_import_classic_jsx_5d71cf9b.js"],"runtimeModuleIds":[56]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/typescript/dts_inline_type_import_classic_jsx/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}


### PR DESCRIPTION
## Summary

- normalize named imports and exports made entirely of inline type specifiers to declaration-level `import type` / `export type`
- apply the preprocess transform to client/server and user/foreign module contexts
- keep mixed value/type imports and exports unchanged
- add snapshots for `.d.ts` imports and re-exports, aliases, mixed specifiers, and classic JSX React preservation

## Why

Utoopack enables SWC's `verbatimModuleSyntax` behavior by default so classic JSX transforms do not lose an otherwise unused `import React` before JSX becomes `React.createElement`.

With that setting, pure inline type declarations such as `import { type Foo } from './types'` and `export { type Foo } from './types'` are emitted as empty runtime imports or exports. This creates unintended runtime dependencies and makes Utoopack try to resolve declaration-only `.d.ts` modules.

The preprocess transform only normalizes a declaration when every specifier is explicitly type-only. This lets SWC erase the declaration while preserving the existing React behavior and all mixed imports and exports.

## Validation

- `cargo test -p pack-tests --test snapshot test_tests__snapshot__typescript__ -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `npx tombi format --check`
- `npx biome ci`
- `typos`
