### PR TITLE
feat(web): add disposable project lifecycle

### DIFF
--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -24,7 +24,7 @@ serde                    = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen       = "0.6.5"
 serde_json               = { workspace = true }
 tar                      = "0.4.45"
-tokio                    = { workspace = true, features = ["rt", "rt-multi-thread", "time"] }
+tokio                    = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time"] }
 tokio-fs-ext             = { workspace = true, features = ["opfs_offload", "opfs_tracing", "opfs_watch"] }
 tracing                  = { workspace = true }
 tracing-subscriber       = { workspace = true }

--- a/crates/utoo-wasm/src/fs.rs
+++ b/crates/utoo-wasm/src/fs.rs
@@ -63,16 +63,14 @@ async fn glob_match(_glob: &OpfsGlob, pattern: &Path) -> Result<Vec<PathBuf>, an
                 current_path.clone()
             };
 
-            let guard = OPFS_PROJECT.read();
-            let read_result = if let Some(project) = guard.as_ref() {
+            let project = OPFS_PROJECT.read().as_ref().cloned();
+            let read_result = if let Some(project) = project {
                 project.read_dir(&dir_path).await
             } else {
                 tokio_fs_ext::read_dir(&dir_path)
                     .await
                     .and_then(|rd| rd.collect())
             };
-            drop(guard);
-
             match read_result {
                 Ok(entries) => {
                     for entry in entries {
@@ -107,9 +105,10 @@ pub struct Fs;
 impl Fs {
     #[wasm_bindgen]
     pub async fn read(path: &str) -> Result<js_sys::Uint8Array, JsError> {
-        let guard = OPFS_PROJECT.read();
-        let project = guard
+        let project = OPFS_PROJECT
+            .read()
             .as_ref()
+            .cloned()
             .ok_or_else(|| JsError::new("not initialised"))?;
         let bytes = project
             .read(path)
@@ -121,9 +120,10 @@ impl Fs {
 
     #[wasm_bindgen(js_name = readToString)]
     pub async fn read_to_string(path: &str) -> Result<String, JsError> {
-        let guard = OPFS_PROJECT.read();
-        let project = guard
+        let project = OPFS_PROJECT
+            .read()
             .as_ref()
+            .cloned()
             .ok_or_else(|| JsError::new("not initialised"))?;
         let buf = project
             .read(path)
@@ -154,9 +154,10 @@ impl Fs {
 
     #[wasm_bindgen(js_name = readDir)]
     pub async fn read_dir(path: &str) -> Result<Vec<DirEntry>, JsError> {
-        let guard = OPFS_PROJECT.read();
-        let project = guard
+        let project = OPFS_PROJECT
+            .read()
             .as_ref()
+            .cloned()
             .ok_or_else(|| JsError::new("not initialised"))?;
         let read_dir = project
             .read_dir(path)

--- a/crates/utoo-wasm/src/lib.rs
+++ b/crates/utoo-wasm/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) mod pack;
 mod deps;
 pub(crate) mod errors;
 mod fs;
+mod operations;
 #[cfg(feature = "utoopack")]
 mod opfs_offload;
 mod pm;

--- a/crates/utoo-wasm/src/operations.rs
+++ b/crates/utoo-wasm/src/operations.rs
@@ -1,0 +1,94 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        LazyLock,
+    },
+};
+
+use futures::future::{self, Aborted};
+use parking_lot::Mutex;
+use tokio::{sync::Notify, task::JoinHandle};
+
+#[derive(Clone)]
+enum OperationAbortHandle {
+    Local(future::AbortHandle),
+    Tokio(tokio::task::AbortHandle),
+}
+
+impl OperationAbortHandle {
+    fn abort(&self) {
+        match self {
+            Self::Local(handle) => handle.abort(),
+            Self::Tokio(handle) => handle.abort(),
+        }
+    }
+}
+
+static ACTIVE_OPERATIONS: LazyLock<Mutex<HashMap<usize, OperationAbortHandle>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static NEXT_OPERATION_ID: AtomicUsize = AtomicUsize::new(0);
+static DISPOSING: AtomicBool = AtomicBool::new(false);
+static OPERATIONS_CHANGED: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+pub(crate) struct OperationGuard {
+    id: usize,
+}
+
+impl OperationGuard {
+    pub(crate) fn track_tokio<T>(task: &JoinHandle<T>) -> Self {
+        Self::track(OperationAbortHandle::Tokio(task.abort_handle()))
+    }
+
+    fn track(abort_handle: OperationAbortHandle) -> Self {
+        let id = NEXT_OPERATION_ID.fetch_add(1, Ordering::Relaxed);
+
+        ACTIVE_OPERATIONS.lock().insert(id, abort_handle.clone());
+        if DISPOSING.load(Ordering::Acquire) {
+            abort_handle.abort();
+        }
+
+        Self { id }
+    }
+}
+
+pub(crate) async fn run_local<F>(operation: F) -> Result<F::Output, Aborted>
+where
+    F: Future,
+{
+    let (operation, abort_handle) = future::abortable(operation);
+    let _guard = OperationGuard::track(OperationAbortHandle::Local(abort_handle));
+    operation.await
+}
+
+impl Drop for OperationGuard {
+    fn drop(&mut self) {
+        ACTIVE_OPERATIONS.lock().remove(&self.id);
+        OPERATIONS_CHANGED.notify_one();
+    }
+}
+
+pub(crate) fn reset() {
+    DISPOSING.store(false, Ordering::Release);
+}
+
+pub(crate) async fn cancel_all() {
+    DISPOSING.store(true, Ordering::Release);
+
+    loop {
+        let changed = OPERATIONS_CHANGED.notified();
+        let abort_handles = {
+            let operations = ACTIVE_OPERATIONS.lock();
+            if operations.is_empty() {
+                return;
+            }
+            operations.values().cloned().collect::<Vec<_>>()
+        };
+
+        for abort_handle in abort_handles {
+            abort_handle.abort();
+        }
+        changed.await;
+    }
+}

--- a/crates/utoo-wasm/src/opfs_offload.rs
+++ b/crates/utoo-wasm/src/opfs_offload.rs
@@ -7,9 +7,10 @@ pub struct OpfsOffload;
 
 impl offload::FsOffload for OpfsOffload {
     async fn read(&self, path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
-        let guard = OPFS_PROJECT.read();
-        let project = guard
+        let project = OPFS_PROJECT
+            .read()
             .as_ref()
+            .cloned()
             .ok_or_else(|| io::Error::other("OpfsProject not initialised"))?;
         project.read(path).await.map(|b| b.to_vec())
     }
@@ -23,9 +24,10 @@ impl offload::FsOffload for OpfsOffload {
     }
 
     async fn read_dir(&self, path: impl AsRef<Path>) -> io::Result<ReadDir> {
-        let guard = OPFS_PROJECT.read();
-        let project = guard
+        let project = OPFS_PROJECT
+            .read()
             .as_ref()
+            .cloned()
             .ok_or_else(|| io::Error::other("OpfsProject not initialised"))?;
         project.read_dir(path).await.map(ReadDir::from_iter)
     }
@@ -51,9 +53,10 @@ impl offload::FsOffload for OpfsOffload {
     }
 
     async fn metadata(&self, path: impl AsRef<Path>) -> io::Result<Metadata> {
-        let guard = OPFS_PROJECT.read();
-        let project = guard
+        let project = OPFS_PROJECT
+            .read()
             .as_ref()
+            .cloned()
             .ok_or_else(|| io::Error::other("OpfsProject not initialised"))?;
         project.metadata(path).await
     }

--- a/crates/utoo-wasm/src/pack.rs
+++ b/crates/utoo-wasm/src/pack.rs
@@ -31,6 +31,7 @@ use turbopack_core::{
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 use crate::fs::Fs;
+use crate::operations::OperationGuard;
 use crate::tokio_runtime::runtime;
 
 // https://github.com/dtolnay/inventory/blob/f1be63af0ab00ce41c39f1dd190a624de949c684/src/lib.rs#L105-L148
@@ -45,16 +46,14 @@ static GLOBAL_PACK_PROJECT: RwLock<Option<Arc<PackProject>>> = RwLock::new(None)
 /// This must be held by JS to keep the subscription active.
 #[wasm_bindgen]
 pub struct RootTask {
-    #[allow(dead_code)]
     turbo_tasks: UtooTurboTasks,
-    #[allow(dead_code)]
     task_id: TaskId,
 }
 
 impl Drop for RootTask {
     fn drop(&mut self) {
-        tracing::debug!("RootTask dropped, subscription will be stopped");
-        // TODO: dispose the root task
+        tracing::debug!("RootTask dropped, disposing subscription");
+        self.turbo_tasks.dispose_root_task(self.task_id);
     }
 }
 
@@ -65,6 +64,7 @@ pub struct PackProject {
 }
 
 /// Options for the build operation, exposed to JS with auto-generated typings.
+#[derive(Default)]
 #[wasm_bindgen]
 pub struct BuildOptions {
     /// Optional bundler config (the content of `utoopack.json`).
@@ -73,15 +73,6 @@ pub struct BuildOptions {
     /// When true, drops the existing global project and creates a fresh instance.
     #[wasm_bindgen]
     pub cleanup: bool,
-}
-
-impl Default for BuildOptions {
-    fn default() -> Self {
-        Self {
-            config: None,
-            cleanup: false,
-        }
-    }
 }
 
 #[wasm_bindgen]
@@ -128,6 +119,13 @@ pub fn create_turbo_tasks() -> Result<UtooTurboTasks> {
             noop_backing_storage(),
         ),
     ))
+}
+
+pub async fn dispose_pack_project() {
+    let project = GLOBAL_PACK_PROJECT.write().take();
+    if let Some(project) = project {
+        project.turbo_tasks.stop_and_wait().await;
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -270,8 +268,7 @@ pub async fn init_pack_project(config: Option<String>, dev: bool) -> Result<()> 
         }
     }
 
-    // Drop the old project
-    GLOBAL_PACK_PROJECT.write().take();
+    dispose_pack_project().await;
 
     let cwd = crate::pm::with_project(|p| p.cwd().to_string_lossy().to_string());
     let project_root = if cwd.starts_with('/') {
@@ -325,25 +322,26 @@ pub async fn init_pack_project(config: Option<String>, dev: bool) -> Result<()> 
 
     tracing::debug!("ProjectOptions: {:?}", options);
 
-    let pack_context = runtime()
-        .spawn(async move {
-            let turbo_tasks = create_turbo_tasks()?;
-            let container = turbo_tasks
-                .run(async move {
-                    let container_op =
-                        ProjectContainer::new_operation("utoopack-web".into(), options.dev);
-                    ProjectContainer::initialize(container_op, options).await?;
+    let init_task = runtime().spawn(async move {
+        let turbo_tasks = create_turbo_tasks()?;
+        let container = turbo_tasks
+            .run(async move {
+                let container_op =
+                    ProjectContainer::new_operation("utoopack-web".into(), options.dev);
+                ProjectContainer::initialize(container_op, options).await?;
 
-                    container_op.resolve().strongly_consistent().await
-                })
-                .await?;
-
-            Ok::<PackProject, anyhow::Error>(PackProject {
-                turbo_tasks,
-                container,
-                dev,
+                container_op.resolve().strongly_consistent().await
             })
+            .await?;
+
+        Ok::<PackProject, anyhow::Error>(PackProject {
+            turbo_tasks,
+            container,
+            dev,
         })
+    });
+    let _operation = OperationGuard::track_tokio(&init_task);
+    let pack_context = init_task
         .await
         .context("fail to initialize pack project")??;
 
@@ -356,8 +354,8 @@ pub async fn build(options: BuildOptions) -> std::result::Result<JsValue, wasm_b
     use wasm_bindgen::JsError;
 
     if options.cleanup {
-        tracing::info!("cleanup: dropping existing pack project");
-        GLOBAL_PACK_PROJECT.write().take();
+        tracing::info!("cleanup: disposing existing pack project");
+        dispose_pack_project().await;
     }
 
     init_pack_project(options.config_string(), false)
@@ -370,42 +368,49 @@ pub async fn build(options: BuildOptions) -> std::result::Result<JsValue, wasm_b
         .cloned()
         .ok_or_else(|| JsError::new("pack project not initialized"))?;
 
-    runtime()
-        .spawn(async move {
-            let start = Instant::now();
-            let turbo_tasks = pack_project.turbo_tasks.clone();
-            let container = pack_project.container;
-            let (entrypoints, issues) = turbo_tasks
-                .run(async move {
-                    let entrypoints_with_issues_op =
-                        get_all_written_entrypoints_with_issues_operation(container);
-                    let entrypoints_with_issues = read_strongly_consistent_and_apply_effects(
-                        entrypoints_with_issues_op,
-                        |v| &v.effects,
-                    )
+    let build_task = runtime().spawn(async move {
+        let start = Instant::now();
+        let turbo_tasks = pack_project.turbo_tasks.clone();
+        let container = pack_project.container;
+        let (entrypoints, issues) = turbo_tasks
+            .run(async move {
+                let entrypoints_with_issues_op =
+                    get_all_written_entrypoints_with_issues_operation(container);
+                let entrypoints_with_issues =
+                    read_strongly_consistent_and_apply_effects(entrypoints_with_issues_op, |v| {
+                        &v.effects
+                    })
                     .await?;
 
-                    let EntrypointsWithIssues {
-                        entrypoints,
-                        issues,
-                        effects: _,
-                    } = &*entrypoints_with_issues;
+                let EntrypointsWithIssues {
+                    entrypoints,
+                    issues,
+                    effects: _,
+                } = &*entrypoints_with_issues;
 
-                    Ok((entrypoints.clone(), issues.clone()))
-                })
-                .await?;
+                Ok((entrypoints.clone(), issues.clone()))
+            })
+            .await?;
 
-            tracing::info!("build finished in {:?}", start.elapsed());
+        tracing::info!("build finished in {:?}", start.elapsed());
 
-            let result = TurbopackResult {
-                issues: issues.iter().map(|i| Issue::from(&**i)).collect(),
-            };
-            let json_str =
-                serde_json::to_string(&result).map_err(|e| anyhow::anyhow!(e.to_string()))?;
-            Ok::<String, anyhow::Error>(json_str)
-        })
+        let result = TurbopackResult {
+            issues: issues.iter().map(|i| Issue::from(&**i)).collect(),
+        };
+        let json_str =
+            serde_json::to_string(&result).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        Ok::<String, anyhow::Error>(json_str)
+    });
+    let _operation = OperationGuard::track_tokio(&build_task);
+    build_task
         .await
-        .map_err(|e| JsError::new(&format!("Failed to spawn build task: {:?}", e)))?
+        .map_err(|error| {
+            if error.is_cancelled() {
+                JsError::new("AbortError: build was disposed")
+            } else {
+                JsError::new(&format!("Failed to run build task: {error:?}"))
+            }
+        })?
         .map_or_else(
             |e| Err(JsError::new(&PrettyPrintError(&e).to_string())),
             |json_str| {

--- a/crates/utoo-wasm/src/pm.rs
+++ b/crates/utoo-wasm/src/pm.rs
@@ -10,13 +10,13 @@
 use anyhow::{anyhow, Result};
 use opfs_project::archive::PackFile;
 use parking_lot::RwLock;
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 use wasm_bindgen::JsCast;
 
 use crate::tokio_runtime::{runtime, TOKIO_RUNTIME};
 
 /// Global OpfsProject instance, initialised the first time `Project::init` is called.
-pub(crate) static OPFS_PROJECT: RwLock<Option<opfs_project::OpfsProject>> = RwLock::new(None);
+pub(crate) static OPFS_PROJECT: RwLock<Option<Arc<opfs_project::OpfsProject>>> = RwLock::new(None);
 
 /// Get a reference to the global OpfsProject for reading.
 ///
@@ -25,15 +25,6 @@ pub(crate) fn with_project<R>(f: impl FnOnce(&opfs_project::OpfsProject) -> R) -
     let guard = OPFS_PROJECT.read();
     let project = guard
         .as_ref()
-        .expect("OpfsProject not initialised — call Project.init() first");
-    f(project)
-}
-
-/// Get a mutable reference to the global OpfsProject.
-pub(crate) fn with_project_mut<R>(f: impl FnOnce(&mut opfs_project::OpfsProject) -> R) -> R {
-    let mut guard = OPFS_PROJECT.write();
-    let project = guard
-        .as_mut()
         .expect("OpfsProject not initialised — call Project.init() first");
     f(project)
 }
@@ -104,9 +95,10 @@ pub async fn install(
         omit: vec![],
     };
 
-    let guard = OPFS_PROJECT.read();
-    let project = guard
+    let project = OPFS_PROJECT
+        .read()
         .as_ref()
+        .cloned()
         .ok_or_else(|| anyhow!("OpfsProject not initialised"))?;
 
     project

--- a/crates/utoo-wasm/src/project.rs
+++ b/crates/utoo-wasm/src/project.rs
@@ -5,10 +5,13 @@
 //! - `pack` module for build/dev operations
 //! - `pm` module for package manager operations (deps, install, gzip, md5)
 
+use std::sync::Arc;
+
 use parking_lot::RwLock;
 use wasm_bindgen::prelude::*;
 
 use crate::errors::to_js_error;
+use crate::operations;
 use crate::pm::{self, with_project, OPFS_PROJECT};
 use crate::tokio_runtime::init_tokio_runtime;
 
@@ -24,6 +27,8 @@ pub struct Project;
 impl Project {
     #[wasm_bindgen(js_name = init)]
     pub fn init(thread_url: String) {
+        operations::reset();
+
         let mut url_guard = GLOBAL_THREAD_URL.write();
         if url_guard.is_none() && !thread_url.is_empty() {
             *url_guard = Some(thread_url.clone());
@@ -38,7 +43,7 @@ impl Project {
         // Initialise the global OpfsProject if not already done
         let mut guard = OPFS_PROJECT.write();
         if guard.is_none() {
-            *guard = Some(opfs_project::OpfsProject::default());
+            *guard = Some(Arc::new(opfs_project::OpfsProject::default()));
         }
     }
 
@@ -82,9 +87,10 @@ impl Project {
         package_lock: String,
         max_concurrent_downloads: Option<usize>,
     ) -> Result<(), JsError> {
-        pm::install(&package_lock, max_concurrent_downloads)
-            .await
-            .map_err(to_js_error)
+        match operations::run_local(pm::install(&package_lock, max_concurrent_downloads)).await {
+            Ok(result) => result.map_err(to_js_error),
+            Err(_) => Err(JsError::new("AbortError: install was disposed")),
+        }
     }
 
     #[cfg(feature = "utoopack")]
@@ -98,6 +104,18 @@ impl Project {
     pub async fn build(options: JsValue) -> Result<(), JsValue> {
         let _ = options;
         unimplemented!()
+    }
+
+    /// Cancel active install/build work and release project-owned state.
+    #[wasm_bindgen]
+    pub async fn dispose() -> Result<(), JsError> {
+        operations::cancel_all().await;
+
+        #[cfg(feature = "utoopack")]
+        pack::dispose_pack_project().await;
+
+        OPFS_PROJECT.write().take();
+        Ok(())
     }
 
     /// Subscribe to entrypoints changes with HMR support.

--- a/packages/utoo-web/API.md
+++ b/packages/utoo-web/API.md
@@ -24,7 +24,7 @@ This architecture ensures that `@utoo/web` delivers a responsive development exp
 
 ## Quick Start Guide
 
-Getting a project up and running involves four main steps. See `examples/utooweb-demo` or try [`utoo-repl`](https://utoo-repl.vercel.app).
+Getting a project up and running involves five main steps. See `examples/utooweb-demo` or try [`utoo-repl`](https://utoo-repl.vercel.app).
 
 ### 1. Instantiate the Project
 
@@ -117,6 +117,77 @@ After these steps, your project is fully initialized and ready for interaction.
 
 ---
 
+## Switching Projects During Install or Build
+
+`@utoo/web` currently uses one shared Worker/WASM runtime. If the user selects another project while dependency installation or a build is still running, await `dispose()` on the current project before constructing the next `Project`. Calls to the switch function should also be serialized so that rapid project selections cannot initialize two projects against the same runtime.
+
+```typescript
+import {
+  Project as UtooProject,
+  type ProjectOptions,
+} from "@utoo/web";
+
+let currentProject: UtooProject | undefined;
+let switchQueue: Promise<void> = Promise.resolve();
+
+function switchProject(options: ProjectOptions): Promise<UtooProject> {
+  const result = switchQueue.then(async () => {
+    const previous = currentProject;
+    currentProject = undefined;
+
+    // This also cancels install() or build() running on the old project.
+    await previous?.dispose();
+
+    const next = new UtooProject(options);
+    try {
+      await next.mount();
+      await next.installServiceWorker();
+      currentProject = next;
+      return next;
+    } catch (error) {
+      await next.dispose();
+      throw error;
+    }
+  });
+
+  // Keep later switches running even if this initialization fails.
+  switchQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+```
+
+An operation that was running on the old project rejects with an `AbortError`. Treat that error as the expected result of navigation, while continuing to surface other failures:
+
+```typescript
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function installDependencies(project: UtooProject, packageLock: string): void {
+  void project.install(packageLock).catch((error) => {
+    if (!isAbortError(error)) {
+      console.error("Dependency installation failed", error);
+    }
+  });
+}
+
+// This may still be running when a route or workspace selection changes.
+installDependencies(currentProject!, packageLock);
+
+// Always await the switch before starting work on the new project.
+const nextProject = await switchProject(nextProjectOptions);
+const nextPackageLock = await nextProject.deps();
+await nextProject.install(nextPackageLock);
+await nextProject.build();
+```
+
+Disposal first asks the Rust runtime to cancel active work and release its state. If cleanup does not finish within the internal timeout, `@utoo/web` terminates the old Worker so that project switching can continue. `dispose()` does not delete project files or the shared package store in OPFS.
+
+---
+
 ## API Reference
 
 ### `new UtooProject(options)`
@@ -134,6 +205,21 @@ Creates a new project instance.
   * `url` (string, required): The URL to the service worker script.
   * `scope` (string, required): The URL scope that the service worker will intercept requests for. This is the base path for your preview environment.
 * `loadersImportMap` (object, optional): A map for configuring Webpack loader imports. This is an optional advanced configuration. Typically, you can simply declare loader dependencies in `package.json` to install and use them. Configuring `loadersImportMap` allows you to provide pre-bundled, single files that adhere to the CommonJS specification (as a URL string or content string). This avoids file system I/O overhead caused by `require` operations during loader execution, thereby significantly improving build performance. The key is the loader's name, and the value is the URL or content string of the UMD/CommonJS module. Loaders will be executed in parallel in a web worker pool.
+
+#### `project.dispose()`
+
+Cancels active dependency installation or build work and releases the shared Worker/WASM runtime, HMR connections, and message ports. Pending `install()` and `build()` promises reject with an `AbortError`.
+
+A disposed instance cannot be reused. Dispose the current project before creating the next one:
+
+```typescript
+await currentProject.dispose();
+currentProject = new UtooProject(nextProjectOptions);
+await currentProject.install(nextPackageLock);
+await currentProject.build();
+```
+
+Calling `dispose()` more than once is safe. Always await it before creating the next project; constructing one while disposal is still in progress throws an error. Because `@utoo/web` currently uses one shared runtime, disposing one project also invalidates other `Project` proxies connected to that runtime. See [Switching Projects During Install or Build](#switching-projects-during-install-or-build) for a complete example and cancellation error handling.
 
 ### File System Methods
 

--- a/packages/utoo-web/API_zh-CN.md
+++ b/packages/utoo-web/API_zh-CN.md
@@ -24,7 +24,7 @@
 
 ## 快速上手指南
 
-启动项目主要涉及四个步骤。参考 `examples/utooweb-demo` 或在线体验 [`utoo-repl`](https://utoo-repl.vercel.app)。
+启动项目主要涉及五个步骤。参考 `examples/utooweb-demo` 或在线体验 [`utoo-repl`](https://utoo-repl.vercel.app)。
 
 ### 1. 实例化项目
 
@@ -117,6 +117,77 @@ await project.build({
 
 ---
 
+## 在安装或构建期间切换项目
+
+`@utoo/web` 当前使用单个共享的 Worker/WASM 运行时。如果用户在依赖安装或构建仍在执行时选择了另一个项目，必须先等待当前项目的 `dispose()` 完成，再创建下一个 `Project`。切换函数也应串行执行，避免用户连续快速选择项目时，让两个项目同时初始化到同一个运行时中。
+
+```typescript
+import {
+  Project as UtooProject,
+  type ProjectOptions,
+} from "@utoo/web";
+
+let currentProject: UtooProject | undefined;
+let switchQueue: Promise<void> = Promise.resolve();
+
+function switchProject(options: ProjectOptions): Promise<UtooProject> {
+  const result = switchQueue.then(async () => {
+    const previous = currentProject;
+    currentProject = undefined;
+
+    // 同时取消旧项目中正在执行的 install() 或 build()。
+    await previous?.dispose();
+
+    const next = new UtooProject(options);
+    try {
+      await next.mount();
+      await next.installServiceWorker();
+      currentProject = next;
+      return next;
+    } catch (error) {
+      await next.dispose();
+      throw error;
+    }
+  });
+
+  // 即使本次初始化失败，后续切换仍可继续执行。
+  switchQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+```
+
+旧项目中正在执行的操作会以 `AbortError` 结束。应用应把它视为项目切换时的预期结果，同时继续抛出其他错误：
+
+```typescript
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function installDependencies(project: UtooProject, packageLock: string): void {
+  void project.install(packageLock).catch((error) => {
+    if (!isAbortError(error)) {
+      console.error("Dependency installation failed", error);
+    }
+  });
+}
+
+// 路由或工作区发生切换时，该操作可能仍在执行。
+installDependencies(currentProject!, packageLock);
+
+// 对新项目执行操作前，必须等待切换完成。
+const nextProject = await switchProject(nextProjectOptions);
+const nextPackageLock = await nextProject.deps();
+await nextProject.install(nextPackageLock);
+await nextProject.build();
+```
+
+释放时会先请求 Rust 运行时取消活动操作并清理状态。如果清理未能在内部超时时间内完成，`@utoo/web` 会终止旧 Worker，确保项目切换可以继续。`dispose()` 不会删除 OPFS 中的项目文件或共享依赖存储。
+
+---
+
 ## API 参考
 
 ### `new UtooProject(options)`
@@ -134,6 +205,21 @@ await project.build({
   * `url` (string, 必需): Service Worker 脚本的 URL。
   * `scope` (string, 必需): Service Worker 将拦截请求的 URL 范围。这是您预览环境的基路径。
 * `loadersImportMap`（对象，可选）：用于配置 webpack Loader 的导入映射。这是一个可选的高级配置。通常情况下，您只需在 `package.json` 中声明 loader 依赖并安装，即可让它工作。配置 `loadersImportMap` 允许您直接提供预构建好的、满足 CommonJS 规范的单一文件（作为 URL 字符串或内容字符串）。这样做可以避免 loader 执行过程中因 `require` 操作产生的文件系统 I/O 开销，从而显著提升构建性能。键是 loader 的名称，值是 UMD/CommonJS 模块的 URL 或内容字符串。loader 将在 Web Worker 池中并行执行。
+
+#### `project.dispose()`
+
+取消正在执行的依赖安装或构建任务，并释放共享的 Worker/WASM 运行时、HMR 连接和消息端口。尚未完成的 `install()`、`build()` Promise 会以 `AbortError` 拒绝。
+
+已释放的实例不能继续使用。请先释放当前项目，再创建下一个项目：
+
+```typescript
+await currentProject.dispose();
+currentProject = new UtooProject(nextProjectOptions);
+await currentProject.install(nextPackageLock);
+await currentProject.build();
+```
+
+重复调用 `dispose()` 是安全的。创建下一个项目前请始终等待它完成；如果释放仍在进行，构造新项目会抛出错误。由于 `@utoo/web` 当前使用单个共享运行时，释放一个项目也会使连接到该运行时的其他 `Project` 代理失效。完整的切换示例和取消错误处理参见[在安装或构建期间切换项目](#在安装或构建期间切换项目)。
 
 ### 文件系统方法
 
@@ -460,4 +546,3 @@ import "@utoo/web/esm/serviceWorker";
 
 * 由于当前 Rust 上默认的内存分配器 [`dlmalloc`](https://github.com/alexcrichton/dlmalloc-rs) 在多线程 `wasm` 上性能不够理想，我们将 [`mimalloc`](https://github.com/microsoft/mimalloc) 移植到了 wasm32-unknown-unknown 平台，以支持开启 CPU 核心数量的线程来运行构建。因此在浏览器环境和在操作系统环境，构建的性能差异十分微小。
 * turbopack 的部分高级功能如[`持久化缓存`](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackPersistentCaching)，目前也在计划之中，未来会在浏览器内直接支持。
-

--- a/packages/utoo-web/README.md
+++ b/packages/utoo-web/README.md
@@ -9,6 +9,7 @@
 - 📂 **Real File System**: Uses Origin Private File System (OPFS) for a Node.js-like file system experience.
 - 📦 **Browser Dependency Resolution**: Resolve dependencies directly from `package.json` without needing a pre-existing lock file. Supports custom registries (npm, npmmirror, private registries).
 - 🌐 **Browser-based Bundling**: Run the Utoo bundler directly in the browser.
+- ♻️ **Project Lifecycle**: Cancel active installs or builds with `dispose()` and safely switch to another project.
 - � **Hot Module Replacement (HMR)**: Full HMR support in the browser via MessagePort communication with preview iframes.
 - �🔌 **Webpack Compatibility**: Supports a subset of Webpack configurations in the browser. See [Features List](../pack/docs/features-list.md) for details.
 - 🔄 **Webpack Loaders**: Compatible with standard Webpack loaders (css-loader, style-loader, etc.).
@@ -49,7 +50,7 @@ npm start -w utooweb-demo
 
 ## 📚 Documentation
 
-For detailed API usage and examples, please refer to the [API Documentation](./API.md) ([中文版](./API_zh-CN.md)).
+For detailed API usage and examples, please refer to the [API Documentation](./API.md) ([中文版](./API_zh-CN.md)). For project switching, see [Switching Projects During Install or Build](./API.md#switching-projects-during-install-or-build) ([中文说明](./API_zh-CN.md#在安装或构建期间切换项目)).
 
 ## �📄 License
 

--- a/packages/utoo-web/package.json
+++ b/packages/utoo-web/package.json
@@ -27,6 +27,7 @@
     "build-threadWorker": "node cli/umd.js -e ./src/workers/threadWorker.ts -o ./esm/threadWorkerInline.js -t webworker -np --base64-url",
     "build-loaderWorker": "node cli/umd.js -e ./src/webpackLoaders/worker.ts -o ./esm/loaderWorkerInline.js -t webworker --base64-url",
     "build-serviceWorker": "node cli/umd.js -e ./src/serviceWorker/index.ts -o ./esm/serviceWorkerBundle.js -t webworker -np",
+    "test": "vitest run tests",
     "clean": "rm -rf esm src/utoo",
     "prepublishOnly": "turbo run build --filter=@utoo/web"
   },

--- a/packages/utoo-web/src/project/InternalProject.ts
+++ b/packages/utoo-web/src/project/InternalProject.ts
@@ -17,7 +17,10 @@ import initWasm, {
   Project as ProjectInternal,
   RootTask,
 } from "../utoo";
-import { runLoaderWorkerPool } from "../webpackLoaders/loaderWorkerPool";
+import {
+  disposeLoaderWorkerPool,
+  runLoaderWorkerPool,
+} from "../webpackLoaders/loaderWorkerPool";
 
 class InternalEndpoint implements ProjectEndpoint {
   wasmInit?: ReturnType<typeof initWasm>;
@@ -82,6 +85,22 @@ class InternalEndpoint implements ProjectEndpoint {
       buildOptions.config = options.config;
     }
     return await ProjectInternal.build(buildOptions);
+  }
+
+  async dispose() {
+    this.rootTask?.free();
+    this.rootTask = undefined;
+
+    for (const rootTask of this.hmrRootTasks.values()) {
+      rootTask.free();
+    }
+    this.hmrRootTasks.clear();
+
+    disposeLoaderWorkerPool();
+    this.loaderWorkerPoolInitialized = false;
+    this.options = undefined;
+
+    await ProjectInternal.dispose();
   }
 
   // @ts-expect-error - Comlink delivers (config, onUpdate) as separate args, not as options object

--- a/packages/utoo-web/src/project/Project.ts
+++ b/packages/utoo-web/src/project/Project.ts
@@ -24,12 +24,93 @@ import { createWorkerFromDataUri } from "../workers/inline";
 import { checkCompatibility } from "./checkCompatibility";
 import { ForkedProject } from "./ForkedProject";
 
-let ProjectWorker: Worker;
+let ProjectWorker: Worker | undefined;
+let ProjectDisposal: Promise<void> | undefined;
 
 const ConnectedPorts = new Set<MessagePort>();
+const ActiveProjects = new Set<Project>();
+const RUST_DISPOSE_TIMEOUT_MS = 5_000;
+
+let listensForWindowMessages = false;
+let listensForServiceWorkerMessages = false;
+
+function connectWorker(event: MessageEvent): void {
+  const port = event.ports[0];
+  if (
+    event.data !== WorkerMessageType.RequestFork ||
+    !port ||
+    !ProjectWorker ||
+    ConnectedPorts.has(port)
+  ) {
+    return;
+  }
+
+  ConnectedPorts.add(port);
+  ProjectWorker.postMessage(WorkerMessageType.InitConnection, [port]);
+}
+
+function listenForWorkerConnections(fromServiceWorker: boolean): void {
+  if (!listensForWindowMessages) {
+    window.addEventListener("message", connectWorker);
+    listensForWindowMessages = true;
+  }
+
+  if (fromServiceWorker && !listensForServiceWorkerMessages) {
+    navigator.serviceWorker.addEventListener("message", connectWorker);
+    listensForServiceWorkerMessages = true;
+  }
+}
+
+function stopListeningForWorkerConnections(): void {
+  if (listensForWindowMessages) {
+    window.removeEventListener("message", connectWorker);
+    listensForWindowMessages = false;
+  }
+
+  if (listensForServiceWorkerMessages) {
+    navigator.serviceWorker.removeEventListener("message", connectWorker);
+    listensForServiceWorkerMessages = false;
+  }
+
+  ConnectedPorts.clear();
+}
+
+function createAbortError(): DOMException {
+  return new DOMException("The project has been disposed.", "AbortError");
+}
+
+async function waitForRustDisposal(disposal: Promise<void>): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const completed = await Promise.race([
+      disposal.then(() => true),
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => resolve(false), RUST_DISPOSE_TIMEOUT_MS);
+      }),
+    ]);
+
+    if (!completed) {
+      console.warn(
+        `[utoo] Rust project disposal exceeded ${RUST_DISPOSE_TIMEOUT_MS}ms; terminating the worker`,
+      );
+    }
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 export class Project implements ProjectEndpoint {
   #mount: Promise<void>;
+
+  #disposed = false;
+
+  readonly #disposeController = new AbortController();
+
+  readonly #port: MessagePort;
+
+  #disposePromise?: Promise<void>;
 
   public readonly cwd: string;
 
@@ -43,6 +124,7 @@ export class Project implements ProjectEndpoint {
       mount: (
         opt: Omit<ProjectOptions, "workerUrl" | "serviceWorker">,
       ) => Promise<void>;
+      dispose: () => Promise<void>;
     }
   >;
 
@@ -60,7 +142,14 @@ export class Project implements ProjectEndpoint {
     this.cwd = cwd;
     this.serviceWorkerOptions = serviceWorker;
 
+    if (ProjectDisposal) {
+      throw new Error(
+        "The previous project is still being disposed. Await project.dispose() before creating another project.",
+      );
+    }
+
     const { port1, port2 } = new MessageChannel();
+    this.#port = port1;
 
     this.remote ??= comlink.wrap(port1);
 
@@ -68,16 +157,9 @@ export class Project implements ProjectEndpoint {
       ProjectWorker = workerUrl.startsWith("data:")
         ? createWorkerFromDataUri(workerUrl)
         : new Worker(workerUrl);
-      window.addEventListener("message", (e) => {
-        this.connectWorker(e);
-      });
-
-      if (this.serviceWorkerOptions) {
-        navigator.serviceWorker.addEventListener("message", (e) => {
-          this.connectWorker(e);
-        });
-      }
     }
+    listenForWorkerConnections(Boolean(this.serviceWorkerOptions));
+    ActiveProjects.add(this);
 
     ProjectWorker.postMessage(WorkerMessageType.InitConnection, [port2]);
 
@@ -91,14 +173,104 @@ export class Project implements ProjectEndpoint {
     });
   }
 
-  private connectWorker(e: MessageEvent) {
-    const port = e.ports[0];
-    if (e.data === WorkerMessageType.RequestFork && !ConnectedPorts.has(port)) {
-      ProjectWorker.postMessage(WorkerMessageType.InitConnection, [port]);
+  #throwIfDisposed() {
+    if (this.#disposed) {
+      throw createAbortError();
+    }
+  }
+
+  async #raceDisposal<T>(promise: Promise<T>): Promise<T> {
+    this.#throwIfDisposed();
+
+    const { signal } = this.#disposeController;
+    return await new Promise<T>((resolve, reject) => {
+      const onDispose = () => reject(createAbortError());
+      signal.addEventListener("abort", onDispose, { once: true });
+
+      promise.then(
+        (value) => {
+          signal.removeEventListener("abort", onDispose);
+          resolve(value);
+        },
+        (error) => {
+          signal.removeEventListener("abort", onDispose);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  async #call<T>(operation: () => Promise<T>): Promise<T> {
+    await this.#raceDisposal(this.#mount);
+    this.#throwIfDisposed();
+    return await this.#raceDisposal(operation());
+  }
+
+  #beginDisposal() {
+    if (this.#disposed) {
+      return;
+    }
+
+    this.#disposed = true;
+    this.#disposeController.abort();
+    this.hmrServer?.close();
+    this.hmrServer = undefined;
+  }
+
+  #releaseConnection() {
+    this.remote[comlink.releaseProxy]();
+    this.#port.close();
+  }
+
+  /**
+   * Stop active install/build work and release the shared worker runtime.
+   * Create a new Project instance before starting work on another project.
+   */
+  public dispose(): Promise<void> {
+    if (this.#disposePromise) {
+      return this.#disposePromise;
+    }
+
+    if (ProjectDisposal) {
+      return ProjectDisposal;
+    }
+
+    if (this.#disposed) {
+      return Promise.resolve();
+    }
+
+    const disposal = this.#disposeRuntime();
+    ProjectDisposal = disposal.finally(() => {
+      ProjectDisposal = undefined;
+    });
+    this.#disposePromise = ProjectDisposal;
+    return ProjectDisposal;
+  }
+
+  async #disposeRuntime(): Promise<void> {
+    // @utoo/web currently has one shared Worker/WASM runtime. Disposing it
+    // invalidates every proxy connected to that runtime, not just this proxy.
+    const projects = Array.from(ActiveProjects);
+    for (const project of projects) {
+      project.#beginDisposal();
+    }
+
+    try {
+      await waitForRustDisposal(this.remote.dispose());
+    } finally {
+      for (const project of projects) {
+        project.#releaseConnection();
+      }
+      ActiveProjects.clear();
+
+      ProjectWorker?.terminate();
+      ProjectWorker = undefined;
+      stopListeningForWorkerConnections();
     }
   }
 
   public async installServiceWorker() {
+    this.#throwIfDisposed();
     if (this.serviceWorkerOptions) {
       const { url, scope, targetDirToCwd } = this.serviceWorkerOptions;
       // Should add "Service-Worker-Allowed": "/" in page root response headers,
@@ -107,25 +279,22 @@ export class Project implements ProjectEndpoint {
   }
 
   public async mount() {
-    return await this.#mount;
+    return await this.#raceDisposal(this.#mount);
   }
 
   public async deps(options?: DepsOptions) {
-    await this.#mount;
-    return await this.remote.deps(options);
+    return await this.#call(() => this.remote.deps(options));
   }
 
   public async install(packageLock: string, options?: InstallOptions) {
-    await this.#mount;
-    return await this.remote.install(packageLock, options);
+    return await this.#call(() => this.remote.install(packageLock, options));
   }
 
   public async build(options?: {
     config?: ConfigComplete;
     cleanup?: boolean;
   }): Promise<BuildOutput> {
-    await this.#mount;
-    const res = await this.remote.build(options);
+    const res = await this.#call(() => this.remote.build(options));
     handleIssues(res.issues, false, false);
     return res;
   }
@@ -134,7 +303,8 @@ export class Project implements ProjectEndpoint {
     config?: ConfigComplete;
     onUpdate?: (result: BuildOutput) => void;
   }): Promise<void> {
-    await this.#mount;
+    await this.#raceDisposal(this.#mount);
+    this.#throwIfDisposed();
 
     // Create HmrServer lazily on first dev() call
     if (!this.hmrServer) {
@@ -148,14 +318,16 @@ export class Project implements ProjectEndpoint {
     }
 
     // Pass config and onUpdate as separate top-level args for Comlink serialization
-    (this.remote.dev as any)(
-      options?.config,
-      options?.onUpdate
-        ? comlink.proxy((result: BuildOutput) => {
-            handleIssues(result.issues, false, false);
-            options.onUpdate!(result);
-          })
-        : undefined,
+    await this.#raceDisposal(
+      (this.remote.dev as any)(
+        options?.config,
+        options?.onUpdate
+          ? comlink.proxy((result: BuildOutput) => {
+              handleIssues(result.issues, false, false);
+              options.onUpdate!(result);
+            })
+          : undefined,
+      ),
     );
   }
 
@@ -163,19 +335,25 @@ export class Project implements ProjectEndpoint {
     identifier: string,
     callback: (update: unknown) => void,
   ): Promise<void> {
-    await this.remote.hmrSubscribe(identifier, comlink.proxy(callback));
+    await this.#call(() =>
+      Promise.resolve(
+        this.remote.hmrSubscribe(identifier, comlink.proxy(callback)),
+      ),
+    );
   }
 
   public updateInfoSubscribe(
     aggregationMs: number,
     callback: (message: UpdateMessage) => void,
   ): void {
+    this.#throwIfDisposed();
     this.remote.updateInfoSubscribe(aggregationMs, comlink.proxy(callback));
   }
 
   public async readFile(path: string, encoding?: "utf8") {
-    await this.#mount;
-    return (await this.remote.readFile(path, encoding)) as any;
+    return (await this.#call(() =>
+      this.remote.readFile(path, encoding),
+    )) as any;
   }
 
   public async writeFile(
@@ -183,59 +361,55 @@ export class Project implements ProjectEndpoint {
     content: string | Uint8Array,
     encoding?: "utf8",
   ) {
-    await this.#mount;
     if (content instanceof Uint8Array) {
-      return await this.remote.writeFile(path, content, encoding);
+      return await this.#call(() =>
+        this.remote.writeFile(path, content, encoding),
+      );
     }
-    return await this.remote.writeFile(path, content, encoding);
+    return await this.#call(() =>
+      this.remote.writeFile(path, content, encoding),
+    );
   }
 
   public async copyFile(src: string, dst: string) {
-    await this.#mount;
-    return await this.remote.copyFile(src, dst);
+    return await this.#call(() => this.remote.copyFile(src, dst));
   }
 
   public async readdir(
     path: string,
     options?: { recursive?: boolean },
   ): Promise<Dirent[]> {
-    await this.#mount;
-    const dirEntry = (await this.remote.readdir(
-      path,
-      options,
+    const dirEntry = (await this.#call(() =>
+      this.remote.readdir(path, options),
     )) as any as RawDirent[];
     return dirEntry.map((e) => new Dirent(e));
   }
 
   public async mkdir(path: string, options?: { recursive?: boolean }) {
-    await this.#mount;
-    return await this.remote.mkdir(path, options);
+    return await this.#call(() => this.remote.mkdir(path, options));
   }
 
   public async rm(path: string, options?: { recursive?: boolean }) {
-    await this.#mount;
-    return await this.remote.rm(path, options);
+    return await this.#call(() => this.remote.rm(path, options));
   }
 
   public async rmdir(path: string, options?: { recursive?: boolean }) {
-    await this.#mount;
-    return await this.remote.rmdir(path, options);
+    return await this.#call(() => this.remote.rmdir(path, options));
   }
 
   public async stat(path: string): Promise<Stats> {
-    await this.#mount;
-    const raw = (await this.remote.stat(path)) as any as RawStats;
+    const raw = (await this.#call(() =>
+      this.remote.stat(path),
+    )) as any as RawStats;
     return new Stats(raw);
   }
 
   public async gzip(files: PackFile[]): Promise<Uint8Array> {
-    await this.#mount;
-    return await this.remote.gzip(files);
+    return await this.#call(() => this.remote.gzip(files));
   }
 
   public async sigMd5(content: Uint8Array): Promise<string> {
-    await this.#mount;
-    return await this.remote.sigMd5(content);
+    return await this.#call(() => this.remote.sigMd5(content));
   }
 
   /**
@@ -250,6 +424,7 @@ export class Project implements ProjectEndpoint {
     iframe: HTMLIFrameElement,
     origin?: string,
   ): HmrClient | null {
+    this.#throwIfDisposed();
     if (!this.hmrServer) {
       return null;
     }

--- a/packages/utoo-web/src/utoo/index.d.ts
+++ b/packages/utoo-web/src/utoo/index.d.ts
@@ -107,6 +107,10 @@ export class Project {
      */
     static deps(registry?: string | null, concurrency?: number | null): Promise<string>;
     /**
+     * Cancel active install/build work and release project-owned state.
+     */
+    static dispose(): Promise<void>;
+    /**
      * Subscribe to entrypoints changes with HMR support.
      * This will watch for file changes and automatically rebuild.
      * Returns a RootTask that must be held by JS to keep the subscription active.
@@ -221,6 +225,7 @@ export interface InitOutput {
     readonly project_build: (a: number) => any;
     readonly project_cwd: () => [number, number];
     readonly project_deps: (a: number, b: number, c: number) => any;
+    readonly project_dispose: () => any;
     readonly project_entrypointsSubscribe: (a: any, b: any) => any;
     readonly project_gzip: (a: any) => any;
     readonly project_hmrEvents: (a: number, b: number, c: any) => any;

--- a/packages/utoo-web/src/webpackLoaders/loaderWorkerPool.ts
+++ b/packages/utoo-web/src/webpackLoaders/loaderWorkerPool.ts
@@ -93,3 +93,17 @@ export const runLoaderWorkerPool = async (
     },
   );
 };
+
+export function disposeLoaderWorkerPool(): void {
+  for (const workers of Object.values(loaderWorkers)) {
+    for (const worker of workers.values()) {
+      worker.terminate();
+    }
+    workers.clear();
+  }
+
+  for (const entrypoint of Object.keys(loaderWorkers)) {
+    delete loaderWorkers[entrypoint];
+  }
+  nextWorkerId = 0;
+}

--- a/packages/utoo-web/tests/Project.test.ts
+++ b/packages/utoo-web/tests/Project.test.ts
@@ -1,0 +1,108 @@
+import * as comlink from "comlink";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Project } from "../src/project/Project";
+
+class MockWorker extends EventTarget {
+  static instances: MockWorker[] = [];
+  static dispose = async () => {};
+
+  readonly messages: unknown[] = [];
+  terminateCalls = 0;
+
+  constructor(_url: string | URL, _options?: WorkerOptions) {
+    super();
+    MockWorker.instances.push(this);
+  }
+
+  postMessage(message: unknown, transfer?: Transferable[]): void {
+    this.messages.push(message);
+
+    const port = transfer?.[0];
+    if (port instanceof MessagePort) {
+      comlink.expose(
+        {
+          mount: async () => {},
+          install: () => new Promise<void>(() => {}),
+          build: () => new Promise<void>(() => {}),
+          dispose: () => MockWorker.dispose(),
+        },
+        port,
+      );
+    }
+  }
+
+  terminate(): void {
+    this.terminateCalls += 1;
+  }
+}
+
+function createProject(): Project {
+  return new Project({
+    cwd: "/project",
+    workerUrl: "/worker.js",
+    threadWorkerUrl: "/thread-worker.js",
+  });
+}
+
+let project: Project | undefined;
+
+beforeEach(() => {
+  MockWorker.instances = [];
+  MockWorker.dispose = async () => {};
+  vi.stubGlobal("Worker", MockWorker);
+  vi.stubGlobal("window", new EventTarget());
+});
+
+afterEach(async () => {
+  await project?.dispose();
+  project = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe("Project.dispose", () => {
+  it("aborts active install and build calls", async () => {
+    project = createProject();
+    await project.mount();
+
+    const install = project.install("{}");
+    const build = project.build();
+    const disposal = project.dispose();
+
+    await expect(install).rejects.toMatchObject({ name: "AbortError" });
+    await expect(build).rejects.toMatchObject({ name: "AbortError" });
+    await disposal;
+    expect(MockWorker.instances[0].terminateCalls).toBe(1);
+  });
+
+  it("is idempotent and starts a fresh worker for the next project", async () => {
+    project = createProject();
+    const firstWorker = MockWorker.instances[0];
+
+    await Promise.all([project.dispose(), project.dispose()]);
+
+    expect(firstWorker.terminateCalls).toBe(1);
+    await expect(project.mount()).rejects.toMatchObject({ name: "AbortError" });
+
+    project = createProject();
+    expect(MockWorker.instances).toHaveLength(2);
+    expect(MockWorker.instances[1]).not.toBe(firstWorker);
+  });
+
+  it("waits for Rust disposal before terminating the worker", async () => {
+    let finishRustDisposal: (() => void) | undefined;
+    MockWorker.dispose = () =>
+      new Promise<void>((resolve) => {
+        finishRustDisposal = resolve;
+      });
+    project = createProject();
+    await project.mount();
+
+    const disposal = project.dispose();
+    await vi.waitFor(() => expect(finishRustDisposal).toBeDefined());
+
+    expect(MockWorker.instances[0].terminateCalls).toBe(0);
+    finishRustDisposal!();
+    await disposal;
+    expect(MockWorker.instances[0].terminateCalls).toBe(1);
+  });
+});

--- a/packages/utoo-web/tsconfig.json
+++ b/packages/utoo-web/tsconfig.json
@@ -21,5 +21,5 @@
       "@utoo/pack-shared": ["../pack-shared/src/index.ts"]
     }
   },
-  "exclude": ["./esm", "./dist", "./cli", "./tmp"]
+  "exclude": ["./esm", "./dist", "./cli", "./tmp", "./tests"]
 }


### PR DESCRIPTION
## Summary
- Add an awaitable `Project.dispose()` lifecycle API for `@utoo/web`.
- Allow users to cancel an in-flight dependency installation or build before switching to another project.
- Address the missing lifecycle boundary in the shared Worker/WASM runtime, which previously left active Rust and Turbopack work attached to the old project.

## Changes
- Track and cancel active local and Tokio Rust operations, and expose WASM-side project disposal.
- Release Turbopack subscriptions and project state, OPFS offload resources, loader workers, HMR connections, message ports, and shared Worker listeners.
- Reject pending project calls with `AbortError`, make disposal idempotent, prevent reuse of disposed instances, and ensure the next project starts with a fresh Worker.
- Add Vitest coverage for active-operation cancellation, repeated disposal, and Worker recreation.
- Document serialized project switching, cancellation handling, Worker fallback behavior, and OPFS persistence in English and Chinese.

## Validation
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `npx tsc -p packages/utoo-web/tsconfig.build.json --noEmit`
- `npm test -w @utoo/web` — 3 tests passed
- Manual browser verification: cancelled a slow install and started a new project successfully.
- Manual browser verification: cancelled an active build through the Worker timeout fallback, then installed and built the next project successfully.

## Risk / rollout
- No migrations or configuration changes are required.
- `@utoo/web` still has one shared runtime, so disposing any project invalidates every proxy connected to that runtime; this is documented.
- Rust cleanup is given an internal timeout before the old Worker is terminated, ensuring project switching is not blocked even if Turbopack shutdown does not finish promptly.
- Project files and the shared dependency store remain in OPFS after disposal.

## Reviewer notes
- Please focus on cancellation registry synchronization and the Turbopack `stop_and_wait` disposal path.
- Please also review shared singleton lifecycle cleanup in `Project.ts`, especially concurrent/repeated disposal and listener/port release.