### PR TITLE
fix(pm): normalize workspace path filters

### DIFF
--- a/crates/pm/src/service/workspace.rs
+++ b/crates/pm/src/service/workspace.rs
@@ -244,18 +244,26 @@ pub struct WorkspaceJson {
 /// Each filter is matched against the workspace name and its project-relative
 /// path via [`matches_pattern`], which handles both literal equality and the
 /// `*` glob forms supported elsewhere in the codebase (e.g. `packages/*`).
+/// Paths are normalized before matching so CLI-friendly forms such as
+/// `./packages/a` and Windows separators match the stored relative path.
 fn expand_filters(nodes: &[WorkspaceNode], filters: &[String]) -> Result<BTreeSet<String>> {
     // Stringify each node's relative path once instead of per filter.
     let node_paths: Vec<(&str, String)> = nodes
         .iter()
-        .map(|n| (n.name.as_str(), n.path.to_string_lossy().into_owned()))
+        .map(|n| {
+            (
+                n.name.as_str(),
+                normalize_workspace_path(&n.path.to_string_lossy()),
+            )
+        })
         .collect();
 
     let mut selected = BTreeSet::new();
     for filter in filters {
+        let normalized_filter = normalize_workspace_path(filter);
         let mut matched = false;
         for (name, path) in &node_paths {
-            if matches_pattern(name, filter) || matches_pattern(path, filter) {
+            if matches_pattern(name, filter) || matches_pattern(path, &normalized_filter) {
                 selected.insert((*name).to_string());
                 matched = true;
             }
@@ -266,6 +274,13 @@ fn expand_filters(nodes: &[WorkspaceNode], filters: &[String]) -> Result<BTreeSe
     }
 
     Ok(selected)
+}
+
+fn normalize_workspace_path(path: &str) -> String {
+    path.replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_end_matches('/')
+        .to_string()
 }
 
 /// Project the full workspace topology onto a selected subset, preserving
@@ -462,11 +477,26 @@ mod tests {
         assert!(by_path.contains("@scope/b"));
         assert_eq!(by_path.len(), 1);
 
+        // Accept the common explicit-relative form used by package-manager CLIs.
+        let by_explicit_relative_path = expand_filters(&nodes, &["./packages/b".into()]).unwrap();
+        assert!(by_explicit_relative_path.contains("@scope/b"));
+        assert_eq!(by_explicit_relative_path.len(), 1);
+
         // Glob match
-        let by_glob = expand_filters(&nodes, &["packages/*".into()]).unwrap();
+        let by_glob = expand_filters(&nodes, &["./packages/*".into()]).unwrap();
         assert_eq!(by_glob.len(), 2);
         assert!(by_glob.contains("@scope/a"));
         assert!(by_glob.contains("@scope/b"));
+
+        // Normalize both filters and discovered paths across Windows/POSIX.
+        let windows_nodes = vec![WorkspaceNode {
+            name: "@scope/windows".into(),
+            path: PathBuf::from(r"tools\egg-bin"),
+        }];
+        for filter in [r".\tools\egg-bin", "./tools/egg-bin", "tools/egg-bin/"] {
+            let selected = expand_filters(&windows_nodes, &[filter.into()]).unwrap();
+            assert_eq!(selected, BTreeSet::from(["@scope/windows".to_string()]));
+        }
 
         // Multiple filters dedupe
         let multi = expand_filters(&nodes, &["@scope/a".into(), "packages/a".into()]).unwrap();

--- a/crates/pm/tests/cli_contract.rs
+++ b/crates/pm/tests/cli_contract.rs
@@ -593,6 +593,45 @@ fn bare_script_json_captures_the_script_result() {
 }
 
 #[test]
+fn run_accepts_explicit_relative_workspace_path() {
+    let project = tempdir().unwrap();
+    let workspace = project.path().join("tools").join("egg-bin");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"root","private":true,"workspaces":["tools/*"]}"#,
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"name":"@eggjs/bin","version":"1.0.0","scripts":{"build":"node build.js"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("build.js"),
+        r#"process.stdout.write("WORKSPACE_BUILD_MARKER\n");"#,
+    )
+    .unwrap();
+
+    let output = utoo()
+        .current_dir(project.path())
+        .args(["run", "build", "--workspace", "./tools/egg-bin"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("WORKSPACE_BUILD_MARKER"),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn invalid_json_invocation_returns_a_json_usage_error() {
     let output = utoo()
         .args(["--json", "view", "--definitely-invalid"])


### PR DESCRIPTION
## Summary

- normalize workspace path filters before matching
- accept explicit relative paths such as `./tools/egg-bin`
- normalize Windows separators and trailing slashes
- add unit and CLI contract regression coverage

## Motivation

The npm-installed Windows PowerShell launcher can pass `--workspace ./tools/egg-bin` directly to utoo when the caller uses `--` for argument forwarding. Workspace discovery stores the path without the leading `./`, so the literal filter previously failed to select the package.

Normalizing both discovered workspace paths and CLI path filters makes these equivalent forms match consistently across platforms.

## Tests

- `cargo fmt --all --check`
- workspace service tests: 9 passed
- `cargo test -p utoo-pm --test cli_contract`: 29 passed