### PR TITLE
feat(pack): add env to disable persistent cache

### DIFF
--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -9,7 +9,11 @@ import { projectFactory } from "../core/project";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
 import { blockStdout, getPackPath } from "../utils/common";
-import { isTruthyEnv, normalizeTurbopackMemoryEviction } from "../utils/env";
+import {
+  isPersistentCachingEnabled,
+  isTruthyEnv,
+  normalizeTurbopackMemoryEviction,
+} from "../utils/env";
 import { findRootDir } from "../utils/findRoot";
 import { getInitialAssetsFromEndpointPaths } from "../utils/getInitialAssets";
 import { processHtmlEntry } from "../utils/htmlEntry";
@@ -48,7 +52,9 @@ async function buildInternal(
 
   const resolvedProjectPath = projectPath || process.cwd();
   const resolvedRootPath = rootPath || projectPath || process.cwd();
-  const persistentCaching = bundleOptions.config.persistentCaching ?? true;
+  const persistentCaching = isPersistentCachingEnabled(
+    bundleOptions.config.persistentCaching,
+  );
   const turbopackMemoryEviction = normalizeTurbopackMemoryEviction(
     bundleOptions.config.turbopackMemoryEviction,
   ) as MemoryEvictionMode;

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -19,7 +19,11 @@ import { BundleOptions } from "../config/types";
 import { HtmlPlugin } from "../plugins/HtmlPlugin";
 import { cleanOutput, getOutputPath } from "../utils/cleanOutput";
 import { debounce, getPackPath, processIssues } from "../utils/common";
-import { isTruthyEnv, normalizeTurbopackMemoryEviction } from "../utils/env";
+import {
+  isPersistentCachingEnabled,
+  isTruthyEnv,
+  normalizeTurbopackMemoryEviction,
+} from "../utils/env";
 import { getInitialAssetsFromEndpointPaths } from "../utils/getInitialAssets";
 import { processHtmlEntry } from "../utils/htmlEntry";
 import { acquirePersistentCacheLock } from "../utils/lockfile";
@@ -166,7 +170,9 @@ export async function createHotReloader(
   await cleanOutput(bundleOptions.config, resolvedProjectPath);
 
   const createProject = projectFactory();
-  const persistentCaching = bundleOptions.config.persistentCaching ?? true;
+  const persistentCaching = isPersistentCachingEnabled(
+    bundleOptions.config.persistentCaching,
+  );
   const turbopackMemoryEviction = normalizeTurbopackMemoryEviction(
     bundleOptions.config.turbopackMemoryEviction,
   ) as MemoryEvictionMode;
@@ -213,7 +219,7 @@ export async function createHotReloader(
             minify: false,
             moduleIds: "named",
           },
-          persistentCaching: bundleOptions?.config?.persistentCaching ?? true,
+          persistentCaching,
           pluginRuntimeStrategy:
             bundleOptions?.config?.pluginRuntimeStrategy ??
             (useWorkerThreads() ? "workerThreads" : "childProcesses"),
@@ -784,9 +790,7 @@ export async function createHotReloader(
       closed = true;
       const disposePromise = disposeBackgroundWatchSubscriptions();
       closePromise ??= (
-        bundleOptions.config.persistentCaching
-          ? project.shutdown()
-          : project.onExit()
+        persistentCaching ? project.shutdown() : project.onExit()
       )
         .catch((err) => {
           console.error(err);

--- a/packages/pack/src/utils/env.test.ts
+++ b/packages/pack/src/utils/env.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isPersistentCachingEnabled } from "./env";
+
+const previousDisablePersistentCache = process.env.DISABLE_PERSISTENT_CACHE;
+
+afterEach(() => {
+  if (previousDisablePersistentCache === undefined) {
+    delete process.env.DISABLE_PERSISTENT_CACHE;
+  } else {
+    process.env.DISABLE_PERSISTENT_CACHE = previousDisablePersistentCache;
+  }
+});
+
+describe("isPersistentCachingEnabled", () => {
+  it("enables persistent caching by default", () => {
+    delete process.env.DISABLE_PERSISTENT_CACHE;
+
+    expect(isPersistentCachingEnabled(undefined)).toBe(true);
+  });
+
+  it("preserves an explicitly disabled configuration", () => {
+    delete process.env.DISABLE_PERSISTENT_CACHE;
+
+    expect(isPersistentCachingEnabled(false)).toBe(false);
+  });
+
+  it.each(["1", "true"])(
+    "disables persistent caching when the environment variable is %s",
+    (value) => {
+      process.env.DISABLE_PERSISTENT_CACHE = value;
+
+      expect(isPersistentCachingEnabled(true)).toBe(false);
+      expect(isPersistentCachingEnabled(undefined)).toBe(false);
+    },
+  );
+
+  it("ignores other environment variable values", () => {
+    process.env.DISABLE_PERSISTENT_CACHE = "0";
+
+    expect(isPersistentCachingEnabled(undefined)).toBe(true);
+  });
+});

--- a/packages/pack/src/utils/env.test.ts
+++ b/packages/pack/src/utils/env.test.ts
@@ -24,7 +24,7 @@ describe("isPersistentCachingEnabled", () => {
     expect(isPersistentCachingEnabled(false)).toBe(false);
   });
 
-  it.each(["1", "true"])(
+  it.each(["1", "true", "TRUE", "True"])(
     "disables persistent caching when the environment variable is %s",
     (value) => {
       process.env.DISABLE_PERSISTENT_CACHE = value;

--- a/packages/pack/src/utils/env.ts
+++ b/packages/pack/src/utils/env.ts
@@ -2,6 +2,15 @@ export function isTruthyEnv(value: string | undefined): boolean {
   return value === "1" || value === "true";
 }
 
+export function isPersistentCachingEnabled(
+  configuredValue: boolean | undefined,
+): boolean {
+  return (
+    !isTruthyEnv(process.env.DISABLE_PERSISTENT_CACHE) &&
+    (configuredValue ?? true)
+  );
+}
+
 export function normalizeTurbopackMemoryEviction(
   value: boolean | "full" | undefined,
 ): "off" | "full" {

--- a/packages/pack/src/utils/env.ts
+++ b/packages/pack/src/utils/env.ts
@@ -6,7 +6,7 @@ export function isPersistentCachingEnabled(
   configuredValue: boolean | undefined,
 ): boolean {
   return (
-    !isTruthyEnv(process.env.DISABLE_PERSISTENT_CACHE) &&
+    !isTruthyEnv(process.env.DISABLE_PERSISTENT_CACHE?.toLowerCase()) &&
     (configuredValue ?? true)
   );
 }


### PR DESCRIPTION
## Summary

- add `DISABLE_PERSISTENT_CACHE=1`/`true` as a process-level override for persistent caching
- apply the effective cache state consistently to build and dev
- use the effective state for dev shutdown behavior
- cover defaults, explicit config, env overrides, and ignored values with unit tests

## Why

Persistent caching could previously only be disabled through the `persistentCaching` configuration. A process-level override is useful for CI, troubleshooting, and one-off clean builds without rewriting project configuration.
