### PR TITLE
fix(pm): isolate global package dependency trees

### DIFF
--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -186,22 +186,42 @@ pub fn format_save_spec(version_spec: &str, resolved_version: &str) -> String {
     }
 }
 
-pub async fn resolve_package_spec(spec: &str) -> Result<(String, String, String)> {
+/// Fully resolved identity and source needed to materialize a requested package.
+pub struct ResolvedPackageSpec {
+    pub name: String,
+    pub version: String,
+    pub version_spec: String,
+    pub tarball_url: String,
+}
+
+pub async fn resolve_package_spec_details(spec: &str) -> Result<ResolvedPackageSpec> {
     let parsed = PackageSpec::from(spec);
     match parsed {
         PackageSpec::Registry { name, version_spec } => {
             let resolved = resolve_package(&Context::registry().await, &name, &version_spec)
                 .await
                 .context("Failed to resolve package")?;
-            Ok((name, resolved.version, version_spec))
+            let tarball_url = resolved
+                .manifest
+                .dist
+                .tarball
+                .clone()
+                .context("Resolved package has no tarball URL")?;
+            Ok(ResolvedPackageSpec {
+                name,
+                version: resolved.version,
+                version_spec,
+                tarball_url,
+            })
         }
         PackageSpec::Git { url, commit_ish } => {
             let resolved = resolve_git_spec(&url, commit_ish.as_deref(), None).await?;
-            Ok((
-                resolved.name.clone(),
-                resolved.version.clone(),
-                resolved.resolved_url.clone(),
-            ))
+            Ok(ResolvedPackageSpec {
+                name: resolved.name.clone(),
+                version: resolved.version.clone(),
+                version_spec: resolved.resolved_url.clone(),
+                tarball_url: resolved.resolved_url.clone(),
+            })
         }
         PackageSpec::GitHub {
             owner,
@@ -209,11 +229,12 @@ pub async fn resolve_package_spec(spec: &str) -> Result<(String, String, String)
             commit_ish,
         } => {
             let resolved = resolve_github_spec(&owner, &repo, commit_ish.as_deref()).await?;
-            Ok((
-                resolved.name.clone(),
-                resolved.version.clone(),
-                resolved.resolved_url.clone(),
-            ))
+            Ok(ResolvedPackageSpec {
+                name: resolved.name.clone(),
+                version: resolved.version.clone(),
+                version_spec: resolved.resolved_url.clone(),
+                tarball_url: resolved.resolved_url.clone(),
+            })
         }
         PackageSpec::Local { protocol, .. } => {
             anyhow::bail!("Local spec ({protocol}:) not supported in this context")
@@ -222,6 +243,11 @@ pub async fn resolve_package_spec(spec: &str) -> Result<(String, String, String)
             anyhow::bail!("HTTP tarball spec ({url}) not supported in this context")
         }
     }
+}
+
+pub async fn resolve_package_spec(spec: &str) -> Result<(String, String, String)> {
+    let resolved = resolve_package_spec_details(spec).await?;
+    Ok((resolved.name, resolved.version, resolved.version_spec))
 }
 
 /// Root-entry optionalDependencies as the lock will have them: user's own

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -9,8 +9,8 @@ use crate::cmd::deps::build_deps;
 use crate::fs;
 use crate::helper::global_bin::{get_global_bin_dir, get_global_package_dir};
 use crate::helper::lock::{
-    Package, UpdatePackageJsonOptions, extract_package_name, format_save_spec, group_by_depth,
-    is_pkg_lock_outdated, resolve_package_spec, save_package_lock, update_package_json,
+    Package, UpdatePackageJsonOptions, extract_package_name, group_by_depth, is_pkg_lock_outdated,
+    resolve_package_spec_details, save_package_lock, update_package_json,
 };
 use crate::helper::ruborist_context::Context;
 use crate::helper::workspace::init_project_root;
@@ -26,7 +26,9 @@ use crate::util::logger::{
     PROGRESS_BAR, finish_progress_bar, log_progress, print_install_counts, start_progress_bar,
 };
 use crate::util::proxy_env::print_proxy_env_hint_once;
+use utoo_ruborist::builder::DevDeps;
 use utoo_ruborist::compat::{is_cpu_compatible, is_os_compatible};
+use utoo_ruborist::manifest::PackageJson;
 use utoo_ruborist::progress::PackageTarballInfo;
 
 use super::binary::{requires_private_copy, update_package_binary};
@@ -106,10 +108,7 @@ async fn install_packages(
 
 /// Clone/link every package in `groups` into `<cwd>/node_modules`, level by
 /// level, WITHOUT pruning extraneous entries (no `clean_deps`). Within each
-/// level, tasks run concurrently. Global installs (`utoo install -g`, `utoo x`)
-/// reify additively into a shared global `node_modules` so previously-installed
-/// tools survive — and there is no synthetic root `package.json` on disk for
-/// `clean_deps` / `find_workspaces` to read.
+/// level, tasks run concurrently.
 async fn reify_packages(
     groups: &HashMap<usize, Vec<(String, Package)>>,
     cwd: &Path,
@@ -252,6 +251,10 @@ async fn resolve_package_lock_with_scheduler(
 }
 
 pub struct InstallService;
+
+fn global_install_root(prefix: Option<&str>, name: &str) -> Result<std::path::PathBuf> {
+    Ok(get_global_package_dir(prefix)?.join(name))
+}
 
 impl InstallService {
     pub async fn update_packages(
@@ -400,82 +403,121 @@ impl InstallService {
         Ok(())
     }
 
-    /// Install a package globally (`utoo install -g`, `utoo x`).
+    /// Install one tool beneath an npm-style prefix.
     ///
-    /// The tool is installed as a **production dependency** of an in-memory
-    /// synthetic root — never as a root project — so it runs the install
-    /// lifecycle (`preinstall`/`install`/`postinstall` + bin) but never
-    /// `prepare`/`prepublish`, and its `devDependencies` are not installed
-    /// (matching `npm install -g` and bun). No wrapper `package.json` is written:
-    /// the global `node_modules` is the source of truth, reified **additively**
-    /// so previously-installed globals survive.
+    /// `utoo install -g` passes the user's global prefix; `utoo x` passes its
+    /// per-name/version cache prefix. Both produce the same isolated layout:
+    ///
+    /// ```text
+    /// <prefix>/
+    /// ├── bin/<command> -> ../lib/node_modules/<name>/<bin-entry>
+    /// └── lib/node_modules/<name>/
+    ///     ├── package.json
+    ///     └── node_modules/          # this tool's production dependencies
+    /// ```
+    ///
+    /// The installed tool is the dependency-resolution root, so transitive
+    /// packages cannot be hoisted beside other global tools. It participates in
+    /// dependency lifecycle hooks (`preinstall`/`install`/`postinstall`) but not
+    /// project-only hooks (`prepare`/`prepublish`) or root dev dependencies.
     pub async fn install_global_package(npm_spec: &str, prefix: Option<&str>) -> Result<()> {
         print_proxy_env_hint_once();
         install_progress::start_install_run();
-        let (name, resolved_version, version_spec) = resolve_package_spec(npm_spec).await?;
-        // Resolvable spec for the synthetic dependency: registry ranges pinned to
-        // the resolved version; git/file/url specs kept as-is.
-        let dep_spec = format_save_spec(&version_spec, &resolved_version);
-
-        // Shared global `node_modules` base (`<prefix>/lib/node_modules`); reify
-        // from its parent so the tool lands at `<root>/node_modules/<name>`.
+        let resolved = resolve_package_spec_details(npm_spec).await?;
         let global_node_modules = get_global_package_dir(prefix)?;
-        let root_path = global_node_modules
-            .parent()
-            .context("global node_modules has no parent directory")?
-            .to_path_buf();
-        fs::create_dir_all(&root_path).await?;
-
-        // Synthetic private root: `{ private, dependencies: { <name>: <spec> } }`.
-        // Lives only in memory — fed straight to the resolver.
-        let mut pkg = utoo_ruborist::manifest::PackageJson::new("utoo-global", "0.0.0");
-        pkg.private = Some(true);
-        pkg.dependencies = Some(HashMap::from([(name.clone(), dep_spec)]));
+        let root_path = global_install_root(prefix, &resolved.name)?;
+        fs::create_dir_all(&global_node_modules).await?;
 
         tracing::debug!(
-            "Installing global package {name} into {}",
+            "Installing global package {} into {}",
+            resolved.name,
             root_path.display()
         );
-
-        // Production install: never pull devDependencies.
-        let omit = HashSet::from([OmitType::Dev]);
 
         let scheduler_handle = super::install_scheduler::InstallSchedulerHandle::start();
         let scheduler = scheduler_handle.scheduler();
 
-        // Resolve the tool + its prod deps from the synthetic root. Resolver
-        // events drive the download pipeline (same head start a cold install gets).
-        start_progress_bar();
-        let resolve_start = Instant::now();
-        let options = Context::install_deps_options(root_path.clone(), scheduler.clone()).await;
-        let lock = match utoo_ruborist::service::build_deps(options, pkg).await {
-            Ok(lock) => lock,
-            Err(e) => {
-                scheduler_handle.shutdown().await;
-                return Err(e).context("Failed to resolve global package");
+        let install_result: Result<_> = async {
+            // This entry point is overwrite-oriented. `ut x` skips it on a
+            // cache hit; an explicit global install replaces only the requested
+            // tool and never touches siblings in the shared node_modules.
+            if fs::try_exists(&root_path).await.unwrap_or(false) {
+                fs::remove_dir_all(&root_path)
+                    .await
+                    .with_context(|| format!("Failed to replace {}", root_path.display()))?;
             }
-        };
-        finish_progress_bar("package-lock.json resolved", Some(resolve_start.elapsed()));
 
-        // Reify ADDITIVELY (no clean_deps) into the shared global node_modules.
-        let groups = group_by_depth(&lock.packages);
-        if !lock.packages.is_empty() {
+            scheduler
+                .ensure_clone(
+                    resolved.name.clone(),
+                    resolved.version.clone(),
+                    resolved.tarball_url.clone(),
+                    root_path.clone(),
+                    ClonePolicy::Private,
+                )
+                .await
+                .context("Failed to materialize global package")?;
+            update_package_binary(&root_path, &resolved.name).await?;
+
+            let mut pkg: PackageJson = crate::util::json::load_package_json(&root_path)
+                .await
+                .context("Failed to load installed global tool")?;
+            // Published packages are installed as dependencies, never as
+            // workspace roots. Keep package.json intact; only the in-memory
+            // resolution view suppresses workspace discovery.
+            pkg.workspaces = None;
+
+            // Resolve production dependencies with the package itself as the
+            // real root. Resolver paths therefore land below
+            // `<prefix>/lib/node_modules/<name>/node_modules`, not beside it.
             start_progress_bar();
-            PROGRESS_BAR.set_length(lock.packages.len() as u64);
-        }
-        let link_start = Instant::now();
-        let reify = reify_packages(&groups, &root_path, &omit, &scheduler).await;
-        let counts = scheduler_handle.shutdown().await;
-        reify.context("Failed to install global package")?;
-        let clone_elapsed = link_start.elapsed();
-        finish_progress_bar("node_modules cloned", Some(clone_elapsed));
+            let resolve_start = Instant::now();
+            let mut options =
+                Context::install_deps_options(root_path.clone(), scheduler.clone()).await;
+            // A package tarball may contain its publisher's lockfile. It does
+            // not govern consumers, so never seed a global install from it.
+            options.baseline = None;
+            let lock = utoo_ruborist::service::build_deps_with_root_dev_deps(
+                options,
+                pkg,
+                DevDeps::Exclude,
+            )
+            .await
+            .context("Failed to resolve global package")?;
+            finish_progress_bar("package-lock.json resolved", Some(resolve_start.elapsed()));
 
-        // Dependency lifecycle only — preinstall/install/postinstall + bin
-        // linking for the tool and its deps. No project/workspace hooks, so no
-        // `prepare`/`prepublish`, and no disk root `package.json` is required.
-        let packages =
+            // The root was freshly materialized above. Reify only this tool's
+            // lock beneath its own node_modules; sibling global tools are
+            // outside `root_path` and cannot be pruned or overwritten.
+            let groups = group_by_depth(&lock.packages);
+            if !lock.packages.is_empty() {
+                start_progress_bar();
+                PROGRESS_BAR.set_length(lock.packages.len() as u64);
+            }
+            let link_start = Instant::now();
+            reify_packages(&groups, &root_path, &HashSet::new(), &scheduler)
+                .await
+                .context("Failed to install global package")?;
+            finish_progress_bar("node_modules cloned", Some(link_start.elapsed()));
+            Ok(lock)
+        }
+        .await;
+        let counts = scheduler_handle.shutdown().await;
+        let lock = install_result?;
+
+        // Dependency lifecycle only: the shared queue knows only
+        // preinstall/install/postinstall. Add the root package explicitly
+        // because roots are not dependency entries in the lock, but leave its
+        // bins for the prefix-level link step below.
+        let package_info = PackageInfo::from_path(&root_path)
+            .await
+            .context("Failed to load installed global tool")?;
+        let mut root_lifecycle = package_info.clone();
+        root_lifecycle.bin_files.clear();
+        let mut packages =
             PackageService::collect_packages_from_lock(&lock, &root_path, ScriptPolicy::Run)
                 .await?;
+        packages.push((root_lifecycle, false));
         if !packages.is_empty() {
             let queues =
                 PackageService::create_execution_queues_with_options(packages, ScriptPolicy::Run)?;
@@ -483,10 +525,6 @@ impl InstallService {
         }
 
         // Link the tool's own bin into the global bin dir.
-        let tool_dir = global_node_modules.join(&name);
-        let package_info = PackageInfo::from_path(&tool_dir)
-            .await
-            .context("Failed to load installed global tool")?;
         let target_bin_dir =
             get_global_bin_dir(prefix).context("Failed to get global bin directory")?;
         package_info
@@ -502,6 +540,59 @@ impl InstallService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::package::{LifecycleScripts, PackageInfo};
+    use crate::util::platform_const::GLOBAL_NODE_MODULES;
+    use tempfile::tempdir;
+
+    #[test]
+    fn global_install_root_is_the_package_isolation_boundary() {
+        let temp = tempdir().unwrap();
+        let prefix = temp.path().to_string_lossy();
+        let root = global_install_root(Some(&prefix), "@scope/tool").unwrap();
+
+        assert_eq!(
+            root,
+            temp.path()
+                .join(GLOBAL_NODE_MODULES)
+                .join("@scope")
+                .join("tool")
+        );
+        assert_eq!(
+            root.join("node_modules"),
+            temp.path()
+                .join(GLOBAL_NODE_MODULES)
+                .join("@scope")
+                .join("tool")
+                .join("node_modules")
+        );
+    }
+
+    #[test]
+    fn global_tool_queues_dependency_lifecycle_only() {
+        let package = PackageInfo {
+            path: "/global/tool".into(),
+            bin_files: vec![],
+            scripts: Default::default(),
+            lifecycle_scripts: LifecycleScripts::from_scripts(&HashMap::from([
+                ("preinstall".into(), "echo preinstall".into()),
+                ("install".into(), "echo install".into()),
+                ("postinstall".into(), "echo postinstall".into()),
+                ("prepare".into(), "echo prepare".into()),
+            ])),
+            name: "tool".into(),
+        };
+
+        let queues = PackageService::create_execution_queues_with_options(
+            vec![(package, false)],
+            ScriptPolicy::Run,
+        )
+        .unwrap();
+
+        assert_eq!(queues.preinstall.len(), 1);
+        assert_eq!(queues.install.len(), 1);
+        assert_eq!(queues.postinstall.len(), 1);
+        assert!(queues.bin_linking.is_empty());
+    }
 
     #[test]
     fn test_extract_package_name_from_path() {

--- a/crates/pm/src/service/package_management.rs
+++ b/crates/pm/src/service/package_management.rs
@@ -17,7 +17,14 @@ impl PackageManagementService {
 
     /// Install a package to the utoo cache directory using utoo's own installation logic.
     /// Delegates to `InstallService::install_global_package` with a per-tool prefix
-    /// (`~/.utoo/utx/<name>/<version>`), so the tool is installed as a dependency.
+    /// (`~/.utoo/utx/<name>/<version>`), producing the same npm-style isolated
+    /// prefix layout as a persistent global install:
+    ///
+    /// ```text
+    /// <cache-prefix>/
+    /// ├── bin/<command>
+    /// └── lib/node_modules/<name>/node_modules/<dependency>
+    /// ```
     ///
     /// The prefix uses the same `<name>/<version>` two-segment layout as the
     /// package store (`~/.cache/nm`): a scoped name nests naturally

--- a/crates/ruborist/src/service/api.rs
+++ b/crates/ruborist/src/service/api.rs
@@ -95,17 +95,33 @@ impl<G, R> BuildDepsOptions<G, R> {
 
 /// Build dependency tree from an **in-memory root manifest** `pkg` and return the
 /// resolved `package-lock.json`. `options.cwd` is the resolution root, already
-/// resolved by the caller — a normal install reads it via [`read_root_manifest`];
-/// a global install (`utoo install -g`, `utoo x`) synthesizes a private root
-/// `{ dependencies: { <tool>: <spec> } }` so the tool resolves as a *dependency*
-/// (no `prepare`/`prepublish`, no `devDependencies`). It:
+/// resolved by the caller — both project installs and global-tool installs read
+/// their actual root manifest before calling this function. It:
 /// 1. Injects runtime dependencies (node-bin packages from engines.install-node)
 /// 2. Builds the graph and adds root + workspace edges
 /// 3. Resolves all dependencies using the registry
 /// 4. Returns the package lock
 pub async fn build_deps<G, R>(
     options: BuildDepsOptions<G, R>,
+    pkg: PackageJson,
+) -> Result<PackageLock>
+where
+    G: Glob + Clone,
+    R: EventReceiver,
+{
+    build_deps_with_root_dev_deps(options, pkg, DevDeps::Include).await
+}
+
+/// Resolve a root manifest with an explicit root-dev-dependency policy.
+///
+/// Package-manager project installs use [`build_deps`] and include root dev
+/// dependencies. A tool installed globally is itself the resolution root but
+/// must behave like a regular dependency, so its caller passes
+/// [`DevDeps::Exclude`].
+pub async fn build_deps_with_root_dev_deps<G, R>(
+    options: BuildDepsOptions<G, R>,
     mut pkg: PackageJson,
+    dev_deps: DevDeps,
 ) -> Result<PackageLock>
 where
     G: Glob + Clone,
@@ -171,11 +187,12 @@ where
         //    resolved at edge creation).
         let mut graph = DependencyGraph::from_package_json(root_path.clone(), pkg.clone());
         let root_index = graph.root_index;
-        let edge_ctx = EdgeContext::new(peer_deps, DevDeps::Include).with_catalogs(&catalogs);
+        let edge_ctx = EdgeContext::new(peer_deps, dev_deps).with_catalogs(&catalogs);
         add_edges_from(&mut graph, root_index, &pkg, &edge_ctx);
 
-        // 3. Discover and add workspace packages. A synthetic global-install root
-        //    has no `workspaces` field, so this returns immediately without disk.
+        // 3. Discover and add workspace packages. Callers resolving a published
+        //    package as a dependency root clear `workspaces` in their in-memory
+        //    view, so this returns immediately without scanning package contents.
         let discovery = WorkspaceDiscovery::new(glob.clone());
         let workspaces = discovery.find_workspaces_from_pkg(&root_path, &pkg).await?;
         for workspace in workspaces {
@@ -247,7 +264,6 @@ where
 /// Resolve the workspace root for `cwd` and read its `package.json`. The
 /// disk-side counterpart to [`build_deps`]: a normal install calls this to get
 /// the `(root_path, manifest)` pair, then passes the manifest to `build_deps`.
-/// (Global installs skip this and synthesize the manifest in memory.)
 pub async fn read_root_manifest<G: Glob + Clone>(
     cwd: &Path,
     glob: G,
@@ -294,10 +310,8 @@ mod tests {
         );
     }
 
-    /// `build_deps` resolves an **in-memory** synthetic root (no disk
-    /// package.json, no workspace discovery) — the path global installs use. A
-    /// root with no dependencies resolves offline to a lock with only the root
-    /// entry.
+    /// `build_deps` can resolve an in-memory root without touching disk. A root
+    /// with no dependencies resolves offline to a lock with only the root entry.
     #[tokio::test]
     async fn test_build_deps_in_memory_root_no_deps() {
         let options: BuildDepsOptions<NoopGlob, NoopReceiver> = BuildDepsOptions {
@@ -318,8 +332,35 @@ mod tests {
 
         let lock = build_deps(options, pkg)
             .await
-            .expect("in-memory synthetic root should resolve offline");
+            .expect("in-memory root should resolve offline");
         assert!(lock.packages.contains_key(""), "root entry present");
         assert_eq!(lock.packages.len(), 1, "no deps → only the root");
+    }
+
+    #[tokio::test]
+    async fn test_build_deps_can_exclude_root_dev_dependencies() {
+        let options: BuildDepsOptions<NoopGlob, NoopReceiver> = BuildDepsOptions {
+            cwd: PathBuf::from("/global/tool"),
+            registry: UnifiedRegistry::builder()
+                .registry("https://registry.invalid")
+                .build(),
+            cache_dir: None,
+            concurrency: 20,
+            peer_deps: PeerDeps::Skip,
+            glob: NoopGlob,
+            receiver: NoopReceiver,
+            catalogs: HashMap::new(),
+            baseline: None,
+        };
+        let mut pkg = PackageJson::new("tool", "1.0.0");
+        pkg.dev_dependencies = Some(HashMap::from([(
+            "must-not-resolve".to_string(),
+            "1.0.0".to_string(),
+        )]));
+
+        let lock = build_deps_with_root_dev_deps(options, pkg, DevDeps::Exclude)
+            .await
+            .expect("excluded root dev dependency must not hit the registry");
+        assert_eq!(lock.packages.len(), 1, "only the root should remain");
     }
 }

--- a/crates/ruborist/src/service/mod.rs
+++ b/crates/ruborist/src/service/mod.rs
@@ -53,7 +53,7 @@ mod manifest_provider;
 mod registry;
 mod store;
 
-pub use api::{BuildDepsOptions, build_deps, read_root_manifest};
+pub use api::{BuildDepsOptions, build_deps, build_deps_with_root_dev_deps, read_root_manifest};
 pub use cache::{Versions, VersionsInfo};
 pub use fs::{Glob, NoopGlob, exists, read_to_string};
 pub use http::client_builder;

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -185,31 +185,38 @@ echo -e "${GREEN}PASS: antd-test deps tree successful${NC}"
 cd ../../..
 
 
-# Case 7: test global install
-echo -e "${YELLOW}Case 7: cowsay global install/uninstall${NC}"
+# Case 7: test npm-style isolated global installs
+echo -e "${YELLOW}Case 7: isolated global install layout${NC}"
 
-# Test global install. The tool is installed as a *dependency* of a synthetic
-# root (never a root project), so it runs the install lifecycle but never
-# prepare/prepublish, and its devDependencies are not installed.
-utoo install -g cowsay || { echo -e "${RED}FAIL: global install cowsay failed${NC}"; exit 1; }
-if ! which cowsay >/dev/null 2>&1; then
-    echo -e "${RED}FAIL: cowsay not found in PATH after global install${NC}"
+global_prefix=$(mktemp -d)
+utoo install -g --prefix "$global_prefix" cowsay || { echo -e "${RED}FAIL: global install cowsay failed${NC}"; exit 1; }
+cowsay_root="$global_prefix/lib/node_modules/cowsay"
+if [ ! -x "$global_prefix/bin/cowsay" ]; then
+    echo -e "${RED}FAIL: cowsay global bin was not linked${NC}"
+    exit 1
+fi
+if [ ! -d "$cowsay_root/node_modules/yargs" ]; then
+    echo -e "${RED}FAIL: cowsay dependencies were not installed under cowsay/node_modules${NC}"
+    exit 1
+fi
+if [ -d "$global_prefix/lib/node_modules/yargs" ]; then
+    echo -e "${RED}FAIL: cowsay dependency yargs was hoisted beside global tools${NC}"
     exit 1
 fi
 echo -e "${GREEN}PASS: cowsay global install successful${NC}"
 
-# Coexistence: a second global install must reify ADDITIVELY into the shared
-# global node_modules — installing semver must not prune cowsay.
-utoo install -g semver || { echo -e "${RED}FAIL: global install semver failed${NC}"; exit 1; }
-if ! which semver >/dev/null 2>&1; then
-    echo -e "${RED}FAIL: semver not found in PATH after global install${NC}"
+# A second top-level tool shares only the prefix, never the dependency tree.
+utoo install -g --prefix "$global_prefix" semver || { echo -e "${RED}FAIL: global install semver failed${NC}"; exit 1; }
+if [ ! -x "$global_prefix/bin/semver" ]; then
+    echo -e "${RED}FAIL: semver global bin was not linked${NC}"
     exit 1
 fi
-if ! which cowsay >/dev/null 2>&1; then
+if [ ! -x "$global_prefix/bin/cowsay" ]; then
     echo -e "${RED}FAIL: cowsay pruned by second global install (coexistence broken)${NC}"
     exit 1
 fi
-echo -e "${GREEN}PASS: global installs coexist (additive reify)${NC}"
+echo -e "${GREEN}PASS: global installs coexist with isolated dependency trees${NC}"
+rm -rf "$global_prefix"
 
 
 # Case 8: git dependency install


### PR DESCRIPTION
## Summary

Use each globally installed tool directory as the actual dependency-resolution root. `utoo install -g` and `ut x` continue to share `InstallService::install_global_package`; only their prefix differs.

## Root cause

Global installation previously resolved tools beneath a shared synthetic root. That allowed transitive dependencies to be hoisted into the shared global `lib/node_modules`, so installing or upgrading one tool could overlap with another tool's dependency tree.

## Directory layout

Before, tool dependencies could become siblings of global tools:

```text
<prefix>/lib/node_modules/
├── serve/
├── arg/
└── clipboardy/
```

After this change, each tool owns its dependency root:

```text
<prefix>/
├── bin/serve -> ../lib/node_modules/serve/build/main.js
└── lib/node_modules/serve/
    ├── package.json
    └── node_modules/
        ├── arg/
        └── clipboardy/
```

`ut x` uses the same layout beneath its versioned prefix:

```text
~/.utoo/utx/<name>/<version>/
├── bin/<command>
└── lib/node_modules/<name>/node_modules/<dependency>
```

## Behavior

- Resolve production dependencies from `<prefix>/lib/node_modules/<name>`.
- Keep transitive dependencies below the tool's own `node_modules`.
- Exclude root `devDependencies`.
- Run dependency lifecycle hooks only: `preinstall`, `install`, and `postinstall`.
- Preserve sibling global tools when reinstalling one package.
- Do not migrate or rebuild legacy global/utx layouts; reinstalling or upgrading a package adopts the new layout.

## User impact

Global tools no longer share or overwrite hoisted transitive dependencies. Persistent global installs and temporary `ut x` installs now use one implementation with the same npm-style prefix semantics.

## Validation

- `cargo fmt --check`
- `cargo test -p utoo-pm -p utoo-ruborist`
  - PM: 333 passed, 3 ignored
  - Ruborist: 210 passed
  - Ruborist doctests: 10 passed, 12 ignored
- `cargo clippy -p utoo-pm -p utoo-ruborist --all-targets -- -D warnings --no-deps`
- Real `serve@14.2.6` global install:
  - executable linked from `<prefix>/bin/serve`
  - `arg` installed at `serve/node_modules/arg`
  - no shared `<prefix>/lib/node_modules/arg`
