### PR TITLE
fix(pm): self-heal missing npm platform package

### DIFF
--- a/e2e/npm-launcher-package-managers.mjs
+++ b/e2e/npm-launcher-package-managers.mjs
@@ -3,8 +3,11 @@ import {
   access,
   chmod,
   copyFile,
+  lstat,
   mkdir,
   mkdtemp,
+  readdir,
+  readlink,
   readFile,
   rm,
   writeFile,
@@ -186,6 +189,14 @@ async function buildPackages() {
       join(mainDir, "bin", "launcher.js"),
     ),
     copyFile(
+      join(templates, "registry.utoo.js.template"),
+      join(mainDir, "bin", "registry.js"),
+    ),
+    copyFile(
+      join(templates, "self-heal.utoo.js.template"),
+      join(mainDir, "bin", "self-heal.js"),
+    ),
+    copyFile(
       join(templates, "utoo.utoo.js.template"),
       join(mainDir, "bin", "utoo.js"),
     ),
@@ -214,7 +225,11 @@ async function buildPackages() {
     },
   });
 
-  return pack(mainDir);
+  return {
+    mainTarball: await pack(mainDir),
+    platformDir,
+    selected,
+  };
 }
 
 async function installLocal(manager, mainTarball, project) {
@@ -281,8 +296,162 @@ async function localCommand(manager, project, name, args, options = {}) {
   return run(join(project, "node_modules", ".bin", `${name}${suffix}`), args, {
     cwd: project,
     capture: true,
+    env: options.env,
     status: options.status,
   });
+}
+
+async function binSnapshot(project) {
+  const binDir = join(project, "node_modules", ".bin");
+  const entries = (await readdir(binDir)).sort();
+  const snapshot = [];
+  for (const entry of entries) {
+    const entryPath = join(binDir, entry);
+    const stat = await lstat(entryPath);
+    if (stat.isSymbolicLink()) {
+      snapshot.push(
+        `${entry}:link:${(await readlink(entryPath)).replaceAll("\\", "/")}`,
+      );
+    } else {
+      const content = (await readFile(entryPath, "utf8"))
+        .split(project)
+        .join("<PROJECT>")
+        .replaceAll("\\", "/");
+      snapshot.push(`${entry}:file:${content}`);
+    }
+  }
+  return snapshot;
+}
+
+async function verifySelfHeal(
+  normalProject,
+  mainTarball,
+  platformDir,
+  selected,
+) {
+  const project = join(sandbox, "npm-self-heal");
+  await mkdir(project, { recursive: true });
+  await writeJson(join(project, "package.json"), {
+    name: "utoo-launcher-npm-self-heal-e2e",
+    private: true,
+  });
+  await run(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--omit=optional",
+      "--no-audit",
+      "--no-fund",
+      fileSpec(mainTarball),
+    ],
+    { cwd: project },
+  );
+
+  const packageSegments = selected.packageName.split("/");
+  await Promise.all([
+    rm(join(project, "node_modules", ...packageSegments), {
+      recursive: true,
+      force: true,
+    }),
+    rm(join(project, "node_modules", "utoo", "node_modules", ...packageSegments), {
+      recursive: true,
+      force: true,
+    }),
+  ]);
+
+  const expectedBins = await binSnapshot(normalProject);
+  const binsBefore = await binSnapshot(project);
+  if (JSON.stringify(binsBefore) !== JSON.stringify(expectedBins)) {
+    throw new Error(
+      `self-heal bin shims differ before repair\nnormal=${JSON.stringify(expectedBins)}\nheal=${JSON.stringify(binsBefore)}`,
+    );
+  }
+
+  const fakeDir = join(sandbox, "fake-npm-bin");
+  const fakeScript = join(fakeDir, "fake-npm.js");
+  const fakeLog = join(fakeDir, "args.json");
+  await mkdir(fakeDir, { recursive: true });
+  await writeFile(
+    fakeScript,
+    [
+      '"use strict";',
+      'const fs = require("fs");',
+      'const path = require("path");',
+      "const args = process.argv.slice(2);",
+      'const prefixArg = args.find((arg) => arg.startsWith("--prefix="));',
+      "if (!prefixArg) process.exit(31);",
+      'fs.writeFileSync(process.env.FAKE_NPM_LOG, JSON.stringify(args));',
+      'const target = path.join(prefixArg.slice(9), "node_modules", ...process.env.FAKE_PACKAGE_NAME.split("/"));',
+      "fs.mkdirSync(path.dirname(target), { recursive: true });",
+      "fs.cpSync(process.env.FAKE_PLATFORM_DIR, target, { recursive: true });",
+      "",
+    ].join("\n"),
+  );
+  if (process.platform === "win32") {
+    await writeFile(
+      join(fakeDir, "npm.cmd"),
+      `@echo off\r\n"${process.execPath}" "${fakeScript}" %*\r\n`,
+    );
+  } else {
+    await writeFile(
+      join(fakeDir, "npm"),
+      `#!${process.execPath}\nrequire(${JSON.stringify(fakeScript)});\n`,
+    );
+    await chmod(join(fakeDir, "npm"), 0o755);
+  }
+
+  const env = {
+    ...process.env,
+    FAKE_NPM_LOG: fakeLog,
+    FAKE_PACKAGE_NAME: selected.packageName,
+    FAKE_PLATFORM_DIR: platformDir,
+    PATH: `${fakeDir}${delimiter}${process.env.PATH || ""}`,
+    UTOO_REGISTRY: "https://registry.example.test/",
+  };
+  const output = await localCommand(
+    "npm",
+    project,
+    "utoo",
+    ["--version"],
+    { env },
+  );
+  assertIncludes(
+    output,
+    process.platform === "win32" ? process.version : "ARGV[1]=--version",
+    "npm self-heal native execution",
+  );
+  assertIncludes(output, "utoo: repaired", "npm self-heal success");
+
+  const npmArgs = JSON.parse(await readFile(fakeLog, "utf8"));
+  if (!npmArgs.includes("--registry=https://registry.example.test")) {
+    throw new Error(`self-heal registry was not normalized: ${npmArgs.join(" ")}`);
+  }
+  const nestedBinary = join(
+    project,
+    "node_modules",
+    "utoo",
+    "node_modules",
+    ...packageSegments,
+    "bin",
+    selected.executable,
+  );
+  if (!(await exists(nestedBinary))) {
+    throw new Error(`self-heal binary missing: ${nestedBinary}`);
+  }
+
+  const binsAfter = await binSnapshot(project);
+  if (JSON.stringify(binsAfter) !== JSON.stringify(expectedBins)) {
+    throw new Error(
+      `self-heal bin shims differ after repair\nnormal=${JSON.stringify(expectedBins)}\nheal=${JSON.stringify(binsAfter)}`,
+    );
+  }
+  const second = await localCommand("npm", project, "utoo", ["--version"], {
+    env: { ...env, PATH: process.env.PATH || "" },
+  });
+  if (second.includes("utoo: repairing")) {
+    throw new Error("second self-heal invocation called npm again");
+  }
 }
 
 function assertIncludes(actual, expected, context) {
@@ -426,7 +595,7 @@ async function verifyGlobal(manager, mainTarball) {
 }
 
 try {
-  const mainTarball = await buildPackages();
+  const { mainTarball, platformDir, selected } = await buildPackages();
   for (const manager of managers) {
     const project = join(sandbox, `${manager}-local`);
     await mkdir(project, { recursive: true });
@@ -436,6 +605,9 @@ try {
     await installLocal(manager, mainTarball, project);
     await verifyCommands(manager, project);
     await verifyManifest(manager, project);
+    if (manager === "npm") {
+      await verifySelfHeal(project, mainTarball, platformDir, selected);
+    }
     await verifyGlobal(manager, mainTarball);
     process.stdout.write(`PASS ${manager}\n`);
   }

--- a/e2e/npm-launcher.sh
+++ b/e2e/npm-launcher.sh
@@ -166,20 +166,22 @@ const fakeRoot = path.join(sandbox, "windows-platform");
 fs.mkdirSync(path.join(fakeRoot, "bin"), { recursive: true });
 fs.writeFileSync(path.join(fakeRoot, "package.json"), "{}");
 fs.writeFileSync(path.join(fakeRoot, "bin", "utoo.exe"), "PE fixture");
-const binary = launcher.findBinary(
-  windows,
-  "win32",
-  "arm64",
-  () => path.join(fakeRoot, "package.json"),
-);
-if (binary !== path.join(fakeRoot, "bin", "utoo.exe")) process.exit(13);
+(async () => {
+  const binary = await launcher.findBinary(
+    windows,
+    "win32",
+    "arm64",
+    () => path.join(fakeRoot, "package.json"),
+  );
+  if (binary !== path.join(fakeRoot, "bin", "utoo.exe")) process.exit(13);
 
-try {
-  launcher.resolveTarget("freebsd", "x64");
-  process.exit(14);
-} catch (error) {
-  if (!error.message.includes("unsupported platform: freebsd-x64")) process.exit(15);
-}
+  try {
+    launcher.resolveTarget("freebsd", "x64");
+    process.exit(14);
+  } catch (error) {
+    if (!error.message.includes("unsupported platform: freebsd-x64")) process.exit(15);
+  }
+})();
 NODE
 rc=$?
 [ "$rc" = "0" ] && ok "Windows ARM64 fallback and unsupported targets" \

--- a/e2e/npm-launcher.sh
+++ b/e2e/npm-launcher.sh
@@ -4,8 +4,8 @@
 # Stages the exact launcher templates below a fake `utoo` package and a nested
 # optional platform package. The native artifact is a small executable stub.
 # This verifies module-based artifact resolution, argument/stdio/exit-code
-# forwarding, `utx` delegation, actionable missing-artifact errors, and the
-# absence of install-time or first-run mutation.
+# forwarding, `utx` delegation, actionable repair errors, and npm-only
+# self-healing into the same package/bin-link layout as a normal install.
 
 set -u
 
@@ -50,6 +50,8 @@ mkdir -p "$PKG_DIR/bin" "$PLATFORM_DIR/bin"
 PKG_DIR_REAL=$(cd "$PKG_DIR" && pwd -P)
 
 cp "$TEMPLATES/launcher.utoo.js.template" "$PKG_DIR/bin/launcher.js"
+cp "$TEMPLATES/registry.utoo.js.template" "$PKG_DIR/bin/registry.js"
+cp "$TEMPLATES/self-heal.utoo.js.template" "$PKG_DIR/bin/self-heal.js"
 cp "$TEMPLATES/utoo.utoo.js.template" "$PKG_DIR/bin/utoo.js"
 cp "$TEMPLATES/utx.utoo.js.template" "$PKG_DIR/bin/utx.js"
 chmod +x "$PKG_DIR/bin/utoo.js" "$PKG_DIR/bin/utx.js"
@@ -183,6 +185,71 @@ rc=$?
 [ "$rc" = "0" ] && ok "Windows ARM64 fallback and unsupported targets" \
     || ko "target table" "node fixture exited $rc"
 
+printf '\n== registry selection ==\n'
+node - "$PKG_DIR/bin/registry.js" <<'NODE'
+const registry = require(process.argv[2]);
+if (registry.resolveRegistry([], {}) !== "https://registry.npmmirror.com") process.exit(41);
+if (
+  registry.resolveRegistry([], { UTOO_REGISTRY: "https://env.example/" }) !==
+  "https://env.example"
+) process.exit(42);
+if (
+  registry.resolveRegistry(
+    ["--registry", "https://cli.example/"],
+    { UTOO_REGISTRY: "https://env.example" },
+  ) !== "https://cli.example"
+) process.exit(43);
+if (
+  registry.resolveRegistry(["--registry=https://equals.example///"], {}) !==
+  "https://equals.example"
+) process.exit(44);
+if (
+  registry.resolveRegistry(
+    ["run", "script", "--", "--registry=https://script-argument.example"],
+    {},
+  ) !== "https://registry.npmmirror.com"
+) process.exit(47);
+for (const args of [["--registry"], ["--registry="]]) {
+  try {
+    registry.resolveRegistry(args, {});
+    process.exit(45);
+  } catch {}
+}
+try {
+  registry.resolveRegistry([], { UTOO_REGISTRY: "file:///tmp/registry" });
+  process.exit(46);
+} catch {}
+NODE
+rc=$?
+[ "$rc" = "0" ] && ok "registry precedence, normalization, and validation" \
+    || ko "registry selection" "node fixture exited $rc"
+
+printf '\n== Windows npm invocation ==\n'
+node - "$PKG_DIR/bin/self-heal.js" <<'NODE'
+const { npmInvocation } = require(process.argv[2]);
+const invocation = npmInvocation(
+  ["install", "--registry=https://registry.example.test"],
+  "win32",
+  { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+);
+if (invocation.command !== "C:\\Windows\\System32\\cmd.exe") process.exit(51);
+if (
+  JSON.stringify(invocation.args) !==
+  JSON.stringify([
+    "/d",
+    "/s",
+    "/c",
+    "call",
+    "npm.cmd",
+    "install",
+    "--registry=https://registry.example.test",
+  ])
+) process.exit(52);
+NODE
+rc=$?
+[ "$rc" = "0" ] && ok "Windows npm.cmd is invoked through ComSpec" \
+    || ko "Windows npm invocation" "node fixture exited $rc"
+
 printf '\n== spawn failure ==\n'
 out=$(node - "$PKG_DIR/bin/launcher.js" "$PLATFORM_DIR/package.json" <<'NODE' 2>&1
 const { EventEmitter } = require("events");
@@ -219,12 +286,22 @@ assert_contains "spawn error retains cause" "EACCES fixture" "$out"
 
 printf '\n== missing optional package ==\n'
 mv "$PLATFORM_DIR" "$SANDBOX/platform-away"
-out=$(node "$PKG_DIR/bin/utoo.js" --version 2>&1)
+FAILING_NPM="$SANDBOX/failing-npm"
+mkdir -p "$FAILING_NPM"
+cat > "$FAILING_NPM/npm" <<'FAKE_NPM'
+#!/bin/sh
+printf 'fake npm failure: %s\n' "$*" >&2
+exit 42
+FAKE_NPM
+chmod +x "$FAILING_NPM/npm"
+out=$(PATH="$FAILING_NPM:$PATH" node "$PKG_DIR/bin/utoo.js" \
+    --registry=https://registry.example.test --version 2>&1)
 rc=$?
 [ "$rc" != "0" ] && ok "missing package fails non-zero" \
     || ko "missing package fails non-zero" "rc=$rc"
 assert_contains "error names expected package" "@utoo/$PLATFORM_NAME@9.9.9-e2e" "$out"
 assert_contains "error recommends reinstall" "without omitting optional dependencies" "$out"
+assert_contains "CLI registry reaches npm" "--registry=https://registry.example.test" "$out"
 [ ! -e "$PLATFORM_DIR" ] && ok "missing package is not downloaded or recreated" \
     || ko "missing package is not downloaded or recreated" "unexpected $PLATFORM_DIR"
 
@@ -233,7 +310,8 @@ NPM_CASE="$SANDBOX/npm-case"
 NPM_PLATFORM="$NPM_CASE/platform"
 NPM_MAIN="$NPM_CASE/main"
 NPM_PREFIX="$NPM_CASE/prefix"
-mkdir -p "$NPM_PLATFORM/bin" "$NPM_MAIN/bin" "$NPM_PREFIX"
+HEAL_PREFIX="$NPM_CASE/heal-prefix"
+mkdir -p "$NPM_PLATFORM/bin" "$NPM_MAIN/bin" "$NPM_PREFIX" "$HEAL_PREFIX"
 cp "$SANDBOX/platform-away/bin/utoo" "$NPM_PLATFORM/bin/utoo"
 chmod +x "$NPM_PLATFORM/bin/utoo"
 cat > "$NPM_PLATFORM/package.json" <<JSON
@@ -249,6 +327,8 @@ platform_tgz=$(cd "$NPM_PLATFORM" && npm pack --silent)
 platform_tgz="$NPM_PLATFORM/$platform_tgz"
 
 cp "$TEMPLATES/launcher.utoo.js.template" "$NPM_MAIN/bin/launcher.js"
+cp "$TEMPLATES/registry.utoo.js.template" "$NPM_MAIN/bin/registry.js"
+cp "$TEMPLATES/self-heal.utoo.js.template" "$NPM_MAIN/bin/self-heal.js"
 cp "$TEMPLATES/utoo.utoo.js.template" "$NPM_MAIN/bin/utoo.js"
 cp "$TEMPLATES/utx.utoo.js.template" "$NPM_MAIN/bin/utx.js"
 chmod +x "$NPM_MAIN/bin/utoo.js" "$NPM_MAIN/bin/utx.js"
@@ -285,6 +365,79 @@ if node -e 'const p=require(process.argv[1]); process.exit(p.scripts ? 1 : 0)' \
 else
     ko "published main package has no lifecycle scripts" "unexpected scripts field"
 fi
+
+printf '\n== npm self-heal matches successful install layout ==\n'
+npm install --global "$main_tgz" --prefix "$HEAL_PREFIX" --ignore-scripts \
+    --omit=optional --no-audit --no-fund >/dev/null 2>&1
+rc=$?
+[ "$rc" = "0" ] && ok "npm installs main package without optional artifact" \
+    || ko "npm omit optional setup" "rc=$rc"
+# Some npm versions retain a file: optional dependency despite --omit. Model
+# the user-visible failure directly by removing every resolvable platform copy.
+rm -rf "$HEAL_PREFIX/lib/node_modules/@utoo" \
+    "$HEAL_PREFIX/lib/node_modules/utoo/node_modules/@utoo"
+
+FAKE_NPM="$NPM_CASE/fake-npm"
+mkdir -p "$FAKE_NPM"
+cat > "$FAKE_NPM/npm" <<'FAKE_NPM'
+#!/usr/bin/env node
+"use strict";
+const fs = require("fs");
+const path = require("path");
+const args = process.argv.slice(2);
+const prefixArg = args.find((arg) => arg.startsWith("--prefix="));
+const registryArg = args.find((arg) => arg.startsWith("--registry="));
+if (!prefixArg || !registryArg) process.exit(31);
+fs.writeFileSync(process.env.FAKE_NPM_LOG, `${args.join("\n")}\n`);
+const prefix = prefixArg.slice("--prefix=".length);
+const target = path.join(prefix, "node_modules", "@utoo", process.env.FAKE_PLATFORM_NAME);
+fs.mkdirSync(path.dirname(target), { recursive: true });
+fs.cpSync(process.env.FAKE_PLATFORM_DIR, target, { recursive: true });
+FAKE_NPM
+chmod +x "$FAKE_NPM/npm"
+
+normal_links=$(find "$NPM_PREFIX/bin" -mindepth 1 -maxdepth 1 \
+    -exec sh -c 'printf "%s -> %s\n" "$(basename "$1")" "$(readlink "$1")"' _ {} \; \
+    | sed "s|$NPM_PREFIX|PREFIX|g" | sort)
+heal_links_before=$(find "$HEAL_PREFIX/bin" -mindepth 1 -maxdepth 1 \
+    -exec sh -c 'printf "%s -> %s\n" "$(basename "$1")" "$(readlink "$1")"' _ {} \; \
+    | sed "s|$HEAL_PREFIX|PREFIX|g" | sort)
+[ "$normal_links" = "$heal_links_before" ] \
+    && ok "bin links match before self-heal" \
+    || ko "bin links before self-heal" "normal:\n$normal_links\nheal:\n$heal_links_before"
+
+heal_out=$(PATH="$FAKE_NPM:$PATH" \
+    FAKE_PLATFORM_NAME="$PLATFORM_NAME" \
+    FAKE_PLATFORM_DIR="$NPM_PLATFORM" \
+    FAKE_NPM_LOG="$NPM_CASE/fake-npm.args" \
+    UTOO_REGISTRY="https://registry.example.test/" \
+    "$HEAL_PREFIX/bin/utoo" healed 2>&1)
+rc=$?
+[ "$rc" = "0" ] && ok "first invocation repairs and runs native artifact" \
+    || ko "self-heal invocation" "rc=$rc\n$heal_out"
+assert_contains "self-heal preserves arguments" "ARGV[1]=healed" "$heal_out"
+assert_contains "environment registry is normalized" \
+    "--registry=https://registry.example.test" \
+    "$(cat "$NPM_CASE/fake-npm.args")"
+
+HEALED_PACKAGE="$HEAL_PREFIX/lib/node_modules/utoo/node_modules/@utoo/$PLATFORM_NAME"
+[ -f "$HEALED_PACKAGE/package.json" ] && ok "platform manifest installed under utoo" \
+    || ko "nested platform manifest" "missing $HEALED_PACKAGE/package.json"
+[ -x "$HEALED_PACKAGE/bin/utoo" ] && ok "platform binary installed under utoo" \
+    || ko "nested platform binary" "missing $HEALED_PACKAGE/bin/utoo"
+
+heal_links_after=$(find "$HEAL_PREFIX/bin" -mindepth 1 -maxdepth 1 \
+    -exec sh -c 'printf "%s -> %s\n" "$(basename "$1")" "$(readlink "$1")"' _ {} \; \
+    | sed "s|$HEAL_PREFIX|PREFIX|g" | sort)
+[ "$normal_links" = "$heal_links_after" ] \
+    && ok "bin links exactly match successful install after self-heal" \
+    || ko "bin links after self-heal" "normal:\n$normal_links\nheal:\n$heal_links_after"
+
+second_out=$(PATH="$FAILING_NPM:$PATH" "$HEAL_PREFIX/bin/utoo" idempotent 2>&1)
+rc=$?
+[ "$rc" = "0" ] && ok "second invocation does not call npm" \
+    || ko "idempotent invocation" "rc=$rc\n$second_out"
+assert_contains "second invocation runs repaired binary" "ARGV[1]=idempotent" "$second_out"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/e2e/utoo-pm.ps1
+++ b/e2e/utoo-pm.ps1
@@ -316,6 +316,8 @@ try {
     # Build the main package from the real immutable launcher templates.
     $tplDir = Join-Path (Split-Path $PSScriptRoot -Parent) "vendor/templates"
     Copy-Item "$tplDir\launcher.utoo.js.template" "$packDir\pkg\bin\launcher.js"
+    Copy-Item "$tplDir\registry.utoo.js.template" "$packDir\pkg\bin\registry.js"
+    Copy-Item "$tplDir\self-heal.utoo.js.template" "$packDir\pkg\bin\self-heal.js"
     Copy-Item "$tplDir\utoo.utoo.js.template" "$packDir\pkg\bin\utoo.js"
     Copy-Item "$tplDir\utx.utoo.js.template" "$packDir\pkg\bin\utx.js"
     @{
@@ -426,6 +428,8 @@ try {
     (Get-Content "$tplDir\utoo.package.json.template" -Raw).Replace("{{version}}", "9.9.9-e2e") |
         Set-Content "$pkgDir\package.json"
     Copy-Item "$tplDir\launcher.utoo.js.template" "$pkgDir\bin\launcher.js"
+    Copy-Item "$tplDir\registry.utoo.js.template" "$pkgDir\bin\registry.js"
+    Copy-Item "$tplDir\self-heal.utoo.js.template" "$pkgDir\bin\self-heal.js"
     Copy-Item "$tplDir\utoo.utoo.js.template" "$pkgDir\bin\utoo.js"
     Copy-Item "$tplDir\utx.utoo.js.template" "$pkgDir\bin\utx.js"
 

--- a/e2e/utoo-pm.sh
+++ b/e2e/utoo-pm.sh
@@ -947,6 +947,8 @@ popd
 # dependency installation and bin-shim generation.
 mkdir -p pkg/bin
 cp "$REPO_ROOT/vendor/templates/launcher.utoo.js.template" pkg/bin/launcher.js
+cp "$REPO_ROOT/vendor/templates/registry.utoo.js.template" pkg/bin/registry.js
+cp "$REPO_ROOT/vendor/templates/self-heal.utoo.js.template" pkg/bin/self-heal.js
 cp "$REPO_ROOT/vendor/templates/utoo.utoo.js.template" pkg/bin/utoo.js
 cp "$REPO_ROOT/vendor/templates/utx.utoo.js.template" pkg/bin/utx.js
 chmod +x pkg/bin/utoo.js pkg/bin/utx.js

--- a/vendor/scripts/npm-utoo.sh
+++ b/vendor/scripts/npm-utoo.sh
@@ -59,11 +59,12 @@ cat "$ENTRY_DIR/package.json" | \
 # copy README.md from repository root
 cp ../../README.md "$ENTRY_DIR/README.md"
 
-# Immutable runtime launchers. Package managers install the matching optional
-# platform artifact; these files only locate and spawn it. No lifecycle hook or
-# mutation of package-manager-owned directories is required.
+# Immutable runtime launchers. A missing optional platform artifact is repaired
+# into utoo's own nested node_modules directory on first invocation.
 mkdir -p "$ENTRY_DIR/bin"
 cp ../templates/launcher.utoo.js.template "$ENTRY_DIR/bin/launcher.js"
+cp ../templates/registry.utoo.js.template "$ENTRY_DIR/bin/registry.js"
+cp ../templates/self-heal.utoo.js.template "$ENTRY_DIR/bin/self-heal.js"
 cp ../templates/utoo.utoo.js.template "$ENTRY_DIR/bin/utoo.js"
 cp ../templates/utx.utoo.js.template "$ENTRY_DIR/bin/utx.js"
 chmod +x "$ENTRY_DIR/bin/utoo.js" "$ENTRY_DIR/bin/utx.js"

--- a/vendor/templates/launcher.utoo.js.template
+++ b/vendor/templates/launcher.utoo.js.template
@@ -1,6 +1,6 @@
 "use strict";
 
-const fs = require("fs");
+const fs = require("fs/promises");
 const path = require("path");
 const { spawn } = require("child_process");
 const { resolveRegistry } = require("./registry.js");
@@ -59,25 +59,25 @@ function resolveTarget(platform = process.platform, arch = process.arch) {
   return target;
 }
 
-function packageVersion(packageRoot = path.join(__dirname, "..")) {
+async function packageVersion(packageRoot = path.join(__dirname, "..")) {
   try {
     return JSON.parse(
-      fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+      await fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
     ).version;
   } catch {
     return "unknown";
   }
 }
 
-function missingArtifactMessage(target, platform, arch) {
+function missingArtifactMessage(target, platform, arch, version) {
   return [
     `native binary for ${platform}-${arch} is missing`,
-    `expected optional package: ${target.packageName}@${packageVersion()}`,
+    `expected optional package: ${target.packageName}@${version}`,
     "reinstall utoo without omitting optional dependencies",
   ].join("\n");
 }
 
-function findBinary(
+async function findBinary(
   target,
   platform = process.platform,
   arch = process.arch,
@@ -91,19 +91,21 @@ function findBinary(
   }
 
   const binary = path.join(path.dirname(packageJson), target.executable);
-  if (!fs.existsSync(binary)) {
+  try {
+    await fs.access(binary);
+  } catch {
     return null;
   }
   return binary;
 }
 
-function spawnNative(binary, args, spawnImpl = spawn) {
+async function spawnNative(binary, args, spawnImpl = spawn) {
   const env = {
     ...process.env,
     // The native executable lives inside an optional dependency. Preserve the
     // main package root so utoo can infer npm-style global prefixes from the
     // public package rather than from the nested platform artifact.
-    UTOO_MANAGED_PACKAGE_ROOT: fs.realpathSync(path.join(__dirname, "..")),
+    UTOO_MANAGED_PACKAGE_ROOT: await fs.realpath(path.join(__dirname, "..")),
   };
   const child = spawnImpl(binary, args, { stdio: "inherit", env });
   const signalHandlers = new Map();
@@ -144,25 +146,26 @@ async function run(args, options = {}) {
   const platform = options.platform || process.platform;
   const arch = options.arch || process.arch;
   const target = resolveTarget(platform, arch);
-  let binary = findBinary(
+  const packageRoot = options.packageRoot || path.join(__dirname, "..");
+  const version = await packageVersion(packageRoot);
+  let binary = await findBinary(
     target,
     platform,
     arch,
     options.resolvePackage || require.resolve,
   );
   if (!binary) {
-    const packageRoot = options.packageRoot || path.join(__dirname, "..");
     try {
       binary = await (options.selfHealImpl || selfHeal)({
         ...target,
         packageRoot,
         platform,
         registry: resolveRegistry(args, options.env || process.env),
-        version: packageVersion(packageRoot),
+        version,
       });
     } catch (error) {
       throw new LauncherError(
-        missingArtifactMessage(target, platform, arch),
+        missingArtifactMessage(target, platform, arch, version),
         error,
       );
     }
@@ -173,7 +176,7 @@ async function run(args, options = {}) {
     throw new LauncherError(
       [
         `failed to start native binary: ${binary}`,
-        `platform package: ${target.packageName}@${packageVersion()}`,
+        `platform package: ${target.packageName}@${version}`,
         "reinstall utoo without omitting optional dependencies",
       ].join("\n"),
       error.cause || error,

--- a/vendor/templates/launcher.utoo.js.template
+++ b/vendor/templates/launcher.utoo.js.template
@@ -3,6 +3,8 @@
 const fs = require("fs");
 const path = require("path");
 const { spawn } = require("child_process");
+const { resolveRegistry } = require("./registry.js");
+const { selfHeal } = require("./self-heal.js");
 
 const TARGETS = Object.freeze({
   "darwin-x64": {
@@ -57,9 +59,11 @@ function resolveTarget(platform = process.platform, arch = process.arch) {
   return target;
 }
 
-function packageVersion() {
+function packageVersion(packageRoot = path.join(__dirname, "..")) {
   try {
-    return require("../package.json").version;
+    return JSON.parse(
+      fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+    ).version;
   } catch {
     return "unknown";
   }
@@ -82,18 +86,13 @@ function findBinary(
   let packageJson;
   try {
     packageJson = resolvePackage(`${target.packageName}/package.json`);
-  } catch (error) {
-    throw new LauncherError(
-      missingArtifactMessage(target, platform, arch),
-      error,
-    );
+  } catch {
+    return null;
   }
 
   const binary = path.join(path.dirname(packageJson), target.executable);
   if (!fs.existsSync(binary)) {
-    throw new LauncherError(
-      `${missingArtifactMessage(target, platform, arch)}\nexpected file: ${binary}`,
-    );
+    return null;
   }
   return binary;
 }
@@ -145,12 +144,29 @@ async function run(args, options = {}) {
   const platform = options.platform || process.platform;
   const arch = options.arch || process.arch;
   const target = resolveTarget(platform, arch);
-  const binary = findBinary(
+  let binary = findBinary(
     target,
     platform,
     arch,
     options.resolvePackage || require.resolve,
   );
+  if (!binary) {
+    const packageRoot = options.packageRoot || path.join(__dirname, "..");
+    try {
+      binary = await (options.selfHealImpl || selfHeal)({
+        ...target,
+        packageRoot,
+        platform,
+        registry: resolveRegistry(args, options.env || process.env),
+        version: packageVersion(packageRoot),
+      });
+    } catch (error) {
+      throw new LauncherError(
+        missingArtifactMessage(target, platform, arch),
+        error,
+      );
+    }
+  }
   try {
     return await spawnNative(binary, args, options.spawnImpl || spawn);
   } catch (error) {

--- a/vendor/templates/registry.utoo.js.template
+++ b/vendor/templates/registry.utoo.js.template
@@ -1,0 +1,48 @@
+"use strict";
+
+const DEFAULT_REGISTRY = "https://registry.npmmirror.com";
+
+function registryFromArgs(args) {
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === "--") return;
+    if (arg === "--registry") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        throw new Error("--registry requires a URL");
+      }
+      return value;
+    }
+    if (arg.startsWith("--registry=")) {
+      const value = arg.slice("--registry=".length);
+      if (!value) throw new Error("--registry requires a URL");
+      return value;
+    }
+  }
+}
+
+function normalizeRegistry(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`invalid registry URL: ${value}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`registry must use http or https: ${value}`);
+  }
+  return value.replace(/\/+$/, "");
+}
+
+function resolveRegistry(args, env = process.env) {
+  return normalizeRegistry(
+    registryFromArgs(args) || env.UTOO_REGISTRY || DEFAULT_REGISTRY,
+  );
+}
+
+module.exports = {
+  DEFAULT_REGISTRY,
+  normalizeRegistry,
+  registryFromArgs,
+  resolveRegistry,
+};

--- a/vendor/templates/self-heal.utoo.js.template
+++ b/vendor/templates/self-heal.utoo.js.template
@@ -1,0 +1,159 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+
+function npmInvocation(args, platform = process.platform, env = process.env) {
+  if (platform !== "win32") return { command: "npm", args };
+  return {
+    command: env.ComSpec || "cmd.exe",
+    args: ["/d", "/s", "/c", "call", "npm.cmd", ...args],
+  };
+}
+
+function runNpm(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = (options.spawnImpl || spawn)(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (status) => {
+      if (status === 0) {
+        resolve();
+        return;
+      }
+      const detail = (stderr || stdout).trim();
+      reject(
+        new Error(
+          `npm exited with status ${status}${detail ? `\n${detail}` : ""}`,
+        ),
+      );
+    });
+  });
+}
+
+function replaceDirectory(staged, target) {
+  const backup = `${target}.utoo-backup-${process.pid}-${Date.now()}`;
+  let backedUp = false;
+  try {
+    if (fs.existsSync(target)) {
+      fs.renameSync(target, backup);
+      backedUp = true;
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.renameSync(staged, target);
+    if (backedUp) {
+      try {
+        fs.rmSync(backup, { recursive: true, force: true });
+      } catch {
+        // The replacement is already live. A scanner-held backup is harmless
+        // and must not turn a successful repair into a launcher failure.
+      }
+    }
+  } catch (error) {
+    if (!fs.existsSync(target) && backedUp && fs.existsSync(backup)) {
+      try {
+        fs.renameSync(backup, target);
+      } catch {
+        // Preserve the original error and the backup for manual recovery.
+      }
+    }
+    error.message += `\nbackup: ${backup}`;
+    throw error;
+  }
+}
+
+async function selfHeal(options) {
+  const {
+    executable,
+    packageName,
+    packageRoot,
+    registry,
+    version,
+  } = options;
+  const packageSegments = packageName.split("/");
+  const target = path.join(packageRoot, "node_modules", ...packageSegments);
+  const targetBinary = path.join(target, executable);
+  if (fs.existsSync(targetBinary)) return targetBinary;
+
+  const staging = fs.mkdtempSync(path.join(packageRoot, ".utoo-heal-"));
+  fs.writeFileSync(
+    path.join(staging, "package.json"),
+    '{"private":true}\n',
+  );
+  const args = [
+    "install",
+    "--loglevel=error",
+    "--no-audit",
+    "--no-fund",
+    "--progress=false",
+    "--prefer-offline",
+    "--ignore-scripts",
+    "--no-save",
+    "--package-lock=false",
+    `--prefix=${staging}`,
+    `--registry=${registry}`,
+    `${packageName}@${version}`,
+  ];
+  const env = { ...process.env, ...options.env };
+  delete env.npm_config_global;
+  delete env.NPM_CONFIG_GLOBAL;
+  const invocation = npmInvocation(args, options.platform, env);
+
+  console.error(`utoo: repairing ${packageName}@${version} with npm...`);
+  try {
+    await runNpm(invocation.command, invocation.args, {
+      cwd: staging,
+      env,
+      spawnImpl: options.spawnImpl,
+    });
+    const staged = path.join(staging, "node_modules", ...packageSegments);
+    const stagedBinary = path.join(staged, executable);
+    if (!fs.existsSync(stagedBinary)) {
+      throw new Error(`npm installed ${packageName}, but ${executable} is missing`);
+    }
+
+    // Another lock-free repair may finish while npm is running. A complete
+    // target wins; otherwise replace a stale/partial package transactionally.
+    if (!fs.existsSync(targetBinary)) replaceDirectory(staged, target);
+    if (!fs.existsSync(targetBinary)) {
+      throw new Error(`failed to publish repaired binary at ${targetBinary}`);
+    }
+    console.error(`utoo: repaired ${packageName}@${version}`);
+    return targetBinary;
+  } catch (error) {
+    const detail = error && error.message ? error.message : String(error);
+    throw new Error(
+      `failed to repair ${packageName}@${version}\n` +
+        `registry: ${registry}\n` +
+        `target: ${target}\n` +
+        `staging: ${staging}\n${detail}`,
+    );
+  } finally {
+    try {
+      fs.rmSync(staging, { recursive: true, force: true });
+    } catch {
+      // Best effort: Windows scanners can briefly retain files after npm exits.
+    }
+  }
+}
+
+module.exports = {
+  npmInvocation,
+  replaceDirectory,
+  runNpm,
+  selfHeal,
+};

--- a/vendor/templates/self-heal.utoo.js.template
+++ b/vendor/templates/self-heal.utoo.js.template
@@ -1,6 +1,6 @@
 "use strict";
 
-const fs = require("fs");
+const fs = require("fs/promises");
 const path = require("path");
 const { spawn } = require("child_process");
 
@@ -45,28 +45,37 @@ function runNpm(command, args, options = {}) {
   });
 }
 
-function replaceDirectory(staged, target) {
+async function exists(target) {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function replaceDirectory(staged, target) {
   const backup = `${target}.utoo-backup-${process.pid}-${Date.now()}`;
   let backedUp = false;
   try {
-    if (fs.existsSync(target)) {
-      fs.renameSync(target, backup);
+    if (await exists(target)) {
+      await fs.rename(target, backup);
       backedUp = true;
     }
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.renameSync(staged, target);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.rename(staged, target);
     if (backedUp) {
       try {
-        fs.rmSync(backup, { recursive: true, force: true });
+        await fs.rm(backup, { recursive: true, force: true });
       } catch {
         // The replacement is already live. A scanner-held backup is harmless
         // and must not turn a successful repair into a launcher failure.
       }
     }
   } catch (error) {
-    if (!fs.existsSync(target) && backedUp && fs.existsSync(backup)) {
+    if (!(await exists(target)) && backedUp && (await exists(backup))) {
       try {
-        fs.renameSync(backup, target);
+        await fs.rename(backup, target);
       } catch {
         // Preserve the original error and the backup for manual recovery.
       }
@@ -87,10 +96,10 @@ async function selfHeal(options) {
   const packageSegments = packageName.split("/");
   const target = path.join(packageRoot, "node_modules", ...packageSegments);
   const targetBinary = path.join(target, executable);
-  if (fs.existsSync(targetBinary)) return targetBinary;
+  if (await exists(targetBinary)) return targetBinary;
 
-  const staging = fs.mkdtempSync(path.join(packageRoot, ".utoo-heal-"));
-  fs.writeFileSync(
+  const staging = await fs.mkdtemp(path.join(packageRoot, ".utoo-heal-"));
+  await fs.writeFile(
     path.join(staging, "package.json"),
     '{"private":true}\n',
   );
@@ -122,14 +131,14 @@ async function selfHeal(options) {
     });
     const staged = path.join(staging, "node_modules", ...packageSegments);
     const stagedBinary = path.join(staged, executable);
-    if (!fs.existsSync(stagedBinary)) {
+    if (!(await exists(stagedBinary))) {
       throw new Error(`npm installed ${packageName}, but ${executable} is missing`);
     }
 
     // Another lock-free repair may finish while npm is running. A complete
     // target wins; otherwise replace a stale/partial package transactionally.
-    if (!fs.existsSync(targetBinary)) replaceDirectory(staged, target);
-    if (!fs.existsSync(targetBinary)) {
+    if (!(await exists(targetBinary))) await replaceDirectory(staged, target);
+    if (!(await exists(targetBinary))) {
       throw new Error(`failed to publish repaired binary at ${targetBinary}`);
     }
     console.error(`utoo: repaired ${packageName}@${version}`);
@@ -144,7 +153,7 @@ async function selfHeal(options) {
     );
   } finally {
     try {
-      fs.rmSync(staging, { recursive: true, force: true });
+      await fs.rm(staging, { recursive: true, force: true });
     } catch {
       // Best effort: Windows scanners can briefly retain files after npm exits.
     }


### PR DESCRIPTION
## Summary

- repair a missing platform-specific optional package on the first `utoo` invocation
- install the exact platform package version with npm into `utoo/node_modules`
- resolve the registry from `--registry`, `UTOO_REGISTRY`, or npmmirror
- preserve the existing immutable launcher and package-manager-owned stores
- support `npm.cmd` through `ComSpec` on Windows

## Root cause

The immutable launcher in `utoo@1.1.6` only reported an error when the matching `@utoo/utoo-<platform>-<arch>` optional dependency was absent. Installs using `--omit=optional`, incomplete installs, or missing platform artifacts therefore left the CLI unable to start.

## Behavior

The launcher now invokes npm with the exact public package version and explicitly selected registry, disables lifecycle scripts, and stages the package before publishing it under the main `utoo` package. Existing complete platform packages remain untouched, partial targets are replaced with rollback support, and cleanup is best-effort for Windows file scanners.

## Validation

- `sh e2e/npm-launcher.sh` — 37 assertions passed
- `node e2e/npm-launcher-package-managers.mjs npm`
- normal-install and self-healed `.bin` shim snapshots match
- the package-manager matrix now triggers self-heal on Ubuntu, macOS, and Windows
- `npx biome check`
- Node syntax checks
- `git diff --check`
- npm package publish dry-run
