### PR TITLE
perf(pack): reduce redundant HMR compiling logs

### DIFF
--- a/packages/pack/src/__test__/serveServerOutputsHmr.test.ts
+++ b/packages/pack/src/__test__/serveServerOutputsHmr.test.ts
@@ -8,8 +8,10 @@ type Scenario = "dist-root" | "server-dist-root";
 
 type FixtureResult = {
   initial: string;
+  initialCompilingLogs: number;
   scenario: Scenario;
   updated: string;
+  updateCompilingLogs: number;
 };
 
 const testDir = path.dirname(fileURLToPath(import.meta.url));
@@ -119,8 +121,10 @@ describe("serve server output HMR", () => {
     async (scenario) => {
       await expect(runServerOutputHmrFixture(scenario)).resolves.toEqual({
         initial: "SERVER_OUTPUT_V1",
+        initialCompilingLogs: 0,
         scenario,
         updated: "SERVER_OUTPUT_V2",
+        updateCompilingLogs: 1,
       });
     },
     60_000,

--- a/packages/pack/src/__test__/serveServerOutputsHmrChild.ts
+++ b/packages/pack/src/__test__/serveServerOutputsHmrChild.ts
@@ -8,6 +8,15 @@ type Scenario = "dist-root" | "server-dist-root";
 
 const execFileAsync = promisify(execFile);
 const [, , projectPath, portArg, scenarioArg] = process.argv;
+let compilingLogCount = 0;
+const originalConsoleLog = console.log;
+
+console.log = (...args: unknown[]) => {
+  if (args[0] === "Compiling...") {
+    compilingLogCount++;
+  }
+  originalConsoleLog(...args);
+};
 
 if (!projectPath || !portArg) {
   throw new Error(
@@ -130,14 +139,17 @@ async function main() {
   );
 
   const initial = await waitForBundleOutput("SERVER_OUTPUT_V1");
+  const initialCompilingLogs = compilingLogCount;
   writeDependency("SERVER_OUTPUT_V2");
   const updated = await waitForBundleOutput("SERVER_OUTPUT_V2");
 
   console.log(
     `__SERVER_OUTPUT_HMR__${JSON.stringify({
       initial,
+      initialCompilingLogs,
       scenario,
       updated,
+      updateCompilingLogs: compilingLogCount - initialCompilingLogs,
     })}`,
   );
   process.kill(process.pid, "SIGTERM");

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -264,6 +264,13 @@ export async function createHotReloader(
   let closed = false;
   let closePromise: Promise<void> | undefined;
 
+  function markHmrEvent() {
+    if (!hmrEventHappened) {
+      console.log("Compiling...");
+      hmrEventHappened = true;
+    }
+  }
+
   function sendToClient(client: WSLike, payload: HMR_ACTION_TYPES) {
     client.send(JSON.stringify(payload));
   }
@@ -306,7 +313,7 @@ export async function createHotReloader(
       clientStates.get(client)?.turbopackUpdates.push(payload);
     }
 
-    hmrEventHappened = true;
+    markHmrEvent();
     sendEnqueuedMessagesDebounce();
   }
 
@@ -400,7 +407,7 @@ export async function createHotReloader(
         }
 
         await writeOutputToDisk(entrypoint);
-        hmrEventHappened = true;
+        markHmrEvent();
       })
       .finally(() => {
         if (shouldCreateWebpackStats) {
@@ -459,7 +466,7 @@ export async function createHotReloader(
               processIssues(currentEntryIssues, issueKey, data, false, true);
 
               if (hasBlockingResultIssues(data)) {
-                hmrEventHappened = true;
+                markHmrEvent();
                 sendEnqueuedMessagesDebounce();
                 continue;
               }
@@ -821,7 +828,6 @@ export async function createHotReloader(
       switch (updateMessage.updateType) {
         case "start": {
           hotReloader.send({ action: HMR_ACTIONS_SENT_TO_BROWSER.BUILDING });
-          console.log("Compiling...");
           break;
         }
         case "end": {

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -406,8 +406,8 @@ export async function createHotReloader(
           return;
         }
 
-        await writeOutputToDisk(entrypoint);
         markHmrEvent();
+        await writeOutputToDisk(entrypoint);
       })
       .finally(() => {
         if (shouldCreateWebpackStats) {


### PR DESCRIPTION
## Summary

- print `Compiling...` only after an actual HMR or watched-output change is observed
- deduplicate the message so each compilation cycle prints it once
- preserve the existing browser `BUILDING` / `BUILT` notifications
- add regression coverage for zero initial logs and one log after a source change

## Root cause

`project.updateInfoSubscribe()` reports every Turbopack computation, including initial work triggered when the page opens and establishes HMR subscriptions. Logging unconditionally for every `start` event therefore produced repeated `Compiling...` lines even when the project had not changed.

## Impact

Starting the dev server or opening a page no longer floods the terminal with compilation messages. A project change still produces one `Compiling...` message followed by the existing completion timing.
