### PR TITLE
fix(pack): watch server output roots for changes

### DIFF
--- a/crates/pack-api/src/project.rs
+++ b/crates/pack-api/src/project.rs
@@ -1520,8 +1520,14 @@ impl Project {
     /// referenced from the roots
     #[turbo_tasks::function]
     pub async fn server_changed(self: Vc<Self>, roots: Vc<OutputAssets>) -> Result<Vc<Completion>> {
-        let path = self.node_root().owned().await?;
-        Ok(any_output_changed(roots, path, true))
+        // `node_root` contains build-time evaluator assets, not endpoint output assets. Endpoint
+        // server outputs are written to `dist_root` and, when configured separately, to
+        // `server_dist_root`.
+        let paths = vec![
+            self.dist_root().owned().await?,
+            self.server_dist_root().owned().await?,
+        ];
+        Ok(any_output_changed(roots, paths, true))
     }
 
     /// Completion when client side changes are detected in output assets
@@ -1529,7 +1535,7 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn client_changed(self: Vc<Self>, roots: Vc<OutputAssets>) -> Result<Vc<Completion>> {
         let path = self.client_root().owned().await?;
-        Ok(any_output_changed(roots, path, false))
+        Ok(any_output_changed(roots, vec![path], false))
     }
 
     #[turbo_tasks::function]
@@ -1784,7 +1790,7 @@ pub struct BaseAndFullModuleGraph {
 #[turbo_tasks::function]
 async fn any_output_changed(
     roots: Vc<OutputAssets>,
-    path: FileSystemPath,
+    paths: Vec<FileSystemPath>,
     server: bool,
 ) -> Result<Vc<Completion>> {
     let all_assets = expand_output_assets(
@@ -1795,13 +1801,13 @@ async fn any_output_changed(
     let completions = all_assets
         .into_iter()
         .map(|m| {
-            let path = path.clone();
+            let paths = paths.clone();
 
             async move {
                 let asset_path = m.path().await?;
                 if !asset_path.path.ends_with(".map")
                     && (!server || !asset_path.path.ends_with(".css"))
-                    && asset_path.is_inside_ref(&path)
+                    && paths.iter().any(|path| asset_path.is_inside_ref(path))
                 {
                     anyhow::Ok(Some(
                         content_changed(*ResolvedVc::upcast(m))

--- a/packages/pack/src/__test__/serveServerOutputsHmr.test.ts
+++ b/packages/pack/src/__test__/serveServerOutputsHmr.test.ts
@@ -1,0 +1,128 @@
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+
+type Scenario = "dist-root" | "server-dist-root";
+
+type FixtureResult = {
+  initial: string;
+  scenario: Scenario;
+  updated: string;
+};
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(testDir, "../..");
+const repoRoot = path.resolve(packageRoot, "../..");
+const childScript = path.join(testDir, "serveServerOutputsHmrChild.ts");
+const viteNode = path.join(repoRoot, "node_modules/vite-node/vite-node.mjs");
+const resultPrefix = "__SERVER_OUTPUT_HMR__";
+
+/*
+ * `serve()` owns native workers, file watchers, and a long-lived HTTP server.
+ * Run each fixture in a child process so the test can terminate that complete
+ * runtime cleanly after observing the rebuilt output.
+ */
+function runServerOutputHmrFixture(scenario: Scenario): Promise<FixtureResult> {
+  return new Promise((resolve, reject) => {
+    const targetDir = path.join(repoRoot, "target");
+    fs.mkdirSync(targetDir, { recursive: true });
+    const projectPath = fs.mkdtempSync(
+      path.join(targetDir, `serve-server-output-${scenario}-`),
+    );
+    const port = 45_200 + Math.floor(Math.random() * 1000);
+    const child = spawn(
+      process.execPath,
+      [viteNode, childScript, projectPath, `${port}`, scenario],
+      {
+        cwd: packageRoot,
+        env: {
+          ...process.env,
+          NODE_PATH: [
+            path.join(packageRoot, "node_modules"),
+            path.join(repoRoot, "node_modules"),
+            process.env.NODE_PATH,
+          ]
+            .filter(Boolean)
+            .join(path.delimiter),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    const cleanup = () => {
+      fs.rmSync(projectPath, { recursive: true, force: true });
+    };
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+      cleanup();
+      reject(
+        new Error(
+          `serve server output fixture timed out for ${scenario}\n${stderr}\n${stdout}`,
+        ),
+      );
+    }, 50_000);
+
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      cleanup();
+      reject(error);
+    });
+    child.on("exit", (code, signal) => {
+      clearTimeout(timeout);
+      if (timedOut) {
+        return;
+      }
+
+      try {
+        if (code !== 0) {
+          throw new Error(
+            `serve server output fixture failed with code ${code}, signal ${signal}\n${stderr}\n${stdout}`,
+          );
+        }
+
+        const line = stdout
+          .split(/\r?\n/)
+          .find((item) => item.startsWith(resultPrefix));
+        if (!line) {
+          throw new Error(
+            `serve server output fixture did not print a result\n${stderr}\n${stdout}`,
+          );
+        }
+
+        resolve(JSON.parse(line.slice(resultPrefix.length)));
+      } catch (error) {
+        reject(error);
+      } finally {
+        cleanup();
+      }
+    });
+  });
+}
+
+describe("serve server output HMR", () => {
+  it.each(["dist-root", "server-dist-root"] as const)(
+    "rewrites changed server assets under %s",
+    async (scenario) => {
+      await expect(runServerOutputHmrFixture(scenario)).resolves.toEqual({
+        initial: "SERVER_OUTPUT_V1",
+        scenario,
+        updated: "SERVER_OUTPUT_V2",
+      });
+    },
+    60_000,
+  );
+});

--- a/packages/pack/src/__test__/serveServerOutputsHmrChild.ts
+++ b/packages/pack/src/__test__/serveServerOutputsHmrChild.ts
@@ -1,0 +1,149 @@
+import { execFile } from "child_process";
+import fs from "fs";
+import path from "path";
+import { promisify } from "util";
+import { serve } from "../index";
+
+type Scenario = "dist-root" | "server-dist-root";
+
+const execFileAsync = promisify(execFile);
+const [, , projectPath, portArg, scenarioArg] = process.argv;
+
+if (!projectPath || !portArg) {
+  throw new Error(
+    "Usage: serveServerOutputsHmrChild <projectPath> <port> <scenario>",
+  );
+}
+if (scenarioArg !== "dist-root" && scenarioArg !== "server-dist-root") {
+  throw new Error(`Unknown server output HMR scenario: ${scenarioArg}`);
+}
+
+const scenario: Scenario = scenarioArg;
+const port = Number(portArg);
+const srcDir = path.join(projectPath, "src");
+const dependencyPath = path.join(srcDir, "dependency.js");
+const bundlePath =
+  scenario === "dist-root"
+    ? path.join(projectPath, "dist", "node", "main.js")
+    : path.join(projectPath, "server-output", "index.js");
+
+function writeDependency(value: string) {
+  fs.writeFileSync(
+    dependencyPath,
+    `export default ${JSON.stringify(value)};\n`,
+  );
+}
+
+async function waitForBundleOutput(
+  expected: string,
+  timeoutMs = 20_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastOutput = "";
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      /*
+       * Execute the entry bundle instead of reading only that file: Turbopack
+       * can put the changed module in a hashed chunk loaded by the entry.
+       */
+      const { stdout, stderr } = await execFileAsync(
+        process.execPath,
+        [bundlePath],
+        { cwd: projectPath },
+      );
+      lastOutput = `${stdout}${stderr}`;
+      if (lastOutput.includes(expected)) {
+        return expected;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(
+    `Timed out waiting for ${bundlePath} to print ${expected}; last output: ${lastOutput}; last error: ${String(lastError)}`,
+  );
+}
+
+async function main() {
+  fs.rmSync(projectPath, { recursive: true, force: true });
+  fs.mkdirSync(srcDir, { recursive: true });
+  writeDependency("SERVER_OUTPUT_V1");
+
+  /*
+   * Cover both locations that Project::server_changed must observe:
+   *
+   * - A normal Node entry is emitted directly under output.path (dist_root).
+   * - A configured server entry is emitted under server.output.path
+   *   (server_dist_root), which may sit outside output.path.
+   */
+  const config =
+    scenario === "dist-root"
+      ? {
+          entry: [{ import: "./src/index.js", name: "main" }],
+          target: "node",
+          output: { path: "./dist/node", clean: true },
+        }
+      : {
+          entry: [{ import: "./src/client.js", name: "client" }],
+          output: { path: "./dist/client", clean: true },
+          server: {
+            entry: "./src/server.js",
+            output: { path: "./server-output", filename: "index.js" },
+          },
+        };
+
+  if (scenario === "dist-root") {
+    fs.writeFileSync(
+      path.join(srcDir, "index.js"),
+      'import value from "./dependency.js";\nconsole.log(value);\n',
+    );
+  } else {
+    fs.writeFileSync(
+      path.join(srcDir, "client.js"),
+      'console.log("client output");\n',
+    );
+    fs.writeFileSync(
+      path.join(srcDir, "server.js"),
+      'import value from "./dependency.js";\nconsole.log(value);\n',
+    );
+  }
+
+  await serve(
+    {
+      config: {
+        ...config,
+        stats: false,
+      },
+    },
+    projectPath,
+    projectPath,
+    {
+      hostname: "127.0.0.1",
+      logServerInfo: false,
+      port,
+    },
+  );
+
+  const initial = await waitForBundleOutput("SERVER_OUTPUT_V1");
+  writeDependency("SERVER_OUTPUT_V2");
+  const updated = await waitForBundleOutput("SERVER_OUTPUT_V2");
+
+  console.log(
+    `__SERVER_OUTPUT_HMR__${JSON.stringify({
+      initial,
+      scenario,
+      updated,
+    })}`,
+  );
+  process.kill(process.pid, "SIGTERM");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Background

In development mode, `@utoo/pack` subscribes to every endpoint's
`serverChanged()` stream. When that stream emits, the hot reloader writes the
endpoint output to disk again.

`Project::server_changed` previously filtered endpoint output assets against
`node_root`. In Utoopack, however, `node_root` contains build-time evaluator
assets under `.turbopack`; it is not where endpoint bundles are emitted. As a
result, source changes affecting server output assets did not invalidate this
subscription, and `serve()` could leave stale server bundles on disk.

## What changed

- Make `any_output_changed` accept multiple filesystem roots and subscribe to
  an asset when it is inside any of them.
- Subscribe `Project::server_changed` to both `dist_root` and
  `server_dist_root` instead of `node_root`.
- Preserve the existing client behavior by passing `client_root` as a
  single-element root list.

Both server roots are required:

- Normal Node entry output is emitted under `output.path` (`dist_root`).
- A configured server entry is emitted under `server.output.path`
  (`server_dist_root`), which may be outside `dist_root`.

Watching only one of them would leave the other supported output layout
uncovered.

## Regression tests

Add a `serve()` integration test covering both output layouts:

1. **dist-root**: build a normal Node entry to `dist/node/main.js`.
2. **server-dist-root**: build a configured server entry to
   `server-output/index.js`, outside the client `dist/client` directory.

Each scenario:

1. Starts with a dependency exporting `SERVER_OUTPUT_V1`.
2. Starts `serve()` and executes the generated server bundle to verify V1.
3. Rewrites the dependency to export `SERVER_OUTPUT_V2`.
4. Repeatedly executes the bundle until the on-disk output reports V2.

The bundle is executed instead of merely reading its entry file because the
changed module may live in a hashed chunk loaded by that entry. The fixture runs
in a child process so its native workers, file watchers, and HTTP server can be
terminated cleanly.

With the previous `node_root` subscription, both scenarios time out waiting for
V2. With this change, both output layouts are rebuilt successfully.

## Validation

- `npm run build:binding:local`
- `npx vitest run src/__test__/serveServerOutputsHmr.test.ts` — 2 tests passed
- `npm test` in `packages/pack` — 32 tests passed
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- Biome check for the new test files
