### PR TITLE
fix(pack): correct webpack stats module metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,6 +5105,7 @@ dependencies = [
  "turbopack-browser",
  "turbopack-core",
  "turbopack-css",
+ "turbopack-ecmascript",
  "turbopack-node",
  "turbopack-nodejs",
  "turbopack-resolve",

--- a/crates/pack-api/Cargo.toml
+++ b/crates/pack-api/Cargo.toml
@@ -6,38 +6,39 @@ license.workspace = true
 
 # tombi: format.rules.table-keys-order.disabled = true
 [dependencies]
-anyhow              = { workspace = true, features = ["backtrace"] }
-async-trait         = { workspace = true }
-bincode             = { workspace = true }
-either              = { workspace = true }
-futures             = { workspace = true }
-parking_lot         = { workspace = true }
-qstring             = { workspace = true }
-rustc-hash          = { workspace = true }
-serde               = { workspace = true }
-serde_json          = { workspace = true }
-tokio               = { workspace = true, features = ["sync"] }
-tracing             = { workspace = true }
-url                 = { workspace = true }
-urlencoding         = { workspace = true }
+anyhow               = { workspace = true, features = ["backtrace"] }
+async-trait          = { workspace = true }
+bincode              = { workspace = true }
+either               = { workspace = true }
+futures              = { workspace = true }
+parking_lot          = { workspace = true }
+qstring              = { workspace = true }
+rustc-hash           = { workspace = true }
+serde                = { workspace = true }
+serde_json           = { workspace = true }
+tokio                = { workspace = true, features = ["sync"] }
+tracing              = { workspace = true }
+url                  = { workspace = true }
+urlencoding          = { workspace = true }
 ## turbpack specific
-pack-core           = { workspace = true }
-turbo-bincode       = { workspace = true }
-turbo-rcstr         = { workspace = true }
-turbo-tasks         = { workspace = true }
-turbo-tasks-backend = { workspace = true }
-turbo-tasks-env     = { workspace = true }
-turbo-tasks-fs      = { workspace = true }
-turbo-tasks-hash    = { workspace = true }
-turbo-unix-path     = { workspace = true }
-turbopack           = { workspace = true }
-turbopack-browser   = { workspace = true }
-turbopack-core      = { workspace = true }
-turbopack-css       = { workspace = true }
-turbopack-node      = { workspace = true, default-features = false }
-turbopack-nodejs    = { workspace = true }
-turbopack-resolve   = { workspace = true }
-turbopack-static    = { workspace = true }
+pack-core            = { workspace = true }
+turbo-bincode        = { workspace = true }
+turbo-rcstr          = { workspace = true }
+turbo-tasks          = { workspace = true }
+turbo-tasks-backend  = { workspace = true }
+turbo-tasks-env      = { workspace = true }
+turbo-tasks-fs       = { workspace = true }
+turbo-tasks-hash     = { workspace = true }
+turbo-unix-path      = { workspace = true }
+turbopack            = { workspace = true }
+turbopack-browser    = { workspace = true }
+turbopack-core       = { workspace = true }
+turbopack-css        = { workspace = true }
+turbopack-ecmascript = { workspace = true }
+turbopack-node       = { workspace = true, default-features = false }
+turbopack-nodejs     = { workspace = true }
+turbopack-resolve    = { workspace = true }
+turbopack-static     = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/pack-api/src/webpack_stats.rs
+++ b/crates/pack-api/src/webpack_stats.rs
@@ -1,21 +1,23 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use pack_core::library::ecmascript::{EcmascriptLibraryChunk, EcmascriptLibraryEvaluateChunk};
 use qstring::QString;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, TryJoinIterExt, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_browser::ecmascript::{
     EcmascriptBrowserChunk, EcmascriptBrowserEvaluateChunk, EcmascriptDevChunkList,
 };
 use turbopack_core::{
     asset::Asset,
-    chunk::{Chunk, ChunkItem, ChunkableModule},
+    chunk::{ChunkItem, ChunkItemExt, ModuleId},
     output::{OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
 };
 use turbopack_css::chunk::CssChunk;
+use turbopack_ecmascript::chunk::EcmascriptChunk;
 use turbopack_nodejs::{EcmascriptBuildNodeChunk, EcmascriptBuildNodeEntryChunk};
 
 #[turbo_tasks::value]
@@ -25,8 +27,55 @@ pub struct AssetIntermediateInfo {
     pub asset: WebpackStatsAsset,
     pub chunks: Vec<WebpackStatsChunk>,
     pub entrypoints: Vec<(RcStr, WebpackStatsEntrypoint)>,
-    pub chunk_items: Vec<(ResolvedVc<Box<dyn ChunkItem>>, RcStr)>,
+    pub modules: Vec<WebpackStatsModule>,
     pub dev_chunk_list: Option<RcStr>,
+}
+
+fn normalize_stats_path(path: RcStr) -> RcStr {
+    path.strip_prefix("./").map(Into::into).unwrap_or(path)
+}
+
+async fn get_chunk_modules(
+    chunk: ResolvedVc<EcmascriptChunk>,
+    chunk_id: RcStr,
+) -> Result<Vec<WebpackStatsModule>> {
+    let content = chunk.chunk_content();
+    let module_names = content
+        .included_chunk_items()
+        .await?
+        .iter()
+        .map(|chunk_item| {
+            let chunk_item = *chunk_item;
+            async move {
+                let id = chunk_item.id().await?;
+                let asset_ident = chunk_item.asset_ident().await?;
+                let name = normalize_stats_path(asset_ident.path.path.clone());
+                Ok::<_, anyhow::Error>((id, name))
+            }
+        })
+        .try_join()
+        .await?
+        .into_iter()
+        .collect::<FxHashMap<_, _>>();
+    let content = content.await?;
+    let chunk_items = content.chunk_item_code_module_ids_and_paths().await?;
+    let mut modules = Vec::new();
+
+    for item in chunk_items {
+        for (id, code, _) in &*item {
+            modules.push(WebpackStatsModule {
+                name: module_names
+                    .get(id)
+                    .cloned()
+                    .with_context(|| format!("missing source path for module {id}"))?,
+                id: id.into(),
+                chunks: vec![chunk_id.clone()],
+                size: code.source_code().len() as u64,
+            });
+        }
+    }
+
+    Ok(modules)
 }
 
 #[turbo_tasks::function]
@@ -40,12 +89,11 @@ pub async fn get_asset_intermediate_info(
         .await?
         .get_relative_path_to(&asset_path_full)
         .unwrap_or_else(|| asset_path_full.path.clone());
-    // Remove leading "./" prefix if present
-    let path: RcStr = path.strip_prefix("./").map(|s| s.into()).unwrap_or(path);
+    let path = normalize_stats_path(path);
 
     let mut local_chunks = vec![];
     let mut local_entrypoints = vec![];
-    let mut local_chunk_items = vec![];
+    let mut local_modules = vec![];
     let mut local_dev_chunk_list = None;
 
     if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBrowserEvaluateChunk>(asset) {
@@ -54,27 +102,13 @@ pub async fn get_asset_intermediate_info(
             .await?
             .get_relative_path_to(&entry_path_full)
             .unwrap_or_else(|| entry_path_full.path.clone());
+        let entry_path = normalize_stats_path(entry_path);
         local_chunks.push(WebpackStatsChunk {
             size: asset_len,
             files: vec![entry_path.clone()],
             id: entry_path.clone(),
             ..Default::default()
         });
-
-        let evaluatable_assets = chunk.evaluatable_assets().await?;
-        let items: Vec<_> = evaluatable_assets
-            .iter()
-            .map(|&evaluatable_asset| {
-                let entry_path = entry_path.clone();
-                async move {
-                    let item = evaluatable_asset
-                        .as_chunk_item(chunk.module_graph(), chunk.chunking_context());
-                    Ok::<_, anyhow::Error>((item.to_resolved().await?, entry_path))
-                }
-            })
-            .try_join()
-            .await?;
-        local_chunk_items.extend(items);
 
         let entry_referenced_assets = chunk.chunks_data().await?;
         let futures: Vec<_> = entry_referenced_assets
@@ -83,7 +117,7 @@ pub async fn get_asset_intermediate_info(
                 let asset = *asset;
                 async move {
                     let chunk_data = asset.await?;
-                    let name: RcStr = chunk_data.path.as_str().into();
+                    let name = normalize_stats_path(chunk_data.path.as_str().into());
                     Ok::<_, anyhow::Error>((name.clone(), WebpackStatsEntrypointAssets { name }))
                 }
             })
@@ -125,6 +159,7 @@ pub async fn get_asset_intermediate_info(
             .await?
             .get_relative_path_to(&chunk_path_full)
             .unwrap_or_else(|| chunk_path_full.path.clone());
+        let chunk_ident = normalize_stats_path(chunk_ident);
         local_chunks.push(WebpackStatsChunk {
             size: asset_len,
             files: vec![chunk_ident.clone()],
@@ -132,9 +167,9 @@ pub async fn get_asset_intermediate_info(
             ..Default::default()
         });
 
-        let chunk_items = chunk.chunk().chunk_items().await?;
-        for item in chunk_items.iter() {
-            local_chunk_items.push((*item, chunk_ident.clone()));
+        let chunk = chunk.chunk().to_resolved().await?;
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptChunk>(chunk) {
+            local_modules.extend(get_chunk_modules(chunk, chunk_ident).await?);
         }
     }
 
@@ -144,6 +179,7 @@ pub async fn get_asset_intermediate_info(
             .await?
             .get_relative_path_to(&chunk_path_full)
             .unwrap_or_else(|| chunk_path_full.path.clone());
+        let chunk_ident = normalize_stats_path(chunk_ident);
 
         local_chunks.push(WebpackStatsChunk {
             size: asset_len,
@@ -152,9 +188,9 @@ pub async fn get_asset_intermediate_info(
             ..Default::default()
         });
 
-        let chunk_items = chunk.chunk().chunk_items().await?;
-        for item in chunk_items.iter() {
-            local_chunk_items.push((*item, chunk_ident.clone()));
+        let chunk = chunk.chunk().to_resolved().await?;
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptChunk>(chunk) {
+            local_modules.extend(get_chunk_modules(chunk, chunk_ident).await?);
         }
     }
 
@@ -164,6 +200,7 @@ pub async fn get_asset_intermediate_info(
             .await?
             .get_relative_path_to(&chunk_path_full)
             .unwrap_or_else(|| chunk_path_full.path.clone());
+        let chunk_ident = normalize_stats_path(chunk_ident);
 
         local_chunks.push(WebpackStatsChunk {
             size: asset_len,
@@ -172,10 +209,8 @@ pub async fn get_asset_intermediate_info(
             ..Default::default()
         });
 
-        let chunk_items = chunk.chunk().chunk_items().await?;
-        for item in chunk_items.iter() {
-            local_chunk_items.push((*item, chunk_ident.clone()));
-        }
+        local_modules
+            .extend(get_chunk_modules(chunk.chunk().to_resolved().await?, chunk_ident).await?);
     }
 
     if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptBuildNodeEntryChunk>(asset) {
@@ -184,6 +219,7 @@ pub async fn get_asset_intermediate_info(
             .await?
             .get_relative_path_to(&entry_path_full)
             .unwrap_or_else(|| entry_path_full.path.clone());
+        let entry_path = normalize_stats_path(entry_path);
 
         local_chunks.push(WebpackStatsChunk {
             size: asset_len,
@@ -192,21 +228,6 @@ pub async fn get_asset_intermediate_info(
             ..Default::default()
         });
 
-        let evaluatable_assets = chunk.evaluatable_assets().await?;
-        let items: Vec<_> = evaluatable_assets
-            .iter()
-            .map(|&evaluatable_asset| {
-                let entry_path = entry_path.clone();
-                async move {
-                    let item = evaluatable_asset
-                        .as_chunk_item(chunk.module_graph(), chunk.chunking_context());
-                    Ok::<_, anyhow::Error>((item.to_resolved().await?, entry_path))
-                }
-            })
-            .try_join()
-            .await?;
-        local_chunk_items.extend(items);
-
         let entry_referenced_assets = chunk.chunks_data().await?;
         let futures: Vec<_> = entry_referenced_assets
             .iter()
@@ -214,7 +235,7 @@ pub async fn get_asset_intermediate_info(
                 let asset = *asset;
                 async move {
                     let chunk_data = asset.await?;
-                    let name: RcStr = chunk_data.path.as_str().into();
+                    let name = normalize_stats_path(chunk_data.path.as_str().into());
                     Ok::<_, anyhow::Error>((name.clone(), WebpackStatsEntrypointAssets { name }))
                 }
             })
@@ -252,6 +273,7 @@ pub async fn get_asset_intermediate_info(
             .await?
             .get_relative_path_to(&chunk_list_path_full)
             .unwrap_or_else(|| chunk_list_path_full.path.clone());
+        let chunk_list_ident = normalize_stats_path(chunk_list_ident);
         local_chunks.push(WebpackStatsChunk {
             size: asset_len,
             files: vec![chunk_list_ident.clone()],
@@ -268,6 +290,7 @@ pub async fn get_asset_intermediate_info(
             .await?
             .get_relative_path_to(&chunk_path_full)
             .unwrap_or_else(|| chunk_path_full.path.clone());
+        let chunk_ident = normalize_stats_path(chunk_ident);
         local_chunks.push(WebpackStatsChunk {
             size: asset_len,
             files: vec![chunk_ident.clone()],
@@ -282,6 +305,7 @@ pub async fn get_asset_intermediate_info(
             .await?
             .get_relative_path_to(&entry_path_full)
             .unwrap_or_else(|| entry_path_full.path.clone());
+        let entry_path = normalize_stats_path(entry_path);
         local_chunks.push(WebpackStatsChunk {
             size: asset_len,
             files: vec![entry_path.clone()],
@@ -289,20 +313,9 @@ pub async fn get_asset_intermediate_info(
             ..Default::default()
         });
 
-        let evaluatable_assets = chunk.evaluatable_assets().await?;
-        let items: Vec<_> = evaluatable_assets
-            .iter()
-            .map(|&evaluatable_asset| {
-                let entry_path = entry_path.clone();
-                async move {
-                    let item = evaluatable_asset
-                        .as_chunk_item(chunk.module_graph(), chunk.chunking_context());
-                    Ok::<_, anyhow::Error>((item.to_resolved().await?, entry_path))
-                }
-            })
-            .try_join()
-            .await?;
-        local_chunk_items.extend(items);
+        local_modules.extend(
+            get_chunk_modules(chunk.chunk().to_resolved().await?, entry_path.clone()).await?,
+        );
 
         let entry_referenced_assets = chunk.chunks_data().await?;
         let futures: Vec<_> = entry_referenced_assets
@@ -311,7 +324,7 @@ pub async fn get_asset_intermediate_info(
                 let asset = *asset;
                 async move {
                     let chunk_data = asset.await?;
-                    let name: RcStr = chunk_data.path.as_str().into();
+                    let name = normalize_stats_path(chunk_data.path.as_str().into());
                     Ok::<_, anyhow::Error>((name.clone(), WebpackStatsEntrypointAssets { name }))
                 }
             })
@@ -359,7 +372,7 @@ pub async fn get_asset_intermediate_info(
         asset: local_asset,
         chunks: local_chunks,
         entrypoints: local_entrypoints,
-        chunk_items: local_chunk_items,
+        modules: local_modules,
         dev_chunk_list: local_dev_chunk_list,
     }
     .cell())
@@ -373,8 +386,7 @@ pub async fn generate_webpack_stats(
     let mut assets = vec![];
     let mut seen_asset_paths = FxHashSet::default();
     let mut chunks = vec![];
-    let mut chunk_items: FxIndexMap<Vc<Box<dyn ChunkItem>>, FxIndexSet<RcStr>> =
-        FxIndexMap::default();
+    let mut modules: FxIndexMap<WebpackStatsModuleId, WebpackStatsModule> = FxIndexMap::default();
     let mut entrypoints: FxIndexMap<RcStr, WebpackStatsEntrypoint> = FxIndexMap::default();
 
     // Reuse Turbopack's graph traversal so shared async chunk graphs are expanded once.
@@ -401,11 +413,16 @@ pub async fn generate_webpack_stats(
         for (name, ep) in info.entrypoints.iter() {
             entrypoints.insert(name.clone(), ep.clone());
         }
-        for (item, chunk_id) in info.chunk_items.iter() {
-            chunk_items
-                .entry(**item)
-                .or_default()
-                .insert(chunk_id.clone());
+        for module in &info.modules {
+            if let Some(existing) = modules.get_mut(&module.id) {
+                for chunk in &module.chunks {
+                    if !existing.chunks.contains(chunk) {
+                        existing.chunks.push(chunk.clone());
+                    }
+                }
+            } else {
+                modules.insert(module.id.clone(), module.clone());
+            }
         }
         if let Some(dev_chunk_list) = &info.dev_chunk_list {
             dev_chunk_lists.push(dev_chunk_list.clone());
@@ -421,29 +438,7 @@ pub async fn generate_webpack_stats(
         }
     }
 
-    let modules = chunk_items
-        .into_iter()
-        .map(|(chunk_item, chunk_ids)| async move {
-            let content_ident = chunk_item.content_ident().await?;
-            let asset_path = chunk_item.asset_ident().await?.path.clone();
-            let size = content_ident
-                .path
-                .read()
-                .await
-                .ok()
-                .and_then(|file_content| {
-                    file_content.as_content().map(|f| f.content().len() as u64)
-                });
-            let path = asset_path.path.clone();
-            Ok::<_, anyhow::Error>(WebpackStatsModule {
-                name: path.clone(),
-                id: path.clone(),
-                chunks: chunk_ids.into_iter().collect(),
-                size,
-            })
-        })
-        .try_join()
-        .await?;
+    let modules = modules.into_values().collect::<Vec<_>>();
 
     #[cfg(feature = "test")]
     let modules = {
@@ -524,14 +519,44 @@ pub struct WebpackStatsChunk {
     pub files: Vec<RcStr>,
 }
 
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
+#[serde(untagged)]
+pub enum WebpackStatsModuleId {
+    Number(u64),
+    String(RcStr),
+}
+
+impl From<&ModuleId> for WebpackStatsModuleId {
+    fn from(id: &ModuleId) -> Self {
+        match id {
+            ModuleId::Number(id) => Self::Number(*id),
+            ModuleId::String(id) => Self::String(id.clone()),
+        }
+    }
+}
+
 #[turbo_tasks::value]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct WebpackStatsModule {
     pub name: RcStr,
-    pub id: RcStr,
+    pub id: WebpackStatsModuleId,
     pub chunks: Vec<RcStr>,
-    pub size: Option<u64>,
+    pub size: u64,
 }
 
 #[turbo_tasks::value]

--- a/crates/pack-core/src/library/ecmascript/chunk.rs
+++ b/crates/pack-core/src/library/ecmascript/chunk.rs
@@ -534,6 +534,11 @@ impl EcmascriptLibraryEvaluateChunk {
     pub fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(*self.chunking_context)
     }
+
+    #[turbo_tasks::function]
+    pub fn chunk(&self) -> Vc<EcmascriptChunk> {
+        *self.chunk
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/pack-tests/tests/snapshot/async_chunk/assert.js
+++ b/crates/pack-tests/tests/snapshot/async_chunk/assert.js
@@ -1,0 +1,73 @@
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const outputDir = path.join(__dirname, "output");
+const stats = JSON.parse(
+  fs.readFileSync(path.join(outputDir, "stats.json"), "utf8"),
+);
+
+const moduleIds = stats.modules.map((module) => module.id);
+assert.strictEqual(
+  new Set(moduleIds).size,
+  moduleIds.length,
+  "webpack stats module ids must be unique",
+);
+
+const importModules = stats.modules.filter(
+  (module) => module.name === "async_chunk/input/import.js",
+);
+assert.strictEqual(
+  importModules.length,
+  2,
+  "stats module names must remain human-readable source paths",
+);
+assert.notStrictEqual(
+  importModules[0].id,
+  importModules[1].id,
+  "different generated modules for one source must keep distinct runtime ids",
+);
+
+const factoriesByChunk = new Map();
+for (const asset of stats.assets) {
+  if (!asset.name.endsWith(".js") || asset.name === "main.js") {
+    continue;
+  }
+
+  globalThis.utooChunk_async_chunk_test = [];
+  require(path.join(outputDir, asset.name));
+
+  const factories = new Map();
+  for (const registration of globalThis.utooChunk_async_chunk_test) {
+    for (let index = 1; index < registration.length; index += 2) {
+      const id = registration[index];
+      const factory = registration[index + 1];
+      if (typeof factory === "function") {
+        factories.set(id, factory);
+      }
+    }
+  }
+  factoriesByChunk.set(asset.name, factories);
+}
+
+for (const module of stats.modules) {
+  for (const chunk of module.chunks) {
+    const factories = factoriesByChunk.get(chunk);
+    assert.ok(
+      factories,
+      `stats module ${module.id} points to non-module chunk ${chunk}`,
+    );
+
+    const factory = factories.get(module.id);
+    assert.ok(
+      factory,
+      `stats module ${module.id} is not emitted in chunk ${chunk}`,
+    );
+
+    assert.strictEqual(
+      module.size,
+      Buffer.byteLength(factory.toString()) + 2,
+      `stats module ${module.id} must use generated module factory size`,
+    );
+  }
+}

--- a/crates/pack-tests/tests/snapshot/async_chunk/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/async_chunk/output/stats.json
@@ -131,52 +131,51 @@
   "modules": [
     {
       "name": "async_chunk/input/import.js",
-      "id": "async_chunk/input/import.js",
-      "chunks": [
-        "input_97190704.js"
-      ],
-      "size": 91
-    },
-    {
-      "name": "async_chunk/input/import.js",
-      "id": "async_chunk/input/import.js",
+      "id": 192,
       "chunks": [
         "input_86dfc83f.js"
       ],
-      "size": 91
-    },
-    {
-      "name": "async_chunk/input/index.js",
-      "id": "async_chunk/input/index.js",
-      "chunks": [
-        "input_86dfc83f.js",
-        "main.js"
-      ],
-      "size": 110
+      "size": 233
     },
     {
       "name": "async_chunk/input/node_modules/bar/index.js",
-      "id": "async_chunk/input/node_modules/bar/index.js",
+      "id": 402,
       "chunks": [
         "input_86dfc83f.js"
       ],
-      "size": 56
+      "size": 154
     },
     {
-      "name": "async_chunk/input/node_modules/foo/index.js",
-      "id": "async_chunk/input/node_modules/foo/index.js",
+      "name": "async_chunk/input/import.js",
+      "id": 476,
       "chunks": [
         "input_97190704.js"
       ],
-      "size": 56
+      "size": 413
     },
     {
-      "name": "async_chunk/input/shared.js",
-      "id": "async_chunk/input/shared.js",
+      "name": "async_chunk/input/index.js",
+      "id": 545,
       "chunks": [
         "input_86dfc83f.js"
       ],
-      "size": 18
+      "size": 348
+    },
+    {
+      "name": "async_chunk/input/shared.js",
+      "id": 743,
+      "chunks": [
+        "input_86dfc83f.js"
+      ],
+      "size": 68
+    },
+    {
+      "name": "async_chunk/input/node_modules/foo/index.js",
+      "id": 976,
+      "chunks": [
+        "input_97190704.js"
+      ],
+      "size": 154
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/basic/chunk_loading_global/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/basic/chunk_loading_global/output/stats.json
@@ -95,12 +95,11 @@
   "modules": [
     {
       "name": "basic/chunk_loading_global/input/index.js",
-      "id": "basic/chunk_loading_global/input/index.js",
+      "id": "[project]/basic/chunk_loading_global/input/index.js [client] (ecmascript)",
       "chunks": [
-        "input_index_eff851b8.js",
-        "main.js"
+        "input_index_eff851b8.js"
       ],
-      "size": 42
+      "size": 93
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/basic/copy/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/basic/copy/output/stats.json
@@ -143,12 +143,11 @@
   "modules": [
     {
       "name": "basic/copy/input/index.js",
-      "id": "basic/copy/input/index.js",
+      "id": "[project]/basic/copy/input/index.js [client] (ecmascript)",
       "chunks": [
-        "input_index_d913cfd2.js",
-        "main.js"
+        "input_index_d913cfd2.js"
       ],
-      "size": 28
+      "size": 79
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/basic/multi_server_entries/output/server/stats.json
+++ b/crates/pack-tests/tests/snapshot/basic/multi_server_entries/output/server/stats.json
@@ -3,53 +3,53 @@
     "detail-server": {
       "name": "detail-server",
       "chunks": [
-        "./entries/detail-server.5d841f26.js",
-        "chunks/server-shared.fbcd5f75.js"
+        "chunks/server-shared.fbcd5f75.js",
+        "entries/detail-server.5d841f26.js"
       ],
       "assets": [
         {
-          "name": "./entries/detail-server.5d841f26.js"
+          "name": "chunks/server-shared.fbcd5f75.js"
         },
         {
-          "name": "chunks/server-shared.fbcd5f75.js"
+          "name": "entries/detail-server.5d841f26.js"
         }
       ]
     },
     "index-server": {
       "name": "index-server",
       "chunks": [
-        "./entries/index-server.5c83aa4e.js",
         "chunks/server-shared-0-1.1b081f62.js",
-        "chunks/server-shared.fbcd5f75.js"
+        "chunks/server-shared.fbcd5f75.js",
+        "entries/index-server.5c83aa4e.js"
       ],
       "assets": [
-        {
-          "name": "./entries/index-server.5c83aa4e.js"
-        },
         {
           "name": "chunks/server-shared-0-1.1b081f62.js"
         },
         {
           "name": "chunks/server-shared.fbcd5f75.js"
+        },
+        {
+          "name": "entries/index-server.5c83aa4e.js"
         }
       ]
     },
     "server": {
       "name": "server",
       "chunks": [
-        "./entries/server.5d80c3de.js",
         "chunks/server-shared-0-1.1b081f62.js",
-        "chunks/server-shared.fbcd5f75.js"
+        "chunks/server-shared.fbcd5f75.js",
+        "entries/server.5d80c3de.js"
       ],
       "assets": [
-        {
-          "name": "./entries/server.5d80c3de.js"
-        },
         {
           "name": "chunks/server-shared-0-1.1b081f62.js"
         },
         {
           "name": "chunks/server-shared.fbcd5f75.js"
+        },
+        {
+          "name": "entries/server.5d80c3de.js"
         }
       ]
     }
@@ -60,11 +60,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./chunks/server-shared-0-1.1b081f62.js",
+      "id": "chunks/server-shared-0-1.1b081f62.js",
       "size": 686,
       "hash": "",
       "files": [
-        "./chunks/server-shared-0-1.1b081f62.js"
+        "chunks/server-shared-0-1.1b081f62.js"
       ]
     },
     {
@@ -72,11 +72,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./chunks/server-shared.fbcd5f75.js",
+      "id": "chunks/server-shared.fbcd5f75.js",
       "size": 262,
       "hash": "",
       "files": [
-        "./chunks/server-shared.fbcd5f75.js"
+        "chunks/server-shared.fbcd5f75.js"
       ]
     },
     {
@@ -84,11 +84,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./entries/detail-server.5d841f26.js",
+      "id": "entries/detail-server.5d841f26.js",
       "size": 32581,
       "hash": "",
       "files": [
-        "./entries/detail-server.5d841f26.js"
+        "entries/detail-server.5d841f26.js"
       ]
     },
     {
@@ -96,11 +96,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./entries/index-server.5c83aa4e.js",
+      "id": "entries/index-server.5c83aa4e.js",
       "size": 32593,
       "hash": "",
       "files": [
-        "./entries/index-server.5c83aa4e.js"
+        "entries/index-server.5c83aa4e.js"
       ]
     },
     {
@@ -108,11 +108,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./entries/server.5d80c3de.js",
+      "id": "entries/server.5d80c3de.js",
       "size": 32560,
       "hash": "",
       "files": [
-        "./entries/server.5d80c3de.js"
+        "entries/server.5d80c3de.js"
       ]
     }
   ],
@@ -181,43 +181,43 @@
   "modules": [
     {
       "name": "basic/multi_server_entries/input/detail.server.ts",
-      "id": "basic/multi_server_entries/input/detail.server.ts",
+      "id": "[project]/basic/multi_server_entries/input/detail.server.ts [server] (ecmascript)",
       "chunks": [
-        "./entries/detail-server.5d841f26.js"
+        "entries/detail-server.5d841f26.js"
       ],
-      "size": 89
+      "size": 536
     },
     {
       "name": "basic/multi_server_entries/input/index.server.ts",
-      "id": "basic/multi_server_entries/input/index.server.ts",
+      "id": "[project]/basic/multi_server_entries/input/index.server.ts [server] (ecmascript)",
       "chunks": [
-        "./entries/index-server.5c83aa4e.js"
+        "entries/index-server.5c83aa4e.js"
       ],
-      "size": 78
+      "size": 514
     },
     {
       "name": "basic/multi_server_entries/input/server.ts",
-      "id": "basic/multi_server_entries/input/server.ts",
+      "id": "[project]/basic/multi_server_entries/input/server.ts [server] (ecmascript)",
       "chunks": [
-        "./entries/server.5d80c3de.js"
+        "entries/server.5d80c3de.js"
       ],
-      "size": 75
+      "size": 511
     },
     {
       "name": "basic/multi_server_entries/input/shared-all.ts",
-      "id": "basic/multi_server_entries/input/shared-all.ts",
+      "id": "[project]/basic/multi_server_entries/input/shared-all.ts [server] (ecmascript)",
       "chunks": [
-        "./chunks/server-shared.fbcd5f75.js"
+        "chunks/server-shared.fbcd5f75.js"
       ],
-      "size": 50
+      "size": 155
     },
     {
       "name": "basic/multi_server_entries/input/shared.ts",
-      "id": "basic/multi_server_entries/input/shared.ts",
+      "id": "[project]/basic/multi_server_entries/input/shared.ts [server] (ecmascript)",
       "chunks": [
-        "./chunks/server-shared-0-1.1b081f62.js"
+        "chunks/server-shared-0-1.1b081f62.js"
       ],
-      "size": 113
+      "size": 583
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/stats.json
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/client/stats.json
@@ -1,24 +1,13 @@
 {
   "entrypoints": {
-    "./a": {
-      "name": "./a",
+    "a": {
+      "name": "a",
       "chunks": [
-        "./a.js"
+        "a.js"
       ],
       "assets": [
         {
-          "name": "./a.js"
-        }
-      ]
-    },
-    "./b": {
-      "name": "./b",
-      "chunks": [
-        "./b.js"
-      ],
-      "assets": [
-        {
-          "name": "./b.js"
+          "name": "a.js"
         }
       ]
     },
@@ -36,6 +25,17 @@
           "name": "input_0d05fffe.js"
         }
       ]
+    },
+    "b": {
+      "name": "b",
+      "chunks": [
+        "b.js"
+      ],
+      "assets": [
+        {
+          "name": "b.js"
+        }
+      ]
     }
   },
   "chunks": [
@@ -44,23 +44,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./a.js",
+      "id": "a.js",
       "size": 447,
       "hash": "",
       "files": [
-        "./a.js"
-      ]
-    },
-    {
-      "rendered": false,
-      "initial": false,
-      "entry": false,
-      "recorded": false,
-      "id": "./b.js",
-      "size": 447,
-      "hash": "",
-      "files": [
-        "./b.js"
+        "a.js"
       ]
     },
     {
@@ -73,6 +61,18 @@
       "hash": "",
       "files": [
         "app.js"
+      ]
+    },
+    {
+      "rendered": false,
+      "initial": false,
+      "entry": false,
+      "recorded": false,
+      "id": "b.js",
+      "size": 447,
+      "hash": "",
+      "files": [
+        "b.js"
       ]
     },
     {
@@ -189,44 +189,43 @@
   "modules": [
     {
       "name": "basic/stats_with_server_and_libraries/input/a.ts",
-      "id": "basic/stats_with_server_and_libraries/input/a.ts",
+      "id": "[project]/basic/stats_with_server_and_libraries/input/a.ts [client] (ecmascript)",
       "chunks": [
         "input_0d05fffe.js"
       ],
-      "size": 28
+      "size": 120
     },
     {
       "name": "basic/stats_with_server_and_libraries/input/a.ts",
-      "id": "basic/stats_with_server_and_libraries/input/a.ts",
+      "id": "[project]/basic/stats_with_server_and_libraries/input/a.ts [library-client] (ecmascript)",
       "chunks": [
-        "./a.js"
+        "a.js"
       ],
-      "size": 28
+      "size": 120
     },
     {
       "name": "basic/stats_with_server_and_libraries/input/app.ts",
-      "id": "basic/stats_with_server_and_libraries/input/app.ts",
-      "chunks": [
-        "input_0d05fffe.js",
-        "app.js"
-      ],
-      "size": 83
-    },
-    {
-      "name": "basic/stats_with_server_and_libraries/input/b.ts",
-      "id": "basic/stats_with_server_and_libraries/input/b.ts",
+      "id": "[project]/basic/stats_with_server_and_libraries/input/app.ts [client] (ecmascript)",
       "chunks": [
         "input_0d05fffe.js"
       ],
-      "size": 28
+      "size": 936
     },
     {
       "name": "basic/stats_with_server_and_libraries/input/b.ts",
-      "id": "basic/stats_with_server_and_libraries/input/b.ts",
+      "id": "[project]/basic/stats_with_server_and_libraries/input/b.ts [client] (ecmascript)",
       "chunks": [
-        "./b.js"
+        "input_0d05fffe.js"
       ],
-      "size": 28
+      "size": 120
+    },
+    {
+      "name": "basic/stats_with_server_and_libraries/input/b.ts",
+      "id": "[project]/basic/stats_with_server_and_libraries/input/b.ts [library-client] (ecmascript)",
+      "chunks": [
+        "b.js"
+      ],
+      "size": 120
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/server/stats.json
+++ b/crates/pack-tests/tests/snapshot/basic/stats_with_server_and_libraries/output/server/stats.json
@@ -1,13 +1,13 @@
 {
   "entrypoints": {
-    "./index": {
-      "name": "./index",
+    "index": {
+      "name": "index",
       "chunks": [
-        "./index.js"
+        "index.js"
       ],
       "assets": [
         {
-          "name": "./index.js"
+          "name": "index.js"
         }
       ]
     }
@@ -18,11 +18,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./index.js",
+      "id": "index.js",
       "size": 412,
       "hash": "",
       "files": [
-        "./index.js"
+        "index.js"
       ]
     }
   ],
@@ -55,11 +55,11 @@
   "modules": [
     {
       "name": "basic/stats_with_server_and_libraries/input/server.ts",
-      "id": "basic/stats_with_server_and_libraries/input/server.ts",
+      "id": "[project]/basic/stats_with_server_and_libraries/input/server.ts [server] (ecmascript)",
       "chunks": [
-        "./index.js"
+        "index.js"
       ],
-      "size": 29
+      "size": 79
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/library/async-module/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/library/async-module/output/stats.json
@@ -1,13 +1,13 @@
 {
   "entrypoints": {
-    "./main": {
-      "name": "./main",
+    "main": {
+      "name": "main",
       "chunks": [
-        "./main.js"
+        "main.js"
       ],
       "assets": [
         {
-          "name": "./main.js"
+          "name": "main.js"
         }
       ]
     }
@@ -18,11 +18,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./main.js",
+      "id": "main.js",
       "size": 4455,
       "hash": "",
       "files": [
-        "./main.js"
+        "main.js"
       ]
     }
   ],
@@ -54,12 +54,52 @@
   ],
   "modules": [
     {
-      "name": "library/async-module/input/index.js",
-      "id": "library/async-module/input/index.js",
+      "name": "library/async-module/input/main.js",
+      "id": 220,
       "chunks": [
-        "./main.js"
+        "main.js"
       ],
-      "size": 82
+      "size": 1152
+    },
+    {
+      "name": "library/async-module/input/shared.js",
+      "id": 263,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 500
+    },
+    {
+      "name": "library/async-module/input/b.js",
+      "id": 356,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 927
+    },
+    {
+      "name": "library/async-module/input/index.js",
+      "id": 511,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 440
+    },
+    {
+      "name": "library/async-module/input/a.js",
+      "id": 513,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 927
+    },
+    {
+      "name": "library/async-module/input/async.js",
+      "id": 864,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 312
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/library/basic/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/library/basic/output/stats.json
@@ -1,13 +1,13 @@
 {
   "entrypoints": {
-    "./main": {
-      "name": "./main",
+    "main": {
+      "name": "main",
       "chunks": [
-        "./main.js"
+        "main.js"
       ],
       "assets": [
         {
-          "name": "./main.js"
+          "name": "main.js"
         }
       ]
     }
@@ -18,11 +18,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./main.js",
+      "id": "main.js",
       "size": 2957,
       "hash": "",
       "files": [
-        "./main.js"
+        "main.js"
       ]
     }
   ],
@@ -54,12 +54,60 @@
   ],
   "modules": [
     {
-      "name": "library/basic/input/index.tsx",
-      "id": "library/basic/input/index.tsx",
+      "name": "root EmotionStyled commonjs emotion-styled",
+      "id": 132,
       "chunks": [
-        "./main.js"
+        "main.js"
       ],
-      "size": 518
+      "size": 279
+    },
+    {
+      "name": "library/basic/input/a.ts",
+      "id": 481,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 116
+    },
+    {
+      "name": "node_modules/@emotion/react/index.js",
+      "id": 486,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 425
+    },
+    {
+      "name": "root React commonjs react",
+      "id": 571,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 253
+    },
+    {
+      "name": "root ReactDOM commonjs react-dom",
+      "id": 611,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 264
+    },
+    {
+      "name": "library/basic/input/index.tsx",
+      "id": 620,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 1130
+    },
+    {
+      "name": "node_modules/@emotion/react/jsx-runtime.js",
+      "id": 861,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 286
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/library/less_css_modules/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/library/less_css_modules/output/stats.json
@@ -19,7 +19,7 @@
       "entry": false,
       "recorded": false,
       "id": "main.js",
-      "size": 9368,
+      "size": 9424,
       "hash": "",
       "files": [
         "main.js"
@@ -31,7 +31,7 @@
       "type": "asset",
       "name": "input_index.less.css.map",
       "info": {},
-      "size": 53,
+      "size": 297,
       "emitted": false,
       "comparedForEmit": false,
       "cached": false,
@@ -43,7 +43,7 @@
       "type": "asset",
       "name": "main.js",
       "info": {},
-      "size": 9368,
+      "size": 9424,
       "emitted": false,
       "comparedForEmit": false,
       "cached": false,
@@ -55,7 +55,7 @@
       "type": "asset",
       "name": "main.js.map",
       "info": {},
-      "size": 15494,
+      "size": 15560,
       "emitted": false,
       "comparedForEmit": false,
       "cached": false,
@@ -95,7 +95,7 @@
       "chunks": [
         "main.js"
       ],
-      "size": 92
+      "size": 148
     },
     {
       "name": "library/less_css_modules/input/index.ts",

--- a/crates/pack-tests/tests/snapshot/library/less_css_modules/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/library/less_css_modules/output/stats.json
@@ -1,13 +1,13 @@
 {
   "entrypoints": {
-    "./main": {
-      "name": "./main",
+    "main": {
+      "name": "main",
       "chunks": [
-        "./main.js"
+        "main.js"
       ],
       "assets": [
         {
-          "name": "./main.js"
+          "name": "main.js"
         }
       ]
     }
@@ -18,11 +18,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./main.js",
-      "size": 9424,
+      "id": "main.js",
+      "size": 9368,
       "hash": "",
       "files": [
-        "./main.js"
+        "main.js"
       ]
     }
   ],
@@ -31,7 +31,7 @@
       "type": "asset",
       "name": "input_index.less.css.map",
       "info": {},
-      "size": 297,
+      "size": 53,
       "emitted": false,
       "comparedForEmit": false,
       "cached": false,
@@ -43,7 +43,7 @@
       "type": "asset",
       "name": "main.js",
       "info": {},
-      "size": 9424,
+      "size": 9368,
       "emitted": false,
       "comparedForEmit": false,
       "cached": false,
@@ -55,7 +55,7 @@
       "type": "asset",
       "name": "main.js.map",
       "info": {},
-      "size": 15560,
+      "size": 15494,
       "emitted": false,
       "comparedForEmit": false,
       "cached": false,
@@ -66,12 +66,44 @@
   ],
   "modules": [
     {
-      "name": "library/less_css_modules/input/index.ts",
-      "id": "library/less_css_modules/input/index.ts",
+      "name": "library/less_css_modules/input/index.less.css",
+      "id": 12,
       "chunks": [
-        "./main.js"
+        "main.js"
       ],
-      "size": 59
+      "size": 633
+    },
+    {
+      "name": "inline_css/injectStylesIntoStyleTag.js",
+      "id": 15,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 7902
+    },
+    {
+      "name": "library/less_css_modules/input/index.less.css",
+      "id": 37,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 265
+    },
+    {
+      "name": "library/less_css_modules/input/index.less",
+      "id": 56,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 92
+    },
+    {
+      "name": "library/less_css_modules/input/index.ts",
+      "id": 91,
+      "chunks": [
+        "main.js"
+      ],
+      "size": 292
     }
   ]
 }

--- a/crates/pack-tests/tests/snapshot/target_node/stats_node/output/stats.json
+++ b/crates/pack-tests/tests/snapshot/target_node/stats_node/output/stats.json
@@ -1,17 +1,17 @@
 {
   "entrypoints": {
-    "./main": {
-      "name": "./main",
+    "main": {
+      "name": "main",
       "chunks": [
-        "./main.js",
-        "_root-of-the-server___7e972a20.js"
+        "_root-of-the-server___7e972a20.js",
+        "main.js"
       ],
       "assets": [
         {
-          "name": "./main.js"
+          "name": "_root-of-the-server___7e972a20.js"
         },
         {
-          "name": "_root-of-the-server___7e972a20.js"
+          "name": "main.js"
         }
       ]
     }
@@ -22,11 +22,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./_root-of-the-server___7e972a20.js",
+      "id": "_root-of-the-server___7e972a20.js",
       "size": 934,
       "hash": "",
       "files": [
-        "./_root-of-the-server___7e972a20.js"
+        "_root-of-the-server___7e972a20.js"
       ]
     },
     {
@@ -34,11 +34,11 @@
       "initial": false,
       "entry": false,
       "recorded": false,
-      "id": "./main.js",
+      "id": "main.js",
       "size": 271,
       "hash": "",
       "files": [
-        "./main.js"
+        "main.js"
       ]
     }
   ],
@@ -119,28 +119,27 @@
   "modules": [
     {
       "name": "path",
-      "id": "path",
+      "id": "[externals]/path [external] (path, cjs)",
       "chunks": [
-        "./_root-of-the-server___7e972a20.js"
+        "_root-of-the-server___7e972a20.js"
       ],
-      "size": null
+      "size": 139
     },
     {
       "name": "target_node/stats_node/input/index.js",
-      "id": "target_node/stats_node/input/index.js",
+      "id": "[project]/target_node/stats_node/input/index.js [server] (ecmascript)",
       "chunks": [
-        "./_root-of-the-server___7e972a20.js",
-        "./main.js"
+        "_root-of-the-server___7e972a20.js"
       ],
-      "size": 147
+      "size": 279
     },
     {
       "name": "target_node/stats_node/input/utils.js",
-      "id": "target_node/stats_node/input/utils.js",
+      "id": "[project]/target_node/stats_node/input/utils.js [server] (ecmascript)",
       "chunks": [
-        "./_root-of-the-server___7e972a20.js"
+        "_root-of-the-server___7e972a20.js"
       ],
-      "size": 135
+      "size": 240
     }
   ]
 }


### PR DESCRIPTION
## What

- report module sizes from emitted JavaScript factories instead of source-file bytes
- use actual runtime module IDs while keeping `name` as a human-readable source path
- associate modules only with chunks that actually emit their factories
- normalize stats paths consistently across browser, Node.js, and library chunks
- add a regression assertion for unique IDs, emitted-chunk membership, and generated sizes

## Why

The previous stats used source paths as module IDs and raw source-file sizes as module sizes. One source file can produce multiple runtime modules, so IDs collided and Bundle Analyzer merged unrelated records. Module-to-chunk associations also included items that were not emitted by that chunk. Together, those behaviors caused `stats.json` to systematically undercount assets and could make `gzip` appear larger than `stat`.

## Impact

`stats.json` now reflects the generated module factories consumed by Bundle Analyzer. The module `name` remains short and readable for the directory tree, while `id`, `chunks`, and `size` carry the accurate runtime metadata.

