### PR TITLE
fix(ci): harden cargo version lookup

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -77,9 +77,21 @@ jobs:
           fi
 
           CUR=$(grep -E '^version[[:space:]]*=' crates/ruborist/Cargo.toml | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')
-          LATEST=$(curl -fsSL "https://crates.io/api/v1/crates/utoo-ruborist" \
-            | jq -r '.crate.max_stable_version // .crate.max_version // empty' 2>/dev/null || true)
-          [ "$LATEST" = "null" ] && LATEST=""
+          # crates.io rejects anonymous API clients without a descriptive
+          # User-Agent. Keep this lookup fail-closed: treating an HTTP error as
+          # "never published" makes the next step try to republish CUR.
+          CRATE_META=$(curl \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --retry 4 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --user-agent "utoo-cargo-publish/1.0 (https://github.com/utooland/utoo)" \
+            "https://crates.io/api/v1/crates/utoo-ruborist")
+          LATEST=$(jq -er '.crate.max_stable_version // .crate.max_version' <<< "$CRATE_META")
 
           echo "current_in_repo=$CUR"
           echo "latest_on_crates_io=${LATEST:-<none>}"


### PR DESCRIPTION
## What changed

- send a descriptive `User-Agent` when querying the crates.io API
- retry transient crates.io request failures with bounded timeouts
- fail the version-resolution step when the HTTP request or JSON parsing fails

## Why

The `utoo-v1.1.5` Cargo release queried crates.io without a `User-Agent` and received HTTP 403. The workflow swallowed that error with `|| true`, interpreted the empty response as “never published,” and attempted to publish `utoo-ruborist@0.1.0` again. Cargo rejected the duplicate crate, so `utoo-pm@1.1.5` was never published.

This keeps the lookup fail-closed and prevents API failures from turning into duplicate publish attempts.

## Validation

- reproduced HTTP 403 without a `User-Agent`
- verified HTTP 200 and resolved `utoo-ruborist@0.1.0` with the workflow `User-Agent`
- `git diff --check`