### PR TITLE
feat(pm): add force mode to update

### DIFF
--- a/crates/pm/src/cli.rs
+++ b/crates/pm/src/cli.rs
@@ -6,6 +6,7 @@
 use clap::{Parser, Subcommand};
 
 use crate::cmd::install::InstallArgs;
+use crate::cmd::update::UpdateArgs;
 use crate::constants::cmd::{
     CLEAN_ABOUT, CLEAN_ALIAS, CLEAN_NAME, COMPLETIONS_ABOUT, COMPLETIONS_ALIAS,
     COMPLETIONS_LONG_ABOUT, COMPLETIONS_NAME, CONFIG_ABOUT, CONFIG_ALIAS, CONFIG_NAME, DEPS_ABOUT,
@@ -148,7 +149,7 @@ pub enum Commands {
     },
 
     #[command(name = UPDATE_NAME, alias = UPDATE_ALIAS, about = UPDATE_ABOUT)]
-    Update,
+    Update(UpdateArgs),
 
     #[command(name = LIST_NAME, alias = LIST_ALIAS, about = LIST_ABOUT)]
     List {
@@ -364,6 +365,24 @@ mod tests {
             result.is_ok(),
             "Should parse 'utoo install' as valid Install command"
         );
+    }
+
+    #[test]
+    fn test_update_force_flags() {
+        for flag in ["--force", "-f"] {
+            let cli = Cli::try_parse_from(["utoo", "update", flag])
+                .unwrap_or_else(|e| panic!("`utoo update {flag}` should parse, got: {e}"));
+            match cli.command {
+                Some(Commands::Update(args)) => assert!(args.force),
+                _ => panic!("expected Update subcommand"),
+            }
+        }
+
+        let cli = Cli::try_parse_from(["utoo", "update"]).unwrap();
+        match cli.command {
+            Some(Commands::Update(args)) => assert!(!args.force),
+            _ => panic!("expected Update subcommand"),
+        }
     }
 
     /// `utx --version` (= `utoo x --version`) must parse — the leading

--- a/crates/pm/src/cmd/install.rs
+++ b/crates/pm/src/cmd/install.rs
@@ -7,7 +7,7 @@ use clap::Args;
 use crate::helper::migrate::{FromPm, migrate_from_pnpm};
 use crate::helper::workspace::init_project_root;
 use crate::service::install::InstallService;
-use crate::util::cli_enum::{OmitType, PackageAction, SaveType, ScriptPolicy};
+use crate::util::cli_enum::{OmitType, PackageAction, ReifyMode, SaveType, ScriptPolicy};
 use crate::util::format_print::pluralized_package_count;
 use crate::util::logger::log_time_end;
 use crate::util::user_config::{
@@ -169,8 +169,16 @@ pub async fn update_packages(
 }
 
 pub async fn install(scripts: ScriptPolicy, root_path: &Path) -> Result<()> {
+    install_with_mode(scripts, root_path, ReifyMode::Incremental).await
+}
+
+pub async fn install_with_mode(
+    scripts: ScriptPolicy,
+    root_path: &Path,
+    mode: ReifyMode,
+) -> Result<()> {
     let omit = get_omit();
-    InstallService::install(scripts, root_path, &omit).await
+    InstallService::install_with_mode(scripts, root_path, &omit, mode).await
 }
 
 pub async fn install_global_package(npm_spec: &str, prefix: Option<&str>) -> Result<()> {

--- a/crates/pm/src/cmd/update.rs
+++ b/crates/pm/src/cmd/update.rs
@@ -1,9 +1,17 @@
 use crate::service::update::clean_package_lock;
-use crate::util::cli_enum::ScriptPolicy;
-use crate::{cmd::install::install, helper::workspace::init_project_root};
+use crate::util::cli_enum::{ReifyMode, ScriptPolicy};
+use crate::{cmd::install::install_with_mode, helper::workspace::init_project_root};
 use anyhow::{Context, Result};
+use clap::Args;
 
-pub async fn update(scripts: ScriptPolicy) -> Result<()> {
+#[derive(Args)]
+pub struct UpdateArgs {
+    /// Force reinstallation of all resolved packages
+    #[arg(short, long)]
+    pub force: bool,
+}
+
+pub async fn update(args: UpdateArgs, scripts: ScriptPolicy) -> Result<()> {
     let cwd = std::env::current_dir().context("Failed to get current directory")?;
     let root_path = init_project_root(&cwd).await?;
 
@@ -13,12 +21,13 @@ pub async fn update(scripts: ScriptPolicy) -> Result<()> {
         .await
         .context("Failed to clean package-lock.json")?;
 
-    // // Clean node_modules
-    // tracing::debug!("Cleaning node_modules...");
-    // clean_node_modules().await?;
-
     // Install dependencies
-    install(scripts, &root_path).await?;
+    let mode = if args.force {
+        ReifyMode::Force
+    } else {
+        ReifyMode::Incremental
+    };
+    install_with_mode(scripts, &root_path, mode).await?;
 
     Ok(())
 }

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -172,8 +172,8 @@ async fn async_main() -> Result<()> {
         Some(Commands::Deps { workspace_only }) => {
             cmd::deps::run(workspace_only).await?;
         }
-        Some(Commands::Update) => {
-            update(ScriptPolicy::Run).await?;
+        Some(Commands::Update(args)) => {
+            update(args, ScriptPolicy::Run).await?;
             log_time_end("All packages updated");
         }
         Some(Commands::List { package }) => {

--- a/crates/pm/src/service/install.rs
+++ b/crates/pm/src/service/install.rs
@@ -17,7 +17,7 @@ use crate::helper::workspace::init_project_root;
 use crate::model::package::PackageInfo;
 use crate::service::package::PackageService;
 use crate::service::rebuild::RebuildService;
-use crate::util::cli_enum::{OmitType, PackageAction, SaveType};
+use crate::util::cli_enum::{OmitType, PackageAction, ReifyMode, SaveType};
 use crate::util::cloner::ClonePolicy;
 use crate::util::install_progress;
 use crate::util::json::load_package_lock_json_from_path;
@@ -98,12 +98,35 @@ async fn install_packages(
     cwd: &Path,
     omit: &HashSet<OmitType>,
     scheduler: &super::install_scheduler::InstallScheduler,
+    mode: ReifyMode,
 ) -> Result<()> {
     // Surface the clean step in the spinner — it doesn't move `pos`, so
     // without a message the bar looks frozen on large trees.
     log_progress("validating node_modules");
     clean_deps(groups, cwd).await?;
-    reify_packages(groups, cwd, omit, scheduler).await
+    reify_packages(groups, cwd, omit, scheduler, mode).await
+}
+
+async fn prepare_reify_target(target: &Path, mode: ReifyMode) -> Result<()> {
+    if mode != ReifyMode::Force {
+        return Ok(());
+    }
+
+    let Ok(metadata) = fs::symlink_metadata(target).await else {
+        return Ok(());
+    };
+    let result = if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(target).await
+    } else {
+        fs::remove_dir_all(target).await
+    };
+    result.with_context(|| format!("Failed to force-replace {}", target.display()))
+}
+
+fn is_node_modules_path(path: &str) -> bool {
+    Path::new(path)
+        .components()
+        .any(|component| component.as_os_str() == "node_modules")
 }
 
 /// Clone/link every package in `groups` into `<cwd>/node_modules`, level by
@@ -114,6 +137,7 @@ async fn reify_packages(
     cwd: &Path,
     omit: &HashSet<OmitType>,
     scheduler: &super::install_scheduler::InstallScheduler,
+    mode: ReifyMode,
 ) -> Result<()> {
     log_progress("linking packages");
 
@@ -138,6 +162,13 @@ async fn reify_packages(
                 // name/version/resolved/target_path it actually needs, so
                 // skipped/linked entries never pay for a LockPackage copy.
                 if let Some(ref resolved) = package.resolved {
+                    if mode == ReifyMode::Force && !is_node_modules_path(path) {
+                        anyhow::bail!(
+                            "Refusing to force-replace path outside node_modules: {path}"
+                        );
+                    }
+                    let target_path = cwd.join(path);
+                    prepare_reify_target(&target_path, mode).await?;
                     // Lockfile stores `file:` URLs root-relative (npm format).
                     // Cloner only understands absolute URLs — re-absolutize
                     // here so the cloner/downloader stays unaware of project
@@ -181,7 +212,6 @@ async fn reify_packages(
                         .version
                         .clone()
                         .ok_or_else(|| anyhow::anyhow!("package {name} missing version"))?;
-                    let target_path = cwd.join(path);
                     let scheduler = scheduler.clone();
                     // Packages with lifecycle scripts and packages patched by
                     // the binary-mirror pass are both mutated after cloning.
@@ -310,6 +340,15 @@ impl InstallService {
         root_path: &Path,
         omit: &HashSet<OmitType>,
     ) -> Result<()> {
+        Self::install_with_mode(scripts, root_path, omit, ReifyMode::Incremental).await
+    }
+
+    pub async fn install_with_mode(
+        scripts: ScriptPolicy,
+        root_path: &Path,
+        omit: &HashSet<OmitType>,
+        mode: ReifyMode,
+    ) -> Result<()> {
         print_proxy_env_hint_once();
         install_progress::start_install_run();
         let lock_path = root_path.join("package-lock.json");
@@ -388,7 +427,7 @@ impl InstallService {
         }
 
         let link_start = Instant::now();
-        let install_result = install_packages(&groups, root_path, omit, &scheduler)
+        let install_result = install_packages(&groups, root_path, omit, &scheduler, mode)
             .await
             .context("Failed to install packages");
 
@@ -495,9 +534,15 @@ impl InstallService {
                 PROGRESS_BAR.set_length(lock.packages.len() as u64);
             }
             let link_start = Instant::now();
-            reify_packages(&groups, &root_path, &HashSet::new(), &scheduler)
-                .await
-                .context("Failed to install global package")?;
+            reify_packages(
+                &groups,
+                &root_path,
+                &HashSet::new(),
+                &scheduler,
+                ReifyMode::Incremental,
+            )
+            .await
+            .context("Failed to install global package")?;
             finish_progress_bar("node_modules cloned", Some(link_start.elapsed()));
             Ok(lock)
         }
@@ -592,6 +637,72 @@ mod tests {
         assert_eq!(queues.install.len(), 1);
         assert_eq!(queues.postinstall.len(), 1);
         assert!(queues.bin_linking.is_empty());
+    }
+
+    #[tokio::test]
+    async fn force_reify_removes_existing_package_target() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().join("node_modules").join("pkg");
+        fs::create_dir_all(&target).await.unwrap();
+        fs::write(
+            target.join("package.json"),
+            br#"{"name":"pkg","version":"1.0.0"}"#,
+        )
+        .await
+        .unwrap();
+        fs::write(target.join("locally-modified.js"), b"modified")
+            .await
+            .unwrap();
+
+        prepare_reify_target(&target, ReifyMode::Force)
+            .await
+            .unwrap();
+
+        assert!(!target.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn force_reify_removes_link_without_touching_source() {
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("workspace");
+        let target = temp.path().join("node_modules").join("workspace");
+        fs::create_dir_all(&source).await.unwrap();
+        fs::create_dir_all(target.parent().unwrap()).await.unwrap();
+        std::os::unix::fs::symlink(&source, &target).unwrap();
+
+        prepare_reify_target(&target, ReifyMode::Force)
+            .await
+            .unwrap();
+
+        assert!(source.exists());
+        assert!(!target.exists());
+    }
+
+    #[tokio::test]
+    async fn incremental_reify_preserves_existing_package_target() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().join("node_modules").join("pkg");
+        fs::create_dir_all(&target).await.unwrap();
+        fs::write(target.join("locally-modified.js"), b"modified")
+            .await
+            .unwrap();
+
+        prepare_reify_target(&target, ReifyMode::Incremental)
+            .await
+            .unwrap();
+
+        assert!(target.join("locally-modified.js").exists());
+    }
+
+    #[test]
+    fn force_reify_is_limited_to_node_modules_paths() {
+        assert!(!is_node_modules_path(""));
+        assert!(!is_node_modules_path("packages/app"));
+        assert!(is_node_modules_path("node_modules/pkg"));
+        assert!(is_node_modules_path(
+            "node_modules/parent/node_modules/child"
+        ));
     }
 
     #[test]

--- a/crates/pm/src/util/cli_enum.rs
+++ b/crates/pm/src/util/cli_enum.rs
@@ -55,6 +55,14 @@ pub enum ScriptPolicy {
     Ignore,
 }
 
+/// Whether existing package targets may be reused during dependency reification.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ReifyMode {
+    #[default]
+    Incremental,
+    Force,
+}
+
 impl From<bool> for ScriptPolicy {
     fn from(ignore: bool) -> Self {
         if ignore { Self::Ignore } else { Self::Run }


### PR DESCRIPTION
## Summary

- add `ut update --force` and `ut update -f`
- force reification of lockfile-managed package targets even when the installed name and version already match
- keep resolver, lifecycle script, and global cache behavior aligned with regular `ut update`
- restrict forced removal to `node_modules` paths and remove workspace links without touching their source directories

## Why

Regular installation reuses an existing package directory when its `name` and `version` match. Local edits or extra files inside that directory therefore survive `ut update`. The force mode deliberately discards those managed targets and materializes them again from the existing cache.

Related to #3211.

## Validation

- `cargo fmt --check`
- `cargo test -p utoo-pm` (338 passed, 3 ignored)
- `cargo clippy -p utoo-pm --all-targets -- -D warnings --no-deps`
