### PR TITLE
fix(pack): prevent CSS module chunk leakage

### DIFF
--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/assert.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/assert.js
@@ -1,0 +1,18 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const marker = "PAGE_A_GLOBAL_ONLY_3275";
+const outputDir = path.join(__dirname, "output");
+const markerAsset = fs
+  .readdirSync(outputDir)
+  .filter((asset) => asset.endsWith(".css"))
+  .find((asset) => fs.readFileSync(path.join(outputDir, asset), "utf8").includes(marker));
+
+assert(markerAsset, "missing page A global CSS marker in emitted CSS");
+
+const pageA = fs.readFileSync(path.join(outputDir, "a.js"), "utf8");
+const pageB = fs.readFileSync(path.join(outputDir, "b.js"), "utf8");
+
+assert(pageA.includes(markerAsset), "page A must load its global CSS asset");
+assert(!pageB.includes(markerAsset), "page B must not load page A global CSS asset");

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/config.json
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/config.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/a.js",
+        "name": "a"
+      },
+      {
+        "import": "input/b.js",
+        "name": "b"
+      }
+    ],
+    "mode": "production",
+    "optimization": {
+      "cssChunking": "graph",
+      "minify": false,
+      "moduleIds": "named"
+    }
+  },
+  "runtimeType": "dummy"
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/input/a.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/input/a.js
@@ -1,0 +1,4 @@
+import pageAStyles from "./a.module.css";
+import sharedStyles from "./shared.module.css";
+
+export const pageAClassNames = [sharedStyles.shared, pageAStyles.local];

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/input/a.module.css
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/input/a.module.css
@@ -1,0 +1,11 @@
+.local {
+  color: red;
+}
+
+:global(:root) {
+  --page-a-global-only: "PAGE_A_GLOBAL_ONLY_3275";
+}
+
+:global(body) {
+  overflow: hidden;
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/input/b.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/input/b.js
@@ -1,0 +1,3 @@
+import sharedStyles from "./shared.module.css";
+
+export const pageBClassNames = [sharedStyles.shared];

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/input/shared.module.css
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/input/shared.module.css
@@ -1,0 +1,3 @@
+.shared {
+  padding: 1rem;
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/a.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/a.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_a_module_a77643d8.css","input_shared_module_ae106522.css","input_6bcae38e.js"],"runtimeModuleIds":["[project]/style/css_module_global_leak_graph/input/a.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/a.js.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/a.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/b.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/b.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_shared_module_ae106522.css","input_312088b8.js"],"runtimeModuleIds":["[project]/style/css_module_global_leak_graph/input/b.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/b.js.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/b.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_312088b8.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_312088b8.js
@@ -1,0 +1,24 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/style/css_module_global_leak_graph/input/b.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_graph$2f$input$2f$shared$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__ = __turbopack_context__.i("[project]/style/css_module_global_leak_graph/input/shared.module.css [client] (css module)");
+;
+const pageBClassNames = [
+    __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_graph$2f$input$2f$shared$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__["default"].shared
+];
+__turbopack_context__.s([
+    "pageBClassNames",
+    0,
+    pageBClassNames
+]);
+}),
+"[project]/style/css_module_global_leak_graph/input/shared.module.css [client] (css module)", ((__turbopack_context__) => {
+
+__turbopack_context__.v({
+  "shared": "shared-module__Sd_Gsq__shared",
+});
+}),
+]);
+
+//# sourceMappingURL=input_312088b8.js.map

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_312088b8.js.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_312088b8.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_graph/input/b.js"],"sourcesContent":["import sharedStyles from \"./shared.module.css\";\n\nexport const pageBClassNames = [sharedStyles.shared];\n"],"names":["pageBClassNames","shared"],"mappings":"AAAA;;AAEO,MAAMA,kBAAkB;IAAC,2KAAY,CAACC,MAAM;CAAC"}},
+    {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_graph/input/shared.module.css [client] (css module)"],"sourcesContent":["__turbopack_context__.v({\n  \"shared\": \"shared-module__Sd_Gsq__shared\",\n});\n"],"names":[],"mappings":"AAAA;AACA;AACA"}}]
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_6bcae38e.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_6bcae38e.js
@@ -1,0 +1,33 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/style/css_module_global_leak_graph/input/a.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_graph$2f$input$2f$a$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__ = __turbopack_context__.i("[project]/style/css_module_global_leak_graph/input/a.module.css [client] (css module)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_graph$2f$input$2f$shared$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__ = __turbopack_context__.i("[project]/style/css_module_global_leak_graph/input/shared.module.css [client] (css module)");
+;
+;
+const pageAClassNames = [
+    __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_graph$2f$input$2f$shared$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__["default"].shared,
+    __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_graph$2f$input$2f$a$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__["default"].local
+];
+__turbopack_context__.s([
+    "pageAClassNames",
+    0,
+    pageAClassNames
+]);
+}),
+"[project]/style/css_module_global_leak_graph/input/a.module.css [client] (css module)", ((__turbopack_context__) => {
+
+__turbopack_context__.v({
+  "local": "a-module__i4MvZq__local",
+});
+}),
+"[project]/style/css_module_global_leak_graph/input/shared.module.css [client] (css module)", ((__turbopack_context__) => {
+
+__turbopack_context__.v({
+  "shared": "shared-module__Sd_Gsq__shared",
+});
+}),
+]);
+
+//# sourceMappingURL=input_6bcae38e.js.map

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_6bcae38e.js.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_6bcae38e.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_graph/input/a.js"],"sourcesContent":["import pageAStyles from \"./a.module.css\";\nimport sharedStyles from \"./shared.module.css\";\n\nexport const pageAClassNames = [sharedStyles.shared, pageAStyles.local];\n"],"names":["pageAClassNames","shared","local"],"mappings":"AAAA;AACA;;;AAEO,MAAMA,kBAAkB;IAAC,2KAAY,CAACC,MAAM;IAAE,sKAAW,CAACC,KAAK;CAAC"}},
+    {"offset": {"line": 20, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_graph/input/a.module.css [client] (css module)"],"sourcesContent":["__turbopack_context__.v({\n  \"local\": \"a-module__i4MvZq__local\",\n});\n"],"names":[],"mappings":"AAAA;AACA;AACA"}},
+    {"offset": {"line": 26, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_graph/input/shared.module.css [client] (css module)"],"sourcesContent":["__turbopack_context__.v({\n  \"shared\": \"shared-module__Sd_Gsq__shared\",\n});\n"],"names":[],"mappings":"AAAA;AACA;AACA"}}]
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_a_module_a77643d8.css
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_a_module_a77643d8.css
@@ -1,0 +1,14 @@
+/* [project]/style/css_module_global_leak_graph/input/a.module.css [client] (css) */
+.a-module__i4MvZq__local {
+  color: red;
+}
+
+:root {
+  --page-a-global-only: "PAGE_A_GLOBAL_ONLY_3275";
+}
+
+body {
+  overflow: hidden;
+}
+
+/*# sourceMappingURL=input_a_module_a77643d8.css.map*/

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_a_module_a77643d8.css.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_a_module_a77643d8.css.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_graph/input/a.module.css"],"sourcesContent":[".local {\n  color: red;\n}\n\n:global(:root) {\n  --page-a-global-only: \"PAGE_A_GLOBAL_ONLY_3275\";\n}\n\n:global(body) {\n  overflow: hidden;\n}\n"],"names":[],"mappings":"AAAA;;;;AAIA;;;;AAIA"}}]
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_shared_module_ae106522.css
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_shared_module_ae106522.css
@@ -1,0 +1,6 @@
+/* [project]/style/css_module_global_leak_graph/input/shared.module.css [client] (css) */
+.shared-module__Sd_Gsq__shared {
+  padding: 1rem;
+}
+
+/*# sourceMappingURL=input_shared_module_ae106522.css.map*/

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_shared_module_ae106522.css.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_graph/output/input_shared_module_ae106522.css.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_graph/input/shared.module.css"],"sourcesContent":[".shared {\n  padding: 1rem;\n}\n"],"names":[],"mappings":"AAAA"}}]
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/assert.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/assert.js
@@ -1,0 +1,18 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const marker = "PAGE_A_GLOBAL_ONLY_3275";
+const outputDir = path.join(__dirname, "output");
+const markerAsset = fs
+  .readdirSync(outputDir)
+  .filter((asset) => asset.endsWith(".css"))
+  .find((asset) => fs.readFileSync(path.join(outputDir, asset), "utf8").includes(marker));
+
+assert(markerAsset, "missing page A global CSS marker in emitted CSS");
+
+const pageA = fs.readFileSync(path.join(outputDir, "a.js"), "utf8");
+const pageB = fs.readFileSync(path.join(outputDir, "b.js"), "utf8");
+
+assert(pageA.includes(markerAsset), "page A must load its global CSS asset");
+assert(!pageB.includes(markerAsset), "page B must not load page A global CSS asset");

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/config.json
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/config.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/a.js",
+        "name": "a"
+      },
+      {
+        "import": "input/b.js",
+        "name": "b"
+      }
+    ],
+    "mode": "production",
+    "optimization": {
+      "cssChunking": "loose",
+      "minify": false,
+      "moduleIds": "named"
+    }
+  },
+  "runtimeType": "dummy"
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/input/a.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/input/a.js
@@ -1,0 +1,4 @@
+import pageAStyles from "./a.module.css";
+import sharedStyles from "./shared.module.css";
+
+export const pageAClassNames = [sharedStyles.shared, pageAStyles.local];

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/input/a.module.css
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/input/a.module.css
@@ -1,0 +1,11 @@
+.local {
+  color: red;
+}
+
+:global(:root) {
+  --page-a-global-only: "PAGE_A_GLOBAL_ONLY_3275";
+}
+
+:global(body) {
+  overflow: hidden;
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/input/b.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/input/b.js
@@ -1,0 +1,3 @@
+import sharedStyles from "./shared.module.css";
+
+export const pageBClassNames = [sharedStyles.shared];

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/input/shared.module.css
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/input/shared.module.css
@@ -1,0 +1,3 @@
+.shared {
+  padding: 1rem;
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/a.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/a.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_a_module_8a752676.css","input_shared_module_aeec91af.css","input_57a5a670.js"],"runtimeModuleIds":["[project]/style/css_module_global_leak_loose/input/a.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/a.js.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/a.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/b.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/b.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_shared_module_aeec91af.css","input_77bc73fd.js"],"runtimeModuleIds":["[project]/style/css_module_global_leak_loose/input/b.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/b.js.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/b.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_57a5a670.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_57a5a670.js
@@ -1,0 +1,33 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/style/css_module_global_leak_loose/input/a.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_loose$2f$input$2f$a$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__ = __turbopack_context__.i("[project]/style/css_module_global_leak_loose/input/a.module.css [client] (css module)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_loose$2f$input$2f$shared$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__ = __turbopack_context__.i("[project]/style/css_module_global_leak_loose/input/shared.module.css [client] (css module)");
+;
+;
+const pageAClassNames = [
+    __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_loose$2f$input$2f$shared$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__["default"].shared,
+    __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_loose$2f$input$2f$a$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__["default"].local
+];
+__turbopack_context__.s([
+    "pageAClassNames",
+    0,
+    pageAClassNames
+]);
+}),
+"[project]/style/css_module_global_leak_loose/input/a.module.css [client] (css module)", ((__turbopack_context__) => {
+
+__turbopack_context__.v({
+  "local": "a-module__-uTsoq__local",
+});
+}),
+"[project]/style/css_module_global_leak_loose/input/shared.module.css [client] (css module)", ((__turbopack_context__) => {
+
+__turbopack_context__.v({
+  "shared": "shared-module__Zdvjja__shared",
+});
+}),
+]);
+
+//# sourceMappingURL=input_57a5a670.js.map

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_57a5a670.js.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_57a5a670.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_loose/input/a.js"],"sourcesContent":["import pageAStyles from \"./a.module.css\";\nimport sharedStyles from \"./shared.module.css\";\n\nexport const pageAClassNames = [sharedStyles.shared, pageAStyles.local];\n"],"names":["pageAClassNames","shared","local"],"mappings":"AAAA;AACA;;;AAEO,MAAMA,kBAAkB;IAAC,2KAAY,CAACC,MAAM;IAAE,sKAAW,CAACC,KAAK;CAAC"}},
+    {"offset": {"line": 20, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_loose/input/a.module.css [client] (css module)"],"sourcesContent":["__turbopack_context__.v({\n  \"local\": \"a-module__-uTsoq__local\",\n});\n"],"names":[],"mappings":"AAAA;AACA;AACA"}},
+    {"offset": {"line": 26, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_loose/input/shared.module.css [client] (css module)"],"sourcesContent":["__turbopack_context__.v({\n  \"shared\": \"shared-module__Zdvjja__shared\",\n});\n"],"names":[],"mappings":"AAAA;AACA;AACA"}}]
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_77bc73fd.js
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_77bc73fd.js
@@ -1,0 +1,24 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/style/css_module_global_leak_loose/input/b.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_loose$2f$input$2f$shared$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__ = __turbopack_context__.i("[project]/style/css_module_global_leak_loose/input/shared.module.css [client] (css module)");
+;
+const pageBClassNames = [
+    __TURBOPACK__imported__module__$5b$project$5d2f$style$2f$css_module_global_leak_loose$2f$input$2f$shared$2e$module$2e$css__$5b$client$5d$__$28$css__module$29$__["default"].shared
+];
+__turbopack_context__.s([
+    "pageBClassNames",
+    0,
+    pageBClassNames
+]);
+}),
+"[project]/style/css_module_global_leak_loose/input/shared.module.css [client] (css module)", ((__turbopack_context__) => {
+
+__turbopack_context__.v({
+  "shared": "shared-module__Zdvjja__shared",
+});
+}),
+]);
+
+//# sourceMappingURL=input_77bc73fd.js.map

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_77bc73fd.js.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_77bc73fd.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_loose/input/b.js"],"sourcesContent":["import sharedStyles from \"./shared.module.css\";\n\nexport const pageBClassNames = [sharedStyles.shared];\n"],"names":["pageBClassNames","shared"],"mappings":"AAAA;;AAEO,MAAMA,kBAAkB;IAAC,2KAAY,CAACC,MAAM;CAAC"}},
+    {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_loose/input/shared.module.css [client] (css module)"],"sourcesContent":["__turbopack_context__.v({\n  \"shared\": \"shared-module__Zdvjja__shared\",\n});\n"],"names":[],"mappings":"AAAA;AACA;AACA"}}]
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_a_module_8a752676.css
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_a_module_8a752676.css
@@ -1,0 +1,14 @@
+/* [project]/style/css_module_global_leak_loose/input/a.module.css [client] (css) */
+.a-module__-uTsoq__local {
+  color: red;
+}
+
+:root {
+  --page-a-global-only: "PAGE_A_GLOBAL_ONLY_3275";
+}
+
+body {
+  overflow: hidden;
+}
+
+/*# sourceMappingURL=input_a_module_8a752676.css.map*/

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_a_module_8a752676.css.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_a_module_8a752676.css.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_loose/input/a.module.css"],"sourcesContent":[".local {\n  color: red;\n}\n\n:global(:root) {\n  --page-a-global-only: \"PAGE_A_GLOBAL_ONLY_3275\";\n}\n\n:global(body) {\n  overflow: hidden;\n}\n"],"names":[],"mappings":"AAAA;;;;AAIA;;;;AAIA"}}]
+}

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_shared_module_aeec91af.css
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_shared_module_aeec91af.css
@@ -1,0 +1,6 @@
+/* [project]/style/css_module_global_leak_loose/input/shared.module.css [client] (css) */
+.shared-module__Zdvjja__shared {
+  padding: 1rem;
+}
+
+/*# sourceMappingURL=input_shared_module_aeec91af.css.map*/

--- a/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_shared_module_aeec91af.css.map
+++ b/crates/pack-tests/tests/snapshot/style/css_module_global_leak_loose/output/input_shared_module_aeec91af.css.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/style/css_module_global_leak_loose/input/shared.module.css"],"sourcesContent":[".shared {\n  padding: 1rem;\n}\n"],"names":[],"mappings":"AAAA"}}]
+}

--- a/crates/pm/src/cli.rs
+++ b/crates/pm/src/cli.rs
@@ -15,9 +15,10 @@ use crate::constants::cmd::{
     LIST_ALIAS, LIST_NAME, LOGIN_ABOUT, LOGIN_ALIAS, LOGIN_NAME, LOGOUT_ABOUT, LOGOUT_ALIAS,
     LOGOUT_NAME, PACK_ABOUT, PACK_ALIAS, PACK_NAME, PING_ABOUT, PING_ALIAS, PING_NAME,
     PUBLISH_ABOUT, PUBLISH_ALIAS, PUBLISH_NAME, REBUILD_ABOUT, REBUILD_ALIAS, REBUILD_NAME,
-    RUN_ABOUT, RUN_ALIAS, RUN_NAME, UNINSTALL_ABOUT, UNINSTALL_ALIAS,UNINSTALL_REMOVE,UNINSTALL_RM, UNINSTALL_NAME, UPDATE_ABOUT,
-    UPDATE_ALIAS, UPDATE_NAME, VIEW_ABOUT, VIEW_ALIAS, VIEW_ALIAS_INFO, VIEW_ALIAS_SHOW, VIEW_NAME,
-    WHOAMI_ABOUT, WHOAMI_ALIAS, WHOAMI_NAME,
+    RUN_ABOUT, RUN_ALIAS, RUN_NAME, UNINSTALL_ABOUT, UNINSTALL_ALIAS, UNINSTALL_NAME,
+    UNINSTALL_REMOVE, UNINSTALL_RM, UPDATE_ABOUT, UPDATE_ALIAS, UPDATE_NAME, VIEW_ABOUT,
+    VIEW_ALIAS, VIEW_ALIAS_INFO, VIEW_ALIAS_SHOW, VIEW_NAME, WHOAMI_ABOUT, WHOAMI_ALIAS,
+    WHOAMI_NAME,
 };
 use crate::constants::{APP_ABOUT, APP_NAME, APP_VERSION};
 use crate::util::cli_enum::PublishAccess;
@@ -479,7 +480,7 @@ mod tests {
     }
 
     //test 'un','uninstall','remove','rm'
-     #[test]
+    #[test]
     fn test_install_un_alias_recognized() {
         // Verify clap correctly recognizes "un" as an alias for uninstall
         let cmd = Cli::command();
@@ -505,7 +506,9 @@ mod tests {
         let cmd = Cli::command();
 
         // Test "uninstall" is recognized as uninstall command
-        let result = cmd.clone().try_get_matches_from(["utoo", "uninstall", "lodash"]);
+        let result = cmd
+            .clone()
+            .try_get_matches_from(["utoo", "uninstall", "lodash"]);
         assert!(
             result.is_ok(),
             "Should parse 'utoo uninstall' as valid uninstall command"
@@ -519,13 +522,15 @@ mod tests {
         );
     }
 
-     #[test]
+    #[test]
     fn test_install_remove_alias_recognized() {
         // Verify clap correctly recognizes "remove" as an alias for uninstall
         let cmd = Cli::command();
 
         // Test "remove" is recognized as uninstall command
-        let result = cmd.clone().try_get_matches_from(["utoo", "remove", "lodash"]);
+        let result = cmd
+            .clone()
+            .try_get_matches_from(["utoo", "remove", "lodash"]);
         assert!(
             result.is_ok(),
             "Should parse 'utoo remove' as valid uninstall command"

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -545,7 +545,7 @@ fn detect_command_token(args: &[String]) -> Option<(&'static str, usize)> {
         }
         let command = match value {
             "i" | "add" | "install" => "install",
-            "un" | "uninstall"|"remove"|"rm" => "uninstall",
+            "un" | "uninstall" | "remove" | "rm" => "uninstall",
             "rb" | "rebuild" => "rebuild",
             "c" | "clean" => "clean",
             "d" | "deps" => "deps",


### PR DESCRIPTION
## Summary

- conservatively classify CSS Modules as `GlobalStyle` so loose/graph chunking cannot over-ship a module with `:global(...)` side effects to unrelated entrypoints
- add two multi-entry regression snapshots covering `cssChunking: "loose"` and `cssChunking: "graph"`
- remove a pre-existing needless `Ok(...?)` in the touched CSS parser so the required Clippy check stays clean

## Root cause

Utoo supports CSS Modules selectors such as `:global(:root)` and `:global(body)`, but Turbopack's chunking metadata classified every CSS Module as isolated. When page A's module and a shared module were merged, page B could receive page A's global CSS through the shared chunk.

## Tradeoff

This is intentionally a conservative hotfix. CSS Modules with different consumer sets can now produce additional CSS chunks/requests. A long-term fix should derive isolation from the parsed CSS selectors and only mark modules containing global side effects as global.

Fixes #3275

## Validation

- reproduced the failure before the fix for both loose and graph chunking
- `cargo test -p pack-tests --test snapshot css_module_global_leak -- --ignored --nocapture`
- `cargo fmt --all -- --check` in Utoo and the Next.js submodule
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `cargo clippy -p turbopack-css --all-targets -- -D warnings --no-deps`

Submodule PR: [utooland/next.js#176](https://github.com/utooland/next.js/pull/176)
Submodule commit: `utooland/next.js@735f7744e34138006e6f3ad6711b52e003649707`
